### PR TITLE
Use elastic ip for alpha test ami.

### DIFF
--- a/scripts/cloud/ec2.py
+++ b/scripts/cloud/ec2.py
@@ -54,6 +54,8 @@ GEONODE_PRECISE_64=""
 
 DEFAULT_BASE_GEONODE=GEONODE_PRECISE_32
 
+ALPHA_ELASTIC_IP="54.235.204.189"
+
 def writeconfig(config):
     # Writing our configuration file to CONFIG_FILE
     configfile = open(CONFIG_FILE, 'wb')
@@ -87,6 +89,14 @@ def launch_geonode():
 def launch_base():
     readconfig(default_ami=DEFAULT_BASE)
     launch()
+    
+def set_alpha_ip():
+    config = readconfig()
+    conn = boto.connect_ec2()
+    # Assign elastic ip to instance
+    instance_id = config.get('ec2', 'INSTANCE')
+    conn.associate_address(instance_id=instance_id, public_ip=ALPHA_ELASTIC_IP)
+
 
 def launch():
     config = readconfig()
@@ -151,7 +161,7 @@ def launch():
         config.set('ec2', 'HOST', dns)
         config.set('ec2', 'INSTANCE', instance.id)
         writeconfig(config)
-
+        
         print "ssh -i %s ubuntu@%s" % (KEY_PATH, dns)
         print "Terminate the instance via the web interface %s" % instance
 
@@ -187,6 +197,8 @@ if sys.argv[1] == "launch_geonode":
     launch_geonode()
 elif sys.argv[1] == "launch_base":
     launch_base()
+elif sys.argv[1] == "set_alpha_ip":
+    set_alpha_ip()
 elif sys.argv[1] == "terminate":
     terminate()
 elif sys.argv[1] == "host":

--- a/scripts/cloud/fabfile.py
+++ b/scripts/cloud/fabfile.py
@@ -182,6 +182,7 @@ def deploy_geonode_dev_package():
     with settings(warn_only=True):
         sudo('cd build.geonode.org/geonode/latest;dpkg -i geonode_2.0.0*.deb',shell=True)
     sudo('apt-get install -f -y')
+    sudo ('source /var/lib/geonode/bin/activate; geonode-updateip alpha.dev.geonode.org')
 
 def change_admin_password():
     put('../misc/changepw.py', '/home/ubuntu/')

--- a/scripts/jenkins/jenkins-geonode-ami.sh
+++ b/scripts/jenkins/jenkins-geonode-ami.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 source ~/.bashrc
 cd scripts/cloud/
-#python ec2.py terminate
+python ec2.py terminate
 rm .gnec2.cfg
 python ec2.py launch_base
+python ec2.py set_alpha_ip
 
 host=$(python ec2.py host)
 key=$(python ec2.py key)


### PR DESCRIPTION
Sets the elastic ip of new alpha amis to 54.235.204.189, which is mapped to alpha.dev.geonode.org.
