### PR TITLE
Web Intents / CKAN / Initial Support

### DIFF
--- a/docs/reference/developers/settings.txt
+++ b/docs/reference/developers/settings.txt
@@ -403,6 +403,18 @@ Default::
 
 A list of dictionaries that is used to generate the social links displayed in the Share tab.  For each origin, the name and and url format parameters are replaced by the actual values of the ResourceBase object (layer, map, document).
 
+CKAN_ORIGINS
+--------------
+Default::
+
+    CKAN_ORIGINS = [{
+        "label":"Humanitarian Data Exchange (HDX)",
+        "url":"https://data.hdx.rwlabs.org/dataset/new?title={name}&notes={abstract}",
+        "css_class":"hdx"
+    }]
+
+A list of dictionaries that is used to generate the links to CKAN instances displayed in the Share tab.  For each origin, the name and and abstract format parameters are replaced by the actual values of the ResourceBase object (layer, map, document).  This is not enabled by default.  To enabled, uncomment the following line: SOCIAL_ORIGINS.extend(CKAN_ORIGINS).
+
 Upload settings
 ===============
 

--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -658,7 +658,7 @@ CKAN_ORIGINS = [{
     "url":"https://data.hdx.rwlabs.org/dataset/new?title={name}&notes={abstract}",
     "css_class":"hdx"
 }]
-SOCIAL_ORIGINS.extend(CKAN_ORIGINS)
+#SOCIAL_ORIGINS.extend(CKAN_ORIGINS)
 
 # Enable Licenses User Interface
 # Regardless of selection, license field stil exists as a field in the Resourcebase model.

--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -651,6 +651,15 @@ SOCIAL_ORIGINS = [{
     "css_class":"gp"
 }]
 
+#CKAN Query String Parameters names pulled from
+#https://github.com/ckan/ckan/blob/2052628c4a450078d58fb26bd6dc239f3cc68c3e/ckan/logic/action/create.py#L43
+CKAN_ORIGINS = [{
+    "label":"Humanitarian Data Exchange (HDX)",
+    "url":"https://data.hdx.rwlabs.org/dataset/new?title={name}&notes={abstract}",
+    "css_class":"hdx"
+}]
+SOCIAL_ORIGINS.extend(CKAN_ORIGINS)
+
 # Enable Licenses User Interface
 # Regardless of selection, license field stil exists as a field in the Resourcebase model.
 # Detail Display: above, below, never

--- a/geonode/utils.py
+++ b/geonode/utils.py
@@ -552,11 +552,13 @@ def format_urls(a, values):
         b.append(j)
     return b
 
+
 def build_abstract(resourcebase, url=None, includeURL=True):
     if resourcebase.abstract and url and includeURL:
         return "{abstract} -- [{url}]({url})".format(abstract=resourcebase.abstract, url=url)
     else:
         return resourcebase.abstract
+
 
 def build_social_links(request, resourcebase):
     social_url = "{protocol}://{host}{path}".format(

--- a/geonode/utils.py
+++ b/geonode/utils.py
@@ -552,6 +552,11 @@ def format_urls(a, values):
         b.append(j)
     return b
 
+def build_abstract(resourcebase, url=None, includeURL=True):
+    if resourcebase.abstract and url and includeURL:
+        return "{abstract} -- [{url}]({url})".format(abstract=resourcebase.abstract, url=url)
+    else:
+        return resourcebase.abstract
 
 def build_social_links(request, resourcebase):
     social_url = "{protocol}://{host}{path}".format(
@@ -560,4 +565,7 @@ def build_social_links(request, resourcebase):
         path=request.get_full_path())
     return format_urls(
         settings.SOCIAL_ORIGINS,
-        {'name': resourcebase.title, 'url': social_url})
+        {
+            'name': resourcebase.title,
+            'abstract': build_abstract(resourcebase, url=social_url, includeURL=True),
+            'url': social_url})


### PR DESCRIPTION
Building on https://github.com/GeoNode/geonode/pull/1918, this PR adds initial support for using "web intents" to register geospatial services with CKAN.  This PR adds support for the optional `abstract` querystring parameter to SOCIAL_ORIGINS.  Commented out by default, this PR adds a block to the settings.py file for managing CKAN "social links", to enable publishing.  To enable, remove the comment from the following line in the settings.py: `SOCIAL_ORIGINS.extend(CKAN_ORIGINS)`.  The commented out example in the settings.py file points to Humanitarian Data Exchange (https://data.hdx.rwlabs.org/).

Additional querystring parameters would need to be supported on the CKAN side to build out the workflow.