### PR TITLE
Lowercase .png references

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+	# -*- coding: utf-8 -*-
 #
 # GeoNode documentation build configuration file, created by
 # sphinx-quickstart on Mon Oct  3 16:20:38 2011.

--- a/docs/i18n/de/LC_MESSAGES/tutorials.po
+++ b/docs/i18n/de/LC_MESSAGES/tutorials.po
@@ -3660,7 +3660,7 @@ msgstr ""
 msgid ""
 "GeoNode has several views that require considerable resources to properly "
 "respond - for example, the download links on layer detail pages require "
-"GeoServer to dynamically generate output in PDF, PNG, etc. format."
+"GeoServer to dynamically generate output in PDF, png, etc. format."
 msgstr ""
 
 #: ../../tutorials/admin/production.txt:188
@@ -3897,7 +3897,7 @@ msgstr ""
 
 #: ../../tutorials/admin/production.txt:324
 msgid ""
-"Enable JPEG and PNG Native Acceleration to speed up the performance of WMS "
+"Enable JPEG and png Native Acceleration to speed up the performance of WMS "
 "requests"
 msgstr ""
 
@@ -12872,7 +12872,7 @@ msgid "GML (geographic markup language)"
 msgstr ""
 
 #: ../../tutorials/users/old/share.txt:46
-msgid "PNG (image)"
+msgid "png (image)"
 msgstr ""
 
 #: ../../tutorials/users/old/share.txt:47

--- a/docs/i18n/el/LC_MESSAGES/tutorials.po
+++ b/docs/i18n/el/LC_MESSAGES/tutorials.po
@@ -3656,7 +3656,7 @@ msgstr ""
 msgid ""
 "GeoNode has several views that require considerable resources to properly "
 "respond - for example, the download links on layer detail pages require "
-"GeoServer to dynamically generate output in PDF, PNG, etc. format."
+"GeoServer to dynamically generate output in PDF, png, etc. format."
 msgstr ""
 
 #: ../../tutorials/admin/production.txt:188
@@ -3893,7 +3893,7 @@ msgstr ""
 
 #: ../../tutorials/admin/production.txt:324
 msgid ""
-"Enable JPEG and PNG Native Acceleration to speed up the performance of WMS "
+"Enable JPEG and png Native Acceleration to speed up the performance of WMS "
 "requests"
 msgstr ""
 
@@ -12868,7 +12868,7 @@ msgid "GML (geographic markup language)"
 msgstr ""
 
 #: ../../tutorials/users/old/share.txt:46
-msgid "PNG (image)"
+msgid "png (image)"
 msgstr ""
 
 #: ../../tutorials/users/old/share.txt:47

--- a/docs/i18n/es/LC_MESSAGES/tutorials.po
+++ b/docs/i18n/es/LC_MESSAGES/tutorials.po
@@ -4711,7 +4711,7 @@ msgstr ""
 msgid ""
 "GeoNode has several views that require considerable resources to properly "
 "respond - for example, the download links on layer detail pages require "
-"GeoServer to dynamically generate output in PDF, PNG, etc. format."
+"GeoServer to dynamically generate output in PDF, png, etc. format."
 msgstr ""
 
 #: ../../tutorials/admin/production.txt:148
@@ -4926,7 +4926,7 @@ msgstr ""
 
 #: ../../tutorials/admin/production.txt:283
 msgid ""
-"Enable JPEG and PNG Native Acceleration to speed up the performance of WMS "
+"Enable JPEG and png Native Acceleration to speed up the performance of WMS "
 "requests"
 msgstr ""
 
@@ -5246,7 +5246,7 @@ msgstr ""
 # 5abefb47a8134f05924723a520db2c8d
 #: ../../tutorials/devel/api/ogc.txt:33
 msgid ""
-"WMS provides an API to retrieve map images (PNG, JPEG, etc.) of geospatial "
+"WMS provides an API to retrieve map images (png, JPEG, etc.) of geospatial "
 "data.  WMS is suitable for visualization and when access to raw data is not "
 "a requirement."
 msgstr ""
@@ -13631,7 +13631,7 @@ msgid "GML (geographic markup language)"
 msgstr ""
 
 #: ../../tutorials/users/old/share.txt:46
-msgid "PNG (image)"
+msgid "png (image)"
 msgstr ""
 
 #: ../../tutorials/users/old/share.txt:47

--- a/docs/i18n/fa/LC_MESSAGES/tutorials.po
+++ b/docs/i18n/fa/LC_MESSAGES/tutorials.po
@@ -3656,7 +3656,7 @@ msgstr ""
 msgid ""
 "GeoNode has several views that require considerable resources to properly "
 "respond - for example, the download links on layer detail pages require "
