### PR TITLE
ssl doc typo

### DIFF
--- a/docs/deploy/ssl.txt
+++ b/docs/deploy/ssl.txt
@@ -39,7 +39,7 @@ Enable the ssl module in Apache with the command::
 
     sudo a2enmod ssl
 
-Next as root edit the Apache geonode config file :file:`/etc/apache/sites-available/geonode`.  At the beginning of the file replace::
+Next as root edit the Apache geonode config file :file:`/etc/apache2/sites-available/geonode`.  At the beginning of the file replace::
 
     <VirtualHost *:80>
 


### PR DESCRIPTION
Fixed typo in SSL documentation apache -> apache2
