### PR TITLE
make social optional

### DIFF
--- a/geonode/documents/templates/documents/document_detail.html
+++ b/geonode/documents/templates/documents/document_detail.html
@@ -154,6 +154,7 @@
   {% include "_permissions_form.html" %}
 {% endblock %}
 {% block extra_script %}
+{% if SOCIAL_BUTTONS %}
 <div id="fb-root"></div>
 <script>(function(d, s, id) {
   var js, fjs = d.getElementsByTagName(s)[0];
@@ -162,7 +163,7 @@
   js.src = "//connect.facebook.net/en_US/all.js#xfbml=1";
   fjs.parentNode.insertBefore(js, fjs);
 }(document, 'script', 'facebook-jssdk'));</script>
-
+{% endif %}
     {% if request.user.is_authenticated %}
         {% user_rating_js request.user document "document" %}
     {% else %}
@@ -179,19 +180,16 @@
             score: {{ the_doc_rating }}
             {% endif %}
         });
+        var activeTab = $('[href=' + location.hash + ']');
+        activeTab && activeTab.tab('show');
     });
-    </script>
-    <script>
-        $(function () {
-            var activeTab = $('[href=' + location.hash + ']');
-            activeTab && activeTab.tab('show');
-        });
-
+        {% if SOCIAL_BUTTONS %}
         (function() {
             var po = document.createElement('script'); po.type = 'text/javascript'; po.async = true;
             po.src = 'https://apis.google.com/js/plusone.js';
             var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(po, s);
         })();
+        {% endif %}
     </script>
     {% include "_permissions_form_js.html" %}
 {% endblock extra_script %}

--- a/geonode/layers/templates/layers/layer_detail.html
+++ b/geonode/layers/templates/layers/layer_detail.html
@@ -235,14 +235,17 @@
   {% endif %}
 {% endblock %}
 {% block extra_script %}
+{% if SOCIAL_BUTTONS %}
 <div id="fb-root"></div>
-<script>(function(d, s, id) {
+<script>
+(function(d, s, id) {
   var js, fjs = d.getElementsByTagName(s)[0];
   if (d.getElementById(id)) {return;}
   js = d.createElement(s); js.id = id;
   js.src = "//connect.facebook.net/en_US/all.js#xfbml=1";
   fjs.parentNode.insertBefore(js, fjs);
 }(document, 'script', 'facebook-jssdk'));</script>
+{% endif %}
 
     {% if request.user.is_authenticated %}
         {% user_rating_js request.user layer "layer" %}
@@ -260,19 +263,16 @@
             score: {{ the_layer_rating }}
             {% endif %}
         });
+        var activeTab = $('[href=' + location.hash + ']');
+        activeTab && activeTab.tab('show');
     });
-    </script>
-    <script>
-        $(function () {
-            var activeTab = $('[href=' + location.hash + ']');
-            activeTab && activeTab.tab('show');
-        });
-
+    {% if SOCIAL_BUTTONS %}
         (function() {
             var po = document.createElement('script'); po.type = 'text/javascript'; po.async = true;
             po.src = 'https://apis.google.com/js/plusone.js';
             var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(po, s);
         })();
+    {% endif %}
         $("#comment_submit_btn").click(function(event) {
             $.ajax({
               type: "POST",

--- a/geonode/maps/templates/maps/map_detail.html
+++ b/geonode/maps/templates/maps/map_detail.html
@@ -179,6 +179,7 @@
 {% endblock %}
 
 {% block extra_script %}
+{% if SOCIAL_BUTTONS %}
 <div id="fb-root"></div>
 <script>(function(d, s, id) {
   var js, fjs = d.getElementsByTagName(s)[0];
@@ -187,7 +188,7 @@
   js.src = "//connect.facebook.net/en_US/all.js#xfbml=1";
   fjs.parentNode.insertBefore(js, fjs);
 }(document, 'script', 'facebook-jssdk'));</script>
-
+{% endif %}
 {% if request.user.is_authenticated %}
       {% user_rating_js request.user map "map" %}
 {% else %}
@@ -247,13 +248,13 @@
 
 
  });
-
+{% if SOCIAL_BUTTONS %}
  (function() {
    var po = document.createElement('script'); po.type = 'text/javascript'; po.async = true;
    po.src = 'https://apis.google.com/js/plusone.js';
    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(po, s);
  })();
-
+{% endif %}
   $("#comment_submit_btn").click(function(event) {
     $.ajax({
       type: "POST",

--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -569,6 +569,7 @@ LEAFLET_CONFIG = {
     'TILES_URL': 'http://{s}.tile2.opencyclemap.org/transport/{z}/{x}/{y}.png'
 }
 
+SOCIAL_BUTTONS = True
 
 # Require users to authenticate before using Geonode
 LOCKDOWN_GEONODE = False

--- a/geonode/templates/base.html
+++ b/geonode/templates/base.html
@@ -134,6 +134,7 @@
                 </ul>
               </nav>
             </div> <!-- ./span10 -->
+            {% if SOCIAL_BUTTONS %}
             <div class="span2">
               <ul class="social">
                   <li><a href="http://www.facebook.com/sharer.php?u=http://{{ request.get_host }}{{ request.get_full_path }}" class="fb">facebook</a></li>
@@ -141,6 +142,7 @@
                   <li><a href="https://plusone.google.com/_/1/confirm?hl=en&url=http://{{ request.get_host }}{{ request.get_full_path }}" class="gp">google+</a></li>
               </ul>
             </div> <!-- /.span2 -->
+            {% endif %}
           </div> <!-- /.row nav-box -->
         </div> <!-- /.container -->
         </section>


### PR DESCRIPTION
adds a config for the social buttons, to be included.  

Also cleans up any glaringly ridiculous JavaScript/html that happened to be next to where I needed to modify the templates (e.g. two inline script tags next to each other, or multiple closures next to each other)
