### PR TITLE
Save Map function doesn't work with UnicodeEncodeError.

### DIFF
--- a/geonode/social/signals.py
+++ b/geonode/social/signals.py
@@ -108,7 +108,7 @@ def activity_post_modify_object(sender, instance, created=None, **kwargs):
     if verb:
         try:
             activity.send(action.get('actor'),
-                          verb='{verb}'.format(verb=verb),
+                          verb=u"{verb}".format(verb=verb),
                           action_object=action.get('action_object'),
                           target=action.get('target', None),
                           object_name=action.get('object_name'),


### PR DESCRIPTION
I get follow error when click "Save Map" in "Create a New Map" view.

```
Internal Server Error: /maps/new/data
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/django/core/handlers/base.py", line 112, in get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/usr/local/lib/python2.7/dist-packages/geonode/maps/views.py", line 406, in new_map_json
    map_obj.save()
  File "/usr/local/lib/python2.7/dist-packages/polymorphic/polymorphic_model.py", line 89, in save
    return super(PolymorphicModel, self).save(*args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/django/db/models/base.py", line 545, in save
    force_update=force_update, update_fields=update_fields)
  File "/usr/lib/python2.7/dist-packages/django/db/models/base.py", line 582, in save_base
    update_fields=update_fields, raw=raw, using=using)
  File "/usr/lib/python2.7/dist-packages/django/dispatch/dispatcher.py", line 185, in send
    response = receiver(signal=self, sender=sender, **named)
  File "/usr/local/lib/python2.7/dist-packages/geonode/social/signals.py", line 111, in activity_post_modify_object
    verb='{verb}'.format(verb=str(verb)),
UnicodeEncodeError: 'ascii' codec can't encode characters in position 0-3: ordinal not in range(128)
```

I fix this error.
