### PR TITLE
'Japanese' was wrongly translated as 'person' instead of 'language'

### DIFF
--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -79,7 +79,7 @@ LANGUAGES = (
     ('el', 'Ελληνικά'),
     ('id', 'Bahasa Indonesia'),
     ('zh-cn', '中文'),
-    ('ja', '日本人'),
+    ('ja', '日本語'),
     ('fa', 'Persian'),
     ('pt', 'Portuguese'),
     ('ru', 'Russian'),


### PR DESCRIPTION
A computer-translation error, I guess.
