### PR TITLE
Retain layer title sent in map json from viewer

### DIFF
--- a/geonode/utils.py
+++ b/geonode/utils.py
@@ -312,7 +312,7 @@ def layer_from_viewer_config(model, layer, source, ordering):
     """
     layer_cfg = dict(layer)
     for k in ["format", "name", "opacity", "styles", "transparent",
-                "fixed", "group", "visibility", "title", "source", "getFeatureInfo"]:
+                "fixed", "group", "visibility", "source", "getFeatureInfo"]:
         if k in layer_cfg: del layer_cfg[k]
 
     source_cfg = dict(source)


### PR DESCRIPTION
Prevents user-modified layer titles for a map from being overwritten.

For issue https://github.com/GeoNode/geonode/issues/320
