### PR TITLE
Fix #1847

### DIFF
--- a/geonode/templates/user_messages/_message_snippet.html
+++ b/geonode/templates/user_messages/_message_snippet.html
@@ -1,0 +1,46 @@
+{% load i18n %}
+
+{% load avatar_tags %}
+
+<table class="table table-striped table-bordered table-condensed">
+    <thead>
+        <tr>
+            <td><strong>{% trans "With" %}</strong></td>
+            <td><strong>{% trans "Subject" %}</strong></td>
+            <td><strong>{% trans "Last Sender" %}</strong></td>
+            <td><strong>{% trans "Preview" %}</strong></td>
+            <td><strong>{% trans "Delete?" %}</strong></td>
+        </tr>
+        </thead>
+        <tbody>
+        {% for thread in threads %}
+        <tr>
+            <td>
+                {% for user in thread.users.all %}
+                    {% ifnotequal request.user user %}
+                        <p>{% avatar user 30 %}</p>
+                        <a href="{{ user.get_absolute_url }}">{{ user }}</a>
+                    {% endifnotequal %}
+                {% endfor %}
+            </td>
+            <td><a href="{{ thread.get_absolute_url }}">{{ thread.subject }}</a></td>
+            <td>
+                {% ifequal request.user thread.latest_message.sender %}
+                  {% trans "me" %}
+                {% else %}
+                  <a href="{{ thread.latest_message.sender.get_absolute_url }}">{{ thread.latest_message.sender }}</a>
+                {% endifequal %}
+            </td>
+            <td>
+                {{ thread.latest_message.content|slice:"50" }}<a href="{{ thread.get_absolute_url }}">...</a>
+            </td>
+            <td>
+                <form id="thread_delete_{{ thread.pk }}" method="post" action="{% url "messages_thread_delete" thread.pk %}">
+                    {% csrf_token %}
+                    <input type="submit" value="{% trans "Delete" %}" class="btn btn-danger" type="button"/>
+                </form>
+            </td>
+        </tr>
+        {% endfor %}
+        </tbody>
+</table>

--- a/geonode/templates/user_messages/inbox.html
+++ b/geonode/templates/user_messages/inbox.html
@@ -6,48 +6,31 @@
 {% block title %}{% trans "Message Inbox" %} — {{ block.super }}{% endblock %}
 
 {% block body %}
-<table class="table table-striped table-bordered table-condensed">
-    <thead>
-        <tr>
-            <td><strong>{% trans "With" %}</strong></td>
-            <td><strong>{% trans "Subject" %}</strong></td>
-            <td><strong>{% trans "Last Sender" %}</strong></td>
-            <td><strong>{% trans "Preview" %}</strong></td>
-            <td><strong>{% trans "Delete?" %}</strong></td>
-        </tr>
-        </thead>
-        <tbody>
-        {% for thread in threads %}
-        <tr>
-            <td>
-                {% for user in thread.users.all %}
-                    {% ifnotequal request.user user %}
-                        <p>{% avatar user 30 %}</p>
-                        <a href="{{ user.get_absolute_url }}">{{ user }}</a>
-                    {% endifnotequal %}
-                {% endfor %}
-            </td>
-            <td><a href="{{ thread.get_absolute_url }}">{{ thread.subject }}</a></td>
-            <td>
-                {% ifequal request.user thread.latest_message.sender %}
-                {% trans "you" %}
-                {% else %}
-                <a href="{{ thread.latest_message.sender.get_absolute_url }}">{{ thread.latest_message.sender }}</a>
-                {% endifequal %}
-            </td>
-            <td>
-                {{ thread.latest_message.content|slice:"50" }}<a href="{{ thread.get_absolute_url }}">...</a>
-            </td>
-            <td>
-                <form id="thread_delete_{{ thread.pk }}" method="post" action="{% url "messages_thread_delete" thread.pk %}">
-                    {% csrf_token %}
-                    <input type="submit" value="{% trans "Delete" %}" class="btn btn-danger" type="button"/>
-                </form>
-            </td>
-        </tr>
-        {% endfor %}
-        </tbody>
-</table>
+<div class="row">
+  <div class="col-md-12">
+    <h2 class="page-title">{%  trans "Messages" %}</h2>
+    <div class="row">
+      <div class="col-md-12">
+        <ul class="nav nav-tabs">
+          <li class="active"><a href="#inbox" data-toggle="tab"><i class=""></i>{% trans "Inbox" %}</a></li>
+          <li><a href="#all" data-toggle="tab"><i class=""></i> {% trans "All" %}</a></li>
+        </ul>
+        <div class="tab-content">
+          <article id="inbox" class="tab-pane active">
+            {% with threads_unread as threads %}
+                {% include "user_messages/_message_snippet.html" %}
+            {% endwith %}
+          </article>
+          <article id="all" class="tab-pane">
+            {% with threads_all as threads %}
+                {% include "user_messages/_message_snippet.html" %}
+            {% endwith %}
+          </article>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
 
 {% endblock %}
 

