### PR TITLE
use GeoExt.Lang.set to pull in translations from gxp

### DIFF
--- a/src/GeoNodePy/geonode/templates/lang.js
+++ b/src/GeoNodePy/geonode/templates/lang.js
@@ -1,5 +1,7 @@
 {% load i18n %}
 
+GeoExt.Lang.set("{{ LANGUAGE_CODE }}");
+
 if (window.GeoExplorer) {
     Ext.apply(GeoExplorer.prototype, {
         addLayersButtonText: gettext("Add Layers"),


### PR DESCRIPTION
Nobody has complained so far, but GeoNode does not use translations available for GeoExt.
