### PR TITLE
Add proxy and gxp files for layer style classifier

### DIFF
--- a/geonode/geoserver/urls.py
+++ b/geonode/geoserver/urls.py
@@ -24,6 +24,8 @@ urlpatterns = patterns('geonode.geoserver.views',
             proxy_path='/gs/rest/styles', downstream_path='rest/styles')),
     (r'^rest/layers', 'geoserver_rest_proxy', dict(
             proxy_path='/gs/rest/layers', downstream_path='rest/layers')),
+    (r'^rest/sldservice', 'geoserver_rest_proxy', dict(
+        proxy_path='/gs/rest/sldservice', downstream_path='rest/sldservice')),
     url(r'^updatelayers/$', 'updatelayers', name="updatelayers"),
     url(r'^(?P<layername>[^/]*)/style$', 'layer_style', name="layer_style"),
     url(r'^(?P<layername>[^/]*)/style/upload$', 'layer_style_upload', name='layer_style_upload'),

--- a/geonode/templates/geonode/geo_header_debug.html
+++ b/geonode/templates/geonode/geo_header_debug.html
@@ -186,6 +186,9 @@
 <script src="http://localhost:9080/script/@/app/static/externals/gxp/src/script/widgets/PointSymbolizer.js"></script>
 <script src="http://localhost:9080/script/@/app/static/externals/openlayers/lib/OpenLayers/Control/ScaleLine.js"></script>
 <script src="http://localhost:9080/script/@/app/static/externals/gxp/src/script/widgets/ScaleOverlay.js"></script>
+<script src="http://localhost:9080/script/@/app/static/externals/gxp/src/script/widgets/ClassificationPanel.js"></script>
+<script src="http://localhost:9080/script/@/app/static/externals/gxp/src/script/spinner/SpinnerField.js"></script>
+<script src="http://localhost:9080/script/@/app/static/externals/gxp/src/script/spinner/Spinner.js"></script>
 <script src="http://localhost:9080/script/@/app/static/externals/gxp/src/script/plugins/Tool.js"></script>
 <script src="http://localhost:9080/script/@/app/static/externals/gxp/src/script/data/WFSProtocolProxy.js"></script>
 <script src="http://localhost:9080/script/@/app/static/externals/gxp/src/script/data/WFSFeatureStore.js"></script>


### PR DESCRIPTION
For the classifier to work, the following jars must also be installed in the geoserver/WEB-INF/lib directory:

gs-sldService-2.5-SNAPSHOT.jar
xom-1.1.jar

Related to https://github.com/GeoNode/geonode/issues/1507
