### PR TITLE
Change to PRINT_NG, check for PRINTNG

### DIFF
--- a/docs/i18n/de/LC_MESSAGES/reference.po
+++ b/docs/i18n/de/LC_MESSAGES/reference.po
@@ -855,7 +855,7 @@ msgstr ""
 # b46bc8c6b54a4db488658cd5c46d38fa
 #: ../../reference/developers/django-apps.txt:228
 #: ../../reference/developers/settings.txt:249
-msgid "PRINTNG_ENABLED"
+msgid "PRINT_NG_ENABLED"
 msgstr ""
 
 # c6f02419b3f7470b899fbb4b3ab671e5

--- a/docs/i18n/es/LC_MESSAGES/reference.po
+++ b/docs/i18n/es/LC_MESSAGES/reference.po
@@ -882,7 +882,7 @@ msgstr ""
 # b46bc8c6b54a4db488658cd5c46d38fa
 #: ../../reference/developers/django-apps.txt:228
 #: ../../reference/developers/settings.txt:249
-msgid "PRINTNG_ENABLED"
+msgid "PRINT_NG_ENABLED"
 msgstr ""
 
 # c6f02419b3f7470b899fbb4b3ab671e5

--- a/docs/i18n/fr/LC_MESSAGES/reference.po
+++ b/docs/i18n/fr/LC_MESSAGES/reference.po
@@ -855,7 +855,7 @@ msgstr ""
 # b46bc8c6b54a4db488658cd5c46d38fa
 #: ../../reference/developers/django-apps.txt:228
 #: ../../reference/developers/settings.txt:249
-msgid "PRINTNG_ENABLED"
+msgid "PRINT_NG_ENABLED"
 msgstr ""
 
 # c6f02419b3f7470b899fbb4b3ab671e5

--- a/docs/i18n/it/LC_MESSAGES/reference.po
+++ b/docs/i18n/it/LC_MESSAGES/reference.po
@@ -855,7 +855,7 @@ msgstr ""
 # b46bc8c6b54a4db488658cd5c46d38fa
 #: ../../reference/developers/django-apps.txt:228
 #: ../../reference/developers/settings.txt:249
-msgid "PRINTNG_ENABLED"
+msgid "PRINT_NG_ENABLED"
 msgstr ""
 
 # c6f02419b3f7470b899fbb4b3ab671e5

--- a/docs/reference/developers/django-apps.txt
+++ b/docs/reference/developers/django-apps.txt
@@ -212,7 +212,7 @@ OGC_SERVER
 
     A boolean that represents whether the Mapfish printing extension is enabled on the server.
 
-  PRINTNG_ENABLED
+  PRINT_NG_ENABLED
     Default: ``True``
 
     A boolean that represents whether printing of maps and layers is enabled.

--- a/docs/reference/developers/settings.txt
+++ b/docs/reference/developers/settings.txt
@@ -256,8 +256,8 @@ Default: ``'geoserver'``
 
 The administrative password for the OGC server as a string.
 
-PRINTNG_ENABLED
-...............
+PRINT_NG_ENABLED
+................
 Default: ``True``
 
 A boolean that represents whether printing of maps and layers is enabled.

--- a/geonode/context_processors.py
+++ b/geonode/context_processors.py
@@ -28,6 +28,9 @@ def resource_urls(request):
     """Global values to pass to templates"""
     site = Site.objects.get_current()
 
