### PR TITLE
Improve security for the proxy view.  Fixes #1308.

### DIFF
--- a/docs/reference/developers/settings.txt
+++ b/docs/reference/developers/settings.txt
@@ -306,6 +306,29 @@ Default: ``'http://localhost:8000/'``
 
 A base URL for use in creating absolute links to Django views and generating links in metadata.
 
+Proxy settings
+==============
+
+PROXY_ALLOWED_HOSTS
+-------------------
+Default: ``()`` (Empty tuple)
+
+A tuple of strings representing the host/domain names that GeoNode can proxy requests to. This is a security measure
+to prevent an attacker from using the GeoNode proxy to render malicious code or access internal sites.
+
+Values in this tuple can be fully qualified names (e.g. 'www.geonode.org'), in which case they will be matched against
+the request’s Host header exactly (case-insensitive, not including port). A value beginning with a period can be used
+as a subdomain wildcard: ``.geonode.org`` will match geonode.org, www.geonode.org, and any other subdomain of
+geonode.org. A value of '*' will match anything and is not recommended for production deployments.
+
+
+PROXY_URL
+---------
+Default ``/proxy?url=``
+
+The url to a proxy that will be used when making client-side requests in GeoNode.  By default, the
+internal GeoNode proxy is used but administrators may favor using their own, less restrictive proxies.
+
 Search settings
 ===============
 

--- a/geonode/context_processors.py
+++ b/geonode/context_processors.py
@@ -43,5 +43,6 @@ def resource_urls(request):
         DEBUG_STATIC = getattr(settings, "DEBUG_STATIC", False),
         MF_PRINT_ENABLED = ogc_server_settings.MAPFISH_PRINT_ENABLED,
         PRINTNG_ENABLED = ogc_server_settings.PRINTNG_ENABLED,
-        GS_SECURITY_ENABLED = ogc_server_settings.GEONODE_SECURITY_ENABLED
+        GS_SECURITY_ENABLED = ogc_server_settings.GEONODE_SECURITY_ENABLED,
+        PROXY_URL = getattr(settings, 'PROXY_URL', '/proxy/?url=')
     )

--- a/geonode/layers/templates/layers/layer_geoext_map.html
+++ b/geonode/layers/templates/layers/layer_geoext_map.html
@@ -14,7 +14,7 @@
                     actionTarget: "main.tbar",
                     outputConfig: {width: 400, height: 200, panIn: false}
                 }],
-                proxy: "/proxy/?url=",
+                proxy: {{ PROXY_URL }},
                 localGeoServerBaseUrl: "{{GEOSERVER_BASE_URL}}",
                 authorizedRoles: "{{ user.is_authenticated|yesno:"ROLE_ADMINISTRATOR,ROLE_ANONYMOUS" }}",
 

