### PR TITLE
removed initial bobby user

### DIFF
--- a/geonode/layers/fixtures/initial_data.json
+++ b/geonode/layers/fixtures/initial_data.json
@@ -43,24 +43,6 @@
     }
 },
 {
-    "pk": 1,
-    "model": "auth.user",
-    "fields": {
-        "username": "bobby",
-        "first_name": "",
-        "last_name": "",
-        "is_active": true,
-        "is_superuser": false,
-        "is_staff": false,
-        "last_login": "2010-06-10 16:59:13",
-        "groups": [],
-        "user_permissions": [],
-        "password": "sha1$8d019$a84eea3f5093eed93bc68bf62fe400f14042ab06",
-        "email": "bobby@bob.com",
-        "date_joined": "2010-06-10 16:58:18"
-    }
-},
-{
     "fields": {
         "subject": "anonymous",
         "object_ct": ["layers", "layer"],


### PR DESCRIPTION
This 'bobby' user in initial_data.json was causing problems when first calling 'syncdb --all'because it has pk=1.  So you create a superuser, which was promptyly overwritten with the bobby account, which is not a superuser.  
