### PR TITLE
Paver and settings improvements for Windows users

### DIFF
--- a/docs/tutorials/admin/install/quick_install.txt
+++ b/docs/tutorials/admin/install/quick_install.txt
@@ -66,12 +66,12 @@ Windows
 To install in Windows it is assumed you're familiar with python development and virtualenv on Windows and that you're familiar with the windows command prompt. You will need the follow prerequists installed:
 
     * Java JDK
-    * Python 2.7
+    * Python 2.7.9
+      * Earlier versions of python require you to installdistutils (easy_install) - http://www.lfd.uci.edu/~gohlke/pythonlibs/#setuptools
     * ant (bin directory must be on system PATH)
     * maven2 (bin directory must be on system PATH)
-    * Python distutils (easy_install) - http://www.lfd.uci.edu/~gohlke/pythonlibs/#setuptools
     * git
-    * GDAL core libraries - http://www.gisinternals.com/sdk/PackageList.aspx?file=release-1600-gdal-1-11-mapserver-6-4.zip - gdal-111-1600-core.msi
+    * GDAL core libraries from [GISInternals](http://www.gisinternals.com) -> Downloads, Stable Releases -> gdal-111-1600-core.msi
 
 Install and configure from the windows command prompt, if you don't already have python virtualenv installed, then do it now::
    
@@ -80,7 +80,8 @@ Install and configure from the windows command prompt, if you don't already have
 Create virtualenv and activate it::
     
     cd <Directory to install the virtualenv & geonode into>
-    virtualenv venvvenv\scripts\activate
+    virtualenv <name of virtualenv folder>
+    virtualenv <name of virtualenv folder>\scripts\activate
 
 Clone GeoNode::
     
@@ -93,22 +94,33 @@ Install Python native dependencies, this command will look for and install binar
     pip install paver
     paver win_install_deps
 
-Go back to the parent directory
-    cd .. 
 
     
 Install GeoNode in the local virtualenv::
 
-    pip install -e geonode --use-mirrors
-    cd geonode
+    pip install -e .
+
+Set up geos and gdal by going to geonode\local_settings.py.sample.  First add the following two lines:
+
+    GEOS_LIBRARY_PATH="C:/path/to/geos_c.dll"
+    GDAL_LIBRARY_PATH="C:/path/to/gdal111.dll"
+
+The geos and gdal libraries can be found 
+
+You can comment out the rest of the settings in local_settings.py.sample for development purposes, then save the file in the same location with local_settings.py
+
     
-Compile GeoServer::
+Setup GeoServer::
     
     paver setup
     
-Start the servers, Windows will most likely require the full java path::
+Start the servers.  You have the option to set the JAVA_HOME environment variable or use the --java_path.::
 
     paver start --java_path="C:\path\to\java\java.exe"
+
+or if you set your JAVA_HOME environment variables (e.g. JAVA_HOME="C:\Program Files\Java\jdk1.7.0_75\")
+
+    paver start
 
 Once the package is installed, please consult :ref:`configure_installation` to learn how to create an account for the admin user and tweak the settings to get more performance.
 

--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -853,6 +853,20 @@ try:
 except ImportError:
     pass
 
+
+#for windows users check if they didn't set GEOS and GDAL in local_settings.py
+#maybe they set it as a windows environment
+if os.name == 'nt':
+    if not "GEOS_LIBRARY_PATH" in locals() or not "GDAL_LIBRARY_PATH" in locals():
+        if os.environ.get("GEOS_LIBRARY_PATH", None) \
+            and os.environ.get("GDAL_LIBRARY_PATH", None):
+            GEOS_LIBRARY_PATH = os.environ.get('GEOS_LIBRARY_PATH') 
+            GDAL_LIBRARY_PATH = os.environ.get('GDAL_LIBRARY_PATH')
+        else:
+            #maybe it will be found regardless if not it will throw 500 error
+            from django.contrib.gis.geos import GEOSGeometry
+
+
 # define the urls after the settings are overridden
 if 'geonode.geoserver' in INSTALLED_APPS:
     LOCAL_GEOSERVER = {

--- a/pavement.py
+++ b/pavement.py
@@ -358,17 +358,32 @@ def start_geoserver(options):
 
         # checking if our loggernullpath exists and if not, reset it to something manageable
         if loggernullpath == "nul":
-            open("../../downloaded/null.txt", 'w+').close()
+            try:
+                open("../../downloaded/null.txt", 'w+').close()
+            except IOError, e:
+                print "Chances are that you have Geoserver currently running.  You \
+                        can either stop all servers with paver stop or start only \
+                        the django application with paver start_django."
+                sys.exit(1)
             loggernullpath = "../../downloaded/null.txt"
 
         try:
             sh(('java -version'))
         except:
-            if not options.get('java_path', None):
-                print "Paver cannot find java in the Windows Environment.  Please provide the --java_path flag with your full path to java.exe e.g. --java_path=C:/path/to/java/bin/java.exe"
+            print "Java was not found in your path.  Trying some other options: "
+            javapath_opt = None
+            if os.environ.get('JAVA_HOME', None):
+                print "Using the JAVA_HOME environment variable"
+                javapath_opt = os.path.join(os.path.abspath(os.environ['JAVA_HOME']), "bin", "java.exe")
+            elif options.get('java_path'):
+                javapath_opt = options.get('java_path')
+            else:
+                print "Paver cannot find java in the Windows Environment.  \
+                Please provide the --java_path flag with your full path to \
+                java.exe e.g. --java_path=C:/path/to/java/bin/java.exe"
                 sys.exit(1)
             # if there are spaces
-            javapath = 'START /B "" "' + options['java_path'] + '"'
+            javapath = 'START /B "" "' + javapath_opt + '"'
 
         sh((
             '%(javapath)s -Xmx512m -XX:MaxPermSize=256m'


### PR DESCRIPTION
This checks if the JAVA_HOME variable is set before complaining to add the --java_path flag to paver start. 
Also, running paver start the second time without doing a paver stop first would throw a "permission denied" to downloaded/null.txt.  Permission was denied because it was being used by the currently running Geoserver.  A better message is thrown now.
Both outlined in #1970 