### PR TITLE
Added a OGC_Servers convenience class.

### DIFF
--- a/geonode/base/tests.py
+++ b/geonode/base/tests.py
@@ -1,5 +1,6 @@
 from django.test import TestCase
 from geonode.base.models import ResourceBase
+from geonode.utils import OGC_Servers_Handler
 
 class ThumbnailTests(TestCase):
 
@@ -29,3 +30,76 @@ class ThumbnailTests(TestCase):
         self.assertEquals(version, thumb.version)
         self.assertEqual(content, thumb.thumb_file.read())
         self.assertEqual(content, thumb.thumb_spec)
+
+class UtilsTests(TestCase):
+
+    def test_ogc_server_settings(self):
+        """
+        Tests the OGC Servers Handler class.
+        """
+
+        OGC_SERVER = {
+            'default': {
+                'BACKEND': 'geonode.geoserver',
+                'LOCATION': 'http://localhost:8080/geoserver/',
+                'USER': 'admin',
+                'PASSWORD': 'geoserver',
+                'MAPFISH_PRINT_ENABLED': True,
+                'PRINTING_ENABLED': True,
+                'GEONODE_SECURITY_ENABLED': True,
+                'GEOGIT_ENABLED': True,
+                'WMST_ENABLED': False,
+                'DATASTORE': str(),
+            }
+        }
+
+        ogc_settings = OGC_Servers_Handler(OGC_SERVER)['default']
+        default = OGC_SERVER.get('default')
+        self.assertEqual(ogc_settings.server, default)
+        self.assertEqual(ogc_settings.BACKEND, default.get('BACKEND'))
+        self.assertEqual(ogc_settings.LOCATION, default.get('LOCATION'))
+        self.assertEqual(ogc_settings.USER, default.get('USER'))
+        self.assertEqual(ogc_settings.PASSWORD, default.get('PASSWORD'))
+        self.assertEqual(ogc_settings.DATASTORE, str())
+        self.assertEqual(ogc_settings.credentials, ('admin', 'geoserver'))
+        self.assertTrue(ogc_settings.MAPFISH_PRINT_ENABLED)
+        self.assertTrue(ogc_settings.PRINTING_ENABLED)
+        self.assertTrue(ogc_settings.GEONODE_SECURITY_ENABLED)
+        self.assertTrue(ogc_settings.GEOGIT_ENABLED)
+        self.assertFalse(ogc_settings.WMST_ENABLED)
+
+
+    def test_ogc_server_defaults(self):
+        """
+        Tests that OGC_SERVER_SETTINGS are built if they do not exist in the settings.
+        """
+
+        OGC_SERVER = {
+             'default': dict(),
+         }
+
+        EXPECTATION ={
+            'default' : {
+                    'BACKEND' : 'geonode.geoserver',
+                    'LOCATION' : 'http://localhost:8080/geoserver/',
+                    'USER' : 'admin',
+                    'PASSWORD' : 'geoserver',
+                    'MAPFISH_PRINT_ENABLED' : True,
+                    'PRINTING_ENABLED' : True,
+                    'GEONODE_SECURITY_ENABLED' : True,
+                    'GEOGIT_ENABLED' : False,
+                    'WMST_ENABLED' : False,
+                    'DATASTORE': str(),
+            }
+        }
+
+        defaults = EXPECTATION.get('default')
+        ogc_settings = OGC_Servers_Handler(OGC_SERVER)['default']
+        self.assertEqual(ogc_settings.server, defaults)
+        self.assertEqual(ogc_settings.rest, defaults['LOCATION']+'rest')
+        self.assertEqual(ogc_settings.ows, defaults['LOCATION']+'wms')
+
+        # Make sure we get None vs a KeyError when the key does not exist
+        self.assertIsNone(ogc_settings.SFDSDFDSF)
+
+

--- a/geonode/context_processors.py
+++ b/geonode/context_processors.py
@@ -22,6 +22,7 @@ from geonode import get_version
 from geonode.catalogue import default_catalogue_backend
 from django.contrib.sites.models import Site
 from django.core.urlresolvers import reverse
+from geonode.utils import ogc_server_settings
 
 def resource_urls(request):
     """Global values to pass to templates"""
