### PR TITLE
Adds fallback to default auth backend in has_perm permission lookup function

### DIFF
--- a/geonode/security/auth.py
+++ b/geonode/security/auth.py
@@ -73,7 +73,7 @@ class GranularBackend(ModelBackend):
         else:
             # in case the user is the owner, he/she has always permissions, 
             # otherwise we need to check
-            if user_obj == obj.owner:
+            if hasattr(obj, 'owner') and user_obj == obj.owner:
                 return True
             else:
                 return perm in self.get_all_permissions(user_obj, obj=obj)


### PR DESCRIPTION
This function is called with obj=None (and fails) when accessing Django's admin interface without Superuser privileges.
