### PR TITLE
Forced UTF-8 encoding on strings that may receive unicode input.  

### DIFF
--- a/geonode/geoserver/helpers.py
+++ b/geonode/geoserver/helpers.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 #########################################################################
 #
 # Copyright (C) 2012 OpenPlans
@@ -281,7 +282,7 @@ def gs_slurp(ignore_errors=True, verbosity=1, console=None, owner=None, workspac
                 "workspace": workspace.name,
                 "store": store.name,
                 "storeType": store.resource_type,
-                "typename": "%s:%s" % (workspace.name, resource.name),
+                "typename": "%s:%s" % (workspace.name.encode('utf-8'), resource.name.encode('utf-8')),
                 "title": resource.title or 'No title provided',
                 "abstract": resource.abstract or 'No abstract provided',
                 "owner": owner,
@@ -297,7 +298,7 @@ def gs_slurp(ignore_errors=True, verbosity=1, console=None, owner=None, workspac
                 if verbosity > 0:
                     msg = "Stopping process because --ignore-errors was not set and an error was found."
                     print >> sys.stderr, msg
-                raise Exception('Failed to process %s' % resource.name, e), None, sys.exc_info()[2]
+                raise Exception('Failed to process %s' % resource.name.encode('utf-8'), e), None, sys.exc_info()[2]
         else:
             if created:
                 layer.set_default_permissions()

--- a/geonode/layers/models.py
+++ b/geonode/layers/models.py
@@ -264,7 +264,7 @@ class Attribute(models.Model):
     objects = AttributeManager()
 
     def __str__(self):
-        return "%s" % self.attribute_label if self.attribute_label else self.attribute
+        return "%s" % self.attribute_label.encode("utf-8") if self.attribute_label else self.attribute.encode("utf-8")
 
     def unique_values_as_list(self):
         return self.unique_values.split(',')

--- a/geonode/layers/populate_layers_data.py
+++ b/geonode/layers/populate_layers_data.py
@@ -21,6 +21,13 @@ styles = [
 
 attributes = [
     {
+        "attribute": u'N\xfamero_De_M\xe9dicos',
+        "attribute_label": u'N\xfamero_De_M\xe9dicos',
+        "attribute_type": "xsd:string",
+        "visible": True,
+        "display_order": 4
+    },
+     {
         "attribute": "the_geom",
         "attribute_label": "Shape",
         "attribute_type": "gml:Geometry",

--- a/geonode/layers/tests.py
+++ b/geonode/layers/tests.py
@@ -315,13 +315,14 @@ class LayersTest(TestCase):
     def test_layer_attributes(self):
         lyr = Layer.objects.get(pk=1)
         #There should be a total of 3 attributes
-        self.assertEqual(len(lyr.attribute_set.all()), 3)
+        self.assertEqual(len(lyr.attribute_set.all()), 4)
         #2 out of 3 attributes should be visible
         custom_attributes = lyr.attribute_set.visible()
-        self.assertEqual(len(custom_attributes), 2)
+        self.assertEqual(len(custom_attributes), 3)
         #place_ name should come before description
         self.assertEqual(custom_attributes[0].attribute_label, "Place Name")
         self.assertEqual(custom_attributes[1].attribute_label, "Description")
+        self.assertEqual(custom_attributes[2].attribute, u'N\xfamero_De_M\xe9dicos')
         # TODO: do test against layer with actual attribute statistics
         self.assertEqual(custom_attributes[1].count, 1)
         self.assertEqual(custom_attributes[1].min, "NA")
@@ -335,7 +336,7 @@ class LayersTest(TestCase):
     def test_layer_attribute_config(self):
         lyr = Layer.objects.get(pk=1)
         custom_attributes = (lyr.attribute_config())["getFeatureInfo"]
-        self.assertEqual(custom_attributes["fields"],["place_name","description"])
+        self.assertEqual(custom_attributes["fields"],["place_name","description", u'N\xfamero_De_M\xe9dicos'])
         self.assertEqual(custom_attributes["propertyNames"]["description"], "Description")
         self.assertEqual(custom_attributes["propertyNames"]["place_name"], "Place Name")
 


### PR DESCRIPTION
This fixes character encoding problems in updatelayers and in the attributes model.  Without the changes on the attributes model any layer with an attribute that has a non-ascii character will cause the layer detail page not to render and will not render the record in the admin portion of the application.
