### PR TITLE
protecting from div by zero when bbox has no extent

### DIFF
--- a/src/GeoNodePy/geonode/maps/models.py
+++ b/src/GeoNodePy/geonode/maps/models.py
@@ -703,7 +703,7 @@ class Layer(models.Model, PermissionLevelMixin):
         dx = float(bbox[1]) - float(bbox[0])
         dy = float(bbox[3]) - float(bbox[2])
 
-        dataAspect = dx / dy
+        dataAspect = 1 if dy == 0 else dx / dy
 
         height = 550
         width = int(height * dataAspect)


### PR DESCRIPTION
In GEM's Modeler's toolkit, there is a chance that model output results in a shapefile with just one point feature. The extent of such a shapefile will have no width and height. This pull request fixes the issue by protecting from div by zero exceptions that happen during updatelayers.
