### PR TITLE
HOLD: Region Filter

### DIFF
--- a/geonode/api/api.py
+++ b/geonode/api/api.py
@@ -9,6 +9,7 @@ from guardian.shortcuts import get_objects_for_user
 
 from geonode.base.models import ResourceBase
 from geonode.base.models import TopicCategory
+from geonode.base.models import Region
 from geonode.layers.models import Layer
 from geonode.maps.models import Map
 from geonode.documents.models import Document
@@ -106,16 +107,15 @@ class RegionResource(TypeFilteredResource):
         resources_ids = resources.values_list('id', flat=True)
 
         if self.type_filter:
-            ctype = ContentType.objects.get_for_model(self.type_filter)
-            count = bundle.obj.taggit_taggeditem_items.filter(
-                content_type=ctype).filter(object_id__in=resources_ids).count()
+            count = bundle.obj.resourcebase_set.filter(
+                id__in=resources_ids).instance_of(self.type_filter).count()
         else:
-            count = bundle.obj.taggit_taggeditem_items.filter(object_id__in=resources_ids).count()
+            count = bundle.obj.resourcebase_set.filter(id__in=resources_ids).count()
 
         return count
 
     class Meta:
-        queryset = Tag.objects.all().order_by('name')
+        queryset = Region.objects.all().order_by('name')
         resource_name = 'regions'
         allowed_methods = ['get']
         filtering = {

--- a/geonode/api/urls.py
+++ b/geonode/api/urls.py
@@ -1,7 +1,7 @@
 from tastypie.api import Api
 
 from .api import TagResource, TopicCategoryResource, ProfileResource, \
-    GroupResource
+    GroupResource, RegionResource
 from .resourcebase_api import LayerResource, MapResource, DocumentResource, \
     ResourceBaseResource, FeaturedResourceBaseResource
 
@@ -13,6 +13,7 @@ api.register(DocumentResource())
 api.register(ProfileResource())
 api.register(ResourceBaseResource())
 api.register(TagResource())
+api.register(RegionResource())
 api.register(TopicCategoryResource())
 api.register(GroupResource())
 api.register(FeaturedResourceBaseResource())

--- a/geonode/layers/search_indexes.py
+++ b/geonode/layers/search_indexes.py
@@ -37,6 +37,10 @@ class LayerIndex(indexes.SearchIndex, indexes.Indexable):
         model_attr="keyword_slug_list",
         null=True,
         faceted=True)
+    regions = indexes.MultiValueField(
+        model_attr="region_slug_list",
+        null=True,
+        faceted=True)
     popular_count = indexes.IntegerField(
         model_attr="popular_count",
         default=0,

--- a/geonode/static/geonode/js/search/search.js
+++ b/geonode/static/geonode/js/search/search.js
@@ -24,7 +24,7 @@
         return data;
     }
 
-  // Load categories and keywords
+  // Load categories, keywords, and regions
   module.load_categories = function ($http, $rootScope, $location){
         var params = typeof FILTER_TYPE == 'undefined' ? {} : {'type': FILTER_TYPE};
         $http.get(CATEGORIES_ENDPOINT, {params: params}).success(function(data){
@@ -44,6 +44,17 @@
                     $location.search()['keywords__slug__in'], 'slug');
             }
             $rootScope.keywords = data.objects;
+            if (HAYSTACK_FACET_COUNTS && $rootScope.query_data) {
+                module.haystack_facets($http, $rootScope, $location);
+            }
+        });
+
+        $http.get(REGIONS_ENDPOINT, {params: params}).success(function(data){
+            if($location.search().hasOwnProperty('regions__name__in')){
+                data.objects = module.set_initial_filters_from_query(data.objects,
+                    $location.search()['regions__name__in'], 'name');
+            }
+            $rootScope.regions = data.objects;
             if (HAYSTACK_FACET_COUNTS && $rootScope.query_data) {
                 module.haystack_facets($http, $rootScope, $location);
             }
@@ -73,6 +84,18 @@
                   keyword.count = $rootScope.keyword_counts[keyword.slug]
               } else {
                   keyword.count = 0;
+              }
+          }
+      }	
+
+      if ("regions" in $rootScope) {
+          $rootScope.regions_counts = data.meta.facets.regions;
+          for (var id in $rootScope.regions) {
+              var region = $rootScope.regions[id];
+              if (region.name in $rootScope.region_counts) {
+                  region.count = $rootScope.region_counts[region.name]
+              } else {
+                  region.count = 0;
               }
           }
       }
@@ -288,7 +311,7 @@
     * Text search management
     */
     var text_autocomplete = $('#text_search_input').yourlabsAutocomplete({
-          url: AUTOCOMPLETE_URL,
+          url: AUTOCOMPLETE_URL_RESOURCEBASE,
           choiceSelector: 'span',
           hideAfter: 200,
           minimumCharacters: 1,
@@ -310,6 +333,31 @@
         query_api($scope.query);
     });
 
