### PR TITLE
Fixed download link at document_list.html

### DIFF
--- a/geonode/documents/templates/documents/_document_list_item.html
+++ b/geonode/documents/templates/documents/_document_list_item.html
@@ -23,7 +23,7 @@
         </ul>
       </div>
       <div class="tools">
-        <p><a href="{% if document.doc_file %}{{ document.doc_file.url }}{% endif %}" class="btn btn-mini">{% trans "Download" %}</a></p>
+        <p><a href="{% if document.doc_file %}{% url "document_download" document.id %}{% endif %}" class="btn btn-mini">{% trans "Download" %}</a></p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
As reported by tosco in issue #1390 the download link was not accessible from document_list.html since it was pointing to the uploads folder of the server to which users did not have permissions to access, now changed the link so that it points to downloads folder instead.
