### PR TITLE
initial work towards storing thumbnails

### DIFF
--- a/geonode/base/tests.py
+++ b/geonode/base/tests.py
@@ -1,0 +1,31 @@
+from django.test import TestCase
+from geonode.base.models import ResourceBase
+
+class ThumbnailTests(TestCase):
+
+    def setUp(self):
+        self.rb = ResourceBase.objects.create()
+
+    def tearDown(self):
+        t = self.rb.thumbnail
+        if t:
+            t.delete()
+
+    def test_initial_behavior(self):
+        self.assertFalse(self.rb.has_thumbnail())
+        missing = self.rb.get_thumbnail_url()
+        self.assertEquals('/static/geonode/img/missing_thumb.png', missing)
+
+    def test_saving(self):
+        # monkey patch our render function to just put the 'spec' into the file
+        self.rb._render_thumbnail = lambda *a, **kw: '%s' % a[0]
+
+        self._do_save_test('abc', 1)
+        self._do_save_test('xyz', 2)
+
+    def _do_save_test(self, content, version):
+        self.rb.save_thumbnail(content)
+        thumb = self.rb.thumbnail
+        self.assertEquals(version, thumb.version)
+        self.assertEqual(content, thumb.thumb_file.read())
+        self.assertEqual(content, thumb.thumb_spec)

--- a/geonode/geoserver/helpers.py
+++ b/geonode/geoserver/helpers.py
@@ -226,7 +226,7 @@ def delete_from_postgis(resource_name):
     finally:
         conn.close()
 
-def gs_slurp(self, ignore_errors=True, verbosity=1, console=None, owner=None, workspace=None):
+def gs_slurp(ignore_errors=True, verbosity=1, console=None, owner=None, workspace=None):
     """Configure the layers available in GeoServer in GeoNode.
 
        It returns a list of dictionaries with the name of the layer,

--- a/geonode/layers/templates/layers/_layer_list_item.html
+++ b/geonode/layers/templates/layers/_layer_list_item.html
@@ -11,7 +11,7 @@
   <h3>Layer</h3>
   <a href="{% url "layer_detail" layer.typename %}">
       <!--div class="img-placeholder pl-153-113">{% trans "No Image Available" %}</div-->
-      <img src="{{ layer|layer_thumbnail }}" />
+      <img src="{{ layer.get_thumbnail_url }}" />
   </a>
   <div class="details">
     <div class="pull-right">

--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -520,7 +520,9 @@ LEAFLET_CONFIG = {
 }
 
 # Default TopicCategory to be used for resources. Use the slug field here
-DEFAULT_TOPICCATEGORY = 'location' 
+DEFAULT_TOPICCATEGORY = 'location'
+
+MISSING_THUMBNAIL = 'geonode/img/missing_thumb.png'
 
 # Load more settings from a file called local_settings.py if it exists
 try:


### PR DESCRIPTION
This is for layers only. There is no upload, only creation of a thumbnail from WMS reflector.

Some explanation:
1) I used md5 hashes to obfuscate the name since images are being served from media directory. In mapstory, I used a version on the URL so I could apply far-future expires. The hashed approach supports this as well, but...
2) because the URL changes each time the thumbnail is saved, it requires a CSW update to the cached metadata XML

I have not tested seriously at this point. Should discuss further at this point.
