### PR TITLE
Use client-side polling (instead of server-side) when using the importer upload.

### DIFF
--- a/geonode/static/geonode/js/upload/LayerInfo.js
+++ b/geonode/static/geonode/js/upload/LayerInfo.js
@@ -280,10 +280,14 @@ define(function (require, exports) {
                             level: 'alert-success',
                             empty: 'true'
                         });
+                    } else if (resp.status === "pending") {
+                        setTimeout(function() {
+                            self.doFinal(resp);
+                        }, 5000);
                     } else {
                         self.displayUploadedLayerLinks(resp);
                     }
-                },
+                }
             });
         } else if (resp.status === "incomplete") {
             var id = resp.url.split('=')[1]


### PR DESCRIPTION
This PR fixes time-outs that were caused by one of the upload views that was polling geoserver to see if the new layer is in the catalog.  This should only affect users that have a deployment configured to use the `geonode.importer` backend.
