### PR TITLE
Added django-admin-bootstrapped as dependency

### DIFF
--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -161,6 +161,8 @@ MAX_DOCUMENT_SIZE = 2 # MB
 
 
 GEONODE_APPS = (
+
+
     # GeoNode internal apps
     'geonode.people',
     'geonode.base',
@@ -187,6 +189,10 @@ GEONODE_APPS = (
 )
 
 INSTALLED_APPS = (
+
+    # Boostrap admin theme
+    'django_admin_bootstrapped.bootstrap3',
+    'django_admin_bootstrapped',
 
     # Apps bundled with Django
     'django.contrib.auth',

--- a/setup.py
+++ b/setup.py
@@ -100,6 +100,7 @@ setup(name='GeoNode',
         "django-taggit==0.12", # python-django-taggit
         "django-mptt==0.6.1", # django-mptt
         "django-guardian==1.2.0", #django-guardian
+        "django-admin-bootstrapped==1.6.5", #django-admin-bootstrapped
 
         ## Apps with packages provided in GeoNode's PPA on Launchpad.
         "pinax-theme-bootstrap==3.0a11",


### PR DESCRIPTION
## Motivation

The front-end for GeoNode now has had a major face-lift and uses Bootstrap to provide clear styling.  However the Django admin still carries a look-and-feel that is out of date in modern web apps.  There are a number of third-party apps for styling the admin, but django-admin-bootstrapped is arguably one of the most straightforward and effective, and the look-and-feel is comparable to that of the "new" GeoNode.
