### PR TITLE
Checks if /dev/null actually exists, and if not, reset it to something Windows understands

### DIFF
--- a/pavement.py
+++ b/pavement.py
@@ -342,6 +342,12 @@ def start_geoserver(options):
     with pushd(data_dir):
         javapath = "java"
         loggernullpath = "/dev/null"
+
+        # checking if our loggernullpath exists and if not, reset it to something manageable
+        if os.devnull == "nul":
+            open("../../downloaded/null.txt", 'w+').close()
+            loggernullpath = "../../downloaded/null.txt"
+
         try:
             sh(('java -version'))
         except:
@@ -350,10 +356,6 @@ def start_geoserver(options):
                 sys.exit(1)
             # if there are spaces
             javapath = 'START /B "" "' + options['java_path'] + '"'
-            # cmd log file needs to exist in windows
-            # using folder from .gitignore
-            open("../../downloaded/null.txt", 'w+').close()
-            loggernullpath = "../../downloaded/null.txt"
 
         sh((
             '%(javapath)s -Xmx512m -XX:MaxPermSize=256m'

--- a/pavement.py
+++ b/pavement.py
@@ -341,10 +341,10 @@ def start_geoserver(options):
     # prevents geonode security from initializing correctly otherwise
     with pushd(data_dir):
         javapath = "java"
-        loggernullpath = "/dev/null"
+        loggernullpath = os.devnull
 
         # checking if our loggernullpath exists and if not, reset it to something manageable
-        if os.devnull == "nul":
+        if loggernullpath == "nul":
             open("../../downloaded/null.txt", 'w+').close()
             loggernullpath = "../../downloaded/null.txt"
 


### PR DESCRIPTION
This is a simple patch to solve bug issue #1919.

The change is simple. I kept the things that check Java support the same, but now we do not rely on the behavior of java being configured to set the loggernullpath. In a test I made with a Windows Server 2008, ```java -version``` worked, and by consequence, loggernullpath was still ```/dev/null```, causing ```paver start``` to fail, when we could not find that filestream.

Now, we just check ```os.devnull```. If it's equals to ```nul```, it means we are on Windows. I did not wanted to change line 344, that configures loggernullpath to be the output of ```os.devnull``` because I'm not aware of the consequences this might have on Mac OSX. So, this could be further optimized as (if someone can guarantee that it will work for Mac OSX - Linux I know it will work):

```python
# function start_geoserver
# ...
with pushd(data_dir):
        javapath = "java"
        loggernullpath = os.devnull

        # checking if our loggernullpath exists and if not, reset it to something manageable
        if loggernullpath == "nul":
            open("../../downloaded/null.txt", 'w+').close()
            loggernullpath = "../../downloaded/null.txt"

        try:
            sh(('java -version'))
        except:
            if not options.get('java_path', None):
                print "Paver cannot find java in the Windows Environment.  Please provide the --java_path flag with your full path to java.exe e.g. --java_path=C:/path/to/java/bin/java.exe"
                sys.exit(1)
            # if there are spaces
            javapath = 'START /B "" "' + options['java_path'] + '"'

        sh((
            '%(javapath)s -Xmx512m -XX:MaxPermSize=256m'
            ' -DGEOSERVER_DATA_DIR=%(data_dir)s'
            # workaround for JAI sealed jar issue and jetty classloader
            ' -Dorg.eclipse.jetty.server.webapp.parentLoaderPriority=true'
            ' -jar %(jetty_runner)s'
            ' --log %(log_file)s'
            ' %(config)s'
            ' > %(loggernullpath)s &' % locals()
        ))
# ...
```

That's pretty much it. I'm not sure how we can test this script. If anyone can point me to the right direction, I can create the UT.