### PR TITLE
Fix #1934

### DIFF
--- a/geonode/layers/models.py
+++ b/geonode/layers/models.py
@@ -295,7 +295,7 @@ class Attribute(models.Model):
         _('attribute label'),
         help_text=_('title of attribute as displayed in GeoNode'),
         max_length=255,
-        blank=False,
+        blank=True,
         null=True,
         unique=False)
     attribute_type = models.CharField(

--- a/geonode/layers/templates/layers/layer_detail.html
+++ b/geonode/layers/templates/layers/layer_detail.html
@@ -58,7 +58,7 @@
               <tbody>
                 {% for attribute in resource.attributes %}
                   <tr>
-                    <td>{{ attribute }}</td>
+                    <td {% if attribute.attribute_label and attribute.attribute_label != attribute.attribute %}title="{{ attribute.attribute }}"{% endif %}>{{ attribute }}</td>
                     {% if attribute.unique_values == "NA" %}
                     <td>{{ attribute.unique_values }}</td>
                     {% else %}


### PR DESCRIPTION
Fixes #1934.  This PR allows attribute labels to be blank so that users do not need to fill in every attribute label if they want to change any of the metadata through the layer metadata page.  This PR also adds tooltips for every attribute under the "Attributes" tab on the Layer detail page to display the actual attribute name when the label is in the table.