### PR TITLE
Fixed issue 382, old keyword can be removed when updating the layer

### DIFF
--- a/geonode/layers/views.py
+++ b/geonode/layers/views.py
@@ -245,6 +245,7 @@ def layer_metadata(request, layername, template='layers/layer_metadata.html'):
             the_layer = layer_form.save(commit=False)
             the_layer.poc = new_poc
             the_layer.metadata_author = new_author
+            the_layer.keywords.clear()
             the_layer.keywords.add(*new_keywords)
             the_layer.save()
             return HttpResponseRedirect(reverse('layer_detail', args=(layer.typename,)))


### PR DESCRIPTION
Fixed the issue here: https://github.com/GeoNode/geonode/issues/382
Old keyword can be removed.
