### PR TITLE
Added upstream library required for psycopg in dev install document

### DIFF
--- a/docs/tutorials/devel/install_devmode/index.txt
+++ b/docs/tutorials/devel/install_devmode/index.txt
@@ -26,7 +26,7 @@ In order to install Geonode 2.0 in developing mode on Ubuntu 12.04 the following
 
    .. code-block:: console
 
-    $ sudo apt-get install -y build-essential libxml2-dev libxslt1-dev
+    $ sudo apt-get install -y build-essential libxml2-dev libxslt1-dev libpq-dev
 
 
 #. Install dependencies
@@ -37,7 +37,7 @@ In order to install Geonode 2.0 in developing mode on Ubuntu 12.04 the following
 
     $ sudo apt-get install -y python-dev python-imaging python-lxml python-pyproj python-shapely python-nose python-httplib2 python-pip python-software-properties
 
-   *Install Python Viturual Environment*
+   *Install Python Virtual Environment*
 
    .. code-block:: console
 


### PR DESCRIPTION
When running the development install on a clean Ubuntu 12.04, I had an error about a missing dependency for `pyscopg`.  The website (http://initd.org/psycopg/install/) confirms that  `libpq-dev` is a requirement for this package.

(Also small spelling mistake correction!)
