### PR TITLE
Added the --allow-root to bower install.

### DIFF
--- a/pavement.py
+++ b/pavement.py
@@ -118,7 +118,7 @@ def _install_data_dir():
 def update_static(options):
     with pushd('geonode/static'):
         sh('npm install')
-        sh('bower install')
+        sh('bower install --allow-root')
         sh('grunt production')
         
 


### PR DESCRIPTION
It looks like in newer bower versions (1.2.5 in my dev server) bower install will fails when running it as root.
There is the new --allow-root option that will prevent this error.
I have successfully run paver update_static with this pavement file both with a new (1.2.5) and old (0.9.2) bower version, so it should be safe to accept this modification.