--- a/geonode/maps/templates/maps/map_embed.html
+++ b/geonode/maps/templates/maps/map_embed.html
@@ -15,7 +15,7 @@
         var config = {
             useCapabilities: false,
             useToolbar: false,
-            proxy: "/proxy/?url=",
+            proxy: '{{ PROXY_URL }}',
             {% if MF_PRINT_ENABLED %}
             printService: "{{GEOSERVER_BASE_URL}}pdf/",
             {% else %}

--- a/geonode/maps/templates/maps/map_geoexplorer.js
+++ b/geonode/maps/templates/maps/map_geoexplorer.js
@@ -27,7 +27,7 @@ Ext.onReady(function() {
     GeoExt.Lang.set("{{ LANGUAGE_CODE }}");
     var config = Ext.apply({
         authStatus: {% if user.is_authenticated %} 200{% else %} 401{% endif %},
-        proxy: "/proxy/?url=",
+        proxy: '{{ PROXY_URL }}',
         {% if PRINTNG_ENABLED %}
         listeners: {
             'save': function(obj_id) {

--- a/geonode/maps/templates/maps/map_include.html
+++ b/geonode/maps/templates/maps/map_include.html
@@ -14,7 +14,7 @@ Ext.onReady(function() {
             outputConfig: {width: 400, height: 200, panIn: false}
         }],
         useToolbar: true,
-        proxy: "/proxy/?url=",
+        proxy: '{{ PROXY_URL }}',
         {% if MF_PRINT_ENABLED %}
         printService: "{{GEOSERVER_BASE_URL}}pdf/",
         {% else %}

--- a/geonode/maps/templates/maps/map_sdk.js
+++ b/geonode/maps/templates/maps/map_sdk.js
@@ -12,7 +12,7 @@ Ext.onReady(function() {
 {% autoescape off %}
     var config = Ext.apply({
         authStatus: {% if user.is_authenticated %} 200{% else %} 401{% endif %},
-        proxy: "/proxy/?url=",
+        proxy: '{{ PROXY_URL }}',
         {% if MF_PRINT_ENABLED %}
         printService: "{{GEOSERVER_BASE_URL}}pdf/",
         {% else %}

--- a/geonode/proxy/tests.py
+++ b/geonode/proxy/tests.py
@@ -24,5 +24,41 @@ unittest). These will both pass when you run "manage.py test".
 
 Replace these with more appropriate tests for your application.
 """
+from django.conf import settings
+from django.contrib.auth.models import User
+from django.core.urlresolvers import reverse
+from django.test import TestCase, Client
+from django.test.utils import override_settings, str_prefix
+from geonode.proxy.views import validate_host
+from geonode.utils import ogc_server_settings
 
-from django.test import TestCase
+class ProxyTest(TestCase):
+
+    def setUp(self):
+        self.admin, created = User.objects.get_or_create(username='admin', password='admin', is_superuser=True)
+
+    @override_settings(DEBUG=True, PROXY_ALLOWED_HOSTS=())
+    def test_validate_host_disabled_in_debug(self):
+        """If PROXY_ALLOWED_HOSTS is empty and DEBUG is True, all hosts pass the proxy."""
+        c = Client()
+        response = c.get('/proxy?url=http://www.google.com', follow=True)
+        self.assertEqual(response.status_code, 200)
+
+    @override_settings(DEBUG=False, PROXY_ALLOWED_HOSTS=())
+    def test_validate_host_disabled_not_in_debug(self):
+        """If PROXY_ALLOWED_HOSTS is empty and DEBUG is False requests should return 403."""
+        c = Client()
+        response = c.get('/proxy?url=http://www.google.com', follow=True)
+        self.assertEqual(response.status_code, 403)
+
+
+    @override_settings(DEBUG=False, PROXY_ALLOWED_HOSTS=('.google.com',))
+    def test_proxy_allowed_host(self):
+        """If PROXY_ALLOWED_HOSTS is empty and DEBUG is False requests should return 403."""
+        c = Client()
+        response = c.get('/proxy?url=http://www.google.com', follow=True)
+        self.assertEqual(response.status_code, 200)
+
+
+
+

--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -581,8 +581,18 @@ AUTH_EXEMPT_URLS = ()
 if LOCKDOWN_GEONODE:
     MIDDLEWARE_CLASSES = MIDDLEWARE_CLASSES + ('geonode.security.middleware.LoginRequiredMiddleware',)
 
+
+# A tuple of hosts the proxy can send requests to.
+PROXY_ALLOWED_HOSTS = ()
+
+# The proxy to use when making cross origin requests.
+PROXY_URL = '/proxy?url='
+
+
 # Load more settings from a file called local_settings.py if it exists
 try:
     from local_settings import *
 except ImportError:
     pass
+
+

--- a/geonode/utils.py
+++ b/geonode/utils.py
@@ -34,7 +34,7 @@ from django.utils import simplejson as json
 from owslib.wms import WebMapService
 from django.http import HttpResponse
 from geonode.security.enumerations import AUTHENTICATED_USERS, ANONYMOUS_USERS, INVALID_PERMISSION_MESSAGE
-
+from urlparse import urlsplit
 
 class ServerDoesNotExist(Exception):
     pass
@@ -107,6 +107,14 @@ class OGC_Server(object):
         The internal REST endpoint for the server.
         """
         return self.LOCATION + 'rest'
+
+    @property
+    def hostname(self):
+        return urlsplit(self.LOCATION).hostname
+
+    @property
+    def netloc(self):
+        return urlsplit(self.LOCATION).netloc
 
     def __str__(self):
         return self.alias


### PR DESCRIPTION
- In production, the proxy will only respond to hosts  listed in the settings.PROXY_ALLOWED_HOSTS tuple and the OGC_SERVER hostname.
- Remove the pass through authentication headers.  Pass through authentication headers were getting added to requests outside of their respective realm.
- Add a PROXY_URL setting so administrators can use proxies other than the GeoNode proxy.
- Only forward session cookies to the OWS url since commit ef1cf1 states that session cookies can influence local OWS GetCapabilities requests.
