### PR TITLE
Adds the GEOGIT_DATASTORE_DIR settings variable.

### DIFF
--- a/geonode/base/tests.py
+++ b/geonode/base/tests.py
@@ -99,6 +99,7 @@ class UtilsTests(TestCase):
                     'BACKEND_WRITE_ENABLED': True,
                     'WPS_ENABLED' : False,
                     'DATASTORE': str(),
+                    'GEOGIT_DATASTORE_DIR': str(),
             }
         }
 

--- a/geonode/upload/utils.py
+++ b/geonode/upload/utils.py
@@ -148,7 +148,7 @@ def create_geoserver_db_featurestore(store_type=None, store_name=None):
             ds = cat.create_datastore(store_name)
             ds.type = "GeoGIT"
             ds.connection_parameters.update(
-                geogit_repository=store_name,
+                geogit_repository=os.path.join(ogc_server_settings.GEOGIT_DATASTORE_DIR, store_name),
                 create="true")
             cat.save(ds)
             ds = cat.get_store(store_name)

--- a/geonode/utils.py
+++ b/geonode/utils.py
@@ -120,6 +120,7 @@ class OGC_Servers_Handler(object):
         server.setdefault('USER', 'admin')
         server.setdefault('PASSWORD', 'geoserver')
         server.setdefault('DATASTORE', str())
+        server.setdefault('GEOGIT_DATASTORE_DIR', str())
 
         for option in ['MAPFISH_PRINT_ENABLED', 'PRINTING_ENABLED', 'GEONODE_SECURITY_ENABLED', 'BACKEND_WRITE_ENABLED']:
             server.setdefault(option, True)


### PR DESCRIPTION
Yet another OGC_SERVER settings variable.  This one allows the admin to specify a default directory to create new geogit stores in.  I'll add this to the OGC_SERVER settings documentation when I finish it. 
