### PR TITLE
Add @csrf_exempt to ajax_login view

### DIFF
--- a/src/GeoNodePy/geonode/views.py
+++ b/src/GeoNodePy/geonode/views.py
@@ -6,6 +6,7 @@ from django.contrib.auth.models import User
 from django.http import HttpResponse
 from django.shortcuts import render_to_response
 from django.template import RequestContext
+from django.views.decorators.csrf import csrf_exempt
 import json
 
 def index(request): 
@@ -31,6 +32,7 @@ class AjaxLoginForm(forms.Form):
     password = forms.CharField(widget=forms.PasswordInput)
     username = forms.CharField()
 
+@csrf_exempt
 def ajax_login(request):
     if request.method != 'POST':
         return HttpResponse(


### PR DESCRIPTION
We've encountered problems in TsuDAT ajax_login view requiring the csrf token. It doesn't really seem to be needed, so it seems logical to make this view csrf_exempt.
