### PR TITLE
Now layer owner can edit it, refs #663

### DIFF
--- a/geonode/layers/tests.py
+++ b/geonode/layers/tests.py
@@ -252,6 +252,9 @@ class LayersTest(TestCase):
         self.assertEqual(info[geonode.maps.models.AUTHENTICATED_USERS], layer.LEVEL_READ)
 
         self.assertEqual(info['users'], sorted(layer_info['users'].items()))
+        
+        # Test that layer owner can edit layer
+        self.assertTrue(layer.owner.has_perm(set([u'layers.change_layer']), layer))
 
         # TODO Much more to do here once jj0hns0n understands the ACL system better
 

--- a/geonode/security/auth.py
+++ b/geonode/security/auth.py
@@ -67,7 +67,11 @@ class GranularBackend(ModelBackend):
                 return all_perms
 
     def has_perm(self, user_obj, perm, obj=None):
-        return perm in self.get_all_permissions(user_obj, obj=obj)
+        # in case the user is the owner, he/she has always permissions, otherwise we need to check
+        if user_obj == obj.owner:
+            return True
+        else:
+            return perm in self.get_all_permissions(user_obj, obj=obj)
 
     def _cache_key_for_obj(self, obj):
         model = obj.__class__


### PR DESCRIPTION
The layer (and more general, the object) owner now will always be able to edit it. The has_perm auth method will work like this for every object (map, layer, document etc).
Need some code review to understand if I adopted the correct approach, as I am new to geonode.security
