### PR TITLE
Wrap tabs in a block in the base template

### DIFF
--- a/geonode/templates/base.html
+++ b/geonode/templates/base.html
@@ -37,6 +37,7 @@
         </div>
         <div class="navbar-collapse collapse">
           <ul class="nav navbar-nav">
+            {% block tabs %}
             <li id="nav_layers">
               <a href="{% url "layer_browse" %}">{% trans "Layers" %}</a>
             </li>
@@ -52,6 +53,7 @@
             <li id="nav_groups">
               <a href="{% url "group_list" %}">{% trans "Groups" %}</a>
             </li>
+            {% endblock %}
           </ul>
           <form class="col-md-3" id="search" action="{% url "search" %}">
             <div class="input-group">


### PR DESCRIPTION
This allows to modify the tabs without having to modify all the header.
It's typically useful in a geonode-projects to add a new tab before or
after the existing tabs by redefining the block and calling block.super
