### PR TITLE
Rename files inside zip to match new layer name

### DIFF
--- a/geonode/layers/utils.py
+++ b/geonode/layers/utils.py
@@ -46,7 +46,7 @@ from geonode.layers.metadata import set_metadata
 from geonode.security.enumerations import AUTHENTICATED_USERS, ANONYMOUS_USERS
 from geonode.base.models import SpatialRepresentationType
 from geonode.utils import ogc_server_settings
-from geonode.upload.files import _clean_string
+from geonode.upload.files import _clean_string, _rename_zip
 # Geoserver functionality
 import geoserver
 from geoserver.catalog import FailedRequestError, UploadError
@@ -373,6 +373,8 @@ def save(layer, base_file, user, overwrite=True, title=None,
     #FIXME: DONT DO THIS
     #-------------------
     if 'shp' not in files:
+        if files['base'][-4:] == ".zip":
+            _rename_zip(files['base'], name)
         main_file = files['base']
         data = main_file
     # ------------------

--- a/geonode/upload/files.py
+++ b/geonode/upload/files.py
@@ -25,6 +25,7 @@ scattered over the codebase
 import os.path
 from geoserver.resource import FeatureType
 from geoserver.resource import Coverage
+from tempfile import mkstemp
 
 import zipfile
 import os
@@ -127,7 +128,24 @@ def _rename_files(file_names):
             os.rename(f, safe)
             renamed.append(safe)
     return renamed
-            
+
+
+def _rename_zip(old_name, valid_name):
+    """Rename files inside zip """
+    handle, tempfile = mkstemp()
+    old_zip = zipfile.ZipFile(old_name, 'r')
+    new_zip = zipfile.ZipFile(open(tempfile, "wb"), "w")
+
+    files_zip = old_zip.namelist()
+    files = ['.shp', '.prj', '.shx', '.dbf', '.sld']
+    for file in files_zip:
+        name, ext = os.path.splitext(file)
+        if ext.lower() in files:
+            files.remove(ext) #OS X creates hidden subdirectory with garbage files having same extensions; ignore.
+            new_zip.writestr(valid_name + ext, old_zip.read(file))
+    old_zip.close()
+    new_zip.close()
+    os.rename(tempfile,old_name)
 
 def _find_sld_files(file_names):
     return filter( lambda f: f.lower().endswith('.sld'), file_names)
@@ -181,3 +199,4 @@ def scan_file(file_name):
                             "matching files were found for them.")
                 
     return found
+


### PR DESCRIPTION
Fix for https://github.com/GeoNode/geonode/issues/1319

TODO: Call the new _rename_zip method when using the geonode importer module - currently seems  broken (https://github.com/GeoNode/geonode/issues/1312)