--- a/geonode/templates/user_messages/message_create.html
+++ b/geonode/templates/user_messages/message_create.html
@@ -1,17 +1,20 @@
 {% extends "site_base.html" %}
 
 {% load i18n %}
+{% load bootstrap_tags %}
 
 {% block title %}{% trans "Create Message" %} — {{ block.super }}{% endblock %}
 
 {% block body %}
 <h3>{% trans "Create Message" %}</h3>
 <form method="post" action="{% url "message_create" %}">
-    {% csrf_token %}
-<table width=100%>
-    {{ form }}
-</table>
-<div><input type="submit" value="{% trans "Send message" %}"  class="btn btn-primary" type="button"/></div>
+  {% csrf_token %}
+  <table width=100%>
+    {{ form|as_bootstrap }}
+  </table>
+  <div class="form-actions">
+    <input type="submit" value="{% trans "Send message" %}"  class="btn btn-primary" type="button"/>
+  </div>
 </form>
 {% endblock %}
 

--- a/geonode/templates/user_messages/thread_detail.html
+++ b/geonode/templates/user_messages/thread_detail.html
@@ -9,22 +9,22 @@
 <h3>{{ thread.subject }}</h3>
 <hr />
 {% for message in thread.messages.all %}
-<div class="well">
-{% avatar message.sender 50 %}
-{{ message.sent_at }} by {% ifequal request.user message.sender %}{% trans "you" %}{% else %}<a href="{{ message.sender.get_absolute_url }}">{{ message.sender }}</a>{% endifequal %}
-<p>{{ message.content }}</p>
-</div>
-{% empty %}
-You have no messages.
+  <div class="well">
+    {% avatar message.sender 50 %}
+    {{ message.sent_at }} by {% ifequal request.user message.sender %}{% trans "me" %}{% else %}<a href="{{ message.sender.get_absolute_url }}">{{ message.sender }}</a>{% endifequal %}
+    <p>{{ message.content }}</p>
+  </div>
+  {% empty %}
+  You have no messages.
 {% endfor %}
 <div>
-    <form action="{{ thread.get_absolute_url }}" method="post">
-        {% csrf_token %}
-        <fieldset>
-            <textarea name="content"></textarea>
-            <input type="submit" value="{% trans "Send Reply" %}" class="btn btn-primary" type="button"/>
-        </fieldset>
-    </form>
+  <form action="{{ thread.get_absolute_url }}" method="post">
+    {% csrf_token %}
+    <fieldset>
+      <textarea name="content"></textarea>
+    </fieldset>
+    <input type="submit" value="{% trans "Send Reply" %}" class="btn btn-primary" type="button"/>
+  </form>
 </div>
 {% endblock %}
 


### PR DESCRIPTION
Fixes #1847.  This PR also excludes AnonymousUser from the message "To" drop down and has a few layout fixes/enhancements, including an "Inbox" and "All" tab to filter new messages.  This PR is contingent on a pending PR to https://github.com/GeoNode/geonode-user-messages.  Merge with caution.

The messages system could still use some more enhancements:
- Starring Messages
- Refractor queryset filters into views instead of having security logic in templates.
- Sent Messages