### PR TITLE
Readme documentation changes

### DIFF
--- a/README
+++ b/README
@@ -167,7 +167,7 @@ Mac OSX Development Build Instructions::
     npm install -g bower
     npm install -g grunt-cli
 
-        #Install pip dependencies
+    #Install pip dependencies
     pip install -e .
 
     #Paver handles dependencies for Geonode, first setup (this will download and update your python dependencies - ensure you're in a virtualenv)


### PR DESCRIPTION
On doing a fresh install at the Geonode developers meeting, I conducted a fresh install. Discussion has occurred with @ingenieroariel on this. As such I have updated the documents so that _pillow_ (which installs PIL) is installed and that the packages are installed in an editable mode. If this isn't completed then _paver setup_ fails. 
