### PR TITLE
Activity Filters (All, Layers, Maps, Comments)

### DIFF
--- a/geonode/groups/templates/groups/activity.html
+++ b/geonode/groups/templates/groups/activity.html
@@ -20,13 +20,50 @@
     <h2 class="page-title">{%  trans "Activity Feed for"  %} <a href="{% url "group_detail" group.slug %}">{{ group.title }}</a></h2>
     <div class="row">
       <div class="col-md-12">
-        <ul class="no-style-list">
-	  {% for action in action_list %}
-            {% activity_item action %}
-            {% empty %}
-            <p>{% trans "No actions yet" %}</p>
-          {% endfor %}
+        <ul class="nav nav-tabs">
+          <li class="active"><a href="#all" data-toggle="tab"><i class=""></i>{% trans "All" %}</a></li>
+          <li><a href="#layers" data-toggle="tab"><i class="fa fa-square-o rotate-45"></i> {% trans "Layers" %}</a></li>
+          <li><a href="#maps" data-toggle="tab"><i class="fa fa-map-marker"></i> {% trans "Maps" %}</a></li>
+          <li><a href="#comments" data-toggle="tab"><i class="fa fa-comment-o"></i> {% trans "Comments" %}</a></li>
         </ul>
+    <div class="tab-content">
+      <article id="all" class="tab-pane active">
+        <ul class="no-style-list">
+        {% for action in action_list %}
+          {% activity_item action %}
+          {% empty %}
+          <p>{% trans "No actions yet" %}</p>
+        {% endfor %}
+        </ul>
+      </article>
+      <article id="layers" class="tab-pane">
+        <ul class="no-style-list">
+        {% for action in action_list_layers %}
+          {% activity_item action %}
+          {% empty %}
+          <p>{% trans "No actions yet" %}</p>
+        {% endfor %}
+        </ul>
+      </article>
+      <article id="maps" class="tab-pane">
+        <ul class="no-style-list">
+        {% for action in action_list_maps %}
+          {% activity_item action %}
+          {% empty %}
+          <p>{% trans "No actions yet" %}</p>
+        {% endfor %}
+        </ul>
+      </article>
+      <article id="comments" class="tab-pane">
+        <ul class="no-style-list">
+        {% for action in action_list_comments %}
+          {% activity_item action %}
+          {% empty %}
+          <p>{% trans "No actions yet" %}</p>
+        {% endfor %}
+        </ul>
+      </article>
+    </div>
       </div>
     </div>
   </div>

--- a/geonode/groups/views.py
+++ b/geonode/groups/views.py
@@ -251,4 +251,18 @@ class GroupActivityView(ListView):
     def get_context_data(self, **kwargs):
         context = super(GroupActivityView, self).get_context_data(**kwargs)
         context['group'] = self.group
+        #Additional Filtered Lists Below
+        members = ([(member.user.id) for member in self.group.member_queryset()])
+        context['action_list_layers'] = Action.objects.filter(
+            public=True,
+            actor_object_id__in=members,
+            action_object_content_type__name='layer')[:15]
+        context['action_list_maps'] = Action.objects.filter(
+            public=True,
+            actor_object_id__in=members,
+            action_object_content_type__name='map')[:15]
+        context['action_list_comments'] = Action.objects.filter(
+            public=True,
+            actor_object_id__in=members,
+            action_object_content_type__name='comment')[:15]
         return context

--- a/geonode/groups/views.py
+++ b/geonode/groups/views.py
@@ -251,7 +251,7 @@ class GroupActivityView(ListView):
     def get_context_data(self, **kwargs):
         context = super(GroupActivityView, self).get_context_data(**kwargs)
         context['group'] = self.group
