### PR TITLE
Update user help doc for "Adding New Data"

### DIFF
--- a/docs/users/upload.txt
+++ b/docs/users/upload.txt
@@ -32,7 +32,7 @@ You may not have a .prj file for your GeoTIFF as it is not needed since the proj
 
 If your .prj file does not look like this, the upload may still work fine.  If it doesn’t, the most likely culprit is the projection.  The best way to fix that is to use an application like ArcGIS or QGIS and reproject your file to Geographic WGS 84.  This can be done for shapefiles or GeoTIFF files.
 
-**SLD:**  Optionally provide a Styled Layer Descriptor (SLD) file.  This is an XML document that defines the layer's default style.  For more information on creating SLD files, see :ref:`sld-desktop-ref`.
+**SLD:**  Optionally provide a Styled Layer Descriptor (SLD) file.  This is an XML document that defines the layer's default style.  For more information on creating SLD files, see `Creating styles with desktop software`_.
 
 ***Abstract:**  Provide a description of your data. More information is better.  At the very least when you add real data, please include a brief description of the data, who created it, for what purpose, and when.  Please also include source materials used to create the data layer.  This information is important both for you to remember what the data is about, and to allow someone else a chance to benefit from your work (assuming you want to make the data available for others to use at some point).
 
@@ -162,7 +162,6 @@ Now click the *Create new map* link in the right hand sidebar.  This will take y
 
 .. image:: images/map_composer_from_layer.png
 
-.. _sld-desktop-ref:
 
 Creating styles with desktop software
 =====================================


### PR DESCRIPTION
Suggested fixes and additions to the "Adding New Data" user help document, based on my experience setting up a GeoNode for the first time and walking new users through adding data:
- Expand SLD text
- Add detail to what "edit" and "manage" permissions give users
- Update metadata "required fields" based on fields that are required in the default GeoNode 1.1 install (secondarily, this brings up the question of whether certain fields such as "Supplemental Information" should be required by default even if default text is provided?)
- Add missing metadata fields (Topic Category, Temporal Extent Start)
- Update SLD desktop application reference to include the latest information on ArcMap2SLD (now supports ArcGIS 10) and another ArcGIS plugin, Arc2Earth, that supports SLD export.