@@ -29,7 +30,7 @@ def resource_urls(request):
 
     return dict(
         STATIC_URL=settings.STATIC_URL,
-        GEOSERVER_BASE_URL=settings.OGC_SERVER['default']['LOCATION'],
+        GEOSERVER_BASE_URL=ogc_server_settings.LOCATION,
         CATALOGUE_BASE_URL=default_catalogue_backend()['URL'],
         REGISTRATION_OPEN=settings.REGISTRATION_OPEN,
         VERSION=get_version(),
@@ -37,10 +38,10 @@ def resource_urls(request):
         SITE_DOMAIN=site.domain,
         DOCUMENTS_APP = settings.DOCUMENTS_APP,
         UPLOADER_URL = reverse('data_upload') if getattr(settings, 'UPLOADER', dict()).get('BACKEND', 'geonode.rest') == 'geonode.importer' else reverse('layer_upload'),
-        GEOGIT_ENABLED = getattr(settings, 'UPLOADER', dict()).get('OPTIONS', dict()).get('GEOGIT_ENABLED', False),
+        GEOGIT_ENABLED = ogc_server_settings.GEOGIT_ENABLED,
         TIME_ENABLED = getattr(settings, 'UPLOADER', dict()).get('OPTIONS', dict()).get('TIME_ENABLED', False),
         DEBUG_STATIC = getattr(settings, "DEBUG_STATIC", False),
-        MF_PRINT_ENABLED = settings.OGC_SERVER['default']['OPTIONS'].get("MAPFISH_PRINT_ENABLED", False),
-        PRINTNG_ENABLED = settings.OGC_SERVER['default']['OPTIONS'].get("PRINTNG_ENABLED", False),
-        GS_SECURITY_ENABLED = settings.OGC_SERVER['default']['OPTIONS'].get("GEONODE_SECURITY_ENABLED", False)
+        MF_PRINT_ENABLED = ogc_server_settings.MAPFISH_PRINT_ENABLED,
+        PRINTNG_ENABLED = ogc_server_settings.PRINTNG_ENABLED,
+        GS_SECURITY_ENABLED = ogc_server_settings.GEONODE_SECURITY_ENABLED
     )

--- a/geonode/geoserver/helpers.py
+++ b/geonode/geoserver/helpers.py
@@ -27,7 +27,7 @@ from itertools import cycle, izip
 
 from django.conf import settings
 
-from geonode.utils import _user, _password
+from geonode.utils import _user, _password, ogc_server_settings
 
 from geoserver.catalog import Catalog, FailedRequestError
 
@@ -179,7 +179,7 @@ def cascading_delete(cat, layer_name):
       if e.errno == errno.ECONNREFUSED:
         msg = ('Could not connect to geoserver at "%s"'
                'to save information for layer "%s"' % (
-               settings.OGC_SERVER['default']['LOCATION'], layer_name)
+               ogc_server_settings.LOCATION, layer_name)
               )
         logger.warn(msg, e)
         return None
