### PR TITLE
Change Foreign Key relationship for ResourceBase and Thumbnail

### DIFF
--- a/geonode/base/models.py
+++ b/geonode/base/models.py
@@ -1,14 +1,12 @@
 import datetime
 import math
 import os
-import hashlib
 import logging
 
 from django.db import models
 from django.db.models import Q
 from django.utils.translation import ugettext_lazy as _
 from django.core.exceptions import ValidationError
-from django.core.files.base import ContentFile
 from django.conf import settings
 from django.contrib.staticfiles.templatetags import staticfiles
 from django.contrib.contenttypes.models import ContentType
@@ -153,17 +151,10 @@ class RestrictionCodeType(models.Model):
 
 class Thumbnail(models.Model):
 
+    resourcebase = models.ForeignKey('ResourceBase')
     thumb_file = models.FileField(upload_to='thumbs')
     thumb_spec = models.TextField(null=True, blank=True)
     version = models.PositiveSmallIntegerField(null=True, default=0)
-
-    def save_thumb(self, image, id):
-        """image must be png data in a string for now"""
-        self._delete_thumb()
-        md5 = hashlib.md5()
-        md5.update(id + str(self.version))
-        self.version = self.version + 1
-        self.thumb_file.save(md5.hexdigest() + ".png", ContentFile(image))
 
     def _delete_thumb(self):
         try:
@@ -352,7 +343,6 @@ class ResourceBase(PolymorphicModel, PermissionLevelMixin):
                                     default='<gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd"/>',
                                     blank=True)
 
-    thumbnail = models.ForeignKey(Thumbnail, null=True, blank=True, on_delete=models.SET_NULL)
     popular_count = models.IntegerField(default=0)
     share_count = models.IntegerField(default=0)
 
@@ -364,8 +354,8 @@ class ResourceBase(PolymorphicModel, PermissionLevelMixin):
     rating = models.IntegerField(default=0, null=True)
 
     def delete(self, *args, **kwargs):
+        resourcebase_pre_delete(self)
         super(ResourceBase, self).delete(*args, **kwargs)
-        resourcebase_post_delete(self)
 
     def __unicode__(self):
         return self.title
@@ -547,13 +537,13 @@ class ResourceBase(PolymorphicModel, PermissionLevelMixin):
 
     def has_thumbnail(self):
         """Determine if the thumbnail object exists and an image exists"""
-        if self.thumbnail is None:
+        if not self.thumbnail_set.exists():
             return False
 
-        if not hasattr(self.thumbnail.thumb_file, 'path'):
+        if not hasattr(self.thumbnail_set.get().thumb_file, 'path'):
             return False
 
