### PR TITLE
Set AMI IP after setup

### DIFF
--- a/scripts/jenkins/jenkins-geonode-ami.sh
+++ b/scripts/jenkins/jenkins-geonode-ami.sh
@@ -4,7 +4,6 @@ cd scripts/cloud/
 python ec2.py terminate
 rm .gnec2.cfg
 python ec2.py launch_base
-python ec2.py set_alpha_ip
 
 host=$(python ec2.py host)
 key=$(python ec2.py key)
@@ -13,5 +12,7 @@ echo $key
 
 cd $WORKSPACE/scripts/cloud/
 fab -i $key -H ubuntu@$host deploy_geonode_snapshot_package
+
+python ec2.py set_alpha_ip
 
 #python ec2.py terminate


### PR DESCRIPTION
This moves the assignment of the elastic ip to the end of the setup. This should hopefully prevent the issue where an ami becomes unresponsive part-way through the setup, possibly due to the new ip kicking in.
