### PR TITLE
Add link to spatial reference ID, fix issue #430

### DIFF
--- a/geonode/layers/templates/layers/layer_detail.html
+++ b/geonode/layers/templates/layers/layer_detail.html
@@ -137,7 +137,7 @@
           {% if layer.srid %}
             <li>
               <strong>{% trans "Native SRS" %}:</strong>
-              {{ layer.srid|default:_("No SRS specified.") }}
+              <a href="{{layer.srid_url}}"> {{ layer.srid|default:_("No SRS specified.") }} </a>
             </li>
           {% endif %}
         </ul>

--- a/geonode/layers/views.py
+++ b/geonode/layers/views.py
@@ -186,6 +186,8 @@ def layer_detail(request, layername, template='layers/layer_detail.html'):
 
     maplayer = GXPLayer(name = layer.typename, ows_url = settings.GEOSERVER_BASE_URL + "wms", layer_params=json.dumps( layer.attribute_config()))
 
+    layer.srid_url = "http://www.spatialreference.org/ref/" + layer.srid.replace(':','/').lower() + "/"	
+	
     #layer.popular_count += 1
     #layer.save()
 


### PR DESCRIPTION
Add link to spatial reference ID, based on spatialreference.org. Fixed issue #430.
