### PR TITLE
change the setting to 10 results per page

### DIFF
--- a/geonode/maps/templates/maps/map_list.html
+++ b/geonode/maps/templates/maps/map_list.html
@@ -58,7 +58,7 @@
       <div class="tab-content span8">
         <div class="tab-pane active list loadmore" id="all">
           {% if object_list.count %}
-          {% autopaginate object_list 2 %}
+          {% autopaginate object_list 10 %}
           {% for map in object_list %}
             {% include "maps/_map_list_item.html" %}
           {% endfor %}


### PR DESCRIPTION
Solved issue #454. Now 10 results can be shown in one page. The auto scrolling function is set from the web browser. With list long enough, one should be able to see the auto scrolling at work.
