### PR TITLE
reflect owslib changes

### DIFF
--- a/src/GeoNodePy/geonode/templates/maps/search_result_snippet.html
+++ b/src/GeoNodePy/geonode/templates/maps/search_result_snippet.html
@@ -30,10 +30,27 @@
 </p>
 
 <p><b>{% trans "Keywords:" %}</b>
+{% comment %} old owslib iso {% endcomment %}
 {% for kw in rec.identification.keywords.list %}
   {{kw}}{% if not forloop.last %}, {% endif %}
 {% empty %}
-<em>{% trans "No keywords are listed for this layer." %}</em>
+  {% comment %} new owslib iso {% endcomment %}
+  {% for kws in rec.identification.keywords %}
+    {% for kw in kws.keywords %}
+      {{kw}}{% if not forloop.last %}, {% endif %}
+      {% if forloop.last and kws.thesaurus.title %}
+        ({{ kws.thesaurus.title }}
+         {% if kws.thesaurus.date %} - {{ kws.thesaurus.date }} {% endif %} 
+         {% if kws.thesaurus.datetype %} - {{ kws.thesaurus.datetype }} {% endif %}
+        )
+      {% endif %}
+    {% empty %}
+      <em>{% trans "No keywords are listed for this layer." %}</em>
+    {% endfor %}
+    {% if not forloop.last %}; {% endif %}
+  {% empty %}
+    <em>{% trans "No keywords are listed for this layer." %}</em>
+  {% endfor %}
 {% endfor %}
 </p>
 


### PR DESCRIPTION
A year ago OWSLib has changed the keyword handling [1] so recent GeoNode installations  always return "No keywords are listed for this layer." (search_result_detail).

This patch fixes the issue maintaining backward compatibility.

[1] https://github.com/geopython/OWSLib/commit/73f6fe7fe58029d13c2b7639c234f1dc477c92f4#owslib/iso.py
