### PR TITLE
add additional options to updatelayers management command

### DIFF
--- a/src/GeoNodePy/geonode/maps/management/commands/updatelayers.py
+++ b/src/GeoNodePy/geonode/maps/management/commands/updatelayers.py
@@ -15,16 +15,24 @@ class Command(BaseCommand):
             help='Stop after any errors are encountered.'),
         make_option('-u', '--user', dest="user", default=None,
             help="Name of the user account which should own the imported layers"),
+        make_option('-n', '--new_only', action='store_true', dest="new_only", default=False,
+            help="Only new data: no update the data already imported"),
         )
 
-    def handle(self, **options):
+    args = '[layername layername ...]'
+
+    def handle(self, *lnames, **options):
         ignore_errors = options.get('ignore_errors')
         verbosity = int(options.get('verbosity'))
         user = options.get('user')
         owner = get_valid_user(user)
+        new_only = options.get('new_only')
 
+        if len(lnames) == 0:
+            lnames = None
+            
         start = datetime.datetime.now()
-        output = Layer.objects.slurp(ignore_errors, verbosity=verbosity, owner=owner)
+        output = Layer.objects.slurp(ignore_errors, verbosity=verbosity, owner=owner, new_only=new_only, lnames=lnames)
         updated = [dict_['name'] for dict_ in output if dict_['status']=='updated']
         created = [dict_['name'] for dict_ in output if dict_['status']=='created']
         failed = [dict_['name'] for dict_ in output if dict_['status']=='failed']

--- a/src/GeoNodePy/geonode/maps/models.py
+++ b/src/GeoNodePy/geonode/maps/models.py
@@ -609,7 +609,7 @@ class LayerManager(models.Manager):
     def default_metadata_author(self):
         return self.admin_contact()
 
-    def slurp(self, ignore_errors=True, verbosity=1, console=sys.stdout, owner=None):
+    def slurp(self, ignore_errors=True, verbosity=1, console=sys.stdout, owner=None, new_only=False, lnames=None):
         """Configure the layers available in GeoServer in GeoNode.
 
            It returns a list of dictionaries with the name of the layer,
@@ -624,10 +624,24 @@ class LayerManager(models.Manager):
             msg =  "Found %d layers, starting processing" % number
             print >> console, msg
         output = []
+        
+        # check lnames
+        if lnames is not None:
+            gs_lnames = [resource.name for resource in resources]
+            for l in lnames:
+                if l not in gs_lnames:
+                    raise Exception('Layer %s does not exist' % l )
+
         for i, resource in enumerate(resources):
             name = resource.name
             store = resource.store
             workspace = store.workspace
+
+            if new_only and Layer.objects.filter(name=name).exists():
+                continue
+            elif lnames is not None and name not in lnames:
+                continue
+
             try:
                 layer, created = Layer.objects.get_or_create(name=name, defaults = {
                     "workspace": workspace.name,
@@ -667,7 +681,6 @@ class LayerManager(models.Manager):
             if verbosity > 0:
                 print >> console, msg
         return output
-
 
 class Layer(models.Model, PermissionLevelMixin):
     """


### PR DESCRIPTION
added  option [-n] and arguments [layername layername ...] to  updatelayers management command.

In some of our sites we have over 200 layers and new layers are loaded mainly through the updatelayers.
So we added a "-n" option (new data only: no update the data already imported) and optional arguments [layername layername ...](create or update the specified layers).
These options prevents looping  (slow) on all layers.
