### PR TITLE
use wgs84 for geojson

### DIFF
--- a/geonode/layers/ows.py
+++ b/geonode/layers/ows.py
@@ -93,7 +93,7 @@ def wfs_links(wfs_url, identifier):
             ("gml", _("GML 3.1.1"), "text/xml; subtype=gml/3.1.1", {}),
             ("csv", _("CSV"), "csv", {}),
             ("excel", _("Excel"), "excel", {}),
-            ("json", _("GeoJSON"), "json", {})
+            ("json", _("GeoJSON"), "json", {'srsName': 'EPSG:4326'})
      ]
      output = []
      for ext, name, mime, extra_params in types:


### PR DESCRIPTION
The GeoJSON downloads should default to WGS84 (EPSG:4326), this is a much saner default for this format.
