### PR TITLE
Altered WCS link generation method width/height

### DIFF
--- a/geonode/layers/models.py
+++ b/geonode/layers/models.py
@@ -37,7 +37,7 @@ from django.core.urlresolvers import reverse
 from geonode import GeoNodeException
 from geonode.base.models import ResourceBase, ResourceBaseManager, Link, \
     resourcebase_post_save, resourcebase_post_delete
-from geonode.utils import  _user, _password, get_wms
+from geonode.utils import _user, _password, get_wms
 from geonode.utils import http_client
 from geonode.geoserver.helpers import cascading_delete
 from geonode.people.models import Profile
@@ -48,6 +48,7 @@ from geonode.layers.enumerations import LAYER_ATTRIBUTE_NUMERIC_DATA_TYPES
 from geonode.utils import ogc_server_settings
 
 from geoserver.catalog import Catalog, FailedRequestError
+from owslib.wcs import WebCoverageService
 from agon_ratings.models import OverallRating
 
 logger = logging.getLogger("geonode.layers.models")
@@ -307,7 +308,7 @@ def pre_delete_layer(instance, sender, **kwargs):
         if style.layer_styles.all().count()==1:
             if style != default_style:
                 style.delete()
-    
+
 def post_delete_layer(instance, sender, **kwargs):
     """
     Removed the layer from any associated map, if any.
@@ -413,7 +414,7 @@ def geoserver_post_save(instance, sender, **kwargs):
        to be saved to the database before accessing them.
     """
     url = ogc_server_settings.internal_rest
-    
+
     try:
         gs_catalog = Catalog(url, _user, _password)
         gs_resource = gs_catalog.get_resource(instance.name)
@@ -489,8 +490,13 @@ def geoserver_post_save(instance, sender, **kwargs):
         permissions['authenticated'] = instance.get_gen_level(AUTHENTICATED_USERS)
         instance.set_gen_level(ANONYMOUS_USERS,'layer_readonly')
 
+        #Potentially 3 dimensions can be returned by the grid if there is a z
+        #axis.  Since we only want width/height, slice to the second dimension
+        covWidth, covHeight = get_coverage_grid_extent(instance)[:2]
         links = wcs_links(ogc_server_settings.public_url + 'wcs?', instance.typename.encode('utf-8'),
-            bbox=instance.bbox[:-1], crs=instance.bbox[-1], height=height, width=width)
+                          bbox=gs_resource.native_bbox[:-1],
+                          crs=gs_resource.native_bbox[-1],
+                          height=str(covHeight), width=str(covWidth))
         for ext, name, mime, wcs_url in links:
             Link.objects.get_or_create(resource= instance.resourcebase_ptr,
                                 url=wcs_url,
@@ -501,7 +507,7 @@ def geoserver_post_save(instance, sender, **kwargs):
                                     link_type='data',
                                 )
                             )
-            
+
         instance.set_gen_level(ANONYMOUS_USERS,permissions['anonymous'])
         instance.set_gen_level(AUTHENTICATED_USERS,permissions['authenticated'])
 
@@ -634,6 +640,18 @@ def get_attribute_statistics(layer_name, field):
         return wps_execute_layer_attribute_statistics(layer_name, field)
     except Exception:
         logger.exception('Error generating layer aggregate statistics')
+
+
+def get_coverage_grid_extent(instance):
+    """
+        Returns a list of integers with the size of the coverage
+        extent in pixels
+    """
+
+    wcs = WebCoverageService(ogc_server_settings.public_url + 'wcs', '1.0.0')
+    grid = wcs.contents[instance.workspace + ':' + instance.name].grid
+    return [(int(h) - int(l) + 1) for
+            h, l in zip(grid.highlimits, grid.lowlimits)]
 
 
 def set_attributes(layer, overwrite=False):

--- a/geonode/layers/ows.py
+++ b/geonode/layers/ows.py
@@ -29,6 +29,7 @@ from owslib.util import http_post
 import urllib
 from geonode import GeoNodeException
 from geonode.utils import ogc_server_settings
+from re import sub
 
 logger = logging.getLogger(__name__)
 
@@ -66,10 +67,16 @@ def wcs_links(wcs_url, identifier, bbox=None, crs=None, height=None, width=None,
         for f in formats:
             if exclude_formats and f in DEFAULT_EXCLUDE_FORMATS:
                 continue
-            url = wcs.getCoverage(identifier=coverage.id, format=f, bbox=bbox, crs=crs, 
-                height=height, width=width).geturl()
+            #roundabout, hacky way to accomplish getting a getCoverage url.
+            #nonetheless, it's better than having to load an entire large
+            #coverage just to generate a URL
+            fakeUrl = wcs.getCoverage(identifier=coverage.id, format=f,
+                                      bbox=bbox, crs=crs, height=20,
+                                      width=20).geturl()
+            url = sub(r'(height=)20(\&width=)20', r'\g<1>{0}\g<2>{1}',
+                         fakeUrl).format(height, width)
             # The outputs are: (ext, name, mime, url)
-            # FIXME(Ariel): Find a way to get proper ext, name and mime 
+            # FIXME(Ariel): Find a way to get proper ext, name and mime
             # using format as a default for all is not good enough
             output.append((f, f, f, url))
     return output
@@ -86,7 +93,7 @@ def _wfs_link(wfs_url, identifier, mime, extra_params):
     return wfs_url + urllib.urlencode(params)
 
 
-def wfs_links(wfs_url, identifier): 
+def wfs_links(wfs_url, identifier):
      types = [
             ("zip", _("Zipped Shapefile"), "SHAPE-ZIP", {'format_options': 'charset:UTF-8'}),
             ("gml", _("GML 2.0"), "gml2", {}),
@@ -141,7 +148,7 @@ def wps_execute_layer_attribute_statistics(layer_name, field):
                                'layer_name': 'geonode:%s' %  layer_name,
                                'field': field
                               })
-     
+
     response = http_post(url, request, timeout=ogc_server_settings.TIMEOUT)
 
     exml = etree.fromstring(response)
@@ -154,7 +161,7 @@ def wps_execute_layer_attribute_statistics(layer_name, field):
             result[f] = fr.text
         else:
             result[f] = 'NA'
-   
+
     count = exml.find('Count')
     if count is not None:
         result['Count'] = int(count.text)
@@ -172,7 +179,7 @@ def wps_execute_layer_attribute_statistics(layer_name, field):
 
         response = http_post(url, request, timeout=ogc_server_settings.TIMEOUT)
 
-        exml = etree.fromstring(response)    
+        exml = etree.fromstring(response)
 
         values = []
 
@@ -180,5 +187,5 @@ def wps_execute_layer_attribute_statistics(layer_name, field):
             if value is not None:
                 values.append(value.text)
         result['unique_values'] = ','.join(values)
- 
+
     return result


### PR DESCRIPTION
Fixes #1356; WCS links should now return their native grid height and width
based on the WCS describeCoverage spatial grid.
Also changed how links are generated so that when fetching URLs on
very coverages the server does not need to issue several getCoverage for the
 entire grid extent of the coverage, which would ordinarily bog down the server
for large coverages.