-"GeoServer to dynamically generate output in PDF, PNG, etc. format."
+"GeoServer to dynamically generate output in PDF, png, etc. format."
 msgstr ""
 
 #: ../../tutorials/admin/production.txt:188
@@ -3893,7 +3893,7 @@ msgstr ""
 
 #: ../../tutorials/admin/production.txt:324
 msgid ""
-"Enable JPEG and PNG Native Acceleration to speed up the performance of WMS "
+"Enable JPEG and png Native Acceleration to speed up the performance of WMS "
 "requests"
 msgstr ""
 
@@ -12868,7 +12868,7 @@ msgid "GML (geographic markup language)"
 msgstr ""
 
 #: ../../tutorials/users/old/share.txt:46
-msgid "PNG (image)"
+msgid "png (image)"
 msgstr ""
 
 #: ../../tutorials/users/old/share.txt:47

--- a/docs/i18n/fil/LC_MESSAGES/tutorials.po
+++ b/docs/i18n/fil/LC_MESSAGES/tutorials.po
@@ -3656,7 +3656,7 @@ msgstr ""
 msgid ""
 "GeoNode has several views that require considerable resources to properly "
 "respond - for example, the download links on layer detail pages require "
-"GeoServer to dynamically generate output in PDF, PNG, etc. format."
+"GeoServer to dynamically generate output in PDF, png, etc. format."
 msgstr ""
 
 #: ../../tutorials/admin/production.txt:188
@@ -3893,7 +3893,7 @@ msgstr ""
 
 #: ../../tutorials/admin/production.txt:324
 msgid ""
-"Enable JPEG and PNG Native Acceleration to speed up the performance of WMS "
+"Enable JPEG and png Native Acceleration to speed up the performance of WMS "
 "requests"
 msgstr ""
 
@@ -12868,7 +12868,7 @@ msgid "GML (geographic markup language)"
 msgstr ""
 
 #: ../../tutorials/users/old/share.txt:46
-msgid "PNG (image)"
+msgid "png (image)"
 msgstr ""
 
 #: ../../tutorials/users/old/share.txt:47

--- a/docs/i18n/fr/LC_MESSAGES/tutorials.po
+++ b/docs/i18n/fr/LC_MESSAGES/tutorials.po
@@ -4711,7 +4711,7 @@ msgstr ""
 msgid ""
 "GeoNode has several views that require considerable resources to properly "
 "respond - for example, the download links on layer detail pages require "
-"GeoServer to dynamically generate output in PDF, PNG, etc. format."
+"GeoServer to dynamically generate output in PDF, png, etc. format."
 msgstr ""
 
 #: ../../tutorials/admin/production.txt:148
@@ -4926,7 +4926,7 @@ msgstr ""
 
 #: ../../tutorials/admin/production.txt:283
 msgid ""
-"Enable JPEG and PNG Native Acceleration to speed up the performance of WMS "
+"Enable JPEG and png Native Acceleration to speed up the performance of WMS "
 "requests"
 msgstr ""
 
@@ -5246,7 +5246,7 @@ msgstr ""
 # 5abefb47a8134f05924723a520db2c8d
 #: ../../tutorials/devel/api/ogc.txt:33
 msgid ""
-"WMS provides an API to retrieve map images (PNG, JPEG, etc.) of geospatial "
+"WMS provides an API to retrieve map images (png, JPEG, etc.) of geospatial "
 "data.  WMS is suitable for visualization and when access to raw data is not "
 "a requirement."
 msgstr ""
@@ -13631,7 +13631,7 @@ msgid "GML (geographic markup language)"
 msgstr ""
 
 #: ../../tutorials/users/old/share.txt:46
-msgid "PNG (image)"
+msgid "png (image)"
 msgstr ""
 
 #: ../../tutorials/users/old/share.txt:47

--- a/docs/i18n/id/LC_MESSAGES/tutorials.po
+++ b/docs/i18n/id/LC_MESSAGES/tutorials.po
@@ -3656,7 +3656,7 @@ msgstr ""
 msgid ""
 "GeoNode has several views that require considerable resources to properly "
 "respond - for example, the download links on layer detail pages require "
-"GeoServer to dynamically generate output in PDF, PNG, etc. format."
+"GeoServer to dynamically generate output in PDF, png, etc. format."
 msgstr ""
 
 #: ../../tutorials/admin/production.txt:188
@@ -3893,7 +3893,7 @@ msgstr ""
 
 #: ../../tutorials/admin/production.txt:324
 msgid ""
-"Enable JPEG and PNG Native Acceleration to speed up the performance of WMS "
+"Enable JPEG and png Native Acceleration to speed up the performance of WMS "
 "requests"
 msgstr ""
 
@@ -12868,7 +12868,7 @@ msgid "GML (geographic markup language)"
 msgstr ""
 
 #: ../../tutorials/users/old/share.txt:46
