### PR TITLE
Save topic category in metadata

### DIFF
--- a/src/GeoNodePy/geonode/templates/maps/csw/full_metadata.xml
+++ b/src/GeoNodePy/geonode/templates/maps/csw/full_metadata.xml
@@ -213,8 +213,8 @@
          <gmd:MD_CharacterSetCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#MD_CharacterSetCode"
            codeListValue="utf8" />
        </gmd:characterSet>
-       <gmd:topicCategory nilReason="missing">
-         <gmd:MD_TopicCategoryCode></gmd:MD_TopicCategoryCode>
+       <gmd:topicCategory>
+         <gmd:MD_TopicCategoryCode>{{layer.topic_category}}</gmd:MD_TopicCategoryCode>
        </gmd:topicCategory>
        <gmd:extent>
          <gmd:EX_Extent>


### PR DESCRIPTION
A layer's topic category currently isn't saved in the Geonetwork metadata.  This can be fixed by making a small change to the full_metadata.xml template.
