### PR TITLE
Fix the README contained in the zip file created by a map download

### DIFF
--- a/geonode/maps/models.py
+++ b/geonode/maps/models.py
@@ -126,9 +126,16 @@ class Map(ResourceBase, GXPMapBase):
         # the readme text will appear in a README file in the zip
         readme = (
             "Title: %s\n" +
-            "Author: %s\n"
+            "Author: %s\n" +
             "Abstract: %s\n"
-        ) % (self.title, "The GeoNode Team", self.abstract)
+        ) % (self.title, self.poc, self.abstract)
+        if self.license:
+            readme += "License: %s" % self.license
+            if self.license.url:
+                readme += " (%s)" % self.license.url
+            readme += "\n"
+        if self.constraints_other:
+            readme += "Additional constraints: %s\n" % self.constraints_other
 
         def layer_json(lyr):
             return {


### PR DESCRIPTION
Currently the README contained in a map download has the author hardcoded to "The GeoNode Team". With this fix the "point of contact" field is used instead. Also the license, if present, is added.