### PR TITLE
Fix SLD links on layer detail page

### DIFF
--- a/src/GeoNodePy/geonode/templates/maps/layer.html
+++ b/src/GeoNodePy/geonode/templates/maps/layer.html
@@ -240,7 +240,7 @@
             {{ layer.default_style.name|title }}
          {% endif %}
         </label>
-        <a href="{{ layer.default_style.body_href }}">SLD</a><br/>
+        <a href="{{ GEOSERVER_BASE_URL }}styles/{{ layer.default_style.name }}.sld">SLD</a><br/>
     {% for style in layer.styles %} 
         <input type="radio" name="style" id="{{style.name}}" value="{{style.name}}"/>
         <label for="{{style.name}}" class="style-title">
@@ -250,7 +250,7 @@
             {{ style.name|title }}
          {% endif %}
         </label>
-        <a href="{{ style.body_href }}">SLD</a><br/>
+        <a href="{{ GEOSERVER_BASE_URL }}styles/{{ style.name }}.sld">SLD</a><br/>
     {% endfor %}
     </span>
     {% if user.is_authenticated and can_change %}


### PR DESCRIPTION
Possible fix for [Issue #219](https://github.com/GeoNode/geonode/issues/219#issuecomment-5287038) - the SLD links on the layer page use geoserver's REST URL, which only works when logged in as a superuser. 
