### PR TITLE
Remove the 'Who can edit this data?' div if in the upload are there are ...

### DIFF
--- a/geonode/static/geonode/js/upload/upload.js
+++ b/geonode/static/geonode/js/upload/upload.js
@@ -113,7 +113,12 @@ define(['underscore',
      */
     displayFiles = function (file_queue) {
         file_queue.empty();
+        
+        var permission_edit = $("#permission-edit")
 
+        permission_edit.show();
+        var hasFullPermissionsWidget = false;
+        
         $.each(layers, function (name, info) {
             if (!info.type) {
                 log_error({
@@ -123,10 +128,14 @@ define(['underscore',
                 delete layers[name];
             } else {
                 info.display(file_queue);
+                if(info.type.format=='vector'){
+                    hasFullPermissionsWidget = true;
+                };
             }
         });
+        
+        if(!hasFullPermissionsWidget){permission_edit.hide()};
     };
-
 
     /** Function to ...
      *

--- a/geonode/templates/_permissions.html
+++ b/geonode/templates/_permissions.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 <div class="modal-body" id="permissions-body" >
-  <div class="control-group">
+  <div class="control-group" id="permission-view-download" >
     <label class="control-label"><strong>{% trans "Who can view and download this data?" %}</strong></label>
     <div class="controls">
       <label class="radio inline">
@@ -17,7 +17,7 @@
       </label>
     </div>
   </div>
-  <div class="control-group">
+  <div class="control-group" id="permission-edit" >
     <label class="control-label"><strong>{% trans "Who can edit this data?" %}</strong></label>
     <div class="controls">
       <label class="radio">


### PR DESCRIPTION
This removes the 'Who can edit this data?' div if in the upload area there are only rasters. Refs #603.
I do not know requires.js and so on, so I hope it is the correct location to make the change.

Now we should consider if to leave the label "Who can manage and edit this data?" or change it to just "Who can manage this data", so it would work well for both vector and raster datasets (I am +1 for this solution).
I could change this label by js as well, but I cannot figure out how to support internationalization in such a case (I would need to change the label text {% trans "Who can manage and edit this data?" %} ).
