### PR TITLE
adds maps.contact to people.contact data migration

### DIFF
--- a/geonode/maps/migrations/0005_contact_data.py
+++ b/geonode/maps/migrations/0005_contact_data.py
@@ -1,21 +1,29 @@
 # encoding: utf-8
 import datetime
 from south.db import db
-from south.v2 import SchemaMigration
+from south.v2 import DataMigration
 from django.db import models
 
-class Migration(SchemaMigration):
+class Migration(DataMigration):
 
     def forwards(self, orm):
-        
-        # Adding field 'MapLayer.local'
-        db.add_column('maps_maplayer', 'local', self.gf('django.db.models.fields.BooleanField')(default=False), keep_default=False)
+        "Write your forwards methods here."
 
+        # we migrate all profiles related to a user
+        # 'default_' geonode profiles need to be created in another place, if necessary
+        for map_contact in orm['maps.Contact'].objects.filter(user__isnull=False):
+            people_contact = orm['people.Contact']()
+            for field in map_contact._meta.get_all_field_names():
+                setattr(people_contact, field, getattr(map_contact, field))
+            people_contact.save()
 
     def backwards(self, orm):
-        
-        # Deleting field 'MapLayer.local'
-        db.delete_column('maps_maplayer', 'local')
+        "Write your backwards methods here."
+        for people_contact in orm['people.Contact'].objects.filter(user__isnull=False):
+            map_contact = orm['map.Contact']()
+            for field in map_contact._meta.get_all_field_names():
+                setattr(map_contact, field, getattr(people_contact, field))
+            map_contact.save()
 
 
     models = {
@@ -34,7 +42,7 @@ class Migration(SchemaMigration):
         },
         'auth.user': {
             'Meta': {'object_name': 'User'},
-            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime(2012, 7, 24, 19, 39, 22, 842072)'}),
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime(2012, 8, 23, 9, 23, 31, 551487)'}),
             'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
             'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
             'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
@@ -42,7 +50,7 @@ class Migration(SchemaMigration):
             'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
             'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
             'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
-            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime(2012, 7, 24, 19, 39, 22, 841930)'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime(2012, 8, 23, 9, 23, 31, 551354)'}),
             'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
             'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
             'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
@@ -54,6 +62,22 @@ class Migration(SchemaMigration):
             'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
             'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
             'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'maps.contact': {
+            'Meta': {'object_name': 'Contact'},
+            'area': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'city': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'country': ('django.db.models.fields.CharField', [], {'max_length': '3', 'null': 'True', 'blank': 'True'}),
+            'delivery': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'null': 'True', 'blank': 'True'}),
+            'fax': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'organization': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'position': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']", 'null': 'True', 'blank': 'True'}),
+            'voice': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'zipcode': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'})
         },
         'maps.map': {
             'Meta': {'object_name': 'Map'},
@@ -84,6 +108,23 @@ class Migration(SchemaMigration):
             'styles': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True'}),
             'transparent': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
             'visibility': ('django.db.models.fields.BooleanField', [], {'default': 'True'})
+        },
+        'people.contact': {
+            'Meta': {'object_name': 'Contact'},
+            'area': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'city': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'country': ('django.db.models.fields.CharField', [], {'max_length': '3', 'null': 'True', 'blank': 'True'}),
+            'delivery': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'null': 'True', 'blank': 'True'}),
+            'fax': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'organization': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'position': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'profile': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']"}),
+            'voice': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'zipcode': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'})
         },
         'taggit.tag': {
             'Meta': {'object_name': 'Tag'},

--- a/geonode/maps/migrations/0006_auto__del_contact__chg_field_contactrole_contact.py
+++ b/geonode/maps/migrations/0006_auto__del_contact__chg_field_contactrole_contact.py
@@ -19,18 +19,18 @@ class Migration(SchemaMigration):
         
         # Adding model 'Contact'
         db.create_table('maps_contact', (
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('user', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['auth.User'], null=True, blank=True)),
+            ('name', self.gf('django.db.models.fields.CharField')(max_length=255, null=True, blank=True)),
+            ('organization', self.gf('django.db.models.fields.CharField')(max_length=255, null=True, blank=True)),
+            ('position', self.gf('django.db.models.fields.CharField')(max_length=255, null=True, blank=True)),
+            ('voice', self.gf('django.db.models.fields.CharField')(max_length=255, null=True, blank=True)),
             ('fax', self.gf('django.db.models.fields.CharField')(max_length=255, null=True, blank=True)),
             ('delivery', self.gf('django.db.models.fields.CharField')(max_length=255, null=True, blank=True)),
-            ('user', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['auth.User'], null=True, blank=True)),
-            ('position', self.gf('django.db.models.fields.CharField')(max_length=255, null=True, blank=True)),
-            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
             ('city', self.gf('django.db.models.fields.CharField')(max_length=255, null=True, blank=True)),
-            ('name', self.gf('django.db.models.fields.CharField')(max_length=255, null=True, blank=True)),
             ('area', self.gf('django.db.models.fields.CharField')(max_length=255, null=True, blank=True)),
-            ('country', self.gf('django.db.models.fields.CharField')(max_length=3, null=True, blank=True)),
             ('zipcode', self.gf('django.db.models.fields.CharField')(max_length=255, null=True, blank=True)),
-            ('organization', self.gf('django.db.models.fields.CharField')(max_length=255, null=True, blank=True)),
-            ('voice', self.gf('django.db.models.fields.CharField')(max_length=255, null=True, blank=True)),
+            ('country', self.gf('django.db.models.fields.CharField')(max_length=3, null=True, blank=True)),
             ('email', self.gf('django.db.models.fields.EmailField')(max_length=75, null=True, blank=True)),
         ))
         db.send_create_signal('maps', ['Contact'])

