### PR TITLE
Improve geonode performances

### DIFF
--- a/geonode/api/api.py
+++ b/geonode/api/api.py
@@ -233,17 +233,17 @@ class ProfileResource(ModelResource):
     def dehydrate_layers_count(self, bundle):
         obj_with_perms = get_objects_for_user(bundle.request.user,
                                               'base.view_resourcebase').instance_of(Layer)
-        return bundle.obj.resourcebase_set.filter(id__in=obj_with_perms.values_list('id', flat=True)).distinct().count()
+        return bundle.obj.resourcebase_set.filter(id__in=obj_with_perms.values('id')).distinct().count()
 
     def dehydrate_maps_count(self, bundle):
         obj_with_perms = get_objects_for_user(bundle.request.user,
                                               'base.view_resourcebase').instance_of(Map)
-        return bundle.obj.resourcebase_set.filter(id__in=obj_with_perms.values_list('id', flat=True)).distinct().count()
+        return bundle.obj.resourcebase_set.filter(id__in=obj_with_perms.values('id')).distinct().count()
 
     def dehydrate_documents_count(self, bundle):
         obj_with_perms = get_objects_for_user(bundle.request.user,
                                               'base.view_resourcebase').instance_of(Document)
-        return bundle.obj.resourcebase_set.filter(id__in=obj_with_perms.values_list('id', flat=True)).distinct().count()
+        return bundle.obj.resourcebase_set.filter(id__in=obj_with_perms.values('id')).distinct().count()
 
     def dehydrate_avatar_100(self, bundle):
         return avatar_url(bundle.obj, 100)

--- a/geonode/api/api.py
+++ b/geonode/api/api.py
@@ -1,8 +1,12 @@
+import json
+import time
+
 from django.conf.urls import url
 from django.contrib.auth import get_user_model
 from django.core.urlresolvers import reverse
 from django.contrib.contenttypes.models import ContentType
 from django.conf import settings
+from django.db.models import Count
 
 from avatar.templatetags.avatar_tags import avatar_url
 from guardian.shortcuts import get_objects_for_user
@@ -16,11 +20,13 @@ from geonode.documents.models import Document
 from geonode.groups.models import GroupProfile
 
 from taggit.models import Tag
-
+from django.core.serializers.json import DjangoJSONEncoder
+from tastypie.serializers import Serializer
 from tastypie import fields
 from tastypie.resources import ModelResource
 from tastypie.constants import ALL
 from tastypie.utils import trailing_slash