-msgid "PNG (image)"
+msgid "png (image)"
 msgstr ""
 
 #: ../../tutorials/users/old/share.txt:47

--- a/docs/i18n/it/LC_MESSAGES/tutorials.po
+++ b/docs/i18n/it/LC_MESSAGES/tutorials.po
@@ -4711,7 +4711,7 @@ msgstr ""
 msgid ""
 "GeoNode has several views that require considerable resources to properly "
 "respond - for example, the download links on layer detail pages require "
-"GeoServer to dynamically generate output in PDF, PNG, etc. format."
+"GeoServer to dynamically generate output in PDF, png, etc. format."
 msgstr ""
 
 #: ../../tutorials/admin/production.txt:148
@@ -4926,7 +4926,7 @@ msgstr ""
 
 #: ../../tutorials/admin/production.txt:283
 msgid ""
-"Enable JPEG and PNG Native Acceleration to speed up the performance of WMS "
+"Enable JPEG and png Native Acceleration to speed up the performance of WMS "
 "requests"
 msgstr ""
 
@@ -5246,7 +5246,7 @@ msgstr ""
 # 5abefb47a8134f05924723a520db2c8d
 #: ../../tutorials/devel/api/ogc.txt:33
 msgid ""
-"WMS provides an API to retrieve map images (PNG, JPEG, etc.) of geospatial "
+"WMS provides an API to retrieve map images (png, JPEG, etc.) of geospatial "
 "data.  WMS is suitable for visualization and when access to raw data is not "
 "a requirement."
 msgstr ""
@@ -13631,7 +13631,7 @@ msgid "GML (geographic markup language)"
 msgstr ""
 
 #: ../../tutorials/users/old/share.txt:46
-msgid "PNG (image)"
+msgid "png (image)"
 msgstr ""
 
 #: ../../tutorials/users/old/share.txt:47

--- a/docs/i18n/ja/LC_MESSAGES/tutorials.po
+++ b/docs/i18n/ja/LC_MESSAGES/tutorials.po
@@ -3656,7 +3656,7 @@ msgstr ""
 msgid ""
 "GeoNode has several views that require considerable resources to properly "
 "respond - for example, the download links on layer detail pages require "
-"GeoServer to dynamically generate output in PDF, PNG, etc. format."
+"GeoServer to dynamically generate output in PDF, png, etc. format."
 msgstr ""
 
 #: ../../tutorials/admin/production.txt:188
@@ -3893,7 +3893,7 @@ msgstr ""
 
 #: ../../tutorials/admin/production.txt:324
 msgid ""
-"Enable JPEG and PNG Native Acceleration to speed up the performance of WMS "
+"Enable JPEG and png Native Acceleration to speed up the performance of WMS "
 "requests"
 msgstr ""
 
@@ -12868,7 +12868,7 @@ msgid "GML (geographic markup language)"
 msgstr ""
 
 #: ../../tutorials/users/old/share.txt:46
-msgid "PNG (image)"
+msgid "png (image)"
 msgstr ""
 
 #: ../../tutorials/users/old/share.txt:47

--- a/docs/i18n/ko/LC_MESSAGES/tutorials.po
+++ b/docs/i18n/ko/LC_MESSAGES/tutorials.po
@@ -3658,7 +3658,7 @@ msgstr ""
 msgid ""
 "GeoNode has several views that require considerable resources to properly "
 "respond - for example, the download links on layer detail pages require "
-"GeoServer to dynamically generate output in PDF, PNG, etc. format."
+"GeoServer to dynamically generate output in PDF, png, etc. format."
 msgstr ""
 
 #: ../../tutorials/admin/production.txt:188
@@ -3895,7 +3895,7 @@ msgstr ""
 
 #: ../../tutorials/admin/production.txt:324
 msgid ""
-"Enable JPEG and PNG Native Acceleration to speed up the performance of WMS "
+"Enable JPEG and png Native Acceleration to speed up the performance of WMS "
 "requests"
 msgstr ""
 
@@ -12870,7 +12870,7 @@ msgid "GML (geographic markup language)"
 msgstr ""
 
 #: ../../tutorials/users/old/share.txt:46
-msgid "PNG (image)"
+msgid "png (image)"
 msgstr ""
 
 #: ../../tutorials/users/old/share.txt:47

--- a/docs/i18n/pt/LC_MESSAGES/tutorials.po
+++ b/docs/i18n/pt/LC_MESSAGES/tutorials.po
@@ -3656,7 +3656,7 @@ msgstr ""
 msgid ""
 "GeoNode has several views that require considerable resources to properly "
 "respond - for example, the download links on layer detail pages require "
