### PR TITLE
Moves geoserver-specific url routes to the geoserver app.

### DIFF
--- a/geonode/geoserver/tests.py
+++ b/geonode/geoserver/tests.py
@@ -1,3 +1,4 @@
+import base64
 import json
 
 from django.core.exceptions import ImproperlyConfigured
@@ -6,7 +7,6 @@ from django.test import TestCase
 from django.core.urlresolvers import reverse
 from django.test.client import Client
 from django.test.utils import override_settings
-from geonode.base.models import ResourceBase
 from geonode.geoserver.helpers import OGC_Servers_Handler
 from geonode.search.populate_search_test_data import create_models
 from geonode.layers.populate_layers_data import create_layer_data
@@ -80,6 +80,96 @@ class LayerTests(TestCase):
             response = c.post(reverse('feature_edit_check', args=(valid_layer_typename,)))
             response_json = json.loads(response.content)
             self.assertEquals(response_json['authorized'], True)
+
+    def test_layer_acls(self):
+        """ Verify that the layer_acls view is behaving as expected
+        """
+
+        # Test that HTTP_AUTHORIZATION in request.META is working properly
+        valid_uname_pw = '%s:%s' % ('bobby','bob')
+        invalid_uname_pw = '%s:%s' % ('n0t', 'v@l1d')
+
+        valid_auth_headers = {
+            'HTTP_AUTHORIZATION': 'basic ' + base64.b64encode(valid_uname_pw),
+        }
+
+        invalid_auth_headers = {
+            'HTTP_AUTHORIZATION': 'basic ' + base64.b64encode(invalid_uname_pw),
+        }
+
+        # Test that requesting when supplying the geoserver credentials returns the expected json
+
+        expected_result = {
+             'email': 'bobby@bob.com',
+             'fullname': 'bobby',
+             'is_anonymous': False,
+             'is_superuser': False,
+             'name': 'bobby',
+             'ro': ['geonode:layer2',
+                    'geonode:mylayer',
+                    'geonode:foo',
+                    'geonode:whatever',
+                    'geonode:fooey',
+                    'geonode:quux',
+                    'geonode:fleem'],
+             'rw': ['base:CA']
+        }
+        c = Client()
+        response = c.get(reverse('layer_acls'), **valid_auth_headers)
+        response_json = json.loads(response.content)
+        self.assertEquals(expected_result, response_json)
+
+        # Test that requesting when supplying invalid credentials returns the appropriate error code
+        response = c.get(reverse('layer_acls'), **invalid_auth_headers)
+        self.assertEquals(response.status_code, 401)
+
+        # Test logging in using Djangos normal auth system
+        c.login(username='admin', password='admin')
+
+        # Basic check that the returned content is at least valid json
+        response = c.get(reverse('layer_acls'))
+        response_json = json.loads(response.content)
+
+        self.assertEquals('admin', response_json['fullname'])
+        self.assertEquals('', response_json['email'])
+
+        # TODO Lots more to do here once jj0hns0n understands the ACL system better
+
+    def test_resolve_user(self):
+        """Verify that the resolve_user view is behaving as expected
+        """
+        # Test that HTTP_AUTHORIZATION in request.META is working properly
+        valid_uname_pw = "%s:%s" % ('admin', 'admin')
+        invalid_uname_pw = "%s:%s" % ("n0t", "v@l1d")
+
+        valid_auth_headers = {
+            'HTTP_AUTHORIZATION': 'basic ' + base64.b64encode(valid_uname_pw),
+        }
+
+        invalid_auth_headers = {
+            'HTTP_AUTHORIZATION': 'basic ' + base64.b64encode(invalid_uname_pw),
+        }
+
+        c = Client()
+        response = c.get(reverse('layer_resolve_user'), **valid_auth_headers)
+        response_json = json.loads(response.content)
+        self.assertEquals({'geoserver': False, 'superuser': True, 'user': 'admin'}
+, response_json)
+
+        # Test that requesting when supplying invalid credentials returns the appropriate error code
+        response = c.get(reverse('layer_acls'), **invalid_auth_headers)
+        self.assertEquals(response.status_code, 401)
+
+        # Test logging in using Djangos normal auth system
+        c.login(username='admin', password='admin')
+
+        # Basic check that the returned content is at least valid json
+        response = c.get(reverse('layer_resolve_user'))
+        response_json = json.loads(response.content)
+
+        self.assertEquals('admin', response_json['user'])
+        self.assertEquals('admin', response_json['fullname'])
+        self.assertEquals('', response_json['email'])
 
 
 class UtilsTests(TestCase):

--- a/geonode/geoserver/urls.py
+++ b/geonode/geoserver/urls.py
@@ -26,10 +26,10 @@ urlpatterns = patterns('geonode.geoserver.views',
             proxy_path='/gs/rest/layers', downstream_path='rest/layers')),
     url(r'^updatelayers/$', 'updatelayers', name="updatelayers"),
     url(r'^(?P<layername>[^/]*)/style$', 'layer_style', name="layer_style"),