-        #Additional Filtered Lists Below
+        # Additional Filtered Lists Below
         members = ([(member.user.id) for member in self.group.member_queryset()])
         context['action_list_layers'] = Action.objects.filter(
             public=True,

--- a/geonode/social/templates/social/activity_list.html
+++ b/geonode/social/templates/social/activity_list.html
@@ -11,18 +11,55 @@
 {% endcomment %}
 
 {% block body %}
-<div class="page-header">
+<div class="page-title">
   <h2>{% trans "Recent activity" %}</h2>
 </div>
 <div class="row">
-  <div class="col-md-8">
-    <ul class="no-style-list">
-      {% for action in action_list %}       
-      {% activity_item action %}
-      {% empty %}
-      <p>{% trans "No actions yet" %}</p>
-      {% endfor %}
+  <div class="col-md-12">
+    <ul class="nav nav-tabs">
+      <li class="active"><a href="#all" data-toggle="tab"><i class=""></i>{% trans "All" %}</a></li>
+      <li><a href="#layers" data-toggle="tab"><i class="fa fa-square-o rotate-45"></i> {% trans "Layers" %}</a></li>
+      <li><a href="#maps" data-toggle="tab"><i class="fa fa-map-marker"></i> {% trans "Maps" %}</a></li>
+      <li><a href="#comments" data-toggle="tab"><i class="fa fa-comment-o"></i> {% trans "Comments" %}</a></li>
     </ul>
+    <div class="tab-content">
+      <article id="all" class="tab-pane active">
+        <ul class="no-style-list">
+        {% for action in action_list %}       
+          {% activity_item action %}
+          {% empty %}
+          <p>{% trans "No actions yet" %}</p>
+        {% endfor %}
+        </ul>
+      </article>
+      <article id="layers" class="tab-pane">
+        <ul class="no-style-list">
+        {% for action in action_list_layers %}
+          {% activity_item action %}
+          {% empty %}
+          <p>{% trans "No actions yet" %}</p>
+        {% endfor %}
+        </ul>
+      </article>
+      <article id="maps" class="tab-pane">
+        <ul class="no-style-list">
+        {% for action in action_list_maps %}
+          {% activity_item action %}
+          {% empty %}
+          <p>{% trans "No actions yet" %}</p>
+        {% endfor %}
+        </ul>
+      </article>
+      <article id="comments" class="tab-pane">
+        <ul class="no-style-list">
+        {% for action in action_list_comments %}
+          {% activity_item action %}
+          {% empty %}
+          <p>{% trans "No actions yet" %}</p>
+        {% endfor %}
+        </ul>
+      </article>
+    </div>
   </div>
 </div>
 {% endblock %}

--- a/geonode/social/views.py
+++ b/geonode/social/views.py
@@ -9,3 +9,11 @@ class RecentActivity(ListView):
     context_object_name = 'action_list'
     queryset = Action.objects.filter(public=True)[:15]
     template_name = 'social/activity_list.html'
+
+    def get_context_data(self, *args, **kwargs):
+        context = super(ListView, self).get_context_data(*args, **kwargs)
+        context['action_list_layers'] = Action.objects.filter(public=True,action_object_content_type__name='layer')[:15]
+        context['action_list_maps'] = Action.objects.filter(public=True,action_object_content_type__name='map')[:15]
+        context['action_list_comments'] = Action.objects.filter(public=True,action_object_content_type__name='comment')[:15]
+        return context 
+

--- a/geonode/social/views.py
+++ b/geonode/social/views.py
@@ -12,8 +12,13 @@ class RecentActivity(ListView):
 
     def get_context_data(self, *args, **kwargs):
         context = super(ListView, self).get_context_data(*args, **kwargs)
-        context['action_list_layers'] = Action.objects.filter(public=True,action_object_content_type__name='layer')[:15]
-        context['action_list_maps'] = Action.objects.filter(public=True,action_object_content_type__name='map')[:15]
-        context['action_list_comments'] = Action.objects.filter(public=True,action_object_content_type__name='comment')[:15]
-        return context 
-
+        context['action_list_layers'] = Action.objects.filter(
+            public=True,
+            action_object_content_type__name='layer')[:15]
+        context['action_list_maps'] = Action.objects.filter(
+            public=True,
+            action_object_content_type__name='map')[:15]
+        context['action_list_comments'] = Action.objects.filter(
+            public=True,
+            action_object_content_type__name='comment')[:15]
+        return context


### PR DESCRIPTION
**Activity Filters (All, Layers, Maps, Comments)**

This PR adds tabs to the global activity feed and group activity feeds.  This enhancement allows users to filter activity for only relevant information.  A common use case is an open data geonode.  If users are looking for new spatial data, they should be able to filter the feed to just see new layers (not see comments, new maps, etc.).