### PR TITLE
importlayers raises a message when skipping importing an existing layer and the --overwrite option was not specified

### DIFF
--- a/geonode/layers/utils.py
+++ b/geonode/layers/utils.py
@@ -649,6 +649,11 @@ def upload(incoming, user=None, overwrite=False,
             save_it = False
             status = 'skipped'
             layer = existing_layers[0]
+            if verbosity > 0:
+                msg = ('Stopping process because '
+                       '--overwrite was not set '
+                       'and a layer with this name already exists.')
+                print >> sys.stderr, msg
         else:
             save_it = True
 


### PR DESCRIPTION
importlayers now display a message to the user when stopping the process because --overwrite was not set and a layer with this name already exists
