### PR TITLE
moved DB_DATASTORE parameters into DATABASES dictionary

### DIFF
--- a/geonode/geoserver/helpers.py
+++ b/geonode/geoserver/helpers.py
@@ -225,7 +225,9 @@ def delete_from_postgis(resource_name):
     to be used after deleting a layer from the system.
     """
     import psycopg2
-    conn=psycopg2.connect("dbname='" + settings.DB_DATASTORE_DATABASE + "' user='" + settings.DB_DATASTORE_USER + "'  password='" + settings.DB_DATASTORE_PASSWORD + "' port=" + settings.DB_DATASTORE_PORT + " host='" + settings.DB_DATASTORE_HOST + "'")
+    dsname = settings.OGC_SERVER['default']['OPTIONS']['DATASTORE']
+    db = settings.DATABASES[dsname]
+    conn=psycopg2.connect("dbname='" + db['NAME'] + "' user='" + db['user'] + "'  password='" + db['password'] + "' port=" + db['PORT'] + " host='" + db['HOST'] + "'")
     try:
         cur = conn.cursor()
         cur.execute("SELECT DropGeometryTable ('%s')" %  resource_name)

--- a/geonode/layers/tests.py
+++ b/geonode/layers/tests.py
@@ -716,9 +716,8 @@ class LayersTest(TestCase):
         layer.storeType = "dataStore"
         layer.save()
 
-
         # Test that the method returns authorized=True if it's a datastore
-        with self.settings(DB_DATASTORE=True):
+        if settings.OGC_SERVER['default']['OPTIONS']['DATASTORE']:
             # The check was moved from the template into the view
             response = c.post(reverse('feature_edit_check', args=(valid_layer_typename,)))
             response_json = json.loads(response.content)

--- a/geonode/layers/views.py
+++ b/geonode/layers/views.py
@@ -681,7 +681,7 @@ def feature_edit_check(request, layername):
     Otherwise, return a status of 401 (unauthorized).
     """
     layer = get_object_or_404(Layer, typename=layername)
-    feature_edit = any((getattr(settings, a, None) for a in ("GEOGIT_DATASTORE", "DB_DATASTORE"))) 
+    feature_edit = any((getattr(settings, a, None) for a in ("GEOGIT_DATASTORE", "OGC_SERVER['default']['OPTIONS']['DATASTORE']"))) 
     if request.user.has_perm('maps.change_layer', obj=layer) and layer.storeType == 'dataStore' and feature_edit:
         return HttpResponse(json.dumps({'authorized': True}), mimetype="application/json")
     else:

--- a/geonode/local_settings.py.sample
+++ b/geonode/local_settings.py.sample
@@ -4,5 +4,16 @@ DATABASES = {
          'NAME': 'geonode',
          'USER': 'geonode',
          'PASSWORD': 'geonode',
-     }
+     },
+    # vector datastore for uploads
+    'datastore' : {
+        #'ENGINE': 'django.contrib.gis.db.backends.postgis',
+        'ENGINE': '', # Empty ENGINE name disables 
+        'NAME': 'geonode',
+        'USER' : 'geonode',
+        'PASSWORD' : 'geonode',
+        'HOST' : 'localhost',
+        'PORT' : '5432',
+    }
+}
 }

--- a/geonode/maps/views.py
+++ b/geonode/maps/views.py
@@ -199,7 +199,6 @@ def map_view(request, mapid, template='maps/map_view.html'):
     config = map_obj.viewer_json()
     return render_to_response(template, RequestContext(request, {
         'config': json.dumps(config),
-        'DB_DATASTORE' : settings.DB_DATASTORE,
         'map': map_obj
     }))
 
@@ -240,7 +239,6 @@ def new_map(request, template='maps/map_view.html'):
     else:
         return render_to_response(template, RequestContext(request, {
             'config': config,
-            'DB_DATASTORE' : settings.DB_DATASTORE
         }))
 
 

