### PR TITLE
Handle special characters - []{}() - in shapefiles during upload

### DIFF
--- a/src/GeoNodePy/geonode/maps/utils.py
+++ b/src/GeoNodePy/geonode/maps/utils.py
@@ -55,12 +55,14 @@ def get_files(filename):
     files = {'base': filename}
 
     base_name, extension = os.path.splitext(filename)
+    #Replace special characters in filenames - []{}()
+    glob_name = re.sub(r'([\[\]\(\)\{\}])', r'[\g<1>]', base_name)
 
     if extension.lower() == '.shp':
         required_extensions = dict(
             shp='.[sS][hH][pP]', dbf='.[dD][bB][fF]', shx='.[sS][hH][xX]')
         for ext, pattern in required_extensions.iteritems():
-            matches = glob.glob(base_name + pattern)
+            matches = glob.glob(glob_name + pattern)
             if len(matches) == 0:
                 msg = ('Expected helper file %s does not exist; a Shapefile '
                        'requires helper files with the following extensions: '
@@ -74,7 +76,7 @@ def get_files(filename):
             else:
                 files[ext] = matches[0]
 
-        matches = glob.glob(base_name + ".[pP][rR][jJ]")
+        matches = glob.glob(glob_name + ".[pP][rR][jJ]")
         if len(matches) == 1:
             files['prj'] = matches[0]
         elif len(matches) > 1:
@@ -82,7 +84,7 @@ def get_files(filename):
                    'distinct by spelling and not just case.') % filename
             raise GeoNodeException(msg)
 
-    matches = glob.glob(base_name + ".[sS][lL][dD]")
+    matches = glob.glob(glob_name + ".[sS][lL][dD]")
     if len(matches) == 1:
         files['sld'] = matches[0]
     elif len(matches) > 1:


### PR DESCRIPTION
If a shapefile name contains brackets or parentheses, the upload will fail because glob.glob() fails to find a match when searching for required extensions.  This patch should fix that.
