### PR TITLE
ResourceBase implementation

### DIFF
--- a/geonode/layers/fixtures/map_data.json
+++ b/geonode/layers/fixtures/map_data.json
@@ -35,37 +35,8 @@
              "date_joined": "2010-06-10 16:58:18"
          }
      },
-    {
-        "pk": 1,
-        "model": "layers.layer",
-        "fields": {
-            "constraints_other": "Test",
-            "bbox_x0": "1",
-            "bbox_y1": "1",
-            "date_type": "publication",
-            "srid": "EPSG:4326",
-            "bbox_x1": "1",
-            "edition": "Test",
-            "distribution_url": "Test",
-            "spatial_representation_type": "grid",
-            "uuid": "",
-            "title": "Test",
-            "abstract": "Test",
-            "bbox_y0": "1",
-            "distribution_description": "Test",
-            "topic_category": "location",
-            "purpose": "Test",
-            "date": "2012-08-09T06:02:10",
-            "temporal_extent_end": "2012-08-09",
-            "data_quality_statement": "Test",
-            "language": "eng",
-            "keywords_region": "USA",
-            "maintenance_frequency": "annually",
-            "supplemental_information": "No information provided",
-            "temporal_extent_start": "2012-08-09",
-            "constraints_use": "copyright"
-        }
-    },
+
+
     {
         "fields": {
             "typename": "base:CA",


### PR DESCRIPTION
Abstraction of Layer object to ResourceBase object which Layer inherits from.  This opens up the ability of deriving from ResourceBase, to/from which, for example, a catalogue can interact with.

Passes unit and integration tests.

The south migration requires some verification.  I chose option 3 for most migrations, however it asked for a default value for `Layer.resourcebase_ptr`, to which I set `-1` so as not to clash with legacy models.  I'm not 100% sure of the implications of this default, however.
