### PR TITLE
Added installation guide for GDAL in a virtual environment

### DIFF
--- a/docs/tutorials/devel/install_devmode/gdal_install.txt
+++ b/docs/tutorials/devel/install_devmode/gdal_install.txt
@@ -1,0 +1,58 @@
+.. _install_devmode:
+
+Install GDAL for Development
+============================
+
+In order to install GDAL (1.10.0+) in developing mode, in a virtual environment, on Ubuntu 12.04 the following steps may be required.  If you have already tried any of the approaches suggested elsewhere, it is recommended that, unless you know that this may affect other software, you do a full purge of any existing GDAL-related packages.
+
+#. Install GDAL in your host environment
+
+    .. code-block:: console
+    
+     $ sudo add-apt-repository ppa:ubuntugis/ubuntugis-unstable
+     $ sudo apt-get update
+     $ sudo apt-get -y install libgdal1h libgdal-dev python-gdal
+
+#. Test that GDAL is installed in your host environment
+
+    .. code-block:: console
+    
+     $ deactivate geonode
+     $ python -c "from osgeo import gdal; print gdal.__version__"
+
+#. Assuming that your geonode directory is installed directly off of your home directory, download and configure GDAL
+
+    .. code-block:: console
+    
+     $ workon geonode
+     $ cd ~/.virtualenvs/geonode/
+     $ pip install --no-install GDAL==1.10.0
+     $ nano build/GDAL/setup.cfg
+
+#. Replace the line:
+
+    .. code-block:: console
+    
+     gdal_config = ../../apps/gdal-config
+
+    with:
+
+    .. code-block:: console
+    
+     gdal_config = /usr/bin/gdal-config
+
+#. Install GDAL into the virtual environment
+
+    .. code-block:: console
+    
+     $ cd ~/.virtualenvs/geonode/build/GDAL
+     $ python setup.py build_ext --include-dirs=/usr/include/gdal
+     $ pip install --no-download GDAL==1.10.0
+
+#. Test that GDAL is installed in your virtual environment
+
+    .. code-block:: console
+    
+     $ workon geonode
+     $ python -c "from osgeo import gdal; print gdal.__version__"
+

--- a/docs/tutorials/devel/install_devmode/index.txt
+++ b/docs/tutorials/devel/install_devmode/index.txt
@@ -124,6 +124,8 @@ In order to install Geonode 2.0 in developing mode on Ubuntu 12.04 the following
     $ paver start
 
    Visit the geonode site by typing http://localhost:8000 into your browser window.
+   
+   If the start fails because of an import error related to osgeo, then please consult the `GDAL for Development Guide <http://docs.geonode.org/en/latest/tutorial/devel/install_devmode/gdal_install.html>`_ 
 
 #. To stop the server
 


### PR DESCRIPTION
I have had many problems trying to get the `from osgeo import gdal` to work.  After lots of browsing, this approach seemed to work well.  It still needs to be tested with GDAL 1.11.

I have **not** rebuilt the documentation, so I am not sure the hyperlinks between documents are correct; nor that the necessary headers/footers are in place.
