### PR TITLE
Create missing Maps.Contacts when users are created in the Django admin

### DIFF
--- a/src/GeoNodePy/geonode/maps/models.py
+++ b/src/GeoNodePy/geonode/maps/models.py
@@ -516,6 +516,12 @@ class Contact(models.Model):
         return u"%s (%s)" % (self.name, self.organization)
 
 
+def create_user_profile(sender, instance, created, **kwargs):
+    profile, created = Contact.objects.get_or_create(user=instance, defaults={'name': instance.username})
+
+signals.post_save.connect(create_user_profile, sender=User)
+
+
 _viewer_projection_lookup = {
     "EPSG:900913": {
         "maxResolution": 156543.03390625,


### PR DESCRIPTION
Fix for Issue #132.

Adds a new post_save signal as per https://docs.djangoproject.com/en/dev/topics/auth/#storing-additional-information-about-users to ensure matching user profiles (Maps.Contacts) are created when users are created in the Django admin.
