### PR TITLE
Using label and description in layer attributes when WPS_ENABLED is set to False

### DIFF
--- a/geonode/layers/templates/layers/layer_detail.html
+++ b/geonode/layers/templates/layers/layer_detail.html
@@ -47,30 +47,40 @@
               <thead>
                 <tr>
                   <th>{% trans "Attribute Name" %}</th>
-                  <th>{% trans "Range" %}</th>
-                  <th>{% trans "Average" %}</th>
-                  <th>{% trans "Median" %}</th>
-                  <th>{% trans "Standard Deviation" %}</th>
+                  {% if wps_enabled %}
+                    <th>{% trans "Range" %}</th>
+                    <th>{% trans "Average" %}</th>
+                    <th>{% trans "Median" %}</th>
+                    <th>{% trans "Standard Deviation" %}</th>
+                  {% else %}
+                    <th>{% trans "Label" %}</th>
+                    <th>{% trans "Description" %}</th>
+                  {% endif %}
                 </tr>
               </thead>
               <tbody>
                 {% for attribute in resource.attributes %}
                   <tr>
                     <td {% if attribute.attribute_label and attribute.attribute_label != attribute.attribute %}title="{{ attribute.attribute }}"{% endif %}>{{ attribute }}</td>
-                    {% if attribute.unique_values == "NA" %}
-                    <td>{{ attribute.unique_values }}</td>
+                    {% if wps_enabled %}
+                      {% if attribute.unique_values == "NA" %}
+                      <td>{{ attribute.unique_values }}</td>
+                      {% else %}
+                      <td>
+                        <select name="unique_values">
+                        {% for value in attribute.unique_values_as_list %}
+                          <option value="{{ value }}">{{ value }}</option>
+                        {% endfor %}
+                        </select>
+                      </td>
+                      {% endif %}
+                      <td>{{ attribute.average|floatformat:"2" }}</td>
+                      <td>{{ attribute.median|floatformat:"2" }}</td>
+                      <td>{{ attribute.stddev|floatformat:"2" }}</td>
                     {% else %}
-                    <td>
-                      <select name="unique_values">
-                      {% for value in attribute.unique_values_as_list %}
-                        <option value="{{ value }}">{{ value }}</option>
-                      {% endfor %}
-                      </select>
-                    </td>
+                      <td>{{ attribute.attribute_label }}</td>
+                      <td>{{ attribute.description }}</td>
                     {% endif %}
-                    <td>{{ attribute.average|floatformat:"2" }}</td>
-                    <td>{{ attribute.median|floatformat:"2" }}</td>
-                    <td>{{ attribute.stddev|floatformat:"2" }}</td>
                   </tr>
                 {% endfor %}
               </tbody>

--- a/geonode/layers/templates/layers/layer_detail.html
+++ b/geonode/layers/templates/layers/layer_detail.html
@@ -47,14 +47,13 @@
               <thead>
                 <tr>
                   <th>{% trans "Attribute Name" %}</th>
+                  <th>{% trans "Label" %}</th>
+                  <th>{% trans "Description" %}</th>
                   {% if wps_enabled %}
                     <th>{% trans "Range" %}</th>
                     <th>{% trans "Average" %}</th>
                     <th>{% trans "Median" %}</th>
                     <th>{% trans "Standard Deviation" %}</th>
-                  {% else %}
-                    <th>{% trans "Label" %}</th>
-                    <th>{% trans "Description" %}</th>
                   {% endif %}
                 </tr>
               </thead>
@@ -62,6 +61,8 @@
                 {% for attribute in resource.attributes %}
                   <tr>
                     <td {% if attribute.attribute_label and attribute.attribute_label != attribute.attribute %}title="{{ attribute.attribute }}"{% endif %}>{{ attribute }}</td>
+                    <td>{{ attribute.attribute_label }}</td>
+                    <td>{{ attribute.description }}</td>
                     {% if wps_enabled %}
                       {% if attribute.unique_values == "NA" %}
                       <td>{{ attribute.unique_values }}</td>
@@ -77,9 +78,6 @@
                       <td>{{ attribute.average|floatformat:"2" }}</td>
                       <td>{{ attribute.median|floatformat:"2" }}</td>
                       <td>{{ attribute.stddev|floatformat:"2" }}</td>
-                    {% else %}
-                      <td>{{ attribute.attribute_label }}</td>
-                      <td>{{ attribute.description }}</td>
                     {% endif %}
                   </tr>
                 {% endfor %}

--- a/geonode/layers/views.py
+++ b/geonode/layers/views.py
@@ -271,6 +271,7 @@ def layer_detail(request, layername, template='layers/layer_detail.html'):
         "documents": get_related_documents(layer),
         "metadata": metadata,
         "is_layer": True,
+        "wps_enabled": settings.OGC_SERVER['default']['WPS_ENABLED'],
     }
 
     context_dict["viewer"] = json.dumps(

--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -514,7 +514,7 @@ OGC_SERVER = {
         'GEOGIG_ENABLED': False,
         'WMST_ENABLED': False,
         'BACKEND_WRITE_ENABLED': True,
-        'WPS_ENABLED': True,
+        'WPS_ENABLED': False,
         'LOG_FILE': '%s/geoserver/data/logs/geoserver.log' % os.path.abspath(os.path.join(PROJECT_ROOT, os.pardir)),
         # Set to name of database in DATABASES dictionary to enable
         'DATASTORE': '',  # 'datastore',


### PR DESCRIPTION
In layer details page displaying the attributes label and description in place of WPS indicators when OGC WPS_ENABLED is set to False.
By default, WPS_ENABLED is now set to False. Refs #1412