### PR TITLE
Profile link now points to create profile when none exists

### DIFF
--- a/src/GeoNodePy/geonode/templates/page_layout.html
+++ b/src/GeoNodePy/geonode/templates/page_layout.html
@@ -53,7 +53,7 @@
         <li class=""><a class="" id="dataLink" href="{% url geonode.maps.views.browse_data %}">{% trans "Data" %}</a></li>
         <li class=""><a class="" id="mapsLink" href="{% url geonode.maps.views.maps %}">{% trans "Maps" %}</a></li>
     {% if user.is_authenticated %}
-        <li class=""><a class="" id="profileLink" href="{% url profiles_profile_detail user.username %}">{% trans "Profile" %}</a></li>
+        <li class=""><a class="" id="profileLink" href="{% if user.get_profile %}{{ user.get_profile.get_absolute_url }}{% else %}{% url profiles_create_profile %}{% endif %}">{% trans "Profile" %}</a></li>
     {% if user.is_staff %}
         <li class=""><a class="" id="adminLink" href="/admin/">{% trans "Admin" %}</a></li>
     {% endif %}


### PR DESCRIPTION
When logged in, Username linked correctly pointed to /profile/create/ if a profile didn't exist for the user yet, however the 'Profile' link always pointed to the profile and would generate a 404 if the profile didn't exist. 
This commit simply uses the same code in both places.