-"GeoServer to dynamically generate output in PDF, PNG, etc. format."
+"GeoServer to dynamically generate output in PDF, png, etc. format."
 msgstr ""
 
 #: ../../tutorials/admin/production.txt:188
@@ -3893,7 +3893,7 @@ msgstr ""
 
 #: ../../tutorials/admin/production.txt:324
 msgid ""
-"Enable JPEG and PNG Native Acceleration to speed up the performance of WMS "
+"Enable JPEG and png Native Acceleration to speed up the performance of WMS "
 "requests"
 msgstr ""
 
@@ -12868,7 +12868,7 @@ msgid "GML (geographic markup language)"
 msgstr ""
 
 #: ../../tutorials/users/old/share.txt:46
-msgid "PNG (image)"
+msgid "png (image)"
 msgstr ""
 
 #: ../../tutorials/users/old/share.txt:47

--- a/docs/i18n/ru/LC_MESSAGES/tutorials.po
+++ b/docs/i18n/ru/LC_MESSAGES/tutorials.po
@@ -3656,7 +3656,7 @@ msgstr ""
 msgid ""
 "GeoNode has several views that require considerable resources to properly "
 "respond - for example, the download links on layer detail pages require "
-"GeoServer to dynamically generate output in PDF, PNG, etc. format."
+"GeoServer to dynamically generate output in PDF, png, etc. format."
 msgstr ""
 
 #: ../../tutorials/admin/production.txt:188
@@ -3893,7 +3893,7 @@ msgstr ""
 
 #: ../../tutorials/admin/production.txt:324
 msgid ""
-"Enable JPEG and PNG Native Acceleration to speed up the performance of WMS "
+"Enable JPEG and png Native Acceleration to speed up the performance of WMS "
 "requests"
 msgstr ""
 
@@ -12868,7 +12868,7 @@ msgid "GML (geographic markup language)"
 msgstr ""
 
 #: ../../tutorials/users/old/share.txt:46
-msgid "PNG (image)"
+msgid "png (image)"
 msgstr ""
 
 #: ../../tutorials/users/old/share.txt:47

--- a/docs/i18n/vi/LC_MESSAGES/tutorials.po
+++ b/docs/i18n/vi/LC_MESSAGES/tutorials.po
@@ -3656,7 +3656,7 @@ msgstr ""
 msgid ""
 "GeoNode has several views that require considerable resources to properly "
 "respond - for example, the download links on layer detail pages require "
-"GeoServer to dynamically generate output in PDF, PNG, etc. format."
+"GeoServer to dynamically generate output in PDF, png, etc. format."
 msgstr ""
 
 #: ../../tutorials/admin/production.txt:188
@@ -3893,7 +3893,7 @@ msgstr ""
 
 #: ../../tutorials/admin/production.txt:324
 msgid ""
-"Enable JPEG and PNG Native Acceleration to speed up the performance of WMS "
+"Enable JPEG and png Native Acceleration to speed up the performance of WMS "
 "requests"
 msgstr ""
 
@@ -12868,7 +12868,7 @@ msgid "GML (geographic markup language)"
 msgstr ""
 
 #: ../../tutorials/users/old/share.txt:46
-msgid "PNG (image)"
+msgid "png (image)"
 msgstr ""
 
 #: ../../tutorials/users/old/share.txt:47

--- a/docs/i18n/zh/LC_MESSAGES/tutorials.po
+++ b/docs/i18n/zh/LC_MESSAGES/tutorials.po
@@ -3656,7 +3656,7 @@ msgstr ""
 msgid ""
 "GeoNode has several views that require considerable resources to properly "
 "respond - for example, the download links on layer detail pages require "
-"GeoServer to dynamically generate output in PDF, PNG, etc. format."
+"GeoServer to dynamically generate output in PDF, png, etc. format."
 msgstr ""
 
 #: ../../tutorials/admin/production.txt:188
@@ -3893,7 +3893,7 @@ msgstr ""
 
 #: ../../tutorials/admin/production.txt:324
 msgid ""
-"Enable JPEG and PNG Native Acceleration to speed up the performance of WMS "
+"Enable JPEG and png Native Acceleration to speed up the performance of WMS "
 "requests"
 msgstr ""
 
@@ -12868,7 +12868,7 @@ msgid "GML (geographic markup language)"
 msgstr ""
 
 #: ../../tutorials/users/old/share.txt:46
-msgid "PNG (image)"
+msgid "png (image)"
 msgstr ""
 
 #: ../../tutorials/users/old/share.txt:47

--- a/docs/organizational/contribute/contribute_to_documentation.txt
+++ b/docs/organizational/contribute/contribute_to_documentation.txt
@@ -43,15 +43,15 @@ Edit files
 
 To make some changes to already exiting files or to create new files, go to your GitHub account. Under *repositories* you will find the geonode repository that you have forked. Click on it and you will again see all the folders and files GeoNode needs. 
 
