### PR TITLE
Fix inifinite redirection when trying to remove something while logged in but without the right permissions.

### DIFF
--- a/geonode/documents/views.py
+++ b/geonode/documents/views.py
@@ -282,15 +282,24 @@ def document_replace(request, docid, template='documents/document_replace.html')
 
 @login_required
 def document_remove(request, docid, template='documents/document_remove.html'):
-    document = _resolve_document(request, docid, 'documents.delete_document',
-                           _PERMISSION_MSG_DELETE)
+    try:
+        document = _resolve_document(request, docid, 'documents.delete_document',
+                               _PERMISSION_MSG_DELETE)
 
-    if request.method == 'GET':
-        return render_to_response(template,RequestContext(request, {
-            "document": document
-        }))
-    if request.method == 'POST':
-        document.delete()
-        return HttpResponseRedirect(reverse("documents_browse"))
-    else:
-        return HttpResponse("Not allowed",status=403)
+        if request.method == 'GET':
+            return render_to_response(template,RequestContext(request, {
+                "document": document
+            }))
+        if request.method == 'POST':
+            document.delete()
+            return HttpResponseRedirect(reverse("documents_browse"))
+        else:
+            return HttpResponse("Not allowed",status=403)
+
+    except PermissionDenied:
+        return HttpResponse(
+                'You are not allowed to delete this document',
+                mimetype="text/plain",
+                status=401
+        )
+

--- a/geonode/layers/views.py
+++ b/geonode/layers/views.py
@@ -497,19 +497,25 @@ def layer_replace(request, layername, template='layers/layer_replace.html'):
 
 @login_required
 def layer_remove(request, layername, template='layers/layer_remove.html'):
-    layer = _resolve_layer(request, layername, 'layers.delete_layer',
-                           _PERMISSION_MSG_DELETE)
+    try:
+        layer = _resolve_layer(request, layername, 'layers.delete_layer',
+                               _PERMISSION_MSG_DELETE)
 
-    if (request.method == 'GET'):
-        return render_to_response(template,RequestContext(request, {
-            "layer": layer
-        }))
-    if (request.method == 'POST'):
-        layer.delete()
-        return HttpResponseRedirect(reverse("layer_browse"))
-    else:
-        return HttpResponse("Not allowed",status=403)
-
+        if (request.method == 'GET'):
+            return render_to_response(template,RequestContext(request, {
+                "layer": layer
+            }))
+        if (request.method == 'POST'):
+            layer.delete()
+            return HttpResponseRedirect(reverse("layer_browse"))
+        else:
+            return HttpResponse("Not allowed",status=403)
+    except PermissionDenied:
+        return HttpResponse(
+                'You are not allowed to delete this layer',
+                mimetype="text/plain",
+                status=401
+        )
 
 def layer_batch_download(request):
     """

--- a/geonode/maps/views.py
+++ b/geonode/maps/views.py
@@ -201,22 +201,29 @@ def map_metadata(request, mapid, template='maps/map_metadata.html'):
 @login_required
 def map_remove(request, mapid, template='maps/map_remove.html'):
     ''' Delete a map, and its constituent layers. '''
-    map_obj = _resolve_map(request, mapid, 'maps.delete_map',
-                           _PERMISSION_MSG_DELETE, permission_required=True)
+    try:
+        map_obj = _resolve_map(request, mapid, 'maps.delete_map',
+                               _PERMISSION_MSG_DELETE, permission_required=True)
 
-    if request.method == 'GET':
-        return render_to_response(template, RequestContext(request, {
-            "map": map_obj
-        }))
+        if request.method == 'GET':
+            return render_to_response(template, RequestContext(request, {
+                "map": map_obj
+            }))
 
-    elif request.method == 'POST':
-        layers = map_obj.layer_set.all()
-        for layer in layers:
-            layer.delete()
-        map_obj.delete()
+        elif request.method == 'POST':
+            layers = map_obj.layer_set.all()
+            for layer in layers:
+                layer.delete()
+            map_obj.delete()
 
-        return HttpResponseRedirect(reverse("maps_browse"))
+            return HttpResponseRedirect(reverse("maps_browse"))
 
+    except PermissionDenied:
+            return HttpResponse(
+                   'You are not allowed to delete this map',
+                   mimetype="text/plain",
+                   status=401
+            )
 
 def map_embed(request, mapid=None, template='maps/map_embed.html'):
     if mapid is None:


### PR DESCRIPTION
When you tried to remove a map, a layer, or a document, logged in but without the permissions to do it, it got you into an infinite redirection. 
Catching the PermissionDenied exception sent by resolve_object fixes that.
We should also modify the templates so that when you have read/write permissions, but not manage permissions, it doesn't show the remove and change permissions buttons.
To do that, maybe we could check the role of the user instead of checking his permissions one by one since the buttons remove and change permissions should appears only if the user has admin right on the object.
