### PR TITLE
Don't assume a 'local' MapLayer has been added to GeoNode from GeoServer

### DIFF
--- a/geonode/geoserver/signals.py
+++ b/geonode/geoserver/signals.py
@@ -19,7 +19,6 @@ from geonode.geoserver.helpers import geoserver_upload
 from geonode.utils import http_client
 from geonode.base.models import Link
 from geonode.base.models import Thumbnail
-from geonode.layers.models import Layer
 from geonode.layers.utils import create_thumbnail
 from geonode.people.models import Profile
 


### PR DESCRIPTION
Obtain name from thumbnail from Maplayer.name instead.

Resolves #1613.  

The geoserver_post_save function that creates Map thumbnails assumes all layers from GXP 'Local GeoServer' source have already been added to GeoNode, which may not be the case.  Throws 'layer matching query does not exist' exception when a map includes these layers.  Fix is just to use MapLayer.name to send to GeoServer instead to generate the thumb.