+    /*
+    * Region search management
+    */
+    var region_autocomplete = $('#region_search_input').yourlabsAutocomplete({
+          url: AUTOCOMPLETE_URL_REGION,
+          choiceSelector: 'span',
+          hideAfter: 200,
+          minimumCharacters: 1,
+          appendAutocomplete: $('#region_search_input'),
+          placeholder: gettext('Enter your region here ...')
+    });
+    $('#region_search_input').bind('selectChoice', function(e, choice, region_autocomplete) {
+          if(choice[0].children[0] == undefined) {
+              $('#region_search_input').val(choice[0].innerHTML);
+              $('#region_search_btn').click();
+          }
+    });
+
+    $('#region_search_btn').click(function(){
+        if (HAYSTACK_SEARCH)
+            $scope.query['q'] = $('#region_search_input').val();
+        else
+            $scope.query['regions__name__in'] = $('#region_search_input').val();
+        query_api($scope.query);
+    });
 
     $scope.feature_select = function($event){
       var element = $($event.target);

--- a/geonode/templates/search/_region_filter.html
+++ b/geonode/templates/search/_region_filter.html
@@ -6,7 +6,7 @@
     <ul class="nav closed" id="regions">
         <li>
             <div class="input-group">
-            <input name="region_search_input" id="region_search_input" ng-model="text_query" type="text"
+            <input name="region_search_input" id="region_search_input" type="text"
                    placeholder="Search by region" class="form-control">
             <span class="input-group-btn">
                 <button class="btn btn-primary" type="submit" id="region_search_btn"><i class="fa fa-search"></i></button>

--- a/geonode/templates/search/_region_filter.html
+++ b/geonode/templates/search/_region_filter.html
@@ -2,8 +2,8 @@
 {% load base_tags %}
 <nav class="filter">
 
-    <h4><a href="#" class="toggle toggle-nav"><i class="fa fa-chevron-down"></i>{% trans "Regions" %}</a></h4>
-    <ul class="nav open" id="regions">
+    <h4><a href="#" class="toggle toggle-nav"><i class="fa fa-chevron-right"></i>{% trans "Regions" %}</a></h4>
+    <ul class="nav closed" id="regions">
         <li>
             <div class="input-group">
             <input name="region_search_input" id="region_search_input" ng-model="text_query" type="text"

--- a/geonode/templates/search/_region_filter.html
+++ b/geonode/templates/search/_region_filter.html
@@ -1,0 +1,18 @@
+{% load i18n %}
+{% load base_tags %}
+<nav class="filter">
+
+    <h4><a href="#" class="toggle toggle-nav"><i class="fa fa-chevron-down"></i>{% trans "Regions" %}</a></h4>
+    <ul class="nav open" id="regions">
+        <li>
+            <div class="input-group">
+            <input name="region_search_input" id="region_search_input" ng-model="text_query" type="text"
+                   placeholder="Search by region" class="form-control">
+            <span class="input-group-btn">
+                <button class="btn btn-primary" type="submit" id="region_search_btn"><i class="fa fa-search"></i></button>
+            </span>
+            </div>
+        </li>
+    </ul>
+
+</nav>

--- a/geonode/templates/search/_search_content.html
+++ b/geonode/templates/search/_search_content.html
@@ -13,6 +13,7 @@
         {% include "search/_type_filters.html" %}
         {% endif %}
         {% include "search/_general_filters.html" %}
+        {% include "search/_region_filter.html" %}
         {% include "search/_extent_filter.html" %}
       </div>
   </div>

--- a/geonode/templates/search/search_scripts.html
+++ b/geonode/templates/search/search_scripts.html
@@ -20,10 +20,12 @@
   $("body").attr('ng-controller', 'geonode_search_controller');
   CATEGORIES_ENDPOINT = '{% url 'api_dispatch_list' api_name='api' resource_name='categories' %}';
   KEYWORDS_ENDPOINT = '{% url 'api_dispatch_list' api_name='api' resource_name='keywords' %}';
+  REGIONS_ENDPOINT = '{% url 'api_dispatch_list' api_name='api' resource_name='regions' %}';
   HAYSTACK_SEARCH = "{{ HAYSTACK_SEARCH }}".toLowerCase() === "true";
   HAYSTACK_FACET_COUNTS = "{{ HAYSTACK_FACET_COUNTS }}".toLowerCase() === "true";
   CLIENT_RESULTS_LIMIT = {{ CLIENT_RESULTS_LIMIT }};
-  AUTOCOMPLETE_URL = '{% url "autocomplete_light_autocomplete" "ResourceBaseAutocomplete" %}';
+  AUTOCOMPLETE_URL_RESOURCEBASE = '{% url "autocomplete_light_autocomplete" "ResourceBaseAutocomplete" %}';
+  AUTOCOMPLETE_URL_REGION = '{% url "autocomplete_light_autocomplete" "RegionAutocomplete" %}';
 
   var module = angular.module('search', ['geonode_main_search']);
   module.constant('Configs', {


### PR DESCRIPTION
For issue #1826, this PR creates a region filter to be displayed right above the extent filter.  The filter is collapsed by default.  The filter uses an autocomplete field against the full list of regions.

@simod, any suggestions/issues?

**Need to Fix**
- [x] geonode/api/api.py
- [x] geonode/templates/search/_region_filter.html
- [ ] Merge TagResource and RegionResource

**Known Issues**
- [x] The text and region autocomplete inputs both work.  However, when I type into text field the text appears in the other one.  Not sure how this is happening.

**Future Enhancements**
- [ ] Filter autocomplete list by regions with count > 0
- [ ] Select multiple regions.  Display selections.
- [ ] Leverage region hierarchies for filtering