--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -45,7 +45,16 @@ DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
         'NAME': os.path.join(PROJECT_ROOT, 'development.db'),
-    }
+    },
+    # vector datastore for uploads
+    #'datastore' : {
+    #    'ENGINE': 'django.contrib.gis.db.backends.postgis',
+    #    'NAME': '',
+    #    'USER' : '',
+    #    'PASSWORD' : '',
+    #    'HOST' : '',
+    #    'PORT' : '',
+    #}
 }
 
 # Local time zone for this installation. Choices can be found here:
@@ -396,23 +405,10 @@ OGC_SERVER = {
             'PRINTNG_ENABLED' : True,
             'GEONODE_SECURITY_ENABLED' : True,
             'GEOGIT_ENABLED' : False,
-            'WMST_ENABLED' : False
+            'WMST_ENABLED' : False,
+            # Set to name of database in DATABASES dictionary to enable
+            'DATASTORE': '', #'datastore',
         }
-    }
-}
-
-# Vector Database Settings 
-# TODO: Migrate to DATABASES?
-DB_DATASTORE = {
-    'ENABLED' : False,
-    'default' : {
-        'DATABASE' : '',
-        'USER' : '',
-        'PASSWORD' : '',
-        'HOST' : '',
-        'PORT' : '',
-        'TYPE' : '',
-        'NAME' : ''
     }
 }
 

--- a/geonode/upload/forms.py
+++ b/geonode/upload/forms.py
@@ -48,7 +48,7 @@ class LayerUploadForm(forms.Form):
     spatial_files = ("base_file", "dbf_file", "shx_file", "prj_file", "sld_file", "xml_file")
 
     def clean(self):
-        requires_datastore = () if settings.DB_DATASTORE else ('csv','kml')
+        requires_datastore = () if settings.OGC_SERVER['default']['OPTIONS']['DATASTORE'] else ('csv','kml')
         types = [ t for t in files.types if t.code not in requires_datastore]
         supported_type = lambda ext: any([t.matches(ext) for t in types])
 

--- a/geonode/upload/tests/README.rst
+++ b/geonode/upload/tests/README.rst
@@ -19,11 +19,11 @@ database other than what you might use for other local purposes. This module is:
 
   geonode.upload.tests.local_settings
 
-If the `local_settings` or standard django settings do not enable a DB_DATASTORE,
+If the `local_settings` or standard django settings do not set the name of the OGC_SERVER DATASTORE option,
 the importer tests that import into the database will not run.
 
 The `test_settings` module must also be supplied when launching the tests to run
-the full suite including the DB_DATASTORE tests:
+the full suite including the DATASTORE tests:
 
   DJANGO_SETTINGS_MODULE=geonode.upload.tests.test_settings python manage.py test geonode.upload.tests.integration
 

--- a/geonode/upload/tests/integration.py
+++ b/geonode/upload/tests/integration.py
@@ -362,7 +362,7 @@ class UploaderBase(TestCase):
 
     def check_upload_model(self, original_name):
         # we can only test this if we're using the same DB as the test instance
-        if not settings.DB_DATASTORE: return
+        if not settings.OGC_SERVER['default']['OPTIONS']['DATASTORE']: return
         try:
             upload = Upload.objects.get(layer__name=original_name)
         except Upload.DoesNotExist:
@@ -447,7 +447,7 @@ class UploaderBase(TestCase):
 
 class TestUpload(UploaderBase):
     settings_overrides = [
-        ('DB_DATASTORE', False)
+        ("OGC_SERVER['default']['OPTIONS']['DATASTORE']", False)
     ]
     
     def test_shp_upload(self):
@@ -526,9 +526,7 @@ class TestUpload(UploaderBase):
 
 class TestUploadDBDataStore(TestUpload):
 
-    settings_overrides = [
-        ('DB_DATASTORE', True)
-    ]
+    settings_overrides = []
 
     def test_csv(self):
         """Override the baseclass test and verify a correct CSV upload"""
