### PR TITLE
Date picker in metadata form

### DIFF
--- a/src/GeoNodePy/geonode/maps/models.py
+++ b/src/GeoNodePy/geonode/maps/models.py
@@ -605,7 +605,7 @@ class Layer(models.Model, PermissionLevelMixin):
 
     # section 1
     title = models.CharField(_('title'), max_length=255)
-    date = models.DateTimeField(_('date'), auto_now=True)
+    date = models.DateTimeField(_('date'))
     
     date_type = models.CharField(_('date type'), max_length=255,choices=[(x, x) for x in ['Creation', 'Publication', 'Revision']], default='Publication')
 

--- a/src/GeoNodePy/geonode/maps/views.py
+++ b/src/GeoNodePy/geonode/maps/views.py
@@ -69,6 +69,12 @@ class ContactForm(forms.ModelForm):
         exclude = ('user',)
 
 class LayerForm(forms.ModelForm):
+    date = forms.DateTimeField(widget=forms.SplitDateTimeWidget)
+    date.widget.widgets[0].attrs = {"class":"date"}
+    date.widget.widgets[1].attrs = {"class":"time"}
+    temporal_extent_start = forms.DateField(widget=forms.DateInput(attrs={"class":"date"}))
+    temporal_extent_end = forms.DateField(widget=forms.DateInput(attrs={"class":"date"}))
+    
     poc = forms.ModelChoiceField(empty_label = "Person outside GeoNode (fill form)",
                                  label = "Point Of Contact", required=False,
                                  queryset = Contact.objects.exclude(user=None))

--- a/src/GeoNodePy/geonode/templates/maps/layer_describe.html
+++ b/src/GeoNodePy/geonode/templates/maps/layer_describe.html
@@ -6,28 +6,6 @@
 {% block head %}
 {% include "geonode/ext_header.html" %}
 {{ block.super }}
-<script type="text/javascript">
-    Ext.onReady(function() {
-{% autoescape off %} 
-        // get #poc_form and #metadata_form, and add a `onchange` handler
-        // that shows the form if the blank option is selected.
-		Ext.get('id_layer-poc').on('change', function() {
-	        if (this.getValue()===""){
-			    Ext.get("poc_form").show();
-			}else{
-				Ext.get("poc_form").hide();
-			}
-		   });
-		Ext.get('id_layer-metadata_author').on('change', function() {
-	        if (this.getValue()===""){
-			    Ext.get("metadata_form").show();
-			}else{
-				Ext.get("metadata_form").hide();
-			}
-		});
-{% endautoescape %} 
-	});
-</script>
 {% endblock %}
 {% block main %}
 <div class="twocol">
@@ -48,4 +26,32 @@
       </ul>
   </form>
 </div>
+<script type="text/javascript">
+{% autoescape off %}
+    // Extify form fields
+    Ext.select("input[type='text']").each(function(el) {
+        if (el.hasClass("date")) {
+            new Ext.form.DateField({applyTo: el.id, format: "Y-m-d"});
+        } else if (el.hasClass("time")) {
+            new Ext.form.TimeField({applyTo: el.id, format: "H:i:s"})
+        }
+    });
+    // get #poc_form and #metadata_form, and add a `onchange` handler
+    // that shows the form if the blank option is selected.
+	Ext.get('id_layer-poc').on('change', function() {
+        if (this.getValue()===""){
+		    Ext.get("poc_form").show();
+		}else{
+			Ext.get("poc_form").hide();
+		}
+	});
+	Ext.get('id_layer-metadata_author').on('change', function() {
+        if (this.getValue()===""){
+		    Ext.get("metadata_form").show();
+		}else{
+			Ext.get("metadata_form").hide();
+		}
+	});
+{% endautoescape %} 
+</script>
 {% endblock %}

--- a/src/geonode-client/src/theme/app/site.css
+++ b/src/geonode-client/src/theme/app/site.css
@@ -104,6 +104,23 @@ form td {
 vertical-align: middle;
 }
 
+.x-date-menu em {
+font-style: normal;
+}
+.x-date-menu ul,
+.x-date-menu ol,
+.x-date-menu table {
+margin: 0;
+}
+.x-date-menu th,
+.x-date-menu td {
+padding: 0;
+vertical-align: middle;
+}
+td.x-date-bottom,
+td.x-date-middle {
+padding: 4px;
+}
 
 /*-----------------------
 Layout


### PR DESCRIPTION
With this change, we would get Ext date pickers and a time field in the metadata form. This is to solve http://projects.opengeo.org/CAPRA/ticket/495.

There is one issue with the date picker though: The boilerplate css defines a "left" alignment for td elements. And even if this is overridden with "center !important", the date picker will display the "Today" button and the month with a left alignment. The only solution I found would be to remove the "left" alignment for td elements from the boilerplate css. @ltucker: do we really need the reset.css part of boilerplate? Or maybe you have a better idea?

Another thing to discuss is: do we want to extify all form elements to make our forms look more consistent? It would be really easy to do so (ballpark estimate for all of GeoNode: 3 hours), and give us the benefit of type-ahead and filtering in combo boxes. For text fields and text areas, Ext fields do not add any overhead - Ext only applies CSS classes to the existing elements.
