### PR TITLE
fix map delete

### DIFF
--- a/geonode/maps/templates/maps/map_remove.html
+++ b/geonode/maps/templates/maps/map_remove.html
@@ -6,7 +6,7 @@
 {% block title %}{% trans "Deleting" %} {{ map.title }} — {{ block.super }}{% endblock %}
 
 {% block main %}
-<form action="/maps/{{map.id}}?remove" method="POST">
+<form action="/maps/{{map.id}}/remove" method="POST">
   <legend>
     {% blocktrans with map.title as map_title %}
         Are you sure you want to remove {{ map_title }}?


### PR DESCRIPTION
Fix the map delete from mapinfo by using a slash instead of question mark in the POST url in map_remove template
