### PR TITLE
Geoserver-ext packaging changes

### DIFF
--- a/package/geoserver/build_geonode-geoserver-ext-deb.sh
+++ b/package/geoserver/build_geonode-geoserver-ext-deb.sh
@@ -35,7 +35,7 @@ mkdir $DL_ROOT/$GIT_REV
 cp ../*.deb $DL_ROOT/$GIT_REV/.
 cp target/geoserver.war $DL_ROOT/$GIT_REV/.
 cp target/geonode-geoserver-ext-*-geoserver-plugin.zip $DL_ROOT/$GIT_REV/.
-cp target/data.zip $DL_ROOT/$GIT_REV/.
+cp target/data*.zip $DL_ROOT/$GIT_REV/data.zip
 
 # Remove all but last 4 builds to stop disk from filling up
 (ls -t|tail -n 3)|sort|uniq -u | xargs rm -rf


### PR DESCRIPTION
Somehow GitHub seems to have corrupted https://github.com/GeoNode/geonode/pull/599 which had 2 of these 3 commits in it. Not sure how/why it happened.

This will ensure that the geoserver data.zip ends up in the right place on the server for pavement to find it at setup.
