### PR TITLE
Fix for document metadata links

### DIFF
--- a/geonode/documents/templates/documents/document_detail.html
+++ b/geonode/documents/templates/documents/document_detail.html
@@ -103,7 +103,7 @@
             </div>
             <div class="modal-body">
               <ul>
-                {% for link in resource.link_set.metadata %}
+                {% for link in metadata %}
                 <li><a href="{{ link.url }}">{{ link.name }}</a></li>
                 {% endfor %}
               </ul>

--- a/geonode/documents/views.py
+++ b/geonode/documents/views.py
@@ -86,9 +86,13 @@ def document_detail(request, docid):
         if request.user != document.owner and not request.user.is_superuser:
             Document.objects.filter(id=document.id).update(popular_count=F('popular_count') + 1)
 
+        metadata = document.link_set.metadata().filter(
+            name__in=settings.DOWNLOAD_FORMATS_METADATA)
+
         context_dict = {
             'permissions_json': _perms_info_json(document),
             'resource': document,
+            'metadata': metadata,
             'imgtypes': IMGTYPES,
             'related': related}
 


### PR DESCRIPTION
Only show metadata links for documents that are listed in settings.py.  Original issue identified in https://github.com/GeoNode/geonode/pull/1635.  Implements work done for layers in https://github.com/GeoNode/geonode/commit/8917f3afea685560601d6ec15babfe8d8f372ec2 for documents.