### PR TITLE
improve visual of document_detail page

### DIFF
--- a/geonode/documents/templates/documents/document_detail.html
+++ b/geonode/documents/templates/documents/document_detail.html
@@ -30,7 +30,7 @@
       {% if resource.extension|lower in imgtypes and resource.doc_file %}
       <div id="embedded_map">
         <a style="text-decoration:none;" href="{% url "document_download" resource.id %}" target="_blank">
-          <img src="{% url "document_download" resource.id %}" width='100%' />
+          <img src="{% url "document_download" resource.id %}" width='50%' />
         </a>
       </div>
       {% elif resource.doc_file %}

--- a/geonode/documents/templates/documents/document_detail.html
+++ b/geonode/documents/templates/documents/document_detail.html
@@ -30,7 +30,7 @@
       {% if resource.extension|lower in imgtypes and resource.doc_file %}
       <div id="embedded_map">
         <a style="text-decoration:none;" href="{% url "document_download" resource.id %}" target="_blank">
-          <img src="{% url "document_download" resource.id %}" width='50%' />
+          <img src="{% url "document_download" resource.id %}" width='500' class="img-responsive" />
         </a>
       </div>
       {% elif resource.doc_file %}


### PR DESCRIPTION
A little improvement for visualization of the document preview.

Verified on smartphone and web browser.
The main problem was that the preview was taking too much space.

50% look right for me.