### PR TITLE
Faster jetty startup

### DIFF
--- a/geoserver/jetty-runner.xml
+++ b/geoserver/jetty-runner.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"  encoding="ISO-8859-1"?>
+ <!DOCTYPE Configure PUBLIC "-//Mort Bay Consulting//DTD Configure//EN" "http://jetty.mortbay.org/configure.dtd">
+ <Configure class="org.eclipse.jetty.webapp.WebAppContext">
+    <Set name="contextPath">/geoserver</Set>
+    <Set name="war"><SystemProperty name="jetty.home" default="../"/>geoserver</Set>
+    <Call name="setAttribute">
+      <Arg>org.eclipse.jetty.server.webapp.WebInfIncludeJarPattern</Arg>
+      <Arg>WONTMATCH</Arg>
+    </Call>
+ </Configure>

--- a/pavement.py
+++ b/pavement.py
@@ -297,6 +297,7 @@ def start_geoserver(options):
     data_dir = path('geoserver/data').abspath()
     web_app = path('geoserver/geoserver').abspath()
     log_file = path('geoserver/jetty.log').abspath()
+    config = path('geoserver/jetty-runner.xml').abspath()
 
     # @todo - we should not have set workdir to the datadir but a bug in geoserver
     # prevents geonode security from initializing correctly otherwise
@@ -307,7 +308,7 @@ def start_geoserver(options):
             ' -Dorg.eclipse.jetty.server.webapp.parentLoaderPriority=true'
             ' -jar %(jetty_runner)s'
             ' --log %(log_file)s'
-            ' --path /geoserver %(web_app)s'
+            ' %(config)s'
             ' > /dev/null &' % locals()
           ))
 


### PR DESCRIPTION
The only thing that needs thinking about here is the location of the `jetty-runner.xml` file. In this PR, it is located in the `geoserver` directory which is currently ignored. We could make the ignores more specific, or put it somewhere else, or ...

For me, startup time dropped to 15 seconds from 30, so substantial savings.