+    if ogc_server_settings.get('PRINTNG_ENABLED'):
+        logger.info("Found PRINTNG_ENABLED setting, please update to PRINT_NG_ENABLED")
+
     return dict(
         STATIC_URL=settings.STATIC_URL,
         GEOSERVER_BASE_URL=ogc_server_settings.public_url,
@@ -41,7 +44,7 @@ def resource_urls(request):
         TIME_ENABLED = getattr(settings, 'UPLOADER', dict()).get('OPTIONS', dict()).get('TIME_ENABLED', False),
         DEBUG_STATIC = getattr(settings, "DEBUG_STATIC", False),
         MF_PRINT_ENABLED = ogc_server_settings.MAPFISH_PRINT_ENABLED,
-        PRINTNG_ENABLED = ogc_server_settings.PRINTNG_ENABLED,
+        PRINT_NG_ENABLED = ogc_server_settings.get('PRINT_NG_ENABLED', ogc_server_settings.get('PRINTNG_ENABLED', None))
         GS_SECURITY_ENABLED = ogc_server_settings.GEONODE_SECURITY_ENABLED,
         PROXY_URL = getattr(settings, 'PROXY_URL', '/proxy/?url='),
         SOCIAL_BUTTONS = getattr(settings, 'SOCIAL_BUTTONS', True),

--- a/geonode/local_settings.py.sample
+++ b/geonode/local_settings.py.sample
@@ -26,7 +26,7 @@ OGC_SERVER = {
         'USER' : 'admin',
         'PASSWORD' : 'geoserver',
         'MAPFISH_PRINT_ENABLED' : True,
-        'PRINTNG_ENABLED' : True,
+        'PRINT_NG_ENABLED' : True,
         'GEONODE_SECURITY_ENABLED' : True,
         'GEOGIT_ENABLED' : False,
         'WMST_ENABLED' : False,

--- a/geonode/maps/templates/maps/map_detail.html
+++ b/geonode/maps/templates/maps/map_detail.html
@@ -42,7 +42,7 @@
         </a>
         <ul class="dropdown-menu">
           <li><a href="{% url "map_metadata" map.id %}">{% trans "Edit Map Metadata" %} <i class="icon-chevron-right"></i></a></li>
-          {% if PRINTNG_ENABLED %}
+          {% if PRINT_NG_ENABLED %}
           <li><a href="#" id="set_thumbnail">{% trans "Set Map Thumbnail" %} <i class="icon-chevron-right"></i></a></li>
           {% endif %}
           <li><a href="#modal_perms" data-toggle="modal">{% trans "Edit Map Permissions" %} <i class="icon-chevron-right"></i></a></li>
@@ -271,7 +271,7 @@
     return false;
   });
 
-{% if PRINTNG_ENABLED %}
+{% if PRINT_NG_ENABLED %}
   $('#set_thumbnail').click(function(){
     return createMapThumbnail();
   });

--- a/geonode/maps/templates/maps/map_geoexplorer.js
+++ b/geonode/maps/templates/maps/map_geoexplorer.js
@@ -28,7 +28,7 @@ Ext.onReady(function() {
     var config = Ext.apply({
         authStatus: {% if user.is_authenticated %} 200{% else %} 401{% endif %},
         proxy: '{{ PROXY_URL }}',
-        {% if PRINTNG_ENABLED %}
+        {% if PRINT_NG_ENABLED %}
         listeners: {
             'save': function(obj_id) {
                 createMapThumbnail(obj_id);

--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -412,7 +412,7 @@ OGC_SERVER = {
         'USER' : 'admin',
         'PASSWORD' : 'geoserver',
         'MAPFISH_PRINT_ENABLED' : True,
-        'PRINTNG_ENABLED' : True,
+        'PRINT_NG_ENABLED' : True,
         'GEONODE_SECURITY_ENABLED' : True,
         'GEOGIT_ENABLED' : False,
         'WMST_ENABLED' : False,

--- a/package/osgeo/local_settings.py.sample
+++ b/package/osgeo/local_settings.py.sample
@@ -24,7 +24,7 @@ OGC_SERVER = {
         'USER' : 'admin',
         'PASSWORD' : 'geoserver',
         'MAPFISH_PRINT_ENABLED' : True,
-        'PRINTNG_ENABLED' : True,
+        'PRINT_NG_ENABLED' : True,
         'GEONODE_SECURITY_ENABLED' : True,
         'GEOGIT_ENABLED' : False,
         'WMST_ENABLED' : False,
@@ -47,4 +47,4 @@ GEOGIT_DATASTORE_NAME = 'geogit-repo'
 UPLOADER_SHOW_TIME_STEP=False
 
 # Use the printNG geoserver lib
-PRINTNG_ENABLED=True
+PRINT_NG_ENABLED=True

--- a/package/support/geonode.local_settings
+++ b/package/support/geonode.local_settings
@@ -52,7 +52,7 @@ OGC_SERVER = {
         'USER' : 'admin',
         'PASSWORD' : 'geoserver',
         'MAPFISH_PRINT_ENABLED' : True,
-        'PRINTNG_ENABLED' : True,
+        'PRINT_NG_ENABLED' : True,
         'GEONODE_SECURITY_ENABLED' : True,
         'GEOGIT_ENABLED' : False,
         'WMST_ENABLED' : False,


### PR DESCRIPTION
PRINTNG_ENABLED is obscure for new contributors and looks like a typo.
Changing it to PRINTING_ENABLED doesn't work either, because it exists in distinction to MAPFISH_PRINT_ENABLED, which is still in use.
So change to PRINT_NG_ENABLED.

If PRINTNG_ENABLED is encountered in config, use this, and log a deprecation message.
