### PR TITLE
The last file reading issue for Windows

### DIFF
--- a/geonode/layers/utils.py
+++ b/geonode/layers/utils.py
@@ -300,7 +300,7 @@ def file_upload(filename, name=None, user=None, title=None, abstract=None,
 
     # Add them to the upload session (new file fields are created).
     for type_name, fn in files.items():
-        with open(fn) as f:
+        with open(fn, 'rb') as f:
             us = upload_session.layerfile_set.create(name=type_name,
                                                     file=File(f),
                                                     )


### PR DESCRIPTION
This final change makes it possible to upload shape files using the file storage for geoserver with windows 2008 r2.
For this particular one, the FileField was taking the files from the temp directory, but when they were saved to the uploaded folder, they were only a small piece of the file, thus creating issues downstream for zipping and uploading to geoserver.  This resolves that issue.  
