### PR TITLE
Fixed issue with non ASCII characters

### DIFF
--- a/geonode/utils.py
+++ b/geonode/utils.py
@@ -546,7 +546,7 @@ def format_urls(a, values):
     for i in a:
         j = i.copy()
         try:
-            j['url'] = j['url'].format(**values)
+            j['url'] = unicode(j['url']).format(**values)
         except KeyError:
             j['url'] = None
         b.append(j)


### PR DESCRIPTION
Avoided Internal Server Error on layer_detail, map_detail and document_detail  if there are ASCII characters in resource titles.