### PR TITLE
fixes windows gdal issue 1538

### DIFF
--- a/geonode/layers/forms.py
+++ b/geonode/layers/forms.py
@@ -133,7 +133,7 @@ class LayerUploadForm(forms.Form):
             f = self.cleaned_data[field]
             if f is not None:
                 path = os.path.join(tempdir, f.name)
-                with open(path, 'w') as writable:
+                with open(path, 'wb') as writable:
                     for c in f.chunks():
                         writable.write(c)
         absolute_base_file = os.path.join(tempdir,


### PR DESCRIPTION
For reasons beyond my ability to explain, the shapefiles that were written to the tempdir on windows machines were not correctly written, which raised errors in GDAL with malformed file headers. Adding the buffer flag  seems to solve the problem.  
