### PR TITLE
adds registration condition for registration-link in header. closes #493

### DIFF
--- a/geonode/templates/base_geonode.html
+++ b/geonode/templates/base_geonode.html
@@ -88,7 +88,9 @@
                                         {% trans "Remember Me" %}
                                     </label>
                                     <button type="submit" class="btn pull-right">{% trans "Sign in" %}</button>
+                                    {% if REGISTRATION_OPEN %}
                                     <div>{% trans "Don't have an account yet?" %} <a href="{% url registration_register %}">{% trans "Register now" %}</a></div>
+                                    {% endif %}
                                 </form>
                             </li>
                           </ul>


### PR DESCRIPTION
Hides the line "Don't have an account yet? Register now" from the "Sign in" dropdown if 'REGISTRATION_OPEN=False'. Otherwise user would see error 500.
