### PR TITLE
fix order of arguments to metadata_links

### DIFF
--- a/geonode/geoserver/signals.py
+++ b/geonode/geoserver/signals.py
@@ -85,7 +85,7 @@ def geoserver_pre_save(instance, sender, **kwargs):
     # Get metadata links
     metadata_links = []
     for link in instance.link_set.metadata():
-        metadata_links.append((link.name, link.mime, link.url))
+        metadata_links.append((link.mime, link.name, link.url))
 
     gs_resource.metadata_links = metadata_links
     # gs_resource should only be called if


### PR DESCRIPTION
see boundlessgeo/gsconfig#53 - requires a new gsconfig version so merge w/ care.

Any other spots folks can think of this having an effect? I did grep for metadata_links and it seemed minimal.

Integration tests passed ~~but I had issues running `paver test` but wanted to get this out there.~~