@@ -584,8 +582,7 @@ class TestUploadDBDataStore(TestUpload):
         layer_info = wms.items()[0][1]
         self.assertEquals(100, len(layer_info.timepositions))
 
-
-# disable DB_DATASTORE tests if not setup
-if not settings.DB_DATASTORE:
-    print 'skipping DB_DATASTORE tests'
+# disable DATASTORE tests if not setup
+if not settings.OGC_SERVER['default']['OPTIONS']['DATASTORE']:
+    print 'skipping DATASTORE tests'
     del TestUploadDBDataStore

--- a/geonode/upload/upload.py
+++ b/geonode/upload/upload.py
@@ -303,7 +303,7 @@ def run_import(upload_session, async):
             )
         import_session.tasks[0].set_target(
             target.name, target.workspace.name)
-    elif (settings.DB_DATASTORE and
+    elif (settings.OGC_SERVER['default']['OPTIONS']['DATASTORE'] != '' and
         import_session.tasks[0].items[0].layer.layer_type != 'RASTER'):
         target = create_geoserver_db_featurestore(store_type='postgis', store_name = upload_session.geogit_store)
         _log('setting target datastore %s %s',

--- a/geonode/upload/utils.py
+++ b/geonode/upload/utils.py
@@ -127,6 +127,7 @@ def rename_and_prepare(base_file):
 
 def create_geoserver_db_featurestore(store_type=None, store_name=None):
     cat = Layer.objects.gs_catalog
+    dsname = settings.OGC_SERVER['default']['OPTIONS']['DATASTORE']
     # get or create datastore
     try:
         if store_type == 'geogit' and hasattr(settings, 'GEOGIT_DATASTORE_NAME') and settings.GEOGIT_DATASTORE_NAME:
@@ -134,8 +135,8 @@ def create_geoserver_db_featurestore(store_type=None, store_name=None):
                 ds = cat.get_store(store_name)
             else:
                 ds = cat.get_store(settings.GEOGIT_DATASTORE_NAME)
-        elif settings.DB_DATASTORE_NAME:
-            ds = cat.get_store(settings.DB_DATASTORE_NAME)
+        elif dsname != '':
+            ds = cat.get_store(dsname)
         else:
             return None
     except FailedRequestError:
@@ -153,16 +154,17 @@ def create_geoserver_db_featurestore(store_type=None, store_name=None):
             ds = cat.get_store(store_name)
         else:
             logging.info(
-                'Creating target datastore %s' % settings.DB_DATASTORE['default']['NAME'])
-            ds = cat.create_datastore(settings.DB_DATASTORE['default']['NAME'])
+                'Creating target datastore ' % dsname)
+            ds = cat.create_datastore(dsname)
+            db = settings.DATABASES[dsname]
             ds.connection_parameters.update(
-                host=settings.DB_DATASTORE['default']['HOST'],
-                port=settings.DB_DATASTORE['default']['PORT'],
-                database=settings.DB_DATASTORE['default']['DATABASE'],
-                user=settings.DB_DATASTORE['default']['USER'],
-                passwd=settings.DB_DATASTORE['default']['PASSWORD'],
-                dbtype=settings.DB_DATASTORE['default']['TYPE'])
+                host = db['HOST'],
+                port = db['PORT'],
+                database = db['NAME'],
+                user = db['USER'],
+                passwd = db['PASSWORD'],
+                dbtype = db['ENGINE'])
             cat.save(ds)
-            ds = cat.get_store(settings.DB_DATASTORE['default']['NAME'])
+            ds = cat.get_store(dsname)
 
     return ds

--- a/geonode/upload/views.py
+++ b/geonode/upload/views.py
@@ -63,11 +63,11 @@ logger = logging.getLogger(__name__)
 
 _SESSION_KEY = 'geonode_upload_session'
 _ALLOW_TIME_STEP = getattr(settings, "UPLOADER_SHOW_TIME_STEP", False)
