### PR TITLE
Configuring GeoNode for Production notes

### DIFF
--- a/docs/tutorials/admin/production.txt
+++ b/docs/tutorials/admin/production.txt
@@ -130,6 +130,10 @@ To allow new user registration:
 
 4. With the Django application running, set the domain name of the service properly through the admin interface as specified above in the Sitemaps section.  (This domain name is used in the account activation emails.).
 
+5. Restart apache::
+
+       $ sudo service apache2 restart
+       
 To register as a new user, click the ''Register'' link in the GeoNode index header.
 
 Additional Configuration


### PR DESCRIPTION
Would it make sense to bring these changes?
The path to geoserver data dir by default is /usr/share/geoserver/data/ after an automatic installation of geonode that I did today.

the restart apache is needed to have the settings take effect? 
