### PR TITLE
autofill doc title on upload

### DIFF
--- a/geonode/documents/templates/documents/document_upload.html
+++ b/geonode/documents/templates/documents/document_upload.html
@@ -43,6 +43,11 @@
 {% endwith %}
 
 <script type="text/javascript">
+    $('#id_doc_file').on('change', function(){
+        if($('#id_title').val() == ''){
+            $('#id_title').val($('#id_doc_file').val());
+        }
+    });
     $("#resource").select2({
         minimumInputLength: 1,
         placeholder: 'Select layer, map or empty',


### PR DESCRIPTION
When you're uploading a document, if you skip over the document title and then select the file to upload, the title field will automatically be filled in with the title of the document file.