+
 
 FILTER_TYPES = {
     'layer': Layer,
@@ -29,18 +35,51 @@ FILTER_TYPES = {
 }
 
 
-class TypeFilteredResource(ModelResource):
+class CountJSONSerializer(Serializer):
+    """Custom serializer to post process the api and add counts"""
+    
+    def get_resources_counts(self, options):
+        if settings.SKIP_PERMS_FILTER:
+            resources = ResourceBase.objects.all()
+        else:
+            resources = get_objects_for_user(
+                options['user'],
+                'base.view_resourcebase'
+            )
+        if settings.RESOURCE_PUBLISHING:
+            resources = resources.filter(is_published=True)
 
+        if options['title_filter']:
+            resources = resources.filter(title__icontains=options['title_filter'])
+
+        if options['type_filter']:
+            resources = resources.instance_of(options['type_filter'])
+
+        counts = resources.values(options['count_type']).annotate(count=Count(options['count_type']))
+
+        return dict([(c[options['count_type']], c['count']) for c in counts])
+
+    def to_json(self, data, options=None):
+        options = options or {}
+        data = self.to_simple(data, options)
+        counts = self.get_resources_counts(options)
+        for item in data['objects']:
+            item['count'] = counts.get(item['id'], 0)
+        # Add in the current time.
+        data['requested_time'] = time.time()
+
+        return json.dumps(data, cls=DjangoJSONEncoder, sort_keys=True)
+
+
+class TypeFilteredResource(ModelResource):
     """ Common resource used to apply faceting to categories, keywords, and
     regions based on the type passed as query parameter in the form
     type:layer/map/document"""
+
     count = fields.IntegerField()
 
     type_filter = None
     title_filter = None
-
-    def dehydrate_count(self, bundle):
-        raise Exception('dehydrate_count not implemented in the child class')
 
     def build_filters(self, filters={}):
 
@@ -57,34 +96,15 @@ class TypeFilteredResource(ModelResource):
 
 
 class TagResource(TypeFilteredResource):
-
     """Tags api"""
 
-    def dehydrate_count(self, bundle):
-        count = 0
-        if settings.SKIP_PERMS_FILTER:
-            resources = ResourceBase.objects.all()
-        else:
-            resources = get_objects_for_user(
-                bundle.request.user,
-                'base.view_resourcebase'
-            )
-        if settings.RESOURCE_PUBLISHING:
-            resources = resources.filter(is_published=True)
+    def serialize(self, request, data, format, options={}):
+        options['title_filter'] = self.title_filter
+        options['type_filter'] = self.type_filter
+        options['count_type'] = 'keywords'
+        options['user'] = request.user
 
-        if self.title_filter:
-            resources = resources.filter(title__icontains=self.title_filter)
-        resources_ids = resources.values_list('id', flat=True)
-
-        tags = bundle.obj.taggit_taggeditem_items
-        if self.type_filter:
-            ctype = ContentType.objects.get_for_model(self.type_filter)
-            count = tags.filter(
-                content_type=ctype).filter(object_id__in=resources_ids).count()
-        else:
-            count = tags.filter(object_id__in=resources_ids).count()
-
-        return count
+        return super(TagResource, self).serialize(request, data, format, options)
 
     class Meta:
         queryset = Tag.objects.all().order_by('name')
@@ -93,33 +113,19 @@ class TagResource(TypeFilteredResource):
         filtering = {
             'slug': ALL,
         }
+        serializer = CountJSONSerializer()
 
 
 class RegionResource(TypeFilteredResource):
-
     """Regions api"""
 
-    def dehydrate_count(self, bundle):
-        count = 0
-        if settings.SKIP_PERMS_FILTER:
-            resources = ResourceBase.objects.all()
-        else:
-            resources = get_objects_for_user(
-                bundle.request.user,
-                'base.view_resourcebase'
-            )
-        if settings.RESOURCE_PUBLISHING:
-            resources = resources.filter(is_published=True)
+    def serialize(self, request, data, format, options={}):
+        options['title_filter'] = self.title_filter
+        options['type_filter'] = self.type_filter
+        options['count_type'] = 'regions'
+        options['user'] = request.user
 
-        resources_ids = resources.values_list('id', flat=True)
-
-        if self.type_filter:
-            count = bundle.obj.resourcebase_set.filter(
-                id__in=resources_ids).instance_of(self.type_filter).count()
-        else:
-            count = bundle.obj.resourcebase_set.filter(id__in=resources_ids).count()
-
-        return count
+        return super(RegionResource, self).serialize(request, data, format, options)
 
     class Meta:
         queryset = Region.objects.all().order_by('name')
@@ -128,29 +134,19 @@ class RegionResource(TypeFilteredResource):
         filtering = {
             'name': ALL,
         }
+        serializer = CountJSONSerializer()
 
 
 class TopicCategoryResource(TypeFilteredResource):
-
     """Category api"""
 
-    def dehydrate_count(self, bundle):
-        resources = bundle.obj.resourcebase_set.all()
-        if settings.RESOURCE_PUBLISHING:
-            resources = resources.filter(is_published=True)
-        if self.type_filter:
-            resources = resources.instance_of(self.type_filter)
-        if self.title_filter:
-            resources = resources.filter(title__icontains=self.title_filter)
-        if not settings.SKIP_PERMS_FILTER:
-            permitted = get_objects_for_user(
-                bundle.request.user,
-                'base.view_resourcebase').values_list(
-                'id',
-                flat=True)
-            resources = resources.filter(id__in=permitted)
+    def serialize(self, request, data, format, options={}):
+        options['title_filter'] = self.title_filter
+        options['type_filter'] = self.type_filter
+        options['count_type'] = 'category'
+        options['user'] = request.user
 
-        return resources.count()
+        return super(TopicCategoryResource, self).serialize(request, data, format, options)
 
     class Meta:
         queryset = TopicCategory.objects.all()
@@ -159,10 +155,10 @@ class TopicCategoryResource(TypeFilteredResource):
         filtering = {
             'identifier': ALL,
         }
+        serializer = CountJSONSerializer()
 
 
 class GroupResource(ModelResource):
-
     """Groups api"""
 
     detail_url = fields.CharField()
@@ -189,8 +185,8 @@ class GroupResource(ModelResource):
 
 
 class ProfileResource(ModelResource):
-
     """Profile api"""
+
     avatar_100 = fields.CharField(null=True)
     profile_detail_url = fields.CharField()
     email = fields.CharField(default='')

--- a/geonode/api/api.py
+++ b/geonode/api/api.py
@@ -37,7 +37,7 @@ FILTER_TYPES = {
 
 class CountJSONSerializer(Serializer):
     """Custom serializer to post process the api and add counts"""
-    
+
     def get_resources_counts(self, options):
         if settings.SKIP_PERMS_FILTER:
             resources = ResourceBase.objects.all()
@@ -134,7 +134,8 @@ class RegionResource(TypeFilteredResource):
         filtering = {
             'name': ALL,
         }
-        serializer = CountJSONSerializer()
+        # To activate the counts on regions uncomment the following line
+        # serializer = CountJSONSerializer()
 
 
 class TopicCategoryResource(TypeFilteredResource):

--- a/geonode/api/authorization.py
+++ b/geonode/api/authorization.py
@@ -12,9 +12,7 @@ class GeoNodeAuthorization(DjangoAuthorization):
     def read_list(self, object_list, bundle):
         permitted_ids = get_objects_for_user(
             bundle.request.user,
-            'base.view_resourcebase').values_list(
-            'id',
-            flat=True)
+            'base.view_resourcebase').values('id')
 
         return object_list.filter(id__in=permitted_ids)
 

--- a/geonode/api/resourcebase_api.py
+++ b/geonode/api/resourcebase_api.py
@@ -314,7 +314,7 @@ class CommonModelApi(ModelResource):
             if settings.RESOURCE_PUBLISHING:
                 filter_set = filter_set.filter(is_published=True)
 
-            filter_set_ids = filter_set.values_list('id', flat=True)
+            filter_set_ids = filter_set.values('id')
             # Do the query using the filterset and the query term. Facet the
             # results
             if len(filter_set) > 0:

--- a/geonode/base/models.py
+++ b/geonode/base/models.py
@@ -585,9 +585,9 @@ class ResourceBase(PolymorphicModel, PermissionLevelMixin):
         no_custom_permissions = UserObjectPermission.objects.filter(
             content_type=ContentType.objects.get_for_model(self.get_self_resource()),
             object_pk=str(self.pk)
-            ).count()
+            ).exist()
 
