### PR TITLE
Bumped version dependency for OWSLib

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -131,7 +131,7 @@ setup(name='GeoNode',
         "gisdata==0.5.4",
 
         # geopython dependencies
-        "OWSLib==0.8.8",
+        "OWSLib==0.8.10",
         "pycsw==1.10.0",
 
         # haystack/elasticsearch, uncomment to use


### PR DESCRIPTION
The current OWSLib version does not handle the "om" namespace correctly; and this upgrade is needed in order to work with OGC-compliant XML data from various sources; e.g. a SOS.
