### PR TITLE
Always convert to web mercator SRID & coordinates on layer detail page

### DIFF
--- a/geonode/layers/views.py
+++ b/geonode/layers/views.py
@@ -190,8 +190,7 @@ def layer_detail(request, layername, template='layers/layer_detail.html'):
 
     # Transform WGS84 to Mercator.
     config["srs"] = srid if srid != "EPSG:4326" else "EPSG:900913"
-    config["bbox"] = llbbox_to_mercator(
-       [float(coord) for coord in bbox])
+    config["bbox"] = llbbox_to_mercator([float(coord) for coord in bbox])
 
     config["title"] = layer.title
 


### PR DESCRIPTION
The layer detail map view with  geoexplorer seems to require a web mercator (900913 or ESRI equivalent - 3857 etc) SRID and bbox coordinates in the layer config to display properly.
