### PR TITLE
add custom test runner

### DIFF
--- a/geonode/runner.py
+++ b/geonode/runner.py
@@ -1,0 +1,22 @@
+from django.conf import settings
+from django_nose import NoseTestSuiteRunner
+from urllib2 import urlopen
+
+class GeonodeTestSuiteRunner(NoseTestSuiteRunner):
+
+    def run_tests(self, test_labels, extra_tests=None):
+        """check if geoserver is currently running"""
+
+        try:
+            url_handle = urlopen(settings.GEOSERVER_BASE_URL)
+        except:
+            pass
+        else:
+            url_handle.close()
+            print '*' * 80
+            print 'Server already running on: %s' % settings.GEOSERVER_BASE_URL
+            print 'Bailing early because tests will fail'
+            print '*' * 80
+            return
+
+        return super(GeonodeTestSuiteRunner, self).run_tests(test_labels, extra_tests)

--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -276,7 +276,7 @@ REGISTRATION_OPEN = False
 
 # Setting a custom test runner to avoid running the tests for
 # some problematic 3rd party apps
-TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
+TEST_RUNNER = 'geonode.runner.GeonodeTestSuiteRunner'
 
 # Arguments for the test runner
 NOSE_ARGS = [


### PR DESCRIPTION
This test runner first checks if geoserver is already running before
proceeding with the tests. The motivation behind this is that many of
the tests will begin failing if geoserver is already running, and it's
not obvious why.
