### PR TITLE
Corrected default values for MODELTRANSLATION_LANGUAGES in settings

### DIFF
--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -96,11 +96,7 @@ USE_I18N = True
 
 MODELTRANSLATION_DEFAULT_LANGUAGE = 'en'
 
-MODELTRANSLATION_LANGUAGES = (
-    ('en', 'English'),
-    ('es', 'Español'),
-)
-    
+MODELTRANSLATION_LANGUAGES = ('en', 'es', )
 
 # Absolute path to the directory that holds media.
 # Example: "/home/media/media.lawrence.com/"


### PR DESCRIPTION
The current default for MODELTRANSLATION_LANGUAGES in geonode/settings.py does not match that specified for the djang-modeltranslation app - see Section 2.3.2 of https://media.readthedocs.org/pdf/django-modeltranslation/latest/django-modeltranslation.pdf  or https://django-modeltranslation.readthedocs.org/en/latest/installation.html#modeltranslation-languages
