### PR TITLE
Filter out any user permissions that are not in the PERMISSIONS_TO_FETCH list

### DIFF
--- a/geonode/security/models.py
+++ b/geonode/security/models.py
@@ -56,7 +56,8 @@ def get_users_with_perms(obj):
 
     user_model = get_user_obj_perms_model(obj)
     users_with_perms = user_model.objects.filter(object_pk=obj.pk,
-                                                 content_type_id=ctype.id).values('user_id', 'permission_id')
+                                                 content_type_id=ctype.id,
+                                                 permission_id__in=permissions).values('user_id', 'permission_id')
 
     users = {}
     for item in users_with_perms:


### PR DESCRIPTION
This should prevent KeyError exceptions on layer info pages for any pre-existing layers that may have additional user permissions ('add_layer', 'delete_layer', etc) not in the list.

https://github.com/GeoNode/geonode/issues/2142