### PR TITLE
Social Links Enhancements

### DIFF
--- a/docs/reference/developers/settings.txt
+++ b/docs/reference/developers/settings.txt
@@ -379,6 +379,30 @@ Default: ``True``
 
 A boolean which specifies whether the social media icons and javascript should be rendered in GeoNode.
 
+SOCIAL_ORIGINS
+--------------
+Default::
+
+    SOCIAL_ORIGINS = [{
+        "label":"Email",
+        "url":"mailto:?subject={name}&body={url}",
+        "css_class":"email"
+    }, {
+        "label":"Facebook",
+        "url":"http://www.facebook.com/sharer.php?u={url}",
+        "css_class":"fb"
+    }, {
+        "label":"Twitter",
+        "url":"https://twitter.com/share?url={url}",
+        "css_class":"tw"
+    }, {
+        "label":"Google +",
+        "url":"https://plus.google.com/share?url={url}",
+        "css_class":"gp"
+    }]
+
+A list of dictionaries that is used to generate the social links displayed in the Share tab.  For each origin, the name and and url format parameters are replaced by the actual values of the ResourceBase object (layer, map, document).
+
 Upload settings
 ===============
 

--- a/geonode/context_processors.py
+++ b/geonode/context_processors.py
@@ -45,7 +45,7 @@ def resource_urls(request):
         SOCIAL_BUTTONS=getattr(
             settings,
             'SOCIAL_BUTTONS',
-            True),
+            False),
         HAYSTACK_SEARCH=getattr(
             settings,
             'HAYSTACK_SEARCH',

--- a/geonode/documents/views.py
+++ b/geonode/documents/views.py
@@ -20,7 +20,7 @@ from geonode.base.models import TopicCategory, ResourceBase
 from geonode.documents.models import Document
 from geonode.documents.forms import DocumentForm, DocumentCreateForm, DocumentReplaceForm
 from geonode.documents.models import IMGTYPES
-from geonode.utils import format_urls
+from geonode.utils import build_social_links
 
 ALLOWED_DOC_TYPES = settings.ALLOWED_DOCUMENT_TYPES
 
@@ -91,13 +91,7 @@ def document_detail(request, docid):
             'related': related}
 
         if settings.SOCIAL_ORIGINS:
-            social_url = "{protocol}://{host}{path}".format(
-                protocol=("https" if request.is_secure() else "http"),
-                host=request.get_host(),
-                path=request.get_full_path())
-            context_dict["social_links"] = format_urls(
-                settings.SOCIAL_ORIGINS,
-                {'name': document.title, 'url': social_url})
+            context_dict["social_links"] = build_social_links(request, document)
 
         return render_to_response(
             "documents/document_detail.html",

--- a/geonode/documents/views.py
+++ b/geonode/documents/views.py
@@ -84,7 +84,6 @@ def document_detail(request, docid):
         if request.user != document.owner:
             Document.objects.filter(id=document.id).update(popular_count=F('popular_count') + 1)
 
-
         context_dict = {
             'permissions_json': _perms_info_json(document),
             'resource': document,
@@ -96,11 +95,13 @@ def document_detail(request, docid):
                 protocol=("https" if request.is_secure() else "http"),
                 host=request.get_host(),
                 path=request.get_full_path())
-            context_dict["social_links"] = format_urls(settings.SOCIAL_ORIGINS, {'name':document.title,'url': social_url})
+            context_dict["social_links"] = format_urls(
+                settings.SOCIAL_ORIGINS,
+                {'name': document.title, 'url': social_url})
 
         return render_to_response(
             "documents/document_detail.html",
-            RequestContext(request,context_dict))
+            RequestContext(request, context_dict))
 
 
 def document_download(request, docid):

--- a/geonode/layers/views.py
+++ b/geonode/layers/views.py
@@ -51,6 +51,7 @@ from geonode.utils import resolve_object, llbbox_to_mercator
 from geonode.people.forms import ProfileForm, PocForm
 from geonode.security.views import _perms_info_json
 from geonode.documents.models import get_related_documents
