### PR TITLE
Update README

### DIFF
--- a/README
+++ b/README
@@ -18,7 +18,7 @@ If instead, you are interested in doing development on the source code, here are
     sudo apt-get update
 
     # Essential build tools and libraries
-    sudo apt-get install -y build-essential libxml2-dev libxslt1-dev
+    sudo apt-get install -y build-essential libxml2-dev libxslt1-dev libjpeg-dev
 
     # Python native dependencies
     sudo apt-get install -y python-dev python-imaging python-lxml python-pyproj python-shapely python-nose python-httplib2 python-pip python-software-properties


### PR DESCRIPTION
Fixes missing dependency for jpeg decoder.  

The error caused when trying to upload a JPEG image as a document is:

```
Exception Type: IOError at /documents/upload
Exception Value: decoder jpeg not available
```

This brings the developer documentation (more) into line with that for production.
