### PR TITLE
django admin command cleardeadlayers deletes layers from GeoNetwork as

### DIFF
--- a/src/GeoNodePy/geonode/maps/management/commands/cleardeadlayers.py
+++ b/src/GeoNodePy/geonode/maps/management/commands/cleardeadlayers.py
@@ -21,6 +21,7 @@ class Command(BaseCommand):
             layernames = [l.name for l in cat.get_resources()]
             for l in Layer.objects.all():
                 if l.store not in storenames or l.name not in layernames:
+                    l.delete_from_geonetwork()
                     l.delete()
                     print l
         except URLError:


### PR DESCRIPTION
This commit fixes Issue #212

Simple change, cleardeadlayers removes layers from GeoNode that are no longer in GeoServer, however it did not remove them from GeoNetwork which would result in the layers still showing up in GeoNode search but with an outside link icon....but the link to the layer wouldn't work