+from geonode.utils import format_urls
 
 if 'geonode.geoserver' in settings.INSTALLED_APPS:
 
@@ -252,6 +253,13 @@ def layer_detail(request, layername, template='layers/layer_detail.html'):
             links = layer.link_set.download().filter(
                 name__in=settings.DOWNLOAD_FORMATS_RASTER)
         context_dict["links"] = links
+
+    if settings.SOCIAL_ORIGINS:
+        social_url = "{protocol}://{host}{path}".format(
+            protocol=("https" if request.is_secure() else "http"),
+            host=request.get_host(),
+            path=request.get_full_path())
+        context_dict["social_links"] = format_urls(settings.SOCIAL_ORIGINS, {'name':layer.title,'url': social_url})
 
     return render_to_response(template, RequestContext(request, context_dict))
 

--- a/geonode/layers/views.py
+++ b/geonode/layers/views.py
@@ -51,7 +51,7 @@ from geonode.utils import resolve_object, llbbox_to_mercator
 from geonode.people.forms import ProfileForm, PocForm
 from geonode.security.views import _perms_info_json
 from geonode.documents.models import get_related_documents
-from geonode.utils import format_urls
+from geonode.utils import build_social_links
 
 if 'geonode.geoserver' in settings.INSTALLED_APPS:
 
@@ -255,13 +255,7 @@ def layer_detail(request, layername, template='layers/layer_detail.html'):
         context_dict["links"] = links
 
     if settings.SOCIAL_ORIGINS:
-        social_url = "{protocol}://{host}{path}".format(
-            protocol=("https" if request.is_secure() else "http"),
-            host=request.get_host(),
-            path=request.get_full_path())
-        context_dict["social_links"] = format_urls(
-            settings.SOCIAL_ORIGINS,
-            {'name': layer.title, 'url': social_url})
+        context_dict["social_links"] = build_social_links(request, layer)
 
     return render_to_response(template, RequestContext(request, context_dict))
 

--- a/geonode/layers/views.py
+++ b/geonode/layers/views.py
@@ -259,7 +259,9 @@ def layer_detail(request, layername, template='layers/layer_detail.html'):
             protocol=("https" if request.is_secure() else "http"),
             host=request.get_host(),
             path=request.get_full_path())
-        context_dict["social_links"] = format_urls(settings.SOCIAL_ORIGINS, {'name':layer.title,'url': social_url})
+        context_dict["social_links"] = format_urls(
+            settings.SOCIAL_ORIGINS,
+            {'name': layer.title, 'url': social_url})
 
     return render_to_response(template, RequestContext(request, context_dict))
 

--- a/geonode/maps/views.py
+++ b/geonode/maps/views.py
@@ -125,7 +125,7 @@ def map_detail(request, mapid, snapshot=None, template='maps/map_detail.html'):
             protocol=("https" if request.is_secure() else "http"),
             host=request.get_host(),
             path=request.get_full_path())
-        context_dict["social_links"] = format_urls(settings.SOCIAL_ORIGINS, {'name':map_obj.title,'url': social_url})
+        context_dict["social_links"] = format_urls(settings.SOCIAL_ORIGINS, {'name': map_obj.title, 'url': social_url})
 
     return render_to_response(template, RequestContext(request, context_dict))
 

--- a/geonode/maps/views.py
+++ b/geonode/maps/views.py
@@ -51,7 +51,7 @@ from geonode.tasks.deletion import delete_map
 from geonode.documents.models import get_related_documents
 from geonode.people.forms import ProfileForm
 from geonode.utils import num_encode, num_decode
-from geonode.utils import format_urls
+from geonode.utils import build_social_links
 
 if 'geonode.geoserver' in settings.INSTALLED_APPS:
     # FIXME: The post service providing the map_status object
@@ -121,11 +121,7 @@ def map_detail(request, mapid, snapshot=None, template='maps/map_detail.html'):
     }
 
     if settings.SOCIAL_ORIGINS:
