### PR TITLE
Users should not be able to edit other users profile

### DIFF
--- a/geonode/people/views.py
+++ b/geonode/people/views.py
@@ -55,7 +55,7 @@ def profile_edit(request, username=None):
     else:
         profile = get_object_or_404(Profile, user__username=username)
 
-    if username == request.user.username or request.user.is_superuser:
+    if username == request.user.username:
         if request.method == "POST":
             form = ProfileForm(request.POST, request.FILES, instance=profile)
             if form.is_valid():


### PR DESCRIPTION
Currently a non-superuser user can edit other users profile (even the admin one) simply using this url: `/people/edit/<username>`. With this fix non-admin users cannot edit other users profile.
