### PR TITLE
Don't cascade delete from geoserver for remote layers

### DIFF
--- a/geonode/geoserver/signals.py
+++ b/geonode/geoserver/signals.py
@@ -34,7 +34,8 @@ def geoserver_pre_delete(instance, sender, **kwargs):
     # cascading_delete should only be called if
     # ogc_server_settings.BACKEND_WRITE_ENABLED == True
     if getattr(ogc_server_settings, "BACKEND_WRITE_ENABLED", True):
-        cascading_delete(gs_catalog, instance.typename)
+        if instance.storeType != "remoteStore":
+            cascading_delete(gs_catalog, instance.typename)
 
 
 def geoserver_pre_save(instance, sender, **kwargs):


### PR DESCRIPTION
Potential fix for https://github.com/GeoNode/geonode/issues/1619.

Check to see if a layer has a storeType of "remoteStore" and if so then don't try to delete from GeoServer.
