### PR TITLE
Change Map.abstract to a TextField (no maxlength)

### DIFF
--- a/src/GeoNodePy/geonode/maps/models.py
+++ b/src/GeoNodePy/geonode/maps/models.py
@@ -1147,7 +1147,7 @@ class Map(models.Model, PermissionLevelMixin):
     A display name suitable for search results and page headers
     """
 
-    abstract = models.CharField(_('Abstract'),max_length=200)
+    abstract = models.TextField(_('Abstract'))
     """
     A longer description of the themes in the map.
     """


### PR DESCRIPTION
I've run into issues with trying to populate Map abstracts with something longer than 200 chars. It should be a TextField like the Layer.abstract.
