### PR TITLE
Add layer style link in Edit Layer Dropdown, fix issue #438

### DIFF
--- a/geonode/layers/templates/layers/layer_detail.html
+++ b/geonode/layers/templates/layers/layer_detail.html
@@ -56,7 +56,7 @@
       <ul class="dropdown-menu">
         <!--li><a href="">Edit Layer Data <i class="icon-chevron-right"></i></a></li-->
         <li><a href="{% url "layer_metadata" layer.typename %}">{% trans "Edit Metadata" %} <i class="icon-chevron-right"></i></a></li>
-        <li><a href="#">{% trans "Edit Styles" %} <i class="icon-chevron-right"></i></a></li>
+        <li><a href="{% url "layer_style" layer.typename %}">{% trans "Edit Styles" %} <i class="icon-chevron-right"></i></a></li>
         <li><a href="#modal_perms" data-toggle="modal">{% trans "Edit Permissions" %} <i class="icon-chevron-right"></i></a></li>
         <li><a href="{% url "layer_remove" layer.typename %}">{% trans "Remove this Layer" %} <i class="icon-chevron-right"></i></a></li>
       </ul>


### PR DESCRIPTION
Add layer style link to Edit Layer Dropdown List, in order to solve issue #438. Layer_style function per se seems not working properly - however - it is another problem. Permission and metadata edits are already there so no need to change.
