### PR TITLE
Added a template at /avatar/add/ 

### DIFF
--- a/geonode/templates/avatar/add.html
+++ b/geonode/templates/avatar/add.html
@@ -1,0 +1,16 @@
+{% extends "site_base.html" %}
+{% load i18n avatar_tags %}
+{% load bootstrap_tags %}
+
+{% block body %}
+	<a href="{% url "profile_edit" user.username %}">{% trans "Back to edit your profile information" %}</a>
+	<p>{% trans "Your current avatar: " %}</p>
+    {% avatar user %}
+    {% if not avatars %}
+        <p>{% trans "You haven't uploaded an avatar yet. Please upload one now." %}</p>
+    {% endif %}
+    <form enctype="multipart/form-data" method="POST" action="{% url 'avatar_add' %}">
+        {{ upload_avatar_form.as_p }}
+        <p>{% csrf_token %}<input type="submit" value="{% trans "Upload New Image" %}" /></p>
+    </form>
+{% endblock %}


### PR DESCRIPTION
As reported by @capooti https://github.com/GeoNode/geonode/issues/1357, it gave error "Template does not exists" , It also gave the same error when clicking on upload without selecting an image.
