### PR TITLE
Changed the upload function to use the case-insensitive safe get_files function.

### DIFF
--- a/geonode/geoserver/uploader/uploader.py
+++ b/geonode/geoserver/uploader/uploader.py
@@ -8,8 +8,8 @@ import mimetypes
 from urlparse import urlparse
 from urllib import urlencode
 
+from geonode.layers.utils import get_files
 from geonode.geoserver.uploader.api import parse_response
-from geonode.geoserver.uploader.utils import shp_files 
 
 _logger = logging.getLogger(__name__)
 
@@ -55,8 +55,8 @@ class Uploader(object):
         """
         files = [ fpath ]
         if fpath.lower().endswith(".shp"):
-            files = shp_files(fpath)
-            
+            files = list(set(get_files(fpath).values()))
+
         session = self.start_import(import_id)
         session.upload_task(files, use_url)
         return session

--- a/geonode/geoserver/uploader/utils.py
+++ b/geonode/geoserver/uploader/utils.py
@@ -1,15 +1,6 @@
 from zipfile import ZipFile
 import tempfile
 from os import path
-
-_shp_exts = ["dbf","prj","shx"]
-_shp_exts = _shp_exts + map(lambda s: s.upper(), _shp_exts)
-
-def shp_files(fpath):
-    basename, ext = path.splitext(fpath)
-    paths = [ "%s.%s" % (basename,ext) for ext in _shp_exts ]
-    paths.append(fpath)
-    return filter(lambda f: path.exists(f),  paths)
     
 def create_zip(fpaths):
     _,payload = tempfile.mkstemp(suffix='.zip')


### PR DESCRIPTION
The upload function currently uses the shp_files function in geonode/geoserver/uploader/utils.py to identify sidecar files when given the path of a shapefile.  The shp_files function returns false positives on case-insensitive file systems which causes the uploader to break when using the importer backend.  The get_files function does the same thing as shp_files but works on case-insensitive file systems and is much more heavily tested.  No other logic in geonode uses shp_files.
