### PR TITLE
Fixed the firefox permalink in /maps/id/view

### DIFF
--- a/src/GeoNodePy/geonode/templates/maps/view.html
+++ b/src/GeoNodePy/geonode/templates/maps/view.html
@@ -51,7 +51,7 @@ Ext.onReady(function() {
             }) 
         };
 
-	var moreInfoTemplate = new Ext.Template(Ext.get("more-info-tpl").dom.innerHTML.replace('%7Bpermalink%7D','{permalink}'));
+	var moreInfoTemplate = new Ext.Template(decodeURIComponent(Ext.get("more-info-tpl").dom.innerHTML));
     var mapInfoHtml = config.id ? moreInfoTemplate.apply({permalink : permalink(app.mapID)}) : "This map is currently unsaved";
     Ext.DomHelper.overwrite(Ext.get("more-info"), mapInfoHtml)
 


### PR DESCRIPTION
Made a string replace at line 54 of the templates/maps/view.html file.
Apparently firefox transforms the {permalink} in %7Bpermalink%7D.
This behavior should apply at all brackets written in the HTML code.
The fix replaces back the {permalink} string before Ext modifies the template.