-.. image:: img/repository_geonode.PNG
+.. image:: img/repository_geonode.png
 
 Click on the folder *docs* and search for the file that you want to edit. If you found it, click on it and you will be able to see the content of this file.
 
-.. image:: img/index_txt.PNG
+.. image:: img/index_txt.png
 
 To make changes to this file, hit the button *edit* on the right top. You can now make your changes or add something to the existing content. 
 
-.. image:: img/index_edit.PNG
+.. image:: img/index_edit.png
 
 As you can see now, the documentation is written in *reStructeredText*, a lightweight markup language. To learn how to use it you should read the documentation that can be found here http://docutils.sourceforge.net/docs/user/rst/quickref.html.
 By hitting the *preview* button you will be able to see how your text it is going to look like on the web. To save your changes, click on *Commit Changes* at the bottom of the site. Now you've saved the changes in your repository, but the original geonode repository still doesn't know anything about that!
@@ -63,7 +63,7 @@ In order to tell them that you have made some changes you have to send a *pull r
 If you are planning bigger changes on the structure of the documentation it is recommended to create a new branch and make your edits here. 
 A new branch can be created by clicking on the button *branch: master* as shown here. 
 
-.. image:: img/create_branch_example.PNG
+.. image:: img/create_branch_example.png
 
 Just type the name of your new branch, hit enter and your branch will be created. To learn more about branches it is recommended to take a look here http://git-scm.com/book/en/Git-Branching-What-a-Branch-Is.
 
@@ -82,7 +82,7 @@ If you click on *create new file here* you can first subdirect to another folder
 doesn't exist until now, one will be created. To create a new file in this folder just type *filename.rst* into the box and hit enter.
 A short example on how to manage this is given here http://i.stack.imgur.com/n3Wg3.gif.
 
-.. image:: img/create_file_test.PNG
+.. image:: img/create_file_test.png
 
 Now a black box will appear where you can add your comments. To save the file, hit the green *Commit New File* button at the bottom.
 
@@ -190,5 +190,5 @@ Pull Request
 If you are done with your changes, you can send a pull request. This means, that you let the core developers know that you have done some changes and you would like them to review. They can hit accept and your changes will go in to the main line.
 The *pull request* can be found here.
 
-.. image:: img/pull_request.PNG
+.. image:: img/pull_request.png
 

--- a/docs/organizational/contribute/contribute_to_documentation.txt
+++ b/docs/organizational/contribute/contribute_to_documentation.txt
@@ -32,7 +32,7 @@ Fork a repository
 
 In order to make changes to these files, you first have to fork the repository. On the top of the website you can see the following buttons:
 
-.. image:: img/fork_repo.PNG
+.. image:: img/fork_repo.png
 
 Click on the button *Fork* at the top right and the *geonode* repository will be forked. You should now be able to see your repository *your_name/geonode*.
 If you want to read more about how to fork a repository go to https://help.github.com/articles/fork-a-repo.

--- a/docs/organizational/contribute/contribute_to_translation.txt
+++ b/docs/organizational/contribute/contribute_to_translation.txt
@@ -15,14 +15,14 @@ Here you will see how easy it is to update the translations directly on the tran
 
    Go to `<https://www.transifex.com>`_ and, click *Try it for free* and enter the needed information to create your free account.
 
-   .. figure:: img/transifex_homepage.PNG
+   .. figure:: img/transifex_homepage.png
 
 
 #. Join our project
 
    After activating the link you've got you will be asked whether you want to start a new project or to join an existing project.
 
-   .. figure:: img/transifex_join_project.PNG
+   .. figure:: img/transifex_join_project.png
 
    Click *join an existing project* and type *geonode* into the search bar. You will be directed to the geonode project site on transifex. To join the team, click on the language you want to add a translation in. Then a button *Join the team* will appaer. Hit it, and you will submit for permission to join.
 
@@ -32,7 +32,7 @@ Here you will see how easy it is to update the translations directly on the tran
 
    Click on the language where you want to add a translation. You'll see some bars, e.g. *javascript* and *master*. Choose the one you want to add a translation and you will see a dialog window like this
 
-    .. figure:: img/download_translation.PNG
+    .. figure:: img/download_translation.png
 
    Now you have two options to start translating. Either you use the transifex interface (*option 1*) or you download the file to translate locally (*option 2*).
 
@@ -40,11 +40,11 @@ Here you will see how easy it is to update the translations directly on the tran
 
    To start translating using the Transifex interface, hit *Translate now*. You'll see an interface like this
 
-   .. figure:: img/transifex_interface.PNG
+   .. figure:: img/transifex_interface.png
 
    Click *untranslated* and add your translation like shown below
 
