### PR TITLE
Windows upload 799

### DIFF
--- a/geonode/layers/utils.py
+++ b/geonode/layers/utils.py
@@ -300,10 +300,10 @@ def file_upload(filename, name=None, user=None, title=None, abstract=None,
 
     # Add them to the upload session (new file fields are created).
     for type_name, fn in files.items():
-        f = open(fn)
-        us = upload_session.layerfile_set.create(name=type_name,
-                                                file=File(f),
-                                                )
+        with open(fn) as f:
+            us = upload_session.layerfile_set.create(name=type_name,
+                                                    file=File(f),
+                                                    )
 
     # Set a default title that looks nice ...
     if title is None:


### PR DESCRIPTION
This will close issue #799.  The temporary files in the file_upload function during the upload ajax call were not being closed before shutil.rmtree is called at the end of the upload view function causing a file locking issue referenced in issue 799 for windows.  There is a broader issue of gdal now that I will create a formal issue for once I dig in a little more.  
Thanks
