### PR TITLE
fixes apache config file name

### DIFF
--- a/package/install.sh
+++ b/package/install.sh
@@ -124,8 +124,8 @@ function setup_apache_once() {
     chown www-data -R $GEONODE_WWW
     a2enmod proxy_http
         
-    sed -i '1d' $APACHE_SITES/geonode
-    sed -i "1i WSGIDaemonProcess geonode user=www-data threads=15 processes=2" $APACHE_SITES/geonode
+    sed -i '1d' $APACHE_SITES/geonode.conf
+    sed -i "1i WSGIDaemonProcess geonode user=www-data threads=15 processes=2" $APACHE_SITES/geonode.conf
 
     #FIXME: This could be removed if setup_apache_every_time is called after setup_apache_once
     $APACHE_SERVICE restart


### PR DESCRIPTION
sed command in install.sh get error.
$APACHE_SITES/geonode is not correct, $APACHE_SITES/geonode.conf is correct.