-   .. figure:: img/transifex_add_translation.PNG
+   .. figure:: img/transifex_add_translation.png
 
    When you stop translating, do not forget to hit the green *save* button at the top right!
 
@@ -120,4 +120,4 @@ How to add a new language
 
    To add a new language, click on *Request language* on the right top of the transifex webpage.
 
-   .. figure:: img/transifex_request_language.PNG
+   .. figure:: img/transifex_request_language.png

--- a/docs/reference/developers/settings.txt
+++ b/docs/reference/developers/settings.txt
@@ -509,7 +509,7 @@ Specifies which formats for vector data are available for users to download.
 Default::
 
     DOWNLOAD_FORMATS_VECTOR = [
-        'JPEG', 'PDF', 'PNG', 'Zipped Shapefile', 'GML 2.0', 'GML 3.1.1', 'CSV', 
+        'JPEG', 'PDF', 'png', 'Zipped Shapefile', 'GML 2.0', 'GML 3.1.1', 'CSV', 
         'Excel', 'GeoJSON', 'KML', 'View in Google Earth', 'Tiles',
     ]
     
@@ -521,7 +521,7 @@ Specifies which formats for raster data are available for users to download.
 Default::
 
     DOWNLOAD_FORMATS_RASTER = [
-        'JPEG', 'PDF', 'PNG' 'Tiles',
+        'JPEG', 'PDF', 'png' 'Tiles',
     ]
 
 

--- a/docs/tutorials/admin/install/custom_install.txt
+++ b/docs/tutorials/admin/install/custom_install.txt
@@ -474,7 +474,7 @@ to::
 again using ``sudo service apache2 reload`` and visit localhost/admin.
 Now you should be able to see this:
 
