### PR TITLE
Add missing layers' sources in map composer

### DIFF
--- a/geonode/utils.py
+++ b/geonode/utils.py
@@ -21,6 +21,7 @@ import httplib2
 import base64
 import re
 import math
+import copy
 
 from urlparse import urlparse
 from collections import namedtuple
@@ -343,6 +344,16 @@ class GXPMapBase(object):
                 settings.MAP_BASELAYERS[0]['source']['title'] = 'Local Geoserver'
                 sources[str(int(keys[-1])+1)] = settings.MAP_BASELAYERS[0]['source']
 
+        def _base_source(source):
+            base_source = copy.deepcopy(source)
+            for key in ["id", "baseParams", "title"]:
+                if key in base_source: del base_source[key]
+            return base_source
+
+        for idx, lyr in enumerate(settings.MAP_BASELAYERS):
+            if _base_source(lyr["source"]) not in map(_base_source, sources.values()):
+                sources[str(int(max(sources.keys(), key=int)) +1)] = lyr["source"]
+                
         config = {
             'id': self.id,
             'about': {


### PR DESCRIPTION
When viewing an existing map (GeoNode map composer), only the sources for  the layers included in the map are available in the "View available data from" dropdown menu ("Add layers" tool). The complete list of sources (defined in MAP_BASELAYERS) is not available any more.

I think It is desirable to always add the missing layers' sources to dropdown menu. At least, it seems that many of our users have this need.

It is true that a missing WMS endpoint can be added manually, but can be quite hard to recover the correct URL.
Moreover,   layers of different type (eg. bing, mapquest) can no longer be added.

Here a simple patch to check the missing sources and add them to the map's configuration.
