### PR TITLE
Instruction fix

### DIFF
--- a/docs/tutorials/admin/prep/index.txt
+++ b/docs/tutorials/admin/prep/index.txt
@@ -40,7 +40,7 @@ Edit the geonode role's password in postgres using the same used in the local_se
 
 Launch the command to change the SITEURL directive in local_setting.py to http://localhost:4567 and restart apache among other things.
 
-    $ sudo geonode-updateip localhost
+    $ sudo geonode-updateip localhost:4567
     
 Launch the Geonode command to create a new superuser account within Django for GeoNode
 


### PR DESCRIPTION
Fixed error in that tutorial called for changing the SITEURL manually, adding port 4567, then proceeding to have you run geonodeupdate-ip with only localhost, effectively overwriting/resetting your SITEURL to just localhost (port 80).  Simplified to just running the command with the port added
