### PR TITLE
Use correct wildcard for data.zip

### DIFF
--- a/package/geoserver/build_geonode-geoserver-ext-deb.sh
+++ b/package/geoserver/build_geonode-geoserver-ext-deb.sh
@@ -35,7 +35,7 @@ mkdir $DL_ROOT/$GIT_REV
 cp ../*.deb $DL_ROOT/$GIT_REV/.
 cp target/geoserver.war $DL_ROOT/$GIT_REV/.
 cp target/geonode-geoserver-ext-*-geoserver-plugin.zip $DL_ROOT/$GIT_REV/.
-cp target/data*.zip $DL_ROOT/$GIT_REV/data.zip
+cp target/*data.zip $DL_ROOT/$GIT_REV/data.zip
 
 # Remove all but last 4 builds to stop disk from filling up
 (ls -t|tail -n 3)|sort|uniq -u | xargs rm -rf


### PR DESCRIPTION
Put the \* in the wrong place, causing a file not found error. This should address that and fix the geoserver-ext job.