-_ASYNC_UPLOAD = settings.DB_DATASTORE == True
+_ASYNC_UPLOAD = settings.OGC_SERVER['default']['OPTIONS']['DATASTORE'] == True
 
 # at the moment, the various time support transformations require the database
 if _ALLOW_TIME_STEP and not _ASYNC_UPLOAD:
-    raise Exception("To support the time step, you must enable DB_DATASTORE")
+    raise Exception("To support the time step, you must enable the OGC_SERVER DATASTORE option")
 
 
 def _is_async_step(upload_session):

--- a/package/osgeo/local_settings.py.sample
+++ b/package/osgeo/local_settings.py.sample
@@ -6,6 +6,14 @@ DATABASES = {
          'PASSWORD': 'user',
          'HOST': 'localhost',
      }
+    'datastore': {
+        'ENGINE': 'django.contrib.gis.db.backends.postgis',
+        'NAME': 'geonode_imports',
+        'USER': 'user',
+        'PASSWORD': 'user',
+        'HOST': 'localhost',
+        'PORT': '5432',
+    }
 }
 
 # GeoNode vector data backend configuration.
@@ -19,18 +27,6 @@ GEOGIT_DATASTORE = False
 GEOGIT_DATASTORE_NAME = 'geogit-repo'
 
 UPLOADER_SHOW_TIME_STEP=False
-
-#Import uploaded shapefiles into a database such as PostGIS?
-DB_DATASTORE = False
-
-#Database datastore connection settings
-DB_DATASTORE_DATABASE = 'geonode_imports'
-DB_DATASTORE_USER = 'user'
-DB_DATASTORE_PASSWORD = 'user'
-DB_DATASTORE_HOST = 'localhost'
-DB_DATASTORE_PORT = '5432'
-DB_DATASTORE_TYPE = 'postgis'
-DB_DATASTORE_NAME = 'geonode_imports'
 
 # Use the printNG geoserver lib
 PRINTNG_ENABLED=True

--- a/package/support/geonode.local_settings
+++ b/package/support/geonode.local_settings
@@ -14,27 +14,24 @@ DATABASE_PASSWORD = 'THE_DATABASE_PASSWORD'
 DATABASE_HOST = 'localhost'
 DATABASE_PORT = '5432'
 
-# Make geonode upload vector layers directly to postgis
-DB_DATASTORE_NAME = 'postgres_imports'
-DB_DATASTORE_DATABASE = DATABASE_NAME
-DB_DATASTORE_USER = DATABASE_USER
-DB_DATASTORE_PASSWORD = DATABASE_PASSWORD
-DB_DATASTORE_HOST = DATABASE_HOST
-DB_DATASTORE_PORT = DATABASE_PORT
-DB_DATASTORE_TYPE='postgis'
-
 DATABASES = {
-      'default': {
-            'ENGINE': 'django.db.backends.postgresql_psycopg2',
-            'NAME': DATABASE_NAME,
-            'USER': DATABASE_USER,
-            'PASSWORD': DATABASE_PASSWORD,
-            'HOST': DATABASE_HOST,
-            'PORT': DATABASE_PORT,
-        }
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'NAME': DATABASE_NAME,
+        'USER': DATABASE_USER,
+        'PASSWORD': DATABASE_PASSWORD,
+        'HOST': DATABASE_HOST,
+        'PORT': DATABASE_PORT,
     }
-
-DB_DATASTORE=False
+    'datastore': {
+        'ENGINE': 'django.contrib.gis.db.backends.postgis',
+        'NAME': DATABASE_NAME,
+        'USER': DATABASE_USER,
+        'PASSWORD': DATABASE_PASSWORD,
+        'HOST': DATABASE_HOST,
+        'PORT': DATABASE_PORT,
+    }
+}
 
 LANGUAGE_CODE = 'en'
 


### PR DESCRIPTION
The connection parameters for DB_DATASTORE are moved into the DATABASES directory to make it easier to use with Django's 'using' function for queries or for automatic database routing.

Left in a True/False switch (DB_DATASTORE) to easily enable/disable it.
