### PR TITLE
Fix to accomodate geonode-project template CSS files

### DIFF
--- a/pavement.py
+++ b/pavement.py
@@ -36,8 +36,8 @@ try:
 except ImportError:
     from paver.easy import pushd
 
-#assert sys.version_info >= (2, 7), \
-#    SystemError("GeoNode Build requires python 2.7 or better")
+assert sys.version_info >= (2, 7), \
+    SystemError("GeoNode Build requires python 2.7 or better")
 
 
 def grab(src, dest, name):


### PR DESCRIPTION
Removing the block allows geonode-project to insert header CSS file rules.