--- a/geonode/maps/migrations/0007_add_field_MapLayer_local.py
+++ b/geonode/maps/migrations/0007_add_field_MapLayer_local.py
@@ -1,0 +1,103 @@
+# encoding: utf-8
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        
+        # Adding field 'MapLayer.local'
+        db.add_column('maps_maplayer', 'local', self.gf('django.db.models.fields.BooleanField')(default=False), keep_default=False)
+
+
+    def backwards(self, orm):
+        
+        # Deleting field 'MapLayer.local'
+        db.delete_column('maps_maplayer', 'local')
+
+
+    models = {
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        'auth.permission': {
+            'Meta': {'ordering': "('content_type__app_label', 'content_type__model', 'codename')", 'unique_together': "(('content_type', 'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime(2012, 7, 24, 19, 39, 22, 842072)'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime(2012, 7, 24, 19, 39, 22, 841930)'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'maps.map': {
+            'Meta': {'object_name': 'Map'},
+            'abstract': ('django.db.models.fields.TextField', [], {}),
+            'center_x': ('django.db.models.fields.FloatField', [], {}),
+            'center_y': ('django.db.models.fields.FloatField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_modified': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']", 'null': 'True', 'blank': 'True'}),
+            'projection': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'title': ('django.db.models.fields.TextField', [], {}),
+            'zoom': ('django.db.models.fields.IntegerField', [], {})
+        },
+        'maps.maplayer': {
+            'Meta': {'ordering': "['stack_order']", 'object_name': 'MapLayer'},
+            'fixed': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'format': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True'}),
+            'group': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'layer_params': ('django.db.models.fields.TextField', [], {}),
+            'local': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'map': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'layer_set'", 'to': "orm['maps.Map']"}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True'}),
+            'opacity': ('django.db.models.fields.FloatField', [], {'default': '1.0'}),
+            'ows_url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True'}),
+            'source_params': ('django.db.models.fields.TextField', [], {}),
+            'stack_order': ('django.db.models.fields.IntegerField', [], {}),
+            'styles': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True'}),
+            'transparent': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'visibility': ('django.db.models.fields.BooleanField', [], {'default': 'True'})
+        },
+        'taggit.tag': {
+            'Meta': {'object_name': 'Tag'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '100', 'db_index': 'True'})
+        },
+        'taggit.taggeditem': {
+            'Meta': {'object_name': 'TaggedItem'},
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'taggit_taggeditem_tagged_items'", 'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'object_id': ('django.db.models.fields.IntegerField', [], {'db_index': 'True'}),
+            'tag': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'taggit_taggeditem_items'", 'to': "orm['taggit.Tag']"})
+        }
+    }
+
+    complete_apps = ['maps']


### PR DESCRIPTION
Successfully tested with 'paver sync' on a legacy (1.1) database, after running 'paver upgradedb', and on a fresh GeoNode dev clone.

Notes: 
- The sample_admin (https://github.com/GeoNode/geonode/blob/dev/pavement.py#L140) fixtures overwrites existing users with the same pk, which might not be good for an existing site if the superuser is changed without any warning. On the legacy site I'm working on, I commented that line in pavement.py out. Maybe a cmdoption for sync could be added to run sync without adding sample admin data. 
- Existing dev environments would either need to `reset south` or `migrate maps --fake` to update to the changed migration history