-        return os.path.exists(self.thumbnail.thumb_file.path)
+        return os.path.exists(self.thumbnail_set.get().thumb_file.path)
 
     def set_missing_info(self):
         """Set default permissions and point of contacts.
@@ -682,9 +672,9 @@ class Link(models.Model):
         return '%s link' % self.link_type
 
 
-def resourcebase_post_delete(instance):
-    if instance.thumbnail is not None:
-        instance.thumbnail.delete()
+def resourcebase_pre_delete(instance):
+    if instance.thumbnail_set.exists():
+        instance.thumbnail_set.get().thumb_file.delete()
 
 
 def resourcebase_post_save(instance, *args, **kwargs):

--- a/geonode/base/tests.py
+++ b/geonode/base/tests.py
@@ -8,9 +8,11 @@ class ThumbnailTests(TestCase):
         self.rb = ResourceBase.objects.create()
 
     def tearDown(self):
-        t = self.rb.thumbnail
-        if t:
-            t.delete()
+        # if the thumbnail hasn't already been removed:
+        if self.rb.thumbnail_set.exists():
+            t = self.rb.thumbnail_set.get()
+            if t:
+                t.delete()
 
     def test_initial_behavior(self):
         self.assertFalse(self.rb.has_thumbnail())

--- a/geonode/catalogue/templates/catalogue/full_metadata.xml
+++ b/geonode/catalogue/templates/catalogue/full_metadata.xml
@@ -151,7 +151,7 @@
        <gmd:graphicOverview>
          <gmd:MD_BrowseGraphic>
            <gmd:fileName>
-             <gco:CharacterString>{{ layer.thumbnail }}</gco:CharacterString>
+             <gco:CharacterString>{{ layer.get_thumbnail_url }}</gco:CharacterString>
            </gmd:fileName>
            <gmd:fileDescription>
              <gco:CharacterString>Thumbnail for '{{layer.title}}'</gco:CharacterString>

--- a/geonode/documents/models.py
+++ b/geonode/documents/models.py
@@ -152,21 +152,21 @@ def create_thumbnail(sender, instance, created, **kwargs):
         return
 
     if instance.has_thumbnail():
-        instance.thumbnail.thumb_file.delete()
+        instance.thumbnail_set.get().thumb_file.delete()
     else:
-        instance.thumbnail = Thumbnail()
+        instance.thumbnail_set.add(Thumbnail())
 
     image = instance._render_thumbnail()
 
-    instance.thumbnail.thumb_file.save(
+    instance.thumbnail_set.get().thumb_file.save(
         'doc-%s-thumb.png' %
         instance.id,
         ContentFile(image))
-    instance.thumbnail.thumb_spec = 'Rendered'
-    instance.thumbnail.save()
+    instance.thumbnail_set.get().thumb_spec = 'Rendered'
+    instance.thumbnail_set.get().save()
     Link.objects.get_or_create(
         resource=instance.get_self_resource(),
-        url=instance.thumbnail.thumb_file.url,
+        url=instance.thumbnail_set.get().thumb_file.url,
         defaults=dict(
             name=('Thumbnail'),
             extension='png',

--- a/geonode/geoserver/helpers.py
+++ b/geonode/geoserver/helpers.py
@@ -31,6 +31,7 @@ from bs4 import BeautifulSoup
 import geoserver
 import httplib2
 
+
 from urlparse import urlparse
 from urlparse import urlsplit
 from threading import local
@@ -343,23 +344,25 @@ def gs_slurp(
     cat = Catalog(ogc_server_settings.internal_rest, _user, _password)
     if workspace is not None:
         workspace = cat.get_workspace(workspace)
-
-        # workspace should be returned if exists, otherwise throw an error
-        if workspace is not None:
-            # assume store exists within workspace:
+        if workspace is None:
+            resources = []
+        else:
+            # obtain the store from within the workspace. if it exists, obtain resources
+            # directly from store, otherwise return an empty list:
             if store is not None:
                 store = cat.get_store(store, workspace=workspace)
-                resources = cat.get_resources(store=store)
+                if store is None:
+                    resources = []
+                else:
+                    resources = cat.get_resources(store=store)
             else:
                 resources = cat.get_resources(workspace=workspace)
-        else:
-            raise Exception(
-                "Workspace does not exist in the GeoServer instance")
+
     elif store is not None:
         store = cat.get_store(store)
         resources = cat.get_resources(store=store)
     else:
-        resources = cat.get_resources(workspace=workspace)
+        resources = cat.get_resources()
     if remove_deleted:
         resources_for_delete_compare = resources[:]
         workspace_for_delete_compare = workspace

--- a/geonode/geoserver/signals.py
+++ b/geonode/geoserver/signals.py
@@ -522,20 +522,20 @@ def geoserver_post_save_map(instance, sender, **kwargs):
 
     if image is not None:
         if instance.has_thumbnail():
-            instance.thumbnail.thumb_file.delete()
+            instance.thumbnail_set.get().thumb_file.delete()
         else:
-            instance.thumbnail = Thumbnail()
+            instance.thumbnail_set.add(Thumbnail())
 
-        instance.thumbnail.thumb_file.save(
+        instance.thumbnail_set.get().thumb_file.save(
             'map-%s-thumb.png' %
             instance.id,
             ContentFile(image))
-        instance.thumbnail.thumb_spec = thumbnail_remote_url
-        instance.thumbnail.save()
+        instance.thumbnail_set.get().thumb_spec = thumbnail_remote_url
+        instance.thumbnail_set.get().save()
 
         thumbnail_url = urljoin(
             settings.SITEURL,
-            instance.thumbnail.thumb_file.url)
+            instance.thumbnail_set.get().thumb_file.url)
 
         Link.objects.get_or_create(resource=instance.resourcebase_ptr,
                                    url=thumbnail_url,


### PR DESCRIPTION
**What does this PR do?**
Reverses ForeignKey relationship between Thumbnail and ResourceBase to be Many -> One. Should solve repeated thumbnail issue on Updatelayers execution. The result is a single file on the filesystem per ResourceBase object. Cascade deletes Thumbnails on ResourceBase delete. Doesn't delete thumbnail file on disk for some reason.

Note: Also fixes a legacy issue with Updatelayers code in gs_slurp where some code was overwritten in a bulk merge following 2.0 release.
