### PR TITLE
Generate thumbnails for documents.

### DIFF
--- a/README
+++ b/README
@@ -18,7 +18,7 @@ If instead, you are interested in doing development on the source code, here are
     sudo apt-get update
 
     # Essential build tools and libraries
-    sudo apt-get install -y build-essential libxml2-dev libxslt1-dev
+    sudo apt-get install -y build-essential libxml2-dev libxslt1-dev imagemagick
 
     # Python native dependencies
     sudo apt-get install -y python-dev python-imaging python-lxml python-pyproj python-shapely python-nose python-httplib2 python-pip python-software-properties
@@ -169,6 +169,10 @@ Mac OSX Development Build Instructions::
 
     paver setup
     paver start
+
+    # Optional: To generate document thumbnails of PDFs and other file types
+    # Then download ghostscript: https://www.macupdate.com/app/mac/9980/gpl-ghostscript
+    brew install imagemagick
 
 Once fully started, you should see a message indicating the address of your geonode.
 The default username and password are ``admin`` and ``admin``::

--- a/geonode/base/models.py
+++ b/geonode/base/models.py
@@ -169,6 +169,10 @@ class ThumbnailMixin(object):
         if render is None:
             raise Exception('Must have _render_thumbnail(spec) function')
         image = render(spec)
+
+        if not image:
+            return
+
         #Clean any orphan Thumbnail before
         Thumbnail.objects.filter(resourcebase__id=None).delete()
         

--- a/geonode/documents/templates/documents/_document_list_item.html
+++ b/geonode/documents/templates/documents/_document_list_item.html
@@ -9,8 +9,8 @@
 <article>
   <div class="content">
     <!-- <div class="abstract-placeholder">{{ document.abstract }}</div> -->
-    <div class="icon-placeholder"><i class="icon-file-text-alt"></i></div>
     <div class="item-header">
+        <a href="{% url "document_detail" document.id %}"><img class="thumb" src="{{ document.get_thumbnail_url }}" /></a>
       <h3><i class="icon-file-text-alt"></i> <a href="{% url "document_detail" document.id %}">{{ document.title }}</a></h3>
     </div>
     <div class="details">

--- a/geonode/documents/views.py
+++ b/geonode/documents/views.py
@@ -125,7 +125,6 @@ def document_upload(request):
         if not doc_file.size < settings.MAX_DOCUMENT_SIZE * 1024 * 1024:
             return HttpResponse(_('This file is too big.'))
 
-        
         document = Document(content_type=content_type, object_id=object_id, title=title, doc_file=doc_file)
         document.owner = request.user
         document.save()
@@ -264,7 +263,7 @@ def document_replace(request, docid, template='documents/document_replace.html')
     document = _resolve_document(request, docid, 'documents.change_document')
 
     if request.method == 'GET':
-        return render_to_response(template,RequestContext(request, {
+        return render_to_response(template, RequestContext(request, {
             "document": document
         }))
     if request.method == 'POST':
@@ -274,8 +273,9 @@ def document_replace(request, docid, template='documents/document_replace.html')
             return HttpResponse('This file is too big.')
 
         doc_file = request.FILES['file']
-        document.doc_file=doc_file
+        document.doc_file = doc_file
         document.save()
+        document.update_thumbnail()
         return HttpResponseRedirect(reverse('document_detail', args=(document.id,)))
 
 @login_required

--- a/scripts/cloud/fabfile.py
+++ b/scripts/cloud/fabfile.py
@@ -49,7 +49,7 @@ ACT = 'source ' + GEONODEDIR + '/bin/activate'
 # Install GeoNode dependencies
 def install_depend():
     sudo('cd %s; virtualenv geonode --system-site-packages;' % INSTALLDIR)
-    sudo('apt-get install -y gcc python-pastescript python-dev libxml2-dev libxslt1-dev openjdk-6-jdk python-psycopg2')
+    sudo('apt-get install -y gcc python-pastescript python-dev libxml2-dev libxslt1-dev openjdk-6-jdk python-psycopg2 imagemagick')
     # Web server
     sudo('apt-get install -y apache2 tomcat6 libapache2-mod-wsgi maven2')
     sudo("a2enmod proxy_http")

--- a/setup.py
+++ b/setup.py
@@ -114,6 +114,7 @@ setup(name='GeoNode',
         "MultipartPostHandler",
         # translation
         "transifex-client",
+        "Wand==0.3.5"
         ],
       zip_safe=False,
       )


### PR DESCRIPTION
Adds functionality to generate thumbnails for documents. 

**Dependencies:**
Ubuntu:
- Imagemagick (~50mb). (`apt-get install imagemagick`)
- Wand python library.

Mac:
- `brew install imagemagick`
- For PDF support, install the Ghostscript dmg (https://www.macupdate.com/app/mac/9980/gpl-ghostscript)
- Wand python library.

![screen shot 2013-11-21 at 11 03 05 am](https://f.cloud.github.com/assets/1141646/1593236/7f755588-52c8-11e3-957a-2e36c506405b.png)
