### PR TITLE
Use an SLD's name instead of text from a name element when saving styles.

### DIFF
--- a/geonode/geoserver/helpers.py
+++ b/geonode/geoserver/helpers.py
@@ -729,7 +729,7 @@ def set_styles(layer, gs_catalog):
 
 
 def save_style(gs_style):
-    style, created = Style.objects.get_or_create(name=gs_style.sld_name)
+    style, created = Style.objects.get_or_create(name=gs_style.name)
     style.sld_title = gs_style.sld_title
     style.sld_body = gs_style.sld_body
     style.sld_url = gs_style.body_href()


### PR DESCRIPTION
When saving internal style objects, GeoNode uses the `sld_name` property from **gsconfig** which inspects the SLD and returns text from the `<Name>` element within the `<UserStyle>` element (https://github.com/boundlessgeo/gsconfig/blob/36a6190aa96181d585811ad483aa147e5efd6903/src/geoserver/style.py#L53).  The problem with this is that the name element could be different the actual name of the style in Geoserver which causes problems when GeoNode use a style's name to lookup the style in Geoserver in other places in the code.