### PR TITLE
research user-group insensitive and exclude AnonymousUser

### DIFF
--- a/geonode/views.py
+++ b/geonode/views.py
@@ -79,11 +79,12 @@ def ajax_lookup(request):
             content='use a field named "query" to specify a prefix to filter usernames',
             mimetype='text/plain')
     keyword = request.POST['query']
-    users = get_user_model().objects.filter(Q(username__startswith=keyword) |
-                                            Q(first_name__contains=keyword) |
-                                            Q(organization__contains=keyword))
-    groups = GroupProfile.objects.filter(Q(title__startswith=keyword) |
-                                         Q(description__contains=keyword))
+    users = get_user_model().objects.filter(Q(username__istartswith=keyword) |
+                                            Q(first_name__icontains=keyword) |
+                                            Q(organization__icontains=keyword)).exclude(
+                                            username='AnonymousUser')
+    groups = GroupProfile.objects.filter(Q(title__istartswith=keyword) |
+                                         Q(description__icontains=keyword))
     json_dict = {
         'users': [({'username': u.username}) for u in users],
         'count': users.count(),

--- a/geonode/views.py
+++ b/geonode/views.py
@@ -81,8 +81,7 @@ def ajax_lookup(request):
     keyword = request.POST['query']
     users = get_user_model().objects.filter(Q(username__istartswith=keyword) |
                                             Q(first_name__icontains=keyword) |
-                                            Q(organization__icontains=keyword)).exclude(
-                                            username='AnonymousUser')
+                                            Q(organization__icontains=keyword)).exclude(username='AnonymousUser')
     groups = GroupProfile.objects.filter(Q(title__istartswith=keyword) |
                                          Q(description__icontains=keyword))
     json_dict = {


### PR DESCRIPTION
This PR permit to search user with insensitive case.

![ins](https://cloud.githubusercontent.com/assets/9469134/5955367/7186d598-a7a2-11e4-825a-f28a261f4071.jpg)
(test on Manage Group Members page for a group)

At the same time I exclude AnonymousUser on the list of result.