### PR TITLE
handle invalid y values in forward_mercator better

### DIFF
--- a/src/GeoNodePy/geonode/maps/tests.py
+++ b/src/GeoNodePy/geonode/maps/tests.py
@@ -1315,6 +1315,10 @@ class UtilsTest(TestCase):
 
         self.assertEqual(round(sw[0]), -20037508, "SW lon is correct")
         self.assertTrue(math.isinf(sw[1]), "SW lat is correct")
+        
+        # verify behavior for invalid y values
+        self.assertEqual(float('-inf'), forward_mercator(0, 1e100)[1])
+        self.assertEqual(float('-inf'), forward_mercator(0, -1e100)[1])
 
     def test_inverse_mercator(self):
         arctic = inverse_mercator(forward_mercator((0, 85)))

--- a/src/GeoNodePy/geonode/maps/utils.py
+++ b/src/GeoNodePy/geonode/maps/utils.py
@@ -658,10 +658,12 @@ def _create_db_featurestore(name, data, overwrite = False, charset = None):
 def forward_mercator(lonlat):
     """
         Given geographic coordinates, return a x,y tuple in spherical mercator.
+        
+        If the lat value is out of range, -inf will be returned as the y value
     """
     x = lonlat[0] * 20037508.34 / 180
     n = math.tan((90 + lonlat[1]) * math.pi / 360)
-    if n == 0:
+    if n <= 0:
         y = float("-inf")
     else:
         y = math.log(n) / math.pi * 20037508.34

--- a/src/GeoNodePy/geonode/maps/views.py
+++ b/src/GeoNodePy/geonode/maps/views.py
@@ -256,6 +256,8 @@ def newmap_config(request):
                 y = (miny + maxy) / 2
 
                 center = forward_mercator((x, y))
+                if center[1] == float('-inf'):
+                    center[1] = 0
 
                 if maxx == minx:
                     width_zoom = 15


### PR DESCRIPTION
If a dataset has erroneous y values of large enough of a magnitude, the current forward_mercator implementation will encounter a 'math domain error'. This enhancement ensures invalid values are not passed to the math.log function, updates the doc and test, and ensures the calling code takes appropriate action in this case.
