### PR TITLE
extent filter based on intersection rather than contains

### DIFF
--- a/geonode/api/resourcebase_api.py
+++ b/geonode/api/resourcebase_api.py
@@ -11,6 +11,8 @@ from .authorization import GeoNodeAuthorization
 
 from .api import TagResource, TopicCategoryResource, UserResource, FILTER_TYPES
 
+from django.db.models import Q
+
 FILTER_TYPES.update({
     'vector': 'dataStore',
     'raster': 'coverageStore'
@@ -78,16 +80,14 @@ class CommonModelApi(ModelResource):
         return filtered
 
     def filter_bbox(self, queryset, bbox):
-        '''modify the queryset q to limit to the provided bbox
+        '''modify the queryset q to limit to data that intersects with the provided bbox 
 
         bbox - 4 tuple of floats representing 'southwest_lng,southwest_lat,northeast_lng,northeast_lat'
         returns the modified query
         '''
         bbox = map(str, bbox) # 2.6 compat - float to decimal conversion
-        queryset = queryset.filter(bbox_x0__gte=bbox[0])
-        queryset = queryset.filter(bbox_y0__gte=bbox[1])
-        queryset = queryset.filter(bbox_x1__lte=bbox[2])
-        return queryset.filter(bbox_y1__lte=bbox[3])
+        intersects = ~(Q(bbox_x0__gt=bbox[2]) | Q(bbox_x1__lt=bbox[0]) | Q(bbox_y0__gt=bbox[3]) | Q(bbox_y1__lt=bbox[1]))
+        return queryset.filter(intersects)
 
 
 class ResourceBaseResource(CommonModelApi):


### PR DESCRIPTION
It seems like the general consensus is that the extent filter should use the intersection of layers with the extent map rather than the more restrictive case where the entire layer should be contained within the extent map.
