### PR TITLE
Web Intents / CKAN / Date and Caveats (Social Links 3)

### DIFF
--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -666,7 +666,7 @@ SOCIAL_ORIGINS = [{
 #https://github.com/ckan/ckan/blob/2052628c4a450078d58fb26bd6dc239f3cc68c3e/ckan/logic/action/create.py#L43
 CKAN_ORIGINS = [{
     "label":"Humanitarian Data Exchange (HDX)",
-    "url":"https://data.hdx.rwlabs.org/dataset/new?title={name}&notes={abstract}",
+    "url":"https://data.hdx.rwlabs.org/dataset/new?title={name}&dataset_date={date}&notes={abstract}&caveats={caveats}",
     "css_class":"hdx"
 }]
 #SOCIAL_ORIGINS.extend(CKAN_ORIGINS)

--- a/geonode/utils.py
+++ b/geonode/utils.py
@@ -22,6 +22,7 @@ import base64
 import math
 import copy
 import string
+import datetime
 
 from django.conf import settings
 from django.core.exceptions import PermissionDenied
@@ -573,14 +574,33 @@ def build_abstract(resourcebase, url=None, includeURL=True):
         return resourcebase.abstract
 
 
+def build_caveats(resourcebase):
+    caveats = []
+    if resourcebase.maintenance_frequency:
+        caveats.append(resourcebase.maintenance_frequency_title())
+    if resourcebase.license:
+        caveats.append(resourcebase.license_verbose)
+    if resourcebase.data_quality_statement:
+        caveats.append(resourcebase.data_quality_statement)
+    if len(caveats) > 0:
+        return u"- "+u"%0A- ".join(caveats)
+    else:
+        return u""
+
+
 def build_social_links(request, resourcebase):
-    social_url = "{protocol}://{host}{path}".format(
+    social_url = u"{protocol}://{host}{path}".format(
         protocol=("https" if request.is_secure() else "http"),
         host=request.get_host(),
         path=request.get_full_path())
+    date = datetime.datetime.strftime(resourcebase.date, "%m/%d/%Y") if resourcebase.date else None
+    abstract = build_abstract(resourcebase, url=social_url, includeURL=True),
+    caveats = build_caveats(resourcebase)
     return format_urls(
         settings.SOCIAL_ORIGINS,
         {
             'name': resourcebase.title,
-            'abstract': build_abstract(resourcebase, url=social_url, includeURL=True),
+            'date': date,
+            'abstract': abstract,
+            'caveats': caveats,
             'url': social_url})

--- a/geonode/utils.py
+++ b/geonode/utils.py
@@ -594,7 +594,7 @@ def build_social_links(request, resourcebase):
         host=request.get_host(),
         path=request.get_full_path())
     date = datetime.datetime.strftime(resourcebase.date, "%m/%d/%Y") if resourcebase.date else None
-    abstract = build_abstract(resourcebase, url=social_url, includeURL=True),
+    abstract = build_abstract(resourcebase, url=social_url, includeURL=True)
     caveats = build_caveats(resourcebase)
     return format_urls(
         settings.SOCIAL_ORIGINS,


### PR DESCRIPTION
Following on #1918 and #1930, this PR adds support for building dates and caveats into the CKAN intent url.  Caveats is a list, in markdown format, of: maintenance_frequency, license, and data_quality_statement.

CKAN links are still disabled by default in settings.py