-        if no_custom_permissions == 0:
+        if no_custom_permissions:
             logger.debug('There are no permissions for this object, setting default perms.')
             self.set_default_permissions()
 

--- a/geonode/base/models.py
+++ b/geonode/base/models.py
@@ -585,7 +585,7 @@ class ResourceBase(PolymorphicModel, PermissionLevelMixin):
         no_custom_permissions = UserObjectPermission.objects.filter(
             content_type=ContentType.objects.get_for_model(self.get_self_resource()),
             object_pk=str(self.pk)
-            ).exist()
+            ).exists()
 
         if no_custom_permissions:
             logger.debug('There are no permissions for this object, setting default perms.')

--- a/geonode/base/models.py
+++ b/geonode/base/models.py
@@ -587,7 +587,7 @@ class ResourceBase(PolymorphicModel, PermissionLevelMixin):
             object_pk=str(self.pk)
             ).exists()
 
-        if no_custom_permissions:
+        if not no_custom_permissions:
             logger.debug('There are no permissions for this object, setting default perms.')
             self.set_default_permissions()
 

--- a/geonode/base/templatetags/base_tags.py
+++ b/geonode/base/templatetags/base_tags.py
@@ -31,7 +31,7 @@ def facets(context):
 
     if not settings.SKIP_PERMS_FILTER:
         authorized = get_objects_for_user(
-            request.user, 'base.view_resourcebase').values_list('id', flat=True)
+            request.user, 'base.view_resourcebase').values('id')
 
     if facet_type == 'documents':
 

--- a/geonode/base/templatetags/base_tags.py
+++ b/geonode/base/templatetags/base_tags.py
@@ -3,6 +3,7 @@ from django import template
 from agon_ratings.models import Rating
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.auth import get_user_model
+from django.db.models import Count
 
 from guardian.shortcuts import get_objects_for_user
 from geonode import settings
@@ -25,94 +26,60 @@ def num_ratings(obj):
 def facets(context):
     request = context['request']
     title_filter = request.GET.get('title__icontains', '')
-    facets = {}
 
     facet_type = context['facet_type'] if 'facet_type' in context else 'all'
+
+    if not settings.SKIP_PERMS_FILTER:
+        authorized = get_objects_for_user(
+            request.user, 'base.view_resourcebase').values_list('id', flat=True)
+
     if facet_type == 'documents':
 
-        facets = {
-            'text': 0,
-            'image': 0,
-            'presentation': 0,
-            'archive': 0,
-            'other': 0
-        }
+        documents = Document.objects.filter(title__icontains=title_filter)
 
-        text = Document.objects.filter(doc_type='text').filter(
-            title__icontains=title_filter).values_list('id', flat=True)
-        image = Document.objects.filter(doc_type='image').filter(
-            title__icontains=title_filter).values_list('id', flat=True)
-        presentation = Document.objects.filter(doc_type='presentation').filter(
-            title__icontains=title_filter).values_list('id', flat=True)
-        archive = Document.objects.filter(doc_type='archive').filter(
-            title__icontains=title_filter).values_list('id', flat=True)
-        other = Document.objects.filter(doc_type='other').filter(
-            title__icontains=title_filter).values_list('id', flat=True)
+        if settings.RESOURCE_PUBLISHING:
+            documents = documents.filter(is_published=True)
 
-        if settings.SKIP_PERMS_FILTER:
-            facets['text'] = text.count()
-            facets['image'] = image.count()
-            facets['presentation'] = presentation.count()
-            facets['archive'] = archive.count()
-            facets['other'] = other.count()
-        else:
-            resources = get_objects_for_user(
-                request.user, 'base.view_resourcebase')
-            facets['text'] = resources.filter(id__in=text).count()
-            facets['image'] = resources.filter(id__in=image).count()
-            facets['presentation'] = resources.filter(
-                id__in=presentation).count()
-            facets['archive'] = resources.filter(id__in=archive).count()
-            facets['other'] = resources.filter(id__in=other).count()
+        if not settings.SKIP_PERMS_FILTER:
+            documents = documents.filter(id__in=authorized)
 
-            return facets
+        counts = documents.values('doc_type').annotate(count=Count('doc_type'))
+        facets = dict([(count['doc_type'], count['count']) for count in counts])
+
+        return facets
 
     else:
 
-        facets = {
-            'raster': 0,
-            'vector': 0,
-        }
-
-        vectors = Layer.objects.filter(storeType='dataStore').filter(
-            title__icontains=title_filter).values_list('id', flat=True)
-        rasters = Layer.objects.filter(storeType='coverageStore').filter(
-            title__icontains=title_filter).values_list('id', flat=True)
-        remote = Layer.objects.filter(storeType='remoteStore').filter(
-            title__icontains=title_filter).values_list('id', flat=True)
+        layers = Layer.objects.filter(title__icontains=title_filter)
 
         if settings.RESOURCE_PUBLISHING:
