### PR TITLE
Fixes geoserver_rest_proxy view to be able to send non-ascii chars

### DIFF
--- a/geonode/geoserver/views.py
+++ b/geonode/geoserver/views.py
@@ -275,7 +275,7 @@ def geoserver_rest_proxy(request, proxy_path, downstream_path):
         return path[len(prefix):]
 
     path = strip_prefix(request.get_full_path(), proxy_path)
-    url = "".join([ogc_server_settings.LOCATION, downstream_path, path])
+    url = str("".join([ogc_server_settings.LOCATION, downstream_path, path]))
 
     http = httplib2.Http()
     http.add_credentials(*(ogc_server_settings.credentials))


### PR DESCRIPTION
Possible related issues

https://github.com/GeoNode/geonode/issues/1298
https://github.com/GeoNode/geonode/issues/1695
