### PR TITLE
use Bing instead of Google

### DIFF
--- a/src/GeoNodePy/geonode/settings.py
+++ b/src/GeoNodePy/geonode/settings.py
@@ -162,6 +162,10 @@ GEONETWORK_CREDENTIALS = "admin", "admin"
 AUTHENTICATION_BACKENDS = ('geonode.core.auth.GranularBackend',)
 
 GOOGLE_API_KEY = "ABQIAAAAkofooZxTfcCv9Wi3zzGTVxTnme5EwnLVtEDGnh-lFVzRJhbdQhQgAhB1eT_2muZtc0dl-ZSWrtzmrw"
+
+# Key for http://demo.geonode.org/. Create your own at http://bingmapsportal.com/
+BING_API_KEY = "AhaJDO_bWhekq58C0nGLRkwJSMphRFDTYeccozENkqZTAAa1W0OgoaWmcgbPxatZ"
+
 LOGIN_REDIRECT_URL = "/"
 
 DEFAULT_LAYERS_OWNER='admin'
@@ -176,14 +180,14 @@ DEFAULT_MAP_ZOOM = 7
 
 MAP_BASELAYERSOURCES = {
     "any": {
-        "ptype":"gx_olsource"
+        "ptype":"gxp_olsource"
     },
     "capra": {
         "url":"/geoserver/wms"
     },
-    "google":{
-        "ptype":"gx_googlesource",
-        "apiKey": GOOGLE_API_KEY
+    "bing":{
+        "ptype":"gxp_bingsource",
+        "apiKey": BING_API_KEY
     }
 }
 
@@ -219,9 +223,9 @@ MAP_BASELAYERS = [{
       {"buffer":0}
     ]
   },{
-    "source":"google",
+    "source":"bing",
     "group":"background",
-    "name":"SATELLITE",
+    "name":"Aerial",
     "visibility": False,
     "fixed": True,
 }]


### PR DESCRIPTION
Now that we lost a good way to integrate Google layers, it would make sense to use an imagery provider that integrates better. Bing does. This pull request suggests replacing Google with Bing as default imagery layer. Google layers can still be used if configured in settings.py - geonode-client still has the required resources for it.

The one thing that might need additional work is API key generation for user installs. How do we handle this for Google currently? We would need to do the same for Bing.

I would suggest making this change before the 1.1 release, to avoid complaints of users with Google layer issues.
