### PR TITLE
changing links in homepage for registred and unregistred users

### DIFF
--- a/geonode/templates/index.html
+++ b/geonode/templates/index.html
@@ -19,7 +19,7 @@
     </div>
   </div>
   {% endblock %}
-  
+
   {% block mainbody %}
   <div class="container">
     <div class="row home-facets">
@@ -29,26 +29,27 @@
         <p><a href="{% url "layer_browse" %}"><i class="fa fa-square-o fa-5x rotate-45"></i></a></p>
         <h2><a href="{% url "layer_browse" %}">{{ facets.layer|default:_("No") }} {% blocktrans count counter=facets.layer %}Layer{% plural %}Layers{% endblocktrans %}</a></h2>
         <p>{% trans "Click to search for geospatial data published by other users, organizations and public sources. Download data in standard formats." %}</p> 
-        <p class="text-center"><a class="btn btn-default" href="{% url "layer_browse" %}" role="button">{% trans "Explore Layers" %} &raquo;</a></p>
+        {% if user.is_authenticated %}
+        <p class="text-center"><a class="btn btn-default" href="{% url "layer_upload" %}" role="button">{% trans "Add layers" %} &raquo;</a></p>
+        {% else %}
+        <p class="text-center"><a class="btn btn-default" href="{% url "layer_browse" %}" role="button">{% trans "Explore layers" %} &raquo;</a></p>        
+        {% endif %}
       </div>
       <div class="col-md-4">
         <p><a href="{% url "maps_browse" %}"><i class="fa fa-map-marker fa-5x"></i></a></p>
         <h2><a href="{% url "maps_browse" %}">{{ facets.map|default:_("No") }} {% blocktrans count counter=facets.map %}Map{% plural %}Maps{% endblocktrans %}</a></h2>
         <p>{% trans "Data is available for browsing, aggregating and styling to generate maps which can be shared publicly or restricted to specific users only." %}</p>
-        <p><a class="btn btn-default" href="{% url "maps_browse" %}" role="button">{% trans "Create maps" %} &raquo;</a></p>
+        {% if user.is_authenticated %}
+        <p><a class="btn btn-default" href="{% url "new_map" %}" role="button">{% trans "Create maps" %} &raquo;</a></p>
+        {% else %}
+        <p><a class="btn btn-default" href="{% url "maps_browse" %}" role="button">{% trans "Explore maps" %} &raquo;</a></p>
+        {% endif %}
       </div>
       <div class="col-md-4">
-        {% if user.is_authenticated %}
-        <p><a href="{% url "layer_upload" %}"><i class="fa fa-cloud-upload fa-5x"></i></a></p>
-        <h2><a href="{% url "layer_upload" %}">{{ facets.user|default:_("No") }} {% blocktrans count counter=facets.user %}User{% plural %}Users{% endblocktrans %}</a></h2>
-        <p>{% trans "GeoNode allows registered users to easily upload geospatial data in several formats including shapefile and GeoTiff." %}</p>
-        <p><a class="btn btn-default" href="{% url "layer_upload" %}" role="button">{% trans "Share data" %} &raquo;</a></p>
-        {% else %}
         <p><a href="{% url "profile_browse" %}"><i class="fa fa-user fa-5x"></i></a></p>
         <h2><a href="{% url "profile_browse" %}">{{ facets.user|default:_("No") }} {% blocktrans count counter=facets.user %}User{% plural %}Users{% endblocktrans %}</a></h2>
         <p>{% trans "GeoNode allows registered users to easily upload geospatial data in several formats including shapefile and GeoTiff." %}</p>
-        <p><a class="btn btn-default" href="{% url "profile_browse" %}" role="button">{% trans "Share data" %} &raquo;</a></p>
-        {% endif %}
+        <p><a class="btn btn-default" href="{% url "profile_browse" %}" role="button">{% trans "See users" %} &raquo;</a></p>
       </div>
     {% endwith %}
     </div>


### PR DESCRIPTION
1. fixing links in homepage :
  * Create maps was pointing on explore maps
  * Share data (when unregistred) was pointing on users list
  * Explore layers was replaced by add layers when registred
2. Logic was reviewed for layers and maps : links on top always pointing to lists and button below depend on authentication and leading to creating or viewing the objects.
3. The users parts has become independent from registred or not and will always point to users page. 

![image](https://cloud.githubusercontent.com/assets/6357213/6045727/bf63655c-ac9c-11e4-9fbd-35b6d640438d.png)
