### PR TITLE
Allow category to be null in layer_metadata form. closes #464

### DIFF
--- a/geonode/layers/models.py
+++ b/geonode/layers/models.py
@@ -205,7 +205,7 @@ class ResourceBase(models.Model, PermissionLevelMixin):
     # Section 4
     language = models.CharField(_('language'), max_length=3, choices=ALL_LANGUAGES, default='eng', help_text=_('language used within the dataset'))
     topic_category = models.CharField(_('topic_category'), editable=False, max_length=255, choices=TOPIC_CATEGORIES, default='location')
-    category = models.ForeignKey(TopicCategory, help_text=_('high-level geographic data thematic classification to assist in the grouping and search of available geographic data sets.'), null=True)
+    category = models.ForeignKey(TopicCategory, help_text=_('high-level geographic data thematic classification to assist in the grouping and search of available geographic data sets.'), null=True, blank=True)
 
     # Section 5
     temporal_extent_start = models.DateField(_('temporal extent start'), blank=True, null=True, help_text=_('time period covered by the content of the dataset (start)'))


### PR DESCRIPTION
@ingenieroariel @tomkralidis This closes the immediate issue which is that null=True was set, but not blank=True (database allows nulls, form wouldnt). BUT ... there are 2 model fields for the category in ResourceBase now https://github.com/GeoNode/geonode/blob/dev/geonode/layers/models.py#L207 (since @davelowe added the TopicCategory class). @tomkralidis, can you help to resolve this (as discussed in #geonode yesterday)
