### PR TITLE
set the layer public for the purpose of WCS link creation

### DIFF
--- a/geonode/layers/models.py
+++ b/geonode/layers/models.py
@@ -471,6 +471,10 @@ def geoserver_post_save(instance, sender, **kwargs):
     elif instance.storeType == 'coverageStore':
         #FIXME(Ariel): This works for public layers, does it work for restricted too?
         # would those end up with no geotiff links, like, forever?
+        permissions = {}
+        permissions['anonymous'] = instance.get_gen_level(ANONYMOUS_USERS)
+        permissions['authenticated'] = instance.get_gen_level(AUTHENTICATED_USERS)
+        instance.set_gen_level(ANONYMOUS_USERS,'layer_readonly')
 
         links = wcs_links(settings.GEOSERVER_BASE_URL + 'wcs?', instance.typename, 
             bbox=instance.bbox[:-1], crs=instance.bbox[-1], height=height, width=width)
@@ -484,6 +488,9 @@ def geoserver_post_save(instance, sender, **kwargs):
                                     link_type='data',
                                 )
                             )
+            
+        instance.set_gen_level(ANONYMOUS_USERS,permissions['anonymous'])
+        instance.set_gen_level(AUTHENTICATED_USERS,permissions['authenticated'])
 
     kml_reflector_link_download = settings.GEOSERVER_BASE_URL + "wms/kml?" + urllib.urlencode({
         'layers': instance.typename,


### PR DESCRIPTION
This is a fix for #973, but I'd like you devs to discuss it before pulling.
The problem is that in order to create the WCS links the resource has to be public. This is a very similar problem we had for the printing of private layers that we solved with the optional middleware (in fact the code is almost a duplicate, sorry mr DRY).

At this point I think that this code could be more general than a middleware so that can be reused.
If we pull this now then I will open a ticket against this for the 2.1.

Thanks for comments.