-    url(r'^(?P<layername>[^/]*)/style/upload$','layer_style_upload',name='layer_style_upload'),
-    url(r'^(?P<layername>[^/]*)/style/manage$','layer_style_manage',name='layer_style_manage'),
-    url(r'^(?P<layername>[^/]*)/edit-check?$', 'feature_edit_check',
-        name="feature_edit_check"),
-
-
+    url(r'^(?P<layername>[^/]*)/style/upload$', 'layer_style_upload', name='layer_style_upload'),
+    url(r'^(?P<layername>[^/]*)/style/manage$', 'layer_style_manage', name='layer_style_manage'),
+    url(r'^(?P<layername>[^/]*)/edit-check?$', 'feature_edit_check', name="feature_edit_check"),
+    url(r'^acls/?$', 'layer_acls', name='layer_acls'),
+    url(r'^resolve_user/?$', 'resolve_user', name='layer_resolve_user'),
+    url(r'^download$', 'layer_batch_download', name='layer_batch_download'),
 )

--- a/geonode/layers/tests.py
+++ b/geonode/layers/tests.py
@@ -19,7 +19,6 @@
 #########################################################################
 
 import os
-import base64
 import shutil
 import tempfile
 
@@ -192,96 +191,6 @@ class LayersTest(TestCase):
 
         # Should we do this here, or assume the tests in
         # test_set_layer_permissions will handle for that?
