### PR TITLE
adding extra_user_menu into user menu

### DIFF
--- a/geonode/templates/base.html
+++ b/geonode/templates/base.html
@@ -225,6 +225,8 @@
               {% if user.is_staff %}
               <li><a href="{% url "admin:index" %}"><i class="fa fa-cog"></i> {% trans "Admin" %}</a></li>
               {% endif %}
+              {% block extra_user_menu %}
+              {% endblock %}
               <li class="modal-divider"></li>
               <li><a title="Help" rel="tooltip" href="/help/"><i class="fa fa-question-circle"></i> {% trans "Help" %}</a></li>
             </ul>


### PR DESCRIPTION
On the same way than "extra_tab" block into the nav bar.
Can we adding a extra-block into user menu to permit more custimation of geonode project?