### PR TITLE
Fix #1849

### DIFF
--- a/geonode/base/models.py
+++ b/geonode/base/models.py
@@ -74,7 +74,7 @@ class TopicCategory(models.Model):
     <CodeListDictionary gml:id="MD_MD_TopicCategoryCode">
     """
     identifier = models.CharField(max_length=255, default='location')
-    description = models.TextField()
+    description = models.TextField(default='')
     gn_description = models.TextField('GeoNode description', default='', null=True)
     is_choice = models.BooleanField(default=True)
 

--- a/geonode/layers/utils.py
+++ b/geonode/layers/utils.py
@@ -359,7 +359,7 @@ def file_upload(filename, name=None, user=None, title=None, abstract=None,
             elif key == 'topic_category':
                 value, created = TopicCategory.objects.get_or_create(
                     identifier=value.lower(),
-                    defaults={'description':'', 'gn_description': value})
+                    defaults={'description': '', 'gn_description': value})
                 key = 'category'
                 defaults[key] = value
             else:

--- a/geonode/layers/utils.py
+++ b/geonode/layers/utils.py
@@ -358,8 +358,10 @@ def file_upload(filename, name=None, user=None, title=None, abstract=None,
                 value = SpatialRepresentationType(identifier=value)
             elif key == 'topic_category':
                 value, created = TopicCategory.objects.get_or_create(
-                    identifier=value.lower(), gn_description=value)
+                    identifier=value.lower(),
+                    defaults={'description':'', 'gn_description': value})
                 key = 'category'
+                defaults[key] = value
             else:
                 defaults[key] = value
 


### PR DESCRIPTION
Fixes #1849.  GeoNode was creating duplicate categories, because of a simple error in the get_or_create method.  The description and gn_description fields need to be in the defaults dict.  It tried a lookup using gn_description which will frequently fail because of case mismatch.  Also needs to be actually passed to the defaults variable so it is used later to create the layer. 

According to Django documentatation at https://docs.djangoproject.com/en/dev/ref/models/querysets/#get-or-create:

*Any keyword arguments passed to get_or_create() — except an optional one called defaults — will be used in a get() call*