-            vectors = vectors.filter(is_published=True)
-            rasters = rasters.filter(is_published=True)
-            remote = remote.filter(is_published=True)
+            layers = layers.filter(is_published=True)
 
-        if settings.SKIP_PERMS_FILTER:
-            facets['raster'] = rasters.count()
-            facets['vector'] = vectors.count()
-            facets['remote'] = remote.count()
-        else:
-            resources = get_objects_for_user(
-                request.user, 'base.view_resourcebase').filter(title__icontains=title_filter)
-            facets['raster'] = resources.filter(id__in=rasters).count()
-            facets['vector'] = resources.filter(id__in=vectors).count()
-            facets['remote'] = resources.filter(id__in=remote).count()
+        if not settings.SKIP_PERMS_FILTER:
+            layers = layers.filter(id__in=authorized)
 
-        facet_type = context[
-            'facet_type'] if 'facet_type' in context else 'all'
+        counts = layers.values('storeType').annotate(count=Count('storeType'))
+        count_dict = dict([(count['storeType'], count['count']) for count in counts])
+
+        facets = {
+            'raster': count_dict.get('coverageStore', 0),
+            'vector': count_dict.get('dataStore', 0),
+            'remote': count_dict.get('remoteStore', 0),
+        }
+
         # Break early if only_layers is set.
         if facet_type == 'layers':
             return facets
 
