### PR TITLE
Use a single paver task to execute all of the tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ virtualenv:
 
 branches:
   only:
-    - master 
+    - master
 
 install:
   - sudo apt-get -qq -y update
@@ -16,19 +16,12 @@ install:
   - sudo apt-get install -y python-virtualenv python-imaging python-lxml python-pyproj python-shapely python-nose python-httplib2 python-httplib2 gettext
   - sudo apt-get install -y --force-yes openjdk-6-jdk ant maven2 libjai-imageio-core-java --no-install-recommends
   - pip install -e . --use-mirrors
-  - pip install flake8
 
 before_script:
   - paver setup
-#  - paver static
 
 script:
-  - python manage.py test geonode.tests.smoke
-  - paver test
-  - paver test_integration
-  - paver test_integration -n geonode.tests.csw
-  - flake8 geonode
-#  - paver test_javascript
+  - paver run_tests
 
 after_script:
   - paver reset_hard

--- a/pavement.py
+++ b/pavement.py
@@ -429,6 +429,16 @@ def test_integration(options):
     if not success:
         sys.exit(1)
 
+@task
+def run_tests():
+    """
+    Executes the entire test suite.
+    """
+    sh('python manage.py test geonode.tests.smoke')
+    call_task('test')
+    call_task('test_integration')
+    call_task('test_integration', options={'name': 'geonode.tests.csw'})
+    sh('flake8 geonode')
 
 @task
 @needs(['stop'])

--- a/setup.py
+++ b/setup.py
@@ -139,6 +139,7 @@ setup(name='GeoNode',
 
         # datetimepicker widget
         "django-bootstrap3-datetimepicker==2.2.3",
+        "flake8==2.2.5"
         ],
       zip_safe=False,
       )


### PR DESCRIPTION
This PR improves the developer experience by exposing a single pavement task that runs all of the tests.  Now developers (and travis) can run all of the tests with `paver run_tests`.