@@ -225,8 +225,8 @@ def delete_from_postgis(resource_name):
     to be used after deleting a layer from the system.
     """
     import psycopg2
-    dsname = settings.OGC_SERVER['default']['OPTIONS']['DATASTORE']
-    db = settings.DATABASES[dsname]
+    dsname = ogc_server_settings.DATASTORE
+    db = ogc_server_settings.datastore_db
     conn=psycopg2.connect("dbname='" + db['NAME'] + "' user='" + db['USER'] + "'  password='" + db['PASSWORD'] + "' port=" + db['PORT'] + " host='" + db['HOST'] + "'")
     try:
         cur = conn.cursor()
@@ -248,8 +248,7 @@ def gs_slurp(ignore_errors=True, verbosity=1, console=None, owner=None, workspac
 
     if verbosity > 1:
         print >> console, "Inspecting the available layers in GeoServer ..."
-    url = "%srest" % settings.OGC_SERVER['default']['LOCATION']
-    cat = Catalog(url, _user, _password)
+    cat = Catalog(ogc_server_settings.rest, _user, _password)
     if workspace is not None:
         workspace = cat.get_workspace(workspace)
         resources = cat.get_resources(workspace=workspace)
@@ -320,8 +319,7 @@ def gs_slurp(ignore_errors=True, verbosity=1, console=None, owner=None, workspac
     return output
 
 def get_stores(store_type = None):
-    url = "%srest" % settings.OGC_SERVER['default']['LOCATION']
-    cat = Catalog(url, _user, _password) 
+    cat = Catalog(ogc_server_settings.rest, _user, _password)
     stores = cat.get_stores()
     store_list = []
     for store in stores:

--- a/geonode/layers/ows.py
+++ b/geonode/layers/ows.py
@@ -28,6 +28,7 @@ from owslib.coverage.wcsBase import ServiceException
 from owslib.util import http_post
 import urllib
 from geonode import GeoNodeException
+from geonode.utils import ogc_server_settings
 
 logger = logging.getLogger(__name__)
 
@@ -129,7 +130,7 @@ def wps_execute_layer_attribute_statistics(layer_name, field):
     """Derive aggregate statistics from WPS endpoint"""
 
     # generate statistics using WPS
-    url = '%s/ows' % (settings.OGC_SERVER['default']['LOCATION'])
+    url = '%s/ows' % (ogc_server_settings.LOCATION)
 
     # TODO: use owslib.wps.WebProcessingService for WPS interaction
     # this requires GeoServer's WPS gs:Aggregate function to

--- a/geonode/layers/tests.py
+++ b/geonode/layers/tests.py
@@ -757,7 +757,7 @@ class LayersTest(TestCase):
         layer.save()
 
         # Test that the method returns authorized=True if it's a datastore
-        if settings.OGC_SERVER['default']['OPTIONS']['DATASTORE']:
+        if settings.OGC_SERVER['default']['DATASTORE']:
             # The check was moved from the template into the view
             response = c.post(reverse('feature_edit_check', args=(valid_layer_typename,)))
             response_json = json.loads(response.content)

--- a/geonode/layers/utils.py
+++ b/geonode/layers/utils.py
@@ -45,6 +45,7 @@ from geonode.geoserver.helpers import cascading_delete, get_sld_for, delete_from
 from geonode.layers.metadata import set_metadata
 from geonode.security.enumerations import AUTHENTICATED_USERS, ANONYMOUS_USERS
 from geonode.base.models import SpatialRepresentationType
+from geonode.utils import ogc_server_settings
 
 # Geoserver functionality
 import geoserver
@@ -344,7 +345,7 @@ def save(layer, base_file, user, overwrite=True, title=None,
                 'gathering extra files', name)
     if the_layer_type == FeatureType.resource_type:
         logger.debug('Uploading vector layer: [%s]', base_file)
-        if settings.OGC_SERVER['default']['OPTIONS']['DATASTORE'] != '':
+        if ogc_server_settings.DATASTORE:
             create_store_and_resource = _create_db_featurestore
         else:
             create_store_and_resource = _create_featurestore
@@ -723,13 +724,13 @@ def _create_db_featurestore(name, data, overwrite=False, charset="UTF-8"):
     (and delete the PostGIS table for it).
     """
     cat = Layer.objects.gs_catalog
-    dsname = settings.OGC_SERVER['default']['OPTIONS']['DATASTORE']
+    dsname = ogc_server_settings.DATASTORE
 
     try:
         ds = cat.get_store(dsname)
     except FailedRequestError:
         ds = cat.create_datastore(dsname)
