### PR TITLE
Change layer download links for zipped shapefiles to use UTF-8 encoding

### DIFF
--- a/src/GeoNodePy/geonode/maps/models.py
+++ b/src/GeoNodePy/geonode/maps/models.py
@@ -721,7 +721,8 @@ class Layer(models.Model, PermissionLevelMixin):
                     'service': 'WFS',
                     'request': 'GetFeature',
                     'typename': self.typename,
-                    'outputFormat': mime
+                    'outputFormat': mime,
+                    'format_options': 'charset:UTF-8'
                 })
             types = [
                 ("zip", _("Zipped Shapefile"), "SHAPE-ZIP"),


### PR DESCRIPTION
If a layer has UTF-8 characters (such as Chinese), it's text will be converted to ?'s using the current download link for zipped shapefiles, because the default encoding is windows-1252.  This patch adds another URL parameter to the link which will give the shapefiles UTF-8 encoding.
