### PR TITLE
Simple client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,14 +12,13 @@ target
 /setuptools-0.6c11-py2.6.egg
 
 # supporting stuff pulled in by paver script
+/src/GeoNodePy/geonode/media/static/
 /geoserver_token
 /development.db
 /django.log
 /gs-data/
 /jetty.log
 /shared/geonode-geoserver-data.zip
-/shared/ext-3.2.1.zip
-/src/geonode-client/externals/ext/
 /src/geoserver-geonode-ext/logs/
 /src/gsconfig.py/
 /src/owslib/

--- a/README.rst
+++ b/README.rst
@@ -123,16 +123,19 @@ For JavaScript Developers
 Minified Scripts
 ................
 
-JavaScript Developers can switch to using unminified scripts and CSS styles by
-setting the MINIFIED_RESOURCES entry in :file:`src/geonode/settings.py` to
-``False``.  If you are developing JavaScript and testing against minified builds,
-make sure to use::
+JavaScript Developers can switch to using unminified scripts and CSS:
 
-   $ paver concat_js 
-   $ paver capra_js
+1. Get and run geonode-client:
 
-to update the built script directories for the base GeoNode site and the CAPRA
-extensions, respectively.
+    $ git clone git://github.com/GeoNode/geonode-client.git geonode-client
+    $ cd geonode-client
+    $ ant init debug
+
+2. Set the GEONODE_CLIENT_LOCATION entry in :file:`src/geonode/settings.py` to
+   ``http://localhost:8080/`` and run paver as described above.
+
+Note that this requires ant (http://ant.apache.org/) in addition to the above
+build requirements.
 
 VirtualBox Setup
 ................
@@ -146,13 +149,16 @@ following needs to be done before running ``paver host``:
 * On the host, do ifconfig and write down the IP address of the vboxnet0
   adapter.
 
-* Edit src/GeoNodePy/geonode/settings.py and change the line::
+* Edit :file:`src/GeoNodePy/geonode/settings.py` and change the line::
 
     GEOSERVER_BASE_URL="http://localhost:8001/geoserver/"
 
   to use the IP address you have written down above::
 
     GEOSERVER_BASE_URL="http://192.168.56.1:8001/geoserver/"
+
+* Make sure to change other http://localhost urls in
+  :file:`src/GeoNodePy/geonode/settings.py` accordingly as well
 
 * To start the web server, run::
 

--- a/pavement.py
+++ b/pavement.py
@@ -242,18 +242,17 @@ def setup_geonode_client(options):
     """
     Fetch geonode-client
     """
-    webapps = path("./webapps")
-    if not webapps.exists():
-        webapps.mkdir()
+    static = path("./src/GeoNodePy/geonode/media/static")
+    if not static.exists():
+        static.mkdir()
 
-    src_url = str(options.config.parser.get('geonode-client', 'geonode_client_war_url'))
-    dst_war = webapps / "geonode-client.war"
-    deployed_url = webapps / "geonode-client"
+    src_url = str(options.config.parser.get('geonode-client', 'geonode_client_zip_url'))
+    dst_zip = static / "geonode-client.zip"
 
-    grab(src_url, dst_war)
+    grab(src_url, dst_zip)
 
-    deployed_url.rmtree()
-    zip_extractall(zipfile.ZipFile(dst_war), deployed_url)
+    zip_extractall(zipfile.ZipFile(dst_zip), static)
+    dst_zip.remove()
 
 @task
 def sync_django_db(options):
@@ -519,14 +518,11 @@ def install_sphinx_conditionally(options):
 
 @task
 @cmdopts([
-    ('bind=', 'b', 'IP address to bind to. Default is localhost.'),
-    ('client_src=', 's', 'geonode-client project directory, e.g. ../geonode-client/. If provided, unminified javascript resources will be used.')
+    ('bind=', 'b', 'IP address to bind to. Default is localhost.')
 ])
 def host(options):
     jettylog = open("jetty.log", "w")
     djangolog = open("django.log", "w")
-    if hasattr(options.host, 'client_src'):
-        os.environ["READYGXP_FILES_ROOT"] = os.path.abspath(options.host.client_src)
     with pushd("src/geoserver-geonode-ext"):
         os.environ["MAVEN_OPTS"] = " ".join([
             "-XX:CompileCommand=exclude,net/sf/saxon/event/ReceivingContentHandler.startElement",


### PR DESCRIPTION
This simplifies the geonode-client story. No war required any more, and javascript developers just run "ant debug" from geonode-client and set GEONODE_CLIENT_LOCATION to http://localhost:8080/
