### PR TITLE
Change advertised property test in gs_slurp to account for gsconfig variations

### DIFF
--- a/geonode/geoserver/helpers.py
+++ b/geonode/geoserver/helpers.py
@@ -280,13 +280,13 @@ def gs_slurp(ignore_errors=True, verbosity=1, console=None, owner=None, workspac
         # filter out layers for delete comparison with GeoNode layers by following criteria:
         # enabled = true, if --skip-unadvertised: advertised = true, but disregard the filter parameter in the case of deleting layers
         resources_for_delete_compare = [k for k in resources_for_delete_compare if k.enabled == "true"]
-        if skip_unadvertised: resources_for_delete_compare = [k for k in resources_for_delete_compare if k.advertised == "true" or k.advertised == None]
+        if skip_unadvertised: resources_for_delete_compare = [k for k in resources_for_delete_compare if k.advertised == "true" or k.advertised == True or k.advertised is None]
     if filter:
         resources = [k for k in resources if filter in k.name]
 
     # filter out layers depending on enabled, advertised status:
     resources = [k for k in resources if k.enabled == "true"]
-    if skip_unadvertised: resources = [k for k in resources if k.advertised == "true" or k.advertised == None]
+    if skip_unadvertised: resources = [k for k in resources if k.advertised == "true" or k.advertised == True or k.advertised is None]
     
     # TODO: Should we do something with these?
     # i.e. look for matching layers in GeoNode and also disable? 


### PR DESCRIPTION
There are a differences in the 'advertised' property default value settings in Featuretype and Coverage in different gsconfig versions out there.  Trunk defaults to 'true' whereas 0.6.7 uses True.  Anyway, either should add these extra checks in or release a new version of gsconfig with latest changes in trunk.

This applies when GeoServer REST API is lacking the <advertised> element.  
