### PR TITLE
wms buffer

### DIFF
--- a/src/GeoNodePy/geonode/maps/models.py
+++ b/src/GeoNodePy/geonode/maps/models.py
@@ -1167,8 +1167,10 @@ class Map(models.Model, PermissionLevelMixin):
 
         def layer_config(l):
             cfg = l.layer_config()
-            source = source_lookup(l.source_config())
+            src_cfg = l.source_config();
+            source = source_lookup(src_cfg)
             if source: cfg["source"] = source
+            if src_cfg["ptype"] == "gx_wmssource": cfg["buffer"] = 0
             return cfg
 
         config = {


### PR DESCRIPTION
I'd like to have our WMS layers use a buffer of 0 rather than 1, to speed up loading and reduce the number of dom elements on the map - this will make dragging faster, especially if there are many layers.
