### PR TITLE
Enforce security for maps.change_map in mapJSON view

### DIFF
--- a/src/GeoNodePy/geonode/maps/views.py
+++ b/src/GeoNodePy/geonode/maps/views.py
@@ -175,6 +175,8 @@ def mapJSON(request, mapid):
                 mimetype="text/plain"
             )
         map = get_object_or_404(Map, pk=mapid)
+        if not request.user.has_perm('maps.change_map', obj=map):
+            return HttpResponse("You are not allowed to modify this map.", status=403)
         try:
             map.update_from_viewer(request.raw_post_data)
 


### PR DESCRIPTION
Enforce the existing maps.change_map security in the mapJSON view. It is not currently handled for which allows anyone to modify any map. 

For now the view returns a 403 status code which is not really handled for that well in the Map Composer.

https://skitch.com/ortelius/gq4n3/map-viewer-geonode-44
https://skitch.com/ortelius/gq4nh/map-viewer-geonode-46

403 was chosen over 401 because 401 causes a login dialog to appear in the MapComposer even if the user is already logged in.

403 should be handled for better in the MapComposer eventually.
