### PR TITLE
Added a --not-geonode-registered option in updatelayers.

### DIFF
--- a/docs/tutorials/admin/commands.txt
+++ b/docs/tutorials/admin/commands.txt
@@ -48,9 +48,9 @@ Additional options::
   
   --skip-unadvertised   Skip processing any layers that are marked 'advertised=False' in GeoServer
   
-  --not-geonode-registered   Just processing GeoServer unregistered layers in GeoNode.
-                        Useful if you have an existing GeoServer instance and want to try GeoNode over it, or
-                        when you are importing layers through GeoServer and not through GeoNode.
+  --skip-geonode-registered   Just processing GeoServer layers still not registered in GeoNode.
+                        Useful if you are importing layers through GeoServer and not through GeoNode
+                        and you don't want to run updatelayers on every GeoServer layer but just on the new ones.
   
   --remove-deleted      Remove layers from GeoNode that have been deleted (or marked unavailable) from GeoServer.  
                          Note: this option can be combined with --workspace and --store to only check

--- a/geonode/geoserver/helpers.py
+++ b/geonode/geoserver/helpers.py
@@ -328,7 +328,7 @@ def gs_slurp(
         store=None,
         filter=None,
         skip_unadvertised=False,
-        not_geonode_registered=False,
+        skip_geonode_registered=False,
         remove_deleted=False):
     """Configure the layers available in GeoServer in GeoNode.
 
@@ -382,10 +382,10 @@ def gs_slurp(
                      "true" or k.advertised or k.advertised is None]
 
     # filter out layers already registered in geonode
-    if not_geonode_registered:
+    layer_names = Layer.objects.all().values_list('typename', flat=True)
+    if skip_geonode_registered:
         resources = [k for k in resources 
-            if Layer.objects.filter(name=k.name, 
-                workspace=k.workspace.name).count() == 0]
+            if not '%s:%s' % (k.workspace.name, k.name) in layer_names]
             
     # TODO: Should we do something with these?
     # i.e. look for matching layers in GeoNode and also disable?

--- a/geonode/geoserver/management/commands/updatelayers.py
+++ b/geonode/geoserver/management/commands/updatelayers.py
@@ -42,11 +42,11 @@ class Command(BaseCommand):
             default=False,
             help='Skip processing unadvertised layers from GeoSever.'),
         make_option(
-            '--not-geonode-registered',
+            '--skip-geonode-registered',
             action='store_true',
-            dest='not_geonode_registered',
+            dest='skip_geonode_registered',
             default=False,
-            help='Just processing GeoServer unregistered layers in GeoNode.'),
+            help='Just processing GeoServer layers still not registered in GeoNode.'),
         make_option(
             '--remove-deleted',
             action='store_true',
@@ -81,7 +81,7 @@ class Command(BaseCommand):
     def handle(self, **options):
         ignore_errors = options.get('ignore_errors')
         skip_unadvertised = options.get('skip_unadvertised')
-        not_geonode_registered = options.get('not_geonode_registered')
+        skip_geonode_registered = options.get('skip_geonode_registered')
         remove_deleted = options.get('remove_deleted')
         verbosity = int(options.get('verbosity'))
         user = options.get('user')
@@ -104,7 +104,7 @@ class Command(BaseCommand):
             store=store,
             filter=filter,
             skip_unadvertised=skip_unadvertised,
-            not_geonode_registered=not_geonode_registered,
+            skip_geonode_registered=skip_geonode_registered,
             remove_deleted=remove_deleted)
 
         if verbosity > 1:


### PR DESCRIPTION
This option is useful when you want to register in GeoNode any other layer that is already in GeoServer but not in GeoNode.
It is useful after creating layers directly through GeoServer and not through GeoNode.