-.. figure:: img/admin_interface.PNG
+.. figure:: img/admin_interface.png
 
 Change permissions of folders
 `````````````````````````````
@@ -526,7 +526,7 @@ By starting tomcat it will unpack the geoserver.war and create a new directory
 Let's try to visit http://localhost:8080/geoserver or ``localhost/geoserver``.
 You will now see the geoserver homepage:
 
-.. figure:: img/geoserver_webpage.PNG
+.. figure:: img/geoserver_webpage.png
 
 .. warning:: Geoserver is not a Vanilla Geoserver install, please use the
         geoserver.war that comes with geonode.

--- a/docs/tutorials/admin/manage/permission_and_security.txt
+++ b/docs/tutorials/admin/manage/permission_and_security.txt
@@ -34,15 +34,15 @@ access to this interface, where you can manage users, layers, permission and mor
 check this LINK. For now it will be enough to just follow the steps. To attend the *Django Admin Interface*, go to your geonode website and *sign in* with *your_superuser*. Once you've logged in, the name of your user will appear on the top right. Click on it and the following menu
 will show up:
 
-.. figure:: img/menu_admin.PNG
+.. figure:: img/menu_admin.png
 
 Clicking on *Admin* causes the interface to show up.
 
-.. figure:: img/admin_interface.PNG
+.. figure:: img/admin_interface.png
   
 Go to *Auth* -> *Users* and you will see all the users that exist at the moment. In your case it will only be *your_superuser*. Click on it, and you will see a section on *Personal Info*, one on *Permissions* and one on *Important dates*. For the moment, the section on *Permissions* is the most important.
 
-.. figure:: img/permissions_django_admin.PNG
+.. figure:: img/permissions_django_admin.png
 
 As you can see, there are three boxes that can be checked and unchecked. Because you've created a superuser, all three boxes
 are checked as default. If only the box *active* would have been checked, the user would not be a superuser and would not be able to
@@ -58,11 +58,11 @@ Until now we've only created superusers. So how do you create an ordinary user? 
 
    First we will create a user via the *Django Admin Interface* because we've still got it open. Therefore go back to *Auth* -> *Users* and      	you should find a button on the right that says *Add user*.    
 
-   .. figure:: img/add_user.PNG
+   .. figure:: img/add_user.png
  
    Click on it and a form to fill out will appear. Name the new user test_user, choose a password and click *save* at the right bottom of the  site.
 
-   .. figure:: img/add_test_user.PNG
+   .. figure:: img/add_test_user.png
 
    Now you should be directed to the site where you could
    change the permissions on the user *test_user*. As default only *active* is checked. If you want this user also to be able to attend this admin interface
@@ -77,11 +77,11 @@ Until now we've only created superusers. So how do you create an ordinary user? 
    To create an ordinary user you could also just use the GeoNode website. If you installed GeoNode using a release, you should
     see a *Register* button on the top, beside the *Sign in* button (you might have to log out before).
    
-   .. figure:: img/register.PNG
+   .. figure:: img/register.png
    
    Hit the button and again a form will appear for you to fill out. This user will be named *geonode_user*
   
-   .. figure:: img/sign_up_test_user.PNG
+   .. figure:: img/sign_up_test_user.png
    .. todo:: NEW IMAGE WITH GEONODE USER!
 
    By hitting *Sign up* the user will be signed up, as default only with the status *active*. 
@@ -89,7 +89,7 @@ Until now we've only created superusers. So how do you create an ordinary user? 
 As mentioned before, this status can be changed as well. To do so, sign in with *your_superuser* again and attend the admin interface. Go again to *Auth* -> *Users*, where now three users
 should appear:
 
-   .. img/users_admin_interface.PNG
+   .. img/users_admin_interface.png
    .. todo:: CREATE THIS IMAGE!
 
 We now want to change the permission of the *geonode_user* so that he will be able to attend the admin interface as well. 
@@ -121,7 +121,7 @@ Now that we've already created some users, we will take a closer look on the sec
 
 The permissions on a certain layer can already be set when uploading your files. When the upload form appears (*Layers* -> *Upload Layer*) you will see the permission section on the right side:
 
-.. figure:: img/upload_layer.PNG
+.. figure:: img/upload_layer.png
   
 As it can be seen here, the access on your layer is split up into three groups:
 
@@ -140,7 +140,7 @@ You can now choose whether you want your layer to be viewed and downloaded by
 We will now upload our **test layer** like shown HERE. If you want your layer only be viewed by certain users or a group, you have to choose *Only users who can edit* in the part *Who can view and download this data*.
 In the section *Who can edit this data* you write down the names of the users you want to have admission on this data. For this first layer we will choose the settings like shown in the following image:
 
-.. img/layer_test_permission.PNG
+.. img/layer_test_permission.png
 .. todo:: CREATE THIS IMAGE! settings: view and download = everybody
 					edit = geonode_user
 					manage = your_superuser (you could leave this empty as well)
@@ -149,13 +149,13 @@ In the section *Who can edit this data* you write down the names of the users yo
 
 If you now log out, your layer can still be seen, but the unregistered users won't be able to edit your layer. Now sign in as *geonode_user* and click on the **test layer**. Above the layer you can see this:
 
-.. figure:: img/edit_and_download_layer.PNG
+.. figure:: img/edit_and_download_layer.png
 .. todo:: CHANGE IMAGE TO TEST LAYER!
 
 The *geonode_user* is able to edit the **test_layer**. But before going deeper into this, we have to first take a look on another case. As an administrator you might also upload your layers to geoserver and then make them available on GeoNode using *updatelayers*. Or you even add the layers via the terminal using *importlayers* (LINK TUTORIAL). To set the permissions on this layer, click on the **test layer** (you've uploaded via *updatelayers*) and you will see the same menu as shown in the image above. Click *Edit layer* and the menu will appear.
 
 
-.. figure:: img/edit_and_manage.PNG
+.. figure:: img/edit_and_manage.png
 
 .. todo:: as an owner you are always able to see and edit your layers? CHECK THIS!
 
@@ -163,14 +163,14 @@ The *geonode_user* is able to edit the **test_layer**. But before going deeper i
   
 Choose *edit permissions* and a window with the permission settings will appear. This window can also be opened by scrolling down the website. On the right-hand side of the page you should be able to see a button like this.
 
-.. img/change_layer_permissions.PNG
+.. img/change_layer_permissions.png
 .. todo:: CREATE THIS IMG!! 
   
 Click on it and you will see the same window as before.
 
 Now set the permissions of this layer using the following settings:
 
-..  img/permission_test_layer_2.PNG
+..  img/permission_test_layer_2.png
 .. todo:: CREATE THIS IMG!! view and download = only who can edit
 	 			edit = test_user
 				manage = owner (or empty)
@@ -191,17 +191,17 @@ So be aware that each user assigned to edit this layer can even remove it! In ou
 
 Now you are logged in as the user *test_user*. Below the **test_layer** you can see the following:
 
-.. img/info.PNG
+.. img/info.png
 .. todo:: CREATE/CHANGE THIS IMAGE!!
 
 By clicking *Edit Layer* and *Edit Metadata* on top of the layer, you can change this information. The *test_user* is able to change all the metadata of this layer. We now want to change to *point of contact*, therefore scroll down until you see this:
 
-.. figure:: img/point_of_contact.PNG
+.. figure:: img/point_of_contact.png
 
 
 Change the *point of contact* from *_who_ever_created_this* to *test_user*. *Save* your changes and you will now be able to see the following:
 
-.. img/point_of_contact_changed.PNG
+.. img/point_of_contact_changed.png
 .. todo:: CHANGE THIS IMAGE!
 .. todo:: more detailed!
 .. todo:: did i miss anything?
@@ -221,18 +221,18 @@ Maps
 
 The permission on maps are basically the same as on layers, just that there are fewer options on how to edit the map. Let's create a map (or already TUTORIAL?). Click on **test_map** and scroll down till you see this:
 
-.. figure:: img/change_map_permissions.PNG
+.. figure:: img/change_map_permissions.png
 
 Here you can set the same permissions as known from the layer permissions! Set the permissions of this map as seen here:
 
-.. img/test_map_permissions.PNG
+.. img/test_map_permissions.png
 .. todo:: CREATE THIS IMAGE:: view = anybody
 				edit = *geonode_user* and *test_user*
 				manage = *geonode_user*
 
 Save your changes and then log out and log in as *test_user*. You should now be able to view the *test_map* and click on to *Edit map*.
 
-.. figure:: img/edit_map.PNG
+.. figure:: img/edit_map.png
 
 .. todo:: this IMAGE should be without add permissions!! but not possible at the moment!
 

--- a/docs/tutorials/admin/production.txt
+++ b/docs/tutorials/admin/production.txt
@@ -151,7 +151,7 @@ Some other things that require tweaking:
 Robot Exclusion File
 --------------------
 
-GeoNode has several views that require considerable resources to properly respond - for example, the download links on layer detail pages require GeoServer to dynamically generate output in PDF, PNG, etc. format.
+GeoNode has several views that require considerable resources to properly respond - for example, the download links on layer detail pages require GeoServer to dynamically generate output in PDF, png, etc. format.
 
 Crawlers for web search engines such as Google may cause problems by quickly following many such links in succession.
 
@@ -288,7 +288,7 @@ On the JAI Settings page
 
    There are two considerations for the JAI settings.
    
-      * Enable JPEG and PNG Native Acceleration to speed up the performance of WMS requests
+      * Enable JPEG and png Native Acceleration to speed up the performance of WMS requests
 
       * Disable Tile Recycling as this optimization is less relevant on recent JVM implementations and has some overhead itself.
 

--- a/docs/tutorials/devel/api/ogc.txt
+++ b/docs/tutorials/devel/api/ogc.txt
@@ -30,7 +30,7 @@ The following sections briefly describe the OGC Web Services provided by GeoNode
 Web Map Service (WMS)
 ---------------------
 
-WMS provides an API to retrieve map images (PNG, JPEG, etc.) of geospatial data.  WMS is suitable for visualization and when access to raw data is not a requirement.
+WMS provides an API to retrieve map images (png, JPEG, etc.) of geospatial data.  WMS is suitable for visualization and when access to raw data is not a requirement.
 
 WFS
 ---

--- a/docs/tutorials/users/quickstart/index.txt
+++ b/docs/tutorials/users/quickstart/index.txt
@@ -18,7 +18,7 @@ In this Quickstart guide you will learn the following:
 To start GeoNode on your OSGeoLive DVD you have to choose *Geospatial* => *Browser Clients* => *Start GeoNode* and the GeoNode web page will automatically
 be opened at http://localhost:8000/ (I assume!). The page will look like shown in the image below.
 
-    .. figure:: img/start_page.PNG
+    .. figure:: img/start_page.png
 
 1. Register a new account
 -------------------------
@@ -58,7 +58,7 @@ Layers are a published resource representing a raster or vector spatial data sou
 
 #. Now click *Upload Layers* and you'll see the upload form.
 
-   .. figure:: img/uploadform_new_quickstart.PNG
+   .. figure:: img/uploadform_new_quickstart.png
 
 #. You have two possibilities to add your files. You can either do that by using *drag & drop* or you choose to *browse* them.
    Be aware that you have to upload a complete set of files, consisting of a *shp*, a *prj*, a *dbf* and a *shx* file. If one of them is missing,
@@ -66,13 +66,13 @@ Layers are a published resource representing a raster or vector spatial data sou
 
 #. You shold now be able to see all the files you want to upload. 
 
-   .. figure:: img/files_to_be_uploaded.PNG
+   .. figure:: img/files_to_be_uploaded.png
 
 #. GeoNode has the ability to restrict who can view, edit, and manage layers. On the right side of the page you can see the *Permission* section, where you can limit the access on your layer. 
    Under *Who can view and download this data*, select *Any registered user*. This will ensure that anonymous view access is disabled.
    In the same area, under *Who can edit this data*, select your username. This will ensure that only you are able to edit the data in the layer.
 
-    .. figure:: img/permission.PNG
+    .. figure:: img/permission.png
     
 #. To upload data, click the *Upload* button at the bottom.
 


### PR DESCRIPTION
Somehow some references to screenshot .png files were adjusted to uppercase, breaking the images. These files have now been changed. This would close #1099 and possibly resolve #1096. Using a mirror of the Geonode docs on RTFD these screenshots now appear: http://geonode-docs.readthedocs.org/en/latest/.