### PR TITLE
Fix #1266

### DIFF
--- a/geonode/maps/templates/maps/map_geoexplorer.js
+++ b/geonode/maps/templates/maps/map_geoexplorer.js
@@ -5,7 +5,7 @@
     display: none;
 }
 #paneltbar {
-    margin-top: 90px;
+    margin-top: 81px;
 }
 button.logout {
     display: none;


### PR DESCRIPTION
Removes extra spacing between header and geoexplorer frame
