### PR TITLE
Bump Django to 1.6.10.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ setup(name='GeoNode',
         "pillow", # python-pillow
         "lxml", # python-lxml
         # "psycopg2==2.4.5", # python-psycopg2
-        "Django >=1.6.1, <=1.6.5", # python-django
+        "Django==1.6.10", # python-django
 
         # Other
         "beautifulsoup4==4.2.1", # python-bs4


### PR DESCRIPTION
@ingenieroariel  - This replaces `Django >=1.6.1, <=1.6.5` with `Django==1.6.10`.  Both @simod and I seem to remember that there was a reason why we had to version it that way but not the specific reason why.  Do you remember why?
