### PR TITLE
Fixed port on dev GeoServer proxy

### DIFF
--- a/shared/dev-paste.ini
+++ b/shared/dev-paste.ini
@@ -20,7 +20,7 @@ use = egg:Paste#urlmap
 
 [app:gsproxy_app]
 use=egg:Paste#proxy
-address=http://localhost:8080/geoserver/
+address=http://localhost:8001/geoserver/
 
 # [app:param_proxy]
 # use = egg:jstools


### PR DESCRIPTION
Fixed port number in paster script for GeoServer proxy (to 8001 from 8080)