-        if settings.SKIP_PERMS_FILTER:
-            facets['map'] = Map.objects.filter(
-                title__icontains=title_filter).count()
-            facets['document'] = Document.objects.filter(
-                title__icontains=title_filter).count()
-        else:
-            facets['map'] = resources.filter(title__icontains=title_filter).filter(
-                id__in=Map.objects.values_list('id', flat=True)).count()
-            facets['document'] = resources.filter(title__icontains=title_filter).filter(
-                id__in=Document.objects.values_list('id', flat=True)).count()
+        maps = Map.objects.filter(title__icontains=title_filter)
+        documents = Document.objects.filter(title__icontains=title_filter)
+
+        if not settings.SKIP_PERMS_FILTER:
+            maps = maps.filter(id__in=authorized)
+            documents = documents.filter(id__in=authorized)
+
+        facets['map'] = maps.count()
+        facets['document'] = documents.count()
 
         if facet_type == 'home':
             facets['user'] = get_user_model().objects.exclude(

--- a/geonode/geoserver/helpers.py
+++ b/geonode/geoserver/helpers.py
@@ -990,9 +990,11 @@ def geoserver_upload(
     # Get a short handle to the gsconfig geoserver catalog
     cat = gs_catalog
 
+    workspace = cat.get_default_workspace()
+
     # Check if the store exists in geoserver
     try:
-        store = cat.get_store(name)
+        store = cat.get_store(name, name, workspace=workspace)
     except geoserver.catalog.FailedRequestError as e:
         # There is no store, ergo the road is clear
         pass
@@ -1057,7 +1059,7 @@ def geoserver_upload(
                                                        data,
                                                        charset=charset,
                                                        overwrite=overwrite,
-                                                       workspace=cat.get_default_workspace())
+                                                       workspace=workspace)
     except UploadError as e:
         msg = ('Could not save the layer %s, there was an upload '
                'error: %s' % (name, str(e)))
@@ -1144,7 +1146,7 @@ def geoserver_upload(
     # Step 10. Create the Django record for the layer
     logger.info('>>> Step 10. Creating Django record for [%s]', name)
     # FIXME: Do this inside the layer object
-    typename = gs_resource.store.workspace.name + ':' + gs_resource.name
+    typename = workspace.name + ':' + gs_resource.name
     layer_uuid = str(uuid.uuid1())
     defaults = dict(store=gs_resource.store.name,
                     storeType=gs_resource.store.resource_type,
@@ -1154,9 +1156,7 @@ def geoserver_upload(
                     abstract=abstract or gs_resource.abstract or '',
                     owner=user)
 
-    workspace = gs_resource.store.workspace.name
-
-    return name, workspace, defaults
+    return name, workspace.name, defaults, gs_resource
 
 
 class ServerDoesNotExist(Exception):

--- a/geonode/geoserver/helpers.py
+++ b/geonode/geoserver/helpers.py
@@ -228,11 +228,17 @@ def cascading_delete(cat, layer_name):
         if layer_name.find(':') != -1:
             workspace, name = layer_name.split(':')
             ws = cat.get_workspace(workspace)
+            try:
+                store = cat.get_store(name)
+            except FailedRequestError:
+                logger.debug(
+                    'the store was not found in geoserver')
+                return
             if ws is None:
                 logger.debug(
                     'cascading delete was called on a layer where the workspace was not found')
                 return
-            resource = cat.get_resource(name, workspace=workspace)
+            resource = cat.get_resource(name, store=store, workspace=workspace)
         else:
             resource = cat.get_resource(layer_name)
     except EnvironmentError as e:

--- a/geonode/geoserver/helpers.py
+++ b/geonode/geoserver/helpers.py
@@ -906,19 +906,21 @@ def cleanup(name, uuid):
                        'import for layer: %s', name)
 
 
-def _create_featurestore(name, data, overwrite=False, charset="UTF-8"):
+def _create_featurestore(name, data, overwrite=False, charset="UTF-8", workspace=None):
     cat = gs_catalog
     cat.create_featurestore(name, data, overwrite=overwrite, charset=charset)
-    return cat.get_store(name), cat.get_resource(name)
+    store = cat.get_store(name, workspace)
+    return store, cat.get_resource(name, store=store, workspace=workspace)
 
 
-def _create_coveragestore(name, data, overwrite=False, charset="UTF-8"):
+def _create_coveragestore(name, data, overwrite=False, charset="UTF-8", workspace=None):
     cat = gs_catalog
     cat.create_coveragestore(name, data, overwrite=overwrite)
-    return cat.get_store(name), cat.get_resource(name)
+    store = cat.get_store(name, workspace)
+    return store, cat.get_resource(name, store=store, workspace=workspace)
 
 
-def _create_db_featurestore(name, data, overwrite=False, charset="UTF-8"):
+def _create_db_featurestore(name, data, overwrite=False, charset="UTF-8", workspace=None):
     """Create a database store then use it to import a shapefile.
 
     If the import into the database fails then delete the store
@@ -949,7 +951,7 @@ def _create_db_featurestore(name, data, overwrite=False, charset="UTF-8"):
         cat.add_data_to_store(ds, name, data,
                               overwrite=overwrite,
                               charset=charset)
-        return ds, cat.get_resource(name, store=ds)
+        return ds, cat.get_resource(name, store=ds, workspace=workspace)
     except Exception:
         msg = _("An exception occurred loading data to PostGIS")
         msg += "- %s" % (sys.exc_info()[1])
@@ -1048,7 +1050,8 @@ def geoserver_upload(
         store, gs_resource = create_store_and_resource(name,
                                                        data,
                                                        charset=charset,
-                                                       overwrite=overwrite)
+                                                       overwrite=overwrite,
+                                                       workspace=cat.get_default_workspace())
     except UploadError as e:
         msg = ('Could not save the layer %s, there was an upload '
                'error: %s' % (name, str(e)))

--- a/geonode/geoserver/helpers.py
+++ b/geonode/geoserver/helpers.py
@@ -936,9 +936,9 @@ def _create_db_featurestore(name, data, overwrite=False, charset="UTF-8", worksp
     dsname = ogc_server_settings.DATASTORE
 
     try:
-        ds = cat.get_store(dsname)
+        ds = cat.get_store(dsname, workspace=workspace)
     except FailedRequestError:
-        ds = cat.create_datastore(dsname)
+        ds = cat.create_datastore(dsname, workspace=workspace)
         db = ogc_server_settings.datastore_db
         db_engine = 'postgis' if \
             'postgis' in db['ENGINE'] else db['ENGINE']
@@ -994,7 +994,7 @@ def geoserver_upload(
 
     # Check if the store exists in geoserver
     try:
-        store = cat.get_store(name, name, workspace=workspace)
+        store = cat.get_store(name, workspace=workspace)
     except geoserver.catalog.FailedRequestError as e:
         # There is no store, ergo the road is clear
         pass

--- a/geonode/geoserver/signals.py
+++ b/geonode/geoserver/signals.py
@@ -117,7 +117,6 @@ def geoserver_pre_save(instance, sender, **kwargs):
        * Download links (WMS, WCS or WFS and KML)
        * Styles (SLD)
     """
-    gs_resource = gs_catalog.get_resource(instance.name)
 
     bbox = gs_resource.latlon_bbox
 

--- a/geonode/geoserver/signals.py
+++ b/geonode/geoserver/signals.py
@@ -52,6 +52,8 @@ def geoserver_pre_save(instance, sender, **kwargs):
     if getattr(instance, "service", None) is not None:
         return
 
+    gs_resource = None
+
     # If the store in None then it's a new instance from an upload,
     # only in this case run the geonode_uplaod method
     if not instance.store or getattr(instance, 'overwrite', False):
@@ -60,15 +62,15 @@ def geoserver_pre_save(instance, sender, **kwargs):
         # There is no need to process it if there is not file.
         if base_file is None:
             return
-        gs_name, workspace, values = geoserver_upload(instance,
-                                                      base_file.file.path,
-                                                      instance.owner,
-                                                      instance.name,
-                                                      overwrite=True,
-                                                      title=instance.title,
-                                                      abstract=instance.abstract,
-                                                      # keywords=instance.keywords,
-                                                      charset=instance.charset)
+        gs_name, workspace, values, gs_resource = geoserver_upload(instance,
+                                                                   base_file.file.path,
+                                                                   instance.owner,
+                                                                   instance.name,
+                                                                   overwrite=True,
+                                                                   title=instance.title,
+                                                                   abstract=instance.abstract,
+                                                                   # keywords=instance.keywords,
+                                                                   charset=instance.charset)
         # Set fields obtained via the geoserver upload.
         instance.name = gs_name
         instance.workspace = workspace
@@ -76,10 +78,11 @@ def geoserver_pre_save(instance, sender, **kwargs):
         for key in ['typename', 'store', 'storeType']:
             setattr(instance, key, values[key])
 
-    gs_resource = gs_catalog.get_resource(
-        instance.name,
-        store=instance.store,
-        workspace=instance.workspace)
+    if not gs_resource:
+        gs_resource = gs_catalog.get_resource(
+            instance.name,
+            store=instance.store,
+            workspace=instance.workspace)
 
     gs_resource.title = instance.title
     gs_resource.abstract = instance.abstract
@@ -132,6 +135,9 @@ def geoserver_pre_save(instance, sender, **kwargs):
     instance.bbox_y0 = bbox[2]
     instance.bbox_y1 = bbox[3]
 
+    # store the resource to avoid another geoserver call in the post_save
+    instance.gs_resource = gs_resource
+
 
 def geoserver_post_save(instance, sender, **kwargs):
     """Save keywords to GeoServer
@@ -151,17 +157,20 @@ def geoserver_post_save(instance, sender, **kwargs):
         set_attributes(instance)
         return
 
-    try:
-        gs_resource = gs_catalog.get_resource(
-            instance.name,
-            store=instance.store,
-            workspace=instance.workspace)
-    except socket_error as serr:
-        if serr.errno != errno.ECONNREFUSED:
-            # Not the error we are looking for, re-raise
-            raise serr
-        # If the connection is refused, take it easy.
-        return
+    if not getattr(instance, 'gs_resource', None):
+        try:
+            gs_resource = gs_catalog.get_resource(
+                instance.name,
+                store=instance.store,
+                workspace=instance.workspace)
+        except socket_error as serr:
+            if serr.errno != errno.ECONNREFUSED:
+                # Not the error we are looking for, re-raise
+                raise serr
+            # If the connection is refused, take it easy.
+            return
+    else:
+        gs_resource = instance.gs_resource
 
     if gs_resource is None:
         return

--- a/geonode/geoserver/tests.py
+++ b/geonode/geoserver/tests.py
@@ -47,6 +47,7 @@ class LayerTests(TestCase):
 
         # Setup some layer names to work with
         valid_layer_typename = Layer.objects.all()[0].typename
+        Layer.objects.all()[0].set_default_permissions()
         invalid_layer_typename = "n0ch@nc3"
 
         # Test that an invalid layer.typename is handled for properly

--- a/geonode/geoserver/views.py
+++ b/geonode/geoserver/views.py
@@ -481,7 +481,7 @@ def layer_acls(request):
     # Include permissions on the anonymous user
     # use of polymorphic selectors/functions to optimize performances
     resources_readable = get_objects_for_user(acl_user, 'view_resourcebase',
-                                          ResourceBase.objects.instance_of(Layer)).values_list('id', flat=True)
+                                              ResourceBase.objects.instance_of(Layer)).values_list('id', flat=True)
     layer_writable = get_objects_for_user(acl_user, 'change_layer_data',
                                           Layer.objects.all())
 

--- a/geonode/geoserver/views.py
+++ b/geonode/geoserver/views.py
@@ -480,12 +480,12 @@ def layer_acls(request):
 
     # Include permissions on the anonymous user
     # use of polymorphic selectors/functions to optimize performances
-    layer_readable = get_objects_for_user(acl_user, 'view_resourcebase',
-                                          ResourceBase.objects.instance_of(Layer))
+    resources_readable = get_objects_for_user(acl_user, 'view_resourcebase',
+                                          ResourceBase.objects.instance_of(Layer)).values_list('id', flat=True)
     layer_writable = get_objects_for_user(acl_user, 'change_layer_data',
                                           Layer.objects.all())
 
-    _read = set([l.typename for l in layer_readable.get_real_instances()])
+    _read = set(Layer.objects.filter(id__in=resources_readable).values_list('typename', flat=True))
     _write = set(layer_writable.values_list('typename', flat=True))
 
     read_only = _read ^ _write

--- a/geonode/groups/tests.py
+++ b/geonode/groups/tests.py
@@ -110,6 +110,7 @@ class SmokeTest(TestCase):
         """
         # Add test to test perms being sent to the front end.
         layer = Layer.objects.all()[0]
+        layer.set_default_permissions()
         perms_info = layer.get_all_level_info()
 
         # Ensure there is only one group 'anonymous' by default
@@ -132,6 +133,9 @@ class SmokeTest(TestCase):
         layer = Layer.objects.all()[0]
         document = Document.objects.all()[0]
         map_obj = Map.objects.all()[0]
+        layer.set_default_permissions()
+        document.set_default_permissions()
+        map_obj.set_default_permissions()
 
         objects = layer, document, map_obj
 

--- a/geonode/layers/models.py
+++ b/geonode/layers/models.py
@@ -484,7 +484,6 @@ def pre_delete_layer(instance, sender, **kwargs):
 
     # Delete object permissions
     remove_object_permissions(instance)
-    remove_object_permissions(instance.get_self_resource())
 
 
 def post_delete_layer(instance, sender, **kwargs):

--- a/geonode/layers/utils.py
+++ b/geonode/layers/utils.py
@@ -183,7 +183,7 @@ def get_valid_name(layer_name):
     name = _clean_string(layer_name)
     proposed_name = name
     count = 1
-    while Layer.objects.filter(name=proposed_name).count() > 0:
+    while Layer.objects.filter(name=proposed_name).exists():
         proposed_name = "%s_%d" % (name, count)
         count = count + 1
         logger.info('Requested name already used; adjusting name '

--- a/geonode/security/models.py
+++ b/geonode/security/models.py
@@ -24,7 +24,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.contrib.auth import login
 from django.contrib.auth.models import Group, Permission
 from guardian.utils import get_user_obj_perms_model
-from guardian.shortcuts import assign_perm, remove_perm, get_groups_with_perms
+from guardian.shortcuts import assign_perm, get_groups_with_perms
 
 
 ADMIN_PERMISSIONS = [
@@ -37,6 +37,11 @@ ADMIN_PERMISSIONS = [
     'publish_resourcebase',
 ]
 
+LAYER_ADMIN_PERMISSIONS = [
+    'change_layer_data',
+    'change_layer_style'
+]
+
 
 def get_users_with_perms(obj):
     """
@@ -44,7 +49,7 @@ def get_users_with_perms(obj):
     """
     ctype = ContentType.objects.get_for_model(obj)
     permissions = {}
-    PERMISSIONS_TO_FETCH = ADMIN_PERMISSIONS + ['change_layer_data', 'change_layer_style']
+    PERMISSIONS_TO_FETCH = ADMIN_PERMISSIONS + LAYER_ADMIN_PERMISSIONS
 
     for perm in Permission.objects.filter(codename__in=PERMISSIONS_TO_FETCH, content_type_id=ctype.id):
         permissions[perm.id] = perm.codename
@@ -128,46 +133,19 @@ class PermissionLevelMixin(object):
             self,
             'resourcebase_ptr_id') else self
 
-    def remove_all_permissions(self):
-        """
-        Remove all the permissions for users and groups except for the resource owner
-        """
-        # TODO refactor this
-        # first remove in resourcebase
-        for user, perms in get_users_with_perms(self.get_self_resource()).iteritems():
-            if not self.owner == user:
-                for perm in perms:
-                    remove_perm(perm, user, self.get_self_resource())
-
-        for group, perms in get_groups_with_perms(self.get_self_resource(), attach_perms=True).iteritems():
-            for perm in perms:
-                remove_perm(perm, group, self.get_self_resource())
-
-        # now remove in layer (if resource is layer
-        if hasattr(self, "layer"):
-            for user, perms in get_users_with_perms(self.layer).iteritems():
-                if not self.owner == user:
-                    for perm in perms:
-                        remove_perm(perm, user, self.layer)
-
-            for group, perms in get_groups_with_perms(self.layer, attach_perms=True).iteritems():
-                for perm in perms:
-                    remove_perm(perm, group, self.layer)
-
     def set_default_permissions(self):
         """
         Remove all the permissions except for the owner and assign the
         view permission to the anonymous group
         """
-        self.remove_all_permissions()
+        remove_object_permissions(self)
 
         # default permissions for anonymous users
         anonymous_group, created = Group.objects.get_or_create(name='anonymous')
         assign_perm('view_resourcebase', anonymous_group, self.get_self_resource())
 
         # default permissions for resource owner
-        for perm in ADMIN_PERMISSIONS:
-            assign_perm(perm, self.owner, self.get_self_resource())
+        set_owner_permissions(self)
 
         # only for layer owner
         if self.__class__.__name__ == 'Layer':
@@ -195,7 +173,7 @@ class PermissionLevelMixin(object):
         }
         """
 
-        self.remove_all_permissions()
+        remove_object_permissions(self)
 
         if 'users' in perm_spec and "AnonymousUser" in perm_spec['users']:
             anonymous_group = Group.objects.get(name='anonymous')
@@ -225,16 +203,35 @@ class PermissionLevelMixin(object):
                     else:
                         assign_perm(perm, group, self.get_self_resource())
 
+        # default permissions for resource owner
+        set_owner_permissions(self)
+
+
+def set_owner_permissions(resource):
+    """assign all admin permissions to the owner"""
+    if resource.polymorphic_ctype.name == 'layer':
+        for perm in LAYER_ADMIN_PERMISSIONS:
+            assign_perm(perm, resource.owner, resource.layer)
+    for perm in ADMIN_PERMISSIONS:
+            assign_perm(perm, resource.owner, resource.get_self_resource())
+
 
 def remove_object_permissions(instance):
-    """Remove object perimssions
-       Must be called by Resourcebase children on pre_delete using the Resourcebase instance,
-       for layer must also be called with Layer instance
+    """Remove object perimssions on give resource.
+        If is a layer removes the layer specific permissions then the resourcebase permissions
     """
     from guardian.models import UserObjectPermission, GroupObjectPermission
-    UserObjectPermission.objects.filter(content_type=ContentType.objects.get_for_model(instance),
+
+    if hasattr(instance, "layer"):
+        UserObjectPermission.objects.filter(content_type=ContentType.objects.get_for_model(instance),
+                                            object_pk=instance.id).delete()
+        GroupObjectPermission.objects.filter(content_type=ContentType.objects.get_for_model(instance),
+                                             object_pk=instance.id).delete()
+
+    resource = instance.get_self_resource()
+    UserObjectPermission.objects.filter(content_type=ContentType.objects.get_for_model(resource),
                                         object_pk=instance.id).delete()
-    GroupObjectPermission.objects.filter(content_type=ContentType.objects.get_for_model(instance),
+    GroupObjectPermission.objects.filter(content_type=ContentType.objects.get_for_model(resource),
                                          object_pk=instance.id).delete()
 
 

--- a/geonode/security/tests.py
+++ b/geonode/security/tests.py
@@ -264,7 +264,7 @@ class PermissionsTest(TestCase):
 
         # Test with a Layer object
         layer = Layer.objects.all()[0]
-
+        layer.set_default_permissions()
         # Test that the anonymous user can read
         self.assertTrue(
             self.anonymous_user.has_perm(
@@ -300,7 +300,7 @@ class PermissionsTest(TestCase):
 
         # grab a layer
         layer = Layer.objects.all()[0]
-
+        layer.set_default_permissions()
         # verify bobby has view/change permissions on it but not manage
         self.assertFalse(
             bob.has_perm(
@@ -399,7 +399,7 @@ class PermissionsTest(TestCase):
 
         # grab a layer
         layer = Layer.objects.all()[0]
-
+        layer.set_default_permissions()
         # 1. view_resourcebase
         # 1.1 has view_resourcebase: verify that anonymous user can access
         # the layer detail page

--- a/geonode/social/signals.py
+++ b/geonode/social/signals.py
@@ -194,7 +194,7 @@ if notification_app:
         """
         recipients_ids = NoticeSetting.objects \
             .filter(notice_type__label=notice_type_label) \
-            .values_list('user', flat=True)
+            .values('user')
         profiles = Profile.objects.filter(id__in=recipients_ids)
         if exclude_user:
             profiles.exclude(username=exclude_user.username)

--- a/geonode/templates/_permissions_form_js.html
+++ b/geonode/templates/_permissions_form_js.html
@@ -98,6 +98,15 @@
             var perms = $.parseJSON($.parseJSON(data).permissions);
 
             var perms_users = perms.users;
+
+            /*
+            * If there is the group anonymous then treas it as it is the AnonymousUser
+            * since the server doesn't explicitly send the users that belongs to a group with permissions
+            */
+            if (perms.groups.hasOwnProperty('anonymous')){
+              perms_users.AnonymousUser = perms.groups.anonymous;
+            }
+
             for (var user in perms_users){
               var user_perms = perms_users[user];
               if (user === 'AnonymousUser'){
@@ -123,15 +132,15 @@
             }
             
             // If "anyone" is checked then don't show all the users in the view perms field
-            if (perms_users.hasOwnProperty('AnonymousUser') 
-              && perms_users['AnonymousUser'].indexOf('view_resourcebase') > -1){
-              users.view_resourcebase=[]
-            };
+            // if (perms_users.hasOwnProperty('AnonymousUser') 
+            //   && perms_users['AnonymousUser'].indexOf('view_resourcebase') > -1){
+            //   users.view_resourcebase=[]
+            // };
             
-            if (perms_users.hasOwnProperty('AnonymousUser') 
-              && perms_users['AnonymousUser'].indexOf('download_resourcebase') > -1){
-              users.download_resourcebase=[]
-            };
+            // if (perms_users.hasOwnProperty('AnonymousUser') 
+            //   && perms_users['AnonymousUser'].indexOf('download_resourcebase') > -1){
+            //   users.download_resourcebase=[]
+            // };
 
             for (var perm in users){
               if(['change_resourcebase', 'delete_resourcebase', 'change_resourcebase_permissions', 'publish_resourcebase'].indexOf(user_perms[i]) >= 0){

--- a/geonode/tests/integration.py
+++ b/geonode/tests/integration.py
@@ -114,7 +114,7 @@ class NormalUserTest(TestCase):
             user=norman,
             overwrite=True,
         )
-
+        saved_layer.set_default_permissions()
         url = reverse('layer_metadata', args=[saved_layer.service_typename])
         resp = self.client.get(url)
         self.assertEquals(resp.status_code, 200)
@@ -511,6 +511,7 @@ class GeoNodeMapTest(TestCase):
         """Regression-test for failures caused by zero-width bounding boxes"""
         thefile = os.path.join(gisdata.VECTOR_DATA, 'single_point.shp')
         uploaded = file_upload(thefile, overwrite=True)
+        uploaded.set_default_permissions()
         self.client.login(username='norman', password='norman')
         resp = self.client.get(uploaded.get_absolute_url())
         self.assertEquals(resp.status_code, 200)
@@ -728,6 +729,7 @@ xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.
             gisdata.VECTOR_DATA,
             'san_andres_y_providencia_poi.shp')
         layer = file_upload(thefile, overwrite=True)
+        layer.set_default_permissions()
         check_layer(layer)
 
         # we need some time to have the service up and running
@@ -756,6 +758,7 @@ xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.
                 gisdata.VECTOR_DATA,
                 'san_andres_y_providencia_administrative.shp')
             layer = file_upload(thefile, overwrite=True)
+            layer.set_default_permissions()
             check_layer(layer)
 
             # we need some time to have the service up and running
@@ -833,7 +836,7 @@ class GeoNodeThumbnailTest(TestCase):
             user=norman,
             overwrite=True,
         )
-
+        saved_layer.set_default_permissions()
         map_obj = Map(owner=norman, zoom=0,
                       center_x=0, center_y=0)
         map_obj.create_from_layer_list(norman, [saved_layer], 'title', '')


### PR DESCRIPTION
This PR solves the major issues described in #2130 and #2122.
The guardian permissions are checked faster avoiding complex joins
The categories, regions and keyword counts are done in the post-process in bulk and not per object anymore
The layer_upload uses gsconfig so to not query geoserver for all the layers available
The layer_acls check is improved by ~75%

A proper test to load lot of data has to be done in a realistic way. Loading many times the same layer will hit the db to find an available name so there is still a slight slow down in layer upload like it becomes 1s slower every 300 layer loaded.