-        social_url = "{protocol}://{host}{path}".format(
-            protocol=("https" if request.is_secure() else "http"),
-            host=request.get_host(),
-            path=request.get_full_path())
-        context_dict["social_links"] = format_urls(settings.SOCIAL_ORIGINS, {'name': map_obj.title, 'url': social_url})
+        context_dict["social_links"] = build_social_links(request, map_obj)
 
     return render_to_response(template, RequestContext(request, context_dict))
 

--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -633,6 +633,24 @@ MAP_BASELAYERS = [{
 
 SOCIAL_BUTTONS = True
 
+SOCIAL_ORIGINS = [{
+    "label":"Email",
+    "url":"mailto:?subject={name}&body={url}",
+    "css_class":"email"
+}, {
+    "label":"Facebook",
+    "url":"http://www.facebook.com/sharer.php?u={url}",
+    "css_class":"fb"
+}, {
+    "label":"Twitter",
+    "url":"https://twitter.com/share?url={url}",
+    "css_class":"tw"
+}, {
+    "label":"Google +",
+    "url":"https://plus.google.com/share?url={url}",
+    "css_class":"gp"
+}]
+
 # Enable Licenses User Interface
 # Regardless of selection, license field stil exists as a field in the Resourcebase model.
 # Detail Display: above, below, never

--- a/geonode/templates/social_links.html
+++ b/geonode/templates/social_links.html
@@ -10,9 +10,11 @@
         </header>
         <div>
               <ul class="social">
-                  <li><a href="http://www.facebook.com/sharer.php?u=http://{{ request.get_host }}{{ request.get_full_path }}" class="fb">facebook</a></li>
-                  <li><a href="https://twitter.com/share?url=http://{{ request.get_host }}{{ request.get_full_path }}" class="tw">twitter</a></li>
-                  <li><a href="https://plus.google.com/share?url=http://{{ request.get_host }}{{ request.get_full_path }}" class="gp">google+</a></li>
+                  {% for social_link in social_links %}
+                      {% if social_link.url %}
+                      <li><a href="{{ social_link.url }}" class="{{ social_link.css_class }}">{{ social_link.label }}</a></li>
+                      {% endif %}
+                  {% endfor %}
               </ul>
          </div>
         <!-- TODO: Add more sharing options -->

--- a/geonode/utils.py
+++ b/geonode/utils.py
@@ -551,3 +551,13 @@ def format_urls(a, values):
             j['url'] = None
         b.append(j)
     return b
+
+
+def build_social_links(request, resourcebase):
+    social_url = "{protocol}://{host}{path}".format(
+        protocol=("https" if request.is_secure() else "http"),
+        host=request.get_host(),
+        path=request.get_full_path())
+    return format_urls(
+        settings.SOCIAL_ORIGINS,
+        {'name': resourcebase.title, 'url': social_url})

--- a/geonode/utils.py
+++ b/geonode/utils.py
@@ -540,6 +540,7 @@ def num_decode(s):
         n = n * BASE + ALPHABET_REVERSE[c]
     return n
 
+
 def format_urls(a, values):
     b = []
     for i in a:

--- a/geonode/utils.py
+++ b/geonode/utils.py
@@ -539,3 +539,14 @@ def num_decode(s):
     for c in s:
         n = n * BASE + ALPHABET_REVERSE[c]
     return n
+
+def format_urls(a, values):
+    b = []
+    for i in a:
+        j = i.copy()
+        try:
+            j['url'] = j['url'].format(**values)
+        except KeyError:
+            j['url'] = None
+        b.append(j)
+    return b


### PR DESCRIPTION
The social links are no longer hard coded, but added as a list to the settings.py file.  Admins can now easily remove or add their social networks of choice.  This will be useful for managing customization of multiple deployments.

Minor Changes
- prepended a mailto email link.
- context_processors.py defaults SOCIAL_BUTTONS to False if var is not found in settings.py.  Most settings.py files come with SOCIAL_BUTTONS included.
- included https check when sharing url

More importantly, this will open up a simple way to leverage "Web Intents" / APIs to integrate GeoNode services into other systems, such as discovery platforms, url shorteners, etc.  Are there other web intents that should be added to the default settings.py file?