-
-    def test_layer_acls(self):
-        """ Verify that the layer_acls view is behaving as expected
-        """
-
-        # Test that HTTP_AUTHORIZATION in request.META is working properly
-        valid_uname_pw = '%s:%s' % ('bobby','bob')
-        invalid_uname_pw = '%s:%s' % ('n0t', 'v@l1d')
-
-        valid_auth_headers = {
-            'HTTP_AUTHORIZATION': 'basic ' + base64.b64encode(valid_uname_pw),
-        }
-
-        invalid_auth_headers = {
-            'HTTP_AUTHORIZATION': 'basic ' + base64.b64encode(invalid_uname_pw),
-        }
-
-        # Test that requesting when supplying the geoserver credentials returns the expected json
-
-        expected_result = {
-             'email': 'bobby@bob.com',
-             'fullname': 'bobby',
-             'is_anonymous': False,
-             'is_superuser': False,
-             'name': 'bobby',
-             'ro': ['geonode:layer2',
-                    'geonode:mylayer',
-                    'geonode:foo',
-                    'geonode:whatever',
-                    'geonode:fooey',
-                    'geonode:quux',
-                    'geonode:fleem'],
-             'rw': ['base:CA']
-        }
-        c = Client()
-        response = c.get(reverse('layer_acls'), **valid_auth_headers)
-        response_json = json.loads(response.content)
-        self.assertEquals(expected_result, response_json)
-
-        # Test that requesting when supplying invalid credentials returns the appropriate error code
-        response = c.get(reverse('layer_acls'), **invalid_auth_headers)
-        self.assertEquals(response.status_code, 401)
-
-        # Test logging in using Djangos normal auth system
-        c.login(username='admin', password='admin')
-
-        # Basic check that the returned content is at least valid json
-        response = c.get(reverse('layer_acls'))
-        response_json = json.loads(response.content)
-
-        self.assertEquals('admin', response_json['fullname'])
-        self.assertEquals('', response_json['email'])
-
-        # TODO Lots more to do here once jj0hns0n understands the ACL system better
-
-    def test_resolve_user(self):
-        """Verify that the resolve_user view is behaving as expected
-        """
-        # Test that HTTP_AUTHORIZATION in request.META is working properly
-        valid_uname_pw = "%s:%s" % ('admin', 'admin')
-        invalid_uname_pw = "%s:%s" % ("n0t", "v@l1d")
-
-        valid_auth_headers = {
-            'HTTP_AUTHORIZATION': 'basic ' + base64.b64encode(valid_uname_pw),
-        }
-
-        invalid_auth_headers = {
-            'HTTP_AUTHORIZATION': 'basic ' + base64.b64encode(invalid_uname_pw),
-        }
-
-        c = Client()
-        response = c.get(reverse('layer_resolve_user'), **valid_auth_headers)
-        response_json = json.loads(response.content)
-        self.assertEquals({'geoserver': False, 'superuser': True, 'user': 'admin'}
-, response_json)
-
-        # Test that requesting when supplying invalid credentials returns the appropriate error code
-        response = c.get(reverse('layer_acls'), **invalid_auth_headers)
-        self.assertEquals(response.status_code, 401)
-
-        # Test logging in using Djangos normal auth system
-        c.login(username='admin', password='admin')
-
-        # Basic check that the returned content is at least valid json
-        response = c.get(reverse('layer_resolve_user'))
-        response_json = json.loads(response.content)
-
-        self.assertEquals('admin', response_json['user'])
-        self.assertEquals('admin', response_json['fullname'])
-        self.assertEquals('', response_json['email'])
 
     def test_perms_info(self):
         """ Verify that the perms_info view is behaving as expected

--- a/geonode/layers/urls.py
+++ b/geonode/layers/urls.py
@@ -18,7 +18,8 @@
 #
 #########################################################################
 
-from django.conf.urls.defaults import patterns, url
+from django.conf import settings
+from django.conf.urls.defaults import include, patterns, url
 
 js_info_dict = {
     'packages': ('geonode.layers',),
@@ -28,10 +29,7 @@ urlpatterns = patterns(
     'geonode.layers.views',
     url(r'^$', 'layer_list', name='layer_browse'),
     url(r'^tag/(?P<slug>[-\w]+?)/$', 'layer_tag', name='layer_browse_tag'),
-    url(r'^acls/?$', 'layer_acls', name='layer_acls'),
-    url(r'^resolve_user/?$', 'resolve_user', name='layer_resolve_user'),
     url(r'^upload$', 'layer_upload', name='layer_upload'),
-    url(r'^download$', 'layer_batch_download', name='layer_batch_download'),
     url(r'^(?P<layername>[^/]*)$', 'layer_detail', name="layer_detail"),
     url(r'^(?P<layername>[^/]*)/metadata$', 'layer_metadata',
         name="layer_metadata"),
@@ -42,3 +40,17 @@ urlpatterns = patterns(
     #    name='batch_permssions'),
     #url(r'^api/batch_delete/?$', 'batch_delete', name='batch_delete'),
 )
+
+# -- Deprecated url routes for Geoserver authentication -- remove after GeoNode 2.1
+# -- Use /gs/acls, gs/resolve_user/, gs/download instead
+if 'geonode.geoserver' in settings.INSTALLED_APPS:
+    urlpatterns = patterns('geonode.geoserver.views',
+        url(r'^acls/?$', 'layer_acls', name='layer_acls_dep'),
+        url(r'^resolve_user/?$', 'resolve_user', name='layer_resolve_user_dep'),
+        url(r'^download$', 'layer_batch_download', name='layer_batch_download_dep'),
+    ) + urlpatterns
+
+
+
+
+

--- a/geonode/layers/views.py
+++ b/geonode/layers/views.py
@@ -22,7 +22,6 @@ import os
 import logging
 import shutil
 
-from django.contrib.auth import authenticate, get_backends as get_auth_backends
 from django.contrib.auth.decorators import login_required
 from django.core.urlresolvers import reverse
 from django.core.exceptions import PermissionDenied
@@ -34,10 +33,8 @@ from django.utils.translation import ugettext as _
 from django.utils import simplejson as json
 from django.utils.html import escape
 from django.template.defaultfilters import slugify
-from django.shortcuts import get_object_or_404
 from django.forms.models import inlineformset_factory
 
-from geonode.utils import _get_basic_auth_info
 from geonode.layers.forms import LayerForm, LayerUploadForm, NewLayerUploadForm, LayerAttributeForm
 from geonode.layers.models import Layer, Attribute
 from geonode.base.enumerations import CHARSETS
@@ -364,152 +361,5 @@ def layer_remove(request, layername, template='layers/layer_remove.html'):
                 status=401
         )
 
-def layer_batch_download(request):
-    """
-    batch download a set of layers
 
-    POST - begin download
-    GET?id=<download_id> monitor status
-    """
-
-    from geonode.utils import http_client, _get_basic_auth_info
-    # currently this just piggy-backs on the map download backend
-    # by specifying an ad hoc map that contains all layers requested
-    # for download. assumes all layers are hosted locally.
-    # status monitoring is handled slightly differently.
-
-    if request.method == 'POST':
-        layers = request.POST.getlist("layer")
-        layers = Layer.objects.filter(typename__in=list(layers))
-
-        def layer_son(layer):
-            return {
-                "name" : layer.typename,
-                "service" : layer.service_type,
-                "metadataURL" : "",
-                "serviceURL" : ""
-            }
-
-        readme = """This data is provided by GeoNode.\n\nContents:"""
-        def list_item(lyr):
-            return "%s - %s.*" % (lyr.title, lyr.name)
-
-        readme = "\n".join([readme] + [list_item(l) for l in layers])
-
-        fake_map = {
-            "map": { "readme": readme },
-            "layers" : [layer_son(lyr) for lyr in layers]
-        }
-
-        url = "%srest/process/batchDownload/launch/" % ogc_server_settings.LOCATION
-        resp, content = http_client.request(url,'POST',body=json.dumps(fake_map))
-        return HttpResponse(content, status=resp.status)
-
-
-    if request.method == 'GET':
-        # essentially, this just proxies back to geoserver
-        download_id = request.GET.get('id', None)
-        if download_id is None:
-            return HttpResponse(status=404)
-
-        url = "%srest/process/batchDownload/status/%s" % (ogc_server_settings.LOCATION, download_id)
-        resp,content = http_client.request(url,'GET')
-        return HttpResponse(content, status=resp.status)
-
-def resolve_user(request):
-    user = None
-    geoserver = False
-    superuser = False
-    if 'HTTP_AUTHORIZATION' in request.META:
-        username, password = _get_basic_auth_info(request)
-        acl_user = authenticate(username=username, password=password)
-        if acl_user:
-            user = acl_user.username
-            superuser = acl_user.is_superuser
-        elif _get_basic_auth_info(request) == ogc_server_settings.credentials:
-            geoserver = True
-            superuser = True
-        else:
-            return HttpResponse(_("Bad HTTP Authorization Credentials."),
-                                status=401,
-                                mimetype="text/plain")
-    if not any([user, geoserver, superuser]) and not request.user.is_anonymous():
-        user = request.user.username
-        superuser = request.user.is_superuser
-    resp = {
-        'user' : user,
-        'geoserver' : geoserver,
-        'superuser' : superuser,
-    }
-    if request.user.is_authenticated():
-        resp['fullname'] = request.user.profile.name
-        resp['email'] = request.user.profile.email
-    return HttpResponse(json.dumps(resp))
-
-
-def layer_acls(request):
-    from geonode.utils import http_client, _get_basic_auth_info
-    """
-    returns json-encoded lists of layer identifiers that
-    represent the sets of read-write and read-only layers
-    for the currently authenticated user.
-    """
-
-    # the layer_acls view supports basic auth, and a special
-    # user which represents the geoserver administrator that
-    # is not present in django.
-    acl_user = request.user
-    if 'HTTP_AUTHORIZATION' in request.META:
-        try:
-            username, password = _get_basic_auth_info(request)
-            acl_user = authenticate(username=username, password=password)
-
-            # Nope, is it the special geoserver user?
-            if (acl_user is None and
-                username == ogc_server_settings.USER and
-                password == ogc_server_settings.PASSWORD):
-                # great, tell geoserver it's an admin.
-                result = {
-                   'rw': [],
-                   'ro': [],
-                   'name': username,
-                   'is_superuser':  True,
-                   'is_anonymous': False
-                }
-                return HttpResponse(json.dumps(result), mimetype="application/json")
-        except Exception:
-            pass
-
-        if acl_user is None:
-            return HttpResponse(_("Bad HTTP Authorization Credentials."),
-                                status=401,
-                                mimetype="text/plain")
-    all_readable = set()
-    all_writable = set()
-    for bck in get_auth_backends():
-        if hasattr(bck, 'objects_with_perm'):
-            all_readable.update(bck.objects_with_perm(acl_user,
-                                                      'layers.view_layer',
-                                                      Layer))
-            all_writable.update(bck.objects_with_perm(acl_user,
-                                                      'layers.change_layer',
-                                                      Layer))
-    read_only = [x for x in all_readable if x not in all_writable]
-    read_write = [x for x in all_writable if x in all_readable]
-
-    read_only = [x[0] for x in Layer.objects.filter(id__in=read_only).values_list('typename').all()]
-    read_write = [x[0] for x in Layer.objects.filter(id__in=read_write).values_list('typename').all()]
-
-    result = {
-        'rw': read_write,
-        'ro': read_only,
-        'name': acl_user.username,
-        'is_superuser':  acl_user.is_superuser,
-        'is_anonymous': acl_user.is_anonymous(),
-    }
-    if acl_user.is_authenticated():
-        result['fullname'] = acl_user.profile.name
-        result['email'] = acl_user.profile.email
-
-    return HttpResponse(json.dumps(result), mimetype="application/json")
 

--- a/geonode/security/middleware.py
+++ b/geonode/security/middleware.py
@@ -15,7 +15,9 @@ class LoginRequiredMiddleware(object):
         reverse('jscat'),
         reverse('lang'),
         reverse('layer_acls'),
+        reverse('layer_acls_dep'),
         reverse('layer_resolve_user'),
+        reverse('layer_resolve_user_dep'),
         '/account/(?!.*(?:signup))', # block unauthenticated users from creating new accounts.
         '/static/*',
     )


### PR DESCRIPTION
**What does this PR do?**
Moves the `/layers/acls`, `/layers/resolve_user` and `layers/download` URL routes to the `geonode.geoserver` application. 

**Backwards compatibility.**
For now, the old URL routes (using the `/layer` prefix) still work, but should be removed once legacy code is updated. 

**Issues**
None.