-        db = settings.DATABASES[dsname]
+        db = ogc_server_settings.datastore_db
         db_engine = 'postgis' if \
             'postgis' in db['ENGINE'] else db['ENGINE']
         ds.connection_parameters.update(

--- a/geonode/maps/models.py
+++ b/geonode/maps/models.py
@@ -45,7 +45,7 @@ from geonode.utils import GXPLayerBase
 from geonode.utils import layer_from_viewer_config
 from geonode.utils import default_map_config
 from geonode.utils import forward_mercator
-from geonode.utils import http_client
+from geonode.utils import http_client, ogc_server_settings
 
 from geoserver.catalog import Catalog
 from geoserver.layer import Layer as GsLayer
@@ -53,7 +53,7 @@ from agon_ratings.models import OverallRating
 
 logger = logging.getLogger("geonode.maps.models")
 
-_user, _password = settings.OGC_SERVER['default']['USER'], settings.OGC_SERVER['default']['PASSWORD']
+_user, _password = ogc_server_settings.credentials
 
 class Map(ResourceBase, GXPMapBase):
     """
@@ -206,7 +206,7 @@ class Map(ResourceBase, GXPMapBase):
 
     def _render_thumbnail(self, spec):
         http = httplib2.Http()
-        url = "%srest/printng/render.png" % settings.OGC_SERVER['default']['LOCATION']
+        url = "%srest/printng/render.png" % ogc_server_settings.LOCATION
         hostname = urlparse(settings.SITEURL).hostname
         params = dict(width=198, height=98, auth="%s,%s,%s" % (hostname, _user, _password))
         url = url + "?" + urllib.urlencode(params)
@@ -270,7 +270,7 @@ class Map(ResourceBase, GXPMapBase):
         # with the WMS parser.
         p = "&".join("%s=%s"%item for item in params.items())
 
-        return '<img src="%s"/>' % (settings.OGC_SERVER['default']['LOCATION'] + "wms/reflect?" + p)
+        return '<img src="%s"/>' % (ogc_server_settings.LOCATION + "wms/reflect?" + p)
 
     class Meta:
         # custom permissions,
@@ -357,7 +357,7 @@ class Map(ResourceBase, GXPMapBase):
             map_layers.append(MapLayer(
                 map = self,
                 name = layer.typename,
-                ows_url = settings.OGC_SERVER['default']['LOCATION'] + "wms",
+                ows_url = ogc_server_settings.LOCATION + "wms",
                 stack_order = index,
                 visibility = True
             ))
@@ -503,9 +503,8 @@ def pre_save_maplayer(instance, sender, **kwargs):
     if kwargs.get('raw', False):
         return
 
-    url = "%srest" % settings.OGC_SERVER['default']['LOCATION']
     try:
-        c = Catalog(url, _user, _password)
+        c = Catalog(ogc_server_settings.rest, _user, _password)
         instance.local = isinstance(c.get_layer(instance.name),GsLayer)
     except EnvironmentError, e:
         if e.errno == errno.ECONNREFUSED:

--- a/geonode/maps/views.py
+++ b/geonode/maps/views.py
@@ -47,11 +47,11 @@ from geonode.maps.forms import MapForm
 from geonode.security.enumerations import AUTHENTICATED_USERS, ANONYMOUS_USERS
 from geonode.security.views import _perms_info
 from geonode.documents.models import get_related_documents
-
+from geonode.utils import ogc_server_settings
 
 logger = logging.getLogger("geonode.maps.views")
 
-_user, _password = settings.OGC_SERVER['default']['USER'], settings.OGC_SERVER['default']['PASSWORD']
+_user, _password = ogc_server_settings.credentials
 
 DEFAULT_MAPS_SEARCH_BATCH_SIZE = 10
 MAX_MAPS_SEARCH_BATCH_SIZE = 25
@@ -331,7 +331,7 @@ def new_map_config(request):
                 layers.append(MapLayer(
                     map = map_obj,
                     name = layer.typename,
-                    ows_url = settings.OGC_SERVER['default']['LOCATION'] + "wms",
+                    ows_url = ogc_server_settings.ows,
                     layer_params=json.dumps( layer.attribute_config()),
                     visibility = True
                 ))
@@ -378,7 +378,7 @@ def map_download(request, mapid, template='maps/map_download.html'):
 
     map_status = dict()
     if request.method == 'POST':
-        url = "%srest/process/batchDownload/launch/" % settings.OGC_SERVER['default']['LOCATION']
+        url = "%srest/process/batchDownload/launch/" % ogc_server_settings.LOCATION
 
         def perm_filter(layer):
             return request.user.has_perm('layers.view_layer', obj=layer)
@@ -424,7 +424,7 @@ def map_download(request, mapid, template='maps/map_download.html'):
          "locked_layers": locked_layers,
          "remote_layers": remote_layers,
          "downloadable_layers": downloadable_layers,
-         "geoserver" : settings.OGC_SERVER['default']['LOCATION'],
+         "geoserver" : ogc_server_settings.LOCATION,
          "site" : settings.SITEURL
     }))
 
@@ -436,7 +436,7 @@ def map_download_check(request):
     try:
         layer = request.session["map_status"]
         if type(layer) == dict:
-            url = "%srest/process/batchDownload/status/%s" % (settings.OGC_SERVER['default']['LOCATION'],layer["id"])
+            url = "%srest/process/batchDownload/status/%s" % (ogc_server_settings.LOCATION,layer["id"])
             resp,content = http_client.request(url,'GET')
             status= resp.status
             if resp.status == 400:

--- a/geonode/middleware.py
+++ b/geonode/middleware.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from django.utils import simplejson as json
 
 from geonode.security.enumerations import AUTHENTICATED_USERS, ANONYMOUS_USERS
+from geonode.utils import ogc_server_settings
 
 class PrintProxyMiddleware(object):
     def process_request(self, request):
@@ -17,7 +18,7 @@ def print_map(request):
     permissions = {}
     params = json.loads(request.body)
     for layer in params['layers']:
-        if settings.OGC_SERVER['default']['LOCATION'] in layer['baseURL']:
+        if ogc_server_settings.LOCATION in layer['baseURL']:
             for layer_name in layer['layers']:
                 layer_obj = Layer.objects.get(typename=layer_name)
                 permissions[layer_obj] = {}

--- a/geonode/proxy/views.py
+++ b/geonode/proxy/views.py
@@ -23,6 +23,7 @@ from httplib import HTTPConnection
 from urlparse import urlsplit
 import httplib2
 from django.conf import settings
+from geonode.utils import ogc_server_settings
 
 def proxy(request):
     if 'url' not in request.GET:
@@ -68,10 +69,10 @@ def geoserver_rest_proxy(request, proxy_path, downstream_path):
         return path[len(prefix):]
 
     path = strip_prefix(request.get_full_path(), proxy_path)
-    url = "".join([settings.OGC_SERVER['default']['LOCATION'], downstream_path, path])
+    url = "".join([ogc_server_settings.LOCATION, downstream_path, path])
 
     http = httplib2.Http()
-    http.add_credentials(*(settings.OGC_SERVER['default']['USER'], settings.OGC_SERVER['default']['PASSWORD']))
+    http.add_credentials(*(ogc_server_settings.credentials))
     headers = dict()
 
     if request.method in ("POST", "PUT") and "CONTENT_TYPE" in request.META:

--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -400,15 +400,13 @@ OGC_SERVER = {
         'LOCATION' : 'http://localhost:8080/geoserver/',
         'USER' : 'admin',
         'PASSWORD' : 'geoserver',
-        'OPTIONS' : {
-            'MAPFISH_PRINT_ENABLED' : True,
-            'PRINTNG_ENABLED' : True,
-            'GEONODE_SECURITY_ENABLED' : True,
-            'GEOGIT_ENABLED' : False,
-            'WMST_ENABLED' : False,
-            # Set to name of database in DATABASES dictionary to enable
-            'DATASTORE': '', #'datastore',
-        }
+        'MAPFISH_PRINT_ENABLED' : True,
+        'PRINTNG_ENABLED' : True,
+        'GEONODE_SECURITY_ENABLED' : True,
+        'GEOGIT_ENABLED' : True,
+        'WMST_ENABLED' : False,
+        # Set to name of database in DATABASES dictionary to enable
+        'DATASTORE': '', #'datastore',
     }
 }
 

--- a/geonode/upload/forms.py
+++ b/geonode/upload/forms.py
@@ -20,6 +20,7 @@ from django import forms
 from django.conf import settings
 from geonode.layers.forms import JSONField
 from geonode.upload.models import UploadFile 
+from geonode.utils import ogc_server_settings
 import os
 import tempfile
 import files
@@ -48,7 +49,7 @@ class LayerUploadForm(forms.Form):
     spatial_files = ("base_file", "dbf_file", "shx_file", "prj_file", "sld_file", "xml_file")
 
     def clean(self):
-        requires_datastore = () if settings.OGC_SERVER['default']['OPTIONS']['DATASTORE'] else ('csv','kml')
+        requires_datastore = () if ogc_server_settings.DATASTORE else ('csv','kml')
         types = [ t for t in files.types if t.code not in requires_datastore]
         supported_type = lambda ext: any([t.matches(ext) for t in types])
 

--- a/geonode/upload/models.py
+++ b/geonode/upload/models.py
@@ -20,6 +20,7 @@ from geonode.maps.models import Layer
 
 from geonode.geoserver.uploader.uploader import NotFound
 from geonode.upload.utils import gs_uploader
+from geonode.utils import ogc_server_settings
 
 from django.conf import settings
 from django.contrib.auth.models import User
@@ -96,7 +97,7 @@ class Upload(models.Model):
         return reverse('data_upload_delete', args=[self.import_id])
         
     def get_import_url(self):
-        return "%srest/imports/%s" % (settings.OGC_SERVER['default']['LOCATION'], self.import_id)
+        return "%srest/imports/%s" % (ogc_server_settings.LOCATION, self.import_id)
     
     def delete(self, cascade=True):
         models.Model.delete(self)

--- a/geonode/upload/upload.py
+++ b/geonode/upload/upload.py
@@ -46,6 +46,7 @@ from geonode.upload import signals
 from geonode.upload.utils import create_geoserver_db_featurestore
 from geonode.upload.utils import find_file_re
 from geonode.upload.utils import gs_uploader
+from geonode.utils import ogc_server_settings
 
 import geoserver
 from geoserver.resource import Coverage
@@ -295,16 +296,14 @@ def run_import(upload_session, async):
 
     # if a target datastore is configured, ensure the datastore exists
     # in geoserver and set the uploader target appropriately
-    if (hasattr(settings, 'GEOGIT_DATASTORE') and settings.GEOGIT_DATASTORE and
-        upload_session.geogit == True and
-        import_session.tasks[0].items[0].layer.layer_type != 'RASTER'):
+    if (ogc_server_settings.GEOGIT_ENABLED and upload_session.geogit == True and import_session.tasks[0].items[0].layer.layer_type != 'RASTER'):
         target = create_geoserver_db_featurestore(store_type='geogit', store_name = upload_session.geogit_store)
         _log('setting target datastore %s %s',
              target.name, target.workspace.name
             )
         import_session.tasks[0].set_target(
             target.name, target.workspace.name)
-    elif (settings.OGC_SERVER['default']['OPTIONS']['DATASTORE'] != '' and
+    elif (ogc_server_settings.DATASTORE and
         import_session.tasks[0].items[0].layer.layer_type != 'RASTER'):
         target = create_geoserver_db_featurestore(store_type='postgis', store_name = upload_session.geogit_store)
         _log('setting target datastore %s %s',

--- a/geonode/upload/utils.py
+++ b/geonode/upload/utils.py
@@ -28,11 +28,11 @@ from geonode.geoserver.uploader.uploader import Uploader
 from geonode.layers.models import Layer
 from geonode.utils import _user, _password
 from geoserver.catalog import FailedRequestError
+from geonode.utils import ogc_server_settings
 
 
 def gs_uploader():
-    url = "%srest" % settings.OGC_SERVER['default']['LOCATION']
-    return Uploader(url, _user, _password)
+    return Uploader(ogc_server_settings.rest, _user, _password)
 
 
 def get_upload_type(filename):
@@ -127,15 +127,15 @@ def rename_and_prepare(base_file):
 
 def create_geoserver_db_featurestore(store_type=None, store_name=None):
     cat = Layer.objects.gs_catalog
-    dsname = settings.OGC_SERVER['default']['OPTIONS']['DATASTORE']
+    dsname = ogc_server_settings.DATASTORE
     # get or create datastore
     try:
-        if store_type == 'geogit' and hasattr(settings, 'GEOGIT_DATASTORE_NAME') and settings.GEOGIT_DATASTORE_NAME:
+        if store_type == 'geogit' and ogc_server_settings.GEOGIT_ENABLED:
             if store_name is not None:
                 ds = cat.get_store(store_name)
             else:
                 ds = cat.get_store(settings.GEOGIT_DATASTORE_NAME)
-        elif dsname != '':
+        elif dsname:
             ds = cat.get_store(dsname)
         else:
             return None
@@ -156,7 +156,7 @@ def create_geoserver_db_featurestore(store_type=None, store_name=None):
             logging.info(
                 'Creating target datastore ' % dsname)
             ds = cat.create_datastore(dsname)
-            db = settings.DATABASES[dsname]
+            db = ogc_server_settings.datastore_db
             ds.connection_parameters.update(
                 host = db['HOST'],
                 port = db['PORT'],

--- a/geonode/upload/views.py
+++ b/geonode/upload/views.py
@@ -39,6 +39,7 @@ from geonode.upload import upload
 from geonode.upload.utils import rename_and_prepare, find_sld, get_upload_type
 from geonode.upload.forms import UploadFileForm
 from geonode.base.enumerations import CHARSETS
+from geonode.utils import ogc_server_settings
 from geonode.geoserver.uploader import uploader
 
 from django.conf import settings
@@ -63,8 +64,7 @@ logger = logging.getLogger(__name__)
 
 _SESSION_KEY = 'geonode_upload_session'
 _ALLOW_TIME_STEP = getattr(settings, "UPLOADER_SHOW_TIME_STEP", False)
-_ASYNC_UPLOAD = 'DATASTORE' in settings.OGC_SERVER['default']['OPTIONS'] and \
-                bool(settings.OGC_SERVER['default']['OPTIONS'].get('DATASTORE', str()))
+_ASYNC_UPLOAD = True if ogc_server_settings.DATASTORE else False
 
 # at the moment, the various time support transformations require the database
 if _ALLOW_TIME_STEP and not _ASYNC_UPLOAD:

--- a/geonode/utils.py
+++ b/geonode/utils.py
@@ -22,32 +22,137 @@ import base64
 import re
 import math
 
+from threading import local
 from urlparse import urlparse
-
+from collections import namedtuple
 from django.conf import settings
-from django.core.exceptions import PermissionDenied
+from django.core.exceptions import PermissionDenied, ImproperlyConfigured
 from django.utils.translation import ugettext_lazy as _
 from django.contrib.auth.models import User
 from django.shortcuts import get_object_or_404
 from django.utils import simplejson as json
 from owslib.wms import WebMapService
 from django.http import HttpResponse
-
 from geonode.security.enumerations import AUTHENTICATED_USERS, ANONYMOUS_USERS, INVALID_PERMISSION_MESSAGE
+
+
+class ServerDoesNotExist(Exception):
+    pass
+
+if not (getattr(settings, 'OGC_SERVER', False) and getattr(settings, 'OGC_SERVER', dict()).get('default', False)):
+    raise ImproperlyConfigured("You must define an OGC_SERVER setting.")
+
+class OGC_Server(object):
+    """
+    OGC Server object.
+    """
+    def __init__(self, ogc_server, alias):
+        self.alias = alias
+        self.server = ogc_server
+
+    def __getattr__(self, item):
+        return self.server.get(item)
+
+    @property
+    def credentials(self):
+        """
+        Returns a tuple of the server's credentials.
+        """
+        creds = namedtuple('OGC_SERVER_CREDENTIALS', ['username', 'password'])
+        return creds(username=self.USER, password=self.PASSWORD)
+
+    @property
+    def datastore_db(self):
+        """
+        Returns the server's datastore dict or None.
+        """
+        if self.DATASTORE and settings.DATABASES.get(self.DATSTORE, None):
+            return settings.DATABASES.get(self.DATASTORE, dict())
+        else:
+            return dict()
+
+    @property
+    def ows(self):
+        """
+        The Open Web Service url for the server.
+        """
+        return self.LOCATION + 'wms' if not self.OWS_LOCATION else self.OWS_LOCATION
+
+    @property
+    def rest(self):
+        """
+        The REST endpoint for the server.
+        """
+        return self.LOCATION + 'rest' if not self.REST_LOCATION else self.REST_LOCATION
+
+    def __str__(self):
+        return self.alias
+
+class OGC_Servers_Handler(object):
+    """
+    OGC Server Settings Convenience dict.
+    """
+    def __init__(self, ogc_server_dict):
+        self.servers = ogc_server_dict
+        self._servers = local()
+
+    def ensure_defaults(self, alias):
+        """
+        Puts the defaults into the settings dictionary for a given connection
+        where no settings is provided.
+        """
+        try:
+            server = self.servers[alias]
+        except KeyError:
+            raise ServerDoesNotExist("The server %s doesn't exist" % alias)
+
+        server.setdefault('BACKEND', 'geonode.geoserver')
+        server.setdefault('LOCATION', 'http://localhost:8080/geoserver/')
+        server.setdefault('USER', 'admin')
+        server.setdefault('PASSWORD', 'geoserver')
+        server.setdefault('DATASTORE', str())
+
+        for option in ['MAPFISH_PRINT_ENABLED', 'PRINTING_ENABLED', 'GEONODE_SECURITY_ENABLED']:
+            server.setdefault(option, True)
+
+        for option in ['GEOGIT_ENABLED', 'WMST_ENABLED']:
+            server.setdefault(option, False)
+
+    def __getitem__(self, alias):
+        if hasattr(self._servers, alias):
+            return getattr(self._servers, alias)
+
+        self.ensure_defaults(alias)
+        server = self.servers[alias]
+        server = OGC_Server(alias=alias, ogc_server=server)
+        setattr(self._servers, alias, server)
+        return server
+
+    def __setitem__(self, key, value):
+        setattr(self._servers, key, value)
+
+    def __iter__(self):
+        return iter(self.servers)
+
+    def all(self):
+        return [self[alias] for alias in self]
+
+
+ogc_server_settings = OGC_Servers_Handler(settings.OGC_SERVER)['default']
 
 _wms = None
 _csw = None
-_user, _password = settings.OGC_SERVER['default']['USER'], settings.OGC_SERVER['default']['PASSWORD']
+_user, _password = ogc_server_settings.credentials
 
 http_client = httplib2.Http()
 http_client.add_credentials(_user, _password)
 http_client.add_credentials(_user, _password)
-_netloc = urlparse(settings.OGC_SERVER['default']['LOCATION']).netloc
+_netloc = urlparse(ogc_server_settings.LOCATION).netloc
 http_client.authorizations.append(
     httplib2.BasicAuthentication(
         (_user, _password),
         _netloc,
-        settings.OGC_SERVER['default']['LOCATION'],
+        ogc_server_settings.LOCATION,
         {},
         None,
         None,
@@ -63,16 +168,16 @@ def check_geonode_is_up():
     """Verifies all geoserver is running,
        this is needed to be able to upload.
     """
-    url = "%sweb/" % settings.OGC_SERVER['default']['LOCATION']
+    url = "%sweb/" % ogc_server_settings.LOCATION
     resp, content = http_client.request(url, "GET")
     msg = ('Cannot connect to the GeoServer at %s\nPlease make sure you '
-           'have started it.' % settings.OGC_SERVER['default']['LOCATION'])
+           'have started it.' % ogc_server_settings.LOCATION)
     assert resp['status'] == '200', msg
        
 
 def get_wms():
     global _wms
-    wms_url = settings.OGC_SERVER['default']['LOCATION'] + "wms?request=GetCapabilities&version=1.1.0"
+    wms_url = ogc_server_settings.LOCATION + "wms?request=GetCapabilities&version=1.1.0"
     netloc = urlparse(wms_url).netloc
     http = httplib2.Http()
     http.add_credentials(_user, _password)

--- a/geonode/views.py
+++ b/geonode/views.py
@@ -24,6 +24,7 @@ from django.http import HttpResponse, HttpResponseRedirect
 from django.core.urlresolvers import reverse
 from django.utils import simplejson as json
 from django.conf import settings
+from geonode.utils import ogc_server_settings
 
 def index(request, template='index.html'):
     from geonode.search.views import search_page
@@ -117,7 +118,7 @@ def _fixup_ows_url(thumb_spec):
     # so rendering of thumbnails fails - replace those uri's with full geoserver URL
     import re
     gspath = '"/geoserver/wms' # this should be in img src attributes
-    repl = '"' + settings.OGC_SERVER['default']['LOCATION'] + "/wms"
+    repl = '"' + ogc_server_settings.LOCATION + "/wms"
     return re.sub(gspath, repl, thumb_spec)
 
 def err403(request):


### PR DESCRIPTION
The good:
- Removes the OPTIONS dict.  The OPTIONS dict in the DATABASES setting in Django is used to pass kwargs to the db backend, which is not how we were using it.
- We can store commonly used logic as methods on the OGC_Server class.
- Attributes on OGC_Server instances are translated into get() calls to the server dict which avoid KeyErrors and common if statements.
- Will support mulitiple servers.

The bad:
- No KeyErrors can lead to mistakes.
- Another change to our settings.py (which touches 20 files).
- Tests are in geonode/base/tests.py, the logic is in geonode/utils.py
- Values are called with mix case: ogc_server_settings.LOCATION.
