### PR TITLE
Make haystack search results more similar to standard API search results

### DIFF
--- a/geonode/api/resourcebase_api.py
+++ b/geonode/api/resourcebase_api.py
@@ -255,12 +255,12 @@ class CommonModelApi(ModelResource):
         # filter by date
         if date_start:
             sqs = (SearchQuerySet() if sqs is None else sqs).filter(
-                SQ(modified__gte=date_start)
+                SQ(date__gte=date_start)
             )
 
         if date_end:
             sqs = (SearchQuerySet() if sqs is None else sqs).filter(
-                SQ(modified__lte=date_end)
+                SQ(date__lte=date_end)
             )
 
         # Filter by geographic bounding box
@@ -277,10 +277,10 @@ class CommonModelApi(ModelResource):
         # Apply sort
         if sort.lower() == "-date":
             sqs = (
-                SearchQuerySet() if sqs is None else sqs).order_by("-modified")
+                SearchQuerySet() if sqs is None else sqs).order_by("-date")
         elif sort.lower() == "date":
             sqs = (
-                SearchQuerySet() if sqs is None else sqs).order_by("modified")
+                SearchQuerySet() if sqs is None else sqs).order_by("date")
         elif sort.lower() == "title":
             sqs = (SearchQuerySet() if sqs is None else sqs).order_by(
                 "title_sortable")
@@ -292,7 +292,7 @@ class CommonModelApi(ModelResource):
                 "-popular_count")
         else:
             sqs = (
-                SearchQuerySet() if sqs is None else sqs).order_by("-modified")
+                SearchQuerySet() if sqs is None else sqs).order_by("-date")
 
         return sqs
 
@@ -317,7 +317,7 @@ class CommonModelApi(ModelResource):
             # Do the query using the filterset and the query term. Facet the
             # results
             if len(filter_set) > 0:
-                sqs = sqs.filter(oid__in=filter_set_ids).facet('type').facet('subtype').facet('owner')\
+                sqs = sqs.filter(id__in=filter_set_ids).facet('type').facet('subtype').facet('owner')\
                     .facet('keywords').facet('regions').facet('category')
             else:
                 sqs = None
@@ -368,10 +368,15 @@ class CommonModelApi(ModelResource):
                     "total_count": total_count,
                     "facets": facets,
                     },
-            'objects': map(lambda x: x.get_stored_fields(), objects),
+            'objects': map(lambda x: self.get_haystack_api_fields(x), objects),
         }
         self.log_throttled_access(request)
         return self.create_response(request, object_list)
+
+    def get_haystack_api_fields(self, haystack_object):
+        object_fields = dict((k, v) for k, v in haystack_object.get_stored_fields().items()
+                             if not re.search('_exact$|_sortable$', k))
+        return object_fields
 
     def get_list(self, request, **kwargs):
         """

--- a/geonode/documents/search_indexes.py
+++ b/geonode/documents/search_indexes.py
@@ -3,23 +3,41 @@ from geonode.documents.models import Document
 
 
 class DocumentIndex(indexes.SearchIndex, indexes.Indexable):
-    text = indexes.CharField(document=True, use_template=True)
-    title = indexes.CharField(model_attr="title", boost=2)
-    # https://github.com/toastdriven/django-haystack/issues/569 - Necessary for sorting
-    title_sortable = indexes.CharField(indexed=False)
-    oid = indexes.IntegerField(model_attr='id')
-    type = indexes.CharField(faceted=True)
-    bbox_left = indexes.FloatField(model_attr="bbox_x0", null=True)
-    bbox_right = indexes.FloatField(model_attr="bbox_x1", null=True)
-    bbox_top = indexes.FloatField(model_attr="bbox_y0", null=True)
-    bbox_bottom = indexes.FloatField(model_attr="bbox_y1", null=True)
-    abstract = indexes.CharField(model_attr='abstract', boost=1.5)
-    owner = indexes.CharField(model_attr="owner", faceted=True, null=True)
-    modified = indexes.DateTimeField(model_attr="date")
+    id = indexes.IntegerField(model_attr='id')
+    abstract = indexes.CharField(model_attr="abstract", boost=1.5)
+    category__gn_description = indexes.CharField(model_attr="category__gn_description", null=True)
+    csw_type = indexes.CharField(model_attr="csw_type")
+    csw_wkt_geometry = indexes.CharField(model_attr="csw_wkt_geometry")
     detail_url = indexes.CharField(model_attr="get_absolute_url")
-    popular_count = indexes.IntegerField(model_attr="popular_count", default=0)
-    keywords = indexes.MultiValueField(model_attr="keyword_list", indexed=False, null=True, faceted=True)
+    distribution_description = indexes.CharField(model_attr="distribution_description", null=True)
+    distribution_url = indexes.CharField(model_attr="distribution_url", null=True)
+    owner_username = indexes.CharField(model_attr="owner", faceted=True, null=True)
+    popular_count = indexes.IntegerField(
+        model_attr="popular_count",
+        default=0,
+        boost=20)
+    share_count = indexes.IntegerField(model_attr="share_count", default=0)
+    rating = indexes.IntegerField(null=True)
+    srid = indexes.CharField(model_attr="srid")
+    supplemental_information = indexes.CharField(model_attr="supplemental_information", null=True)
     thumbnail_url = indexes.CharField(model_attr="thumbnail_url", null=True)
+    uuid = indexes.CharField(model_attr="uuid")
+    title = indexes.CharField(model_attr="title", boost=2)
+    date = indexes.DateTimeField(model_attr="date")
+
+    text = indexes.CharField(document=True, use_template=True, stored=False)
+    # https://github.com/toastdriven/django-haystack/issues/569 - Necessary for sorting
+    title_sortable = indexes.CharField(indexed=False, stored=False)
+    type = indexes.CharField(faceted=True, stored=False)
+    bbox_left = indexes.FloatField(model_attr="bbox_x0", null=True, stored=False)
+    bbox_right = indexes.FloatField(model_attr="bbox_x1", null=True, stored=False)
+    bbox_top = indexes.FloatField(model_attr="bbox_y0", null=True, stored=False)
+    bbox_bottom = indexes.FloatField(model_attr="bbox_y1", null=True, stored=False)
+    category = indexes.CharField(
+        model_attr="category__identifier",
+        faceted=True,
+        null=True,
+        stored=False)
 
     def get_model(self):
         return Document

--- a/geonode/groups/search_indexes.py
+++ b/geonode/groups/search_indexes.py
@@ -13,7 +13,7 @@ class GroupIndex(indexes.SearchIndex, indexes.Indexable):
     # https://github.com/toastdriven/django-haystack/issues/569 - Necessary for sorting
     title_sortable = indexes.CharField(indexed=False)
     description = indexes.CharField(model_attr='description', boost=1.5)
-    oid = indexes.IntegerField(model_attr='id')
+    id = indexes.IntegerField(model_attr='id')
     type = indexes.CharField(faceted=True)
     json = indexes.CharField(indexed=False)
 

--- a/geonode/layers/search_indexes.py
+++ b/geonode/layers/search_indexes.py
@@ -7,49 +7,63 @@ from geonode.maps.models import Layer
 
 
 class LayerIndex(indexes.SearchIndex, indexes.Indexable):
-    text = indexes.EdgeNgramField(document=True, use_template=True)
-    oid = indexes.CharField(model_attr='resourcebase_ptr_id')
-    uuid = indexes.CharField(model_attr='uuid')
-    type = indexes.CharField(faceted=True)
-    subtype = indexes.CharField(faceted=True)
-    name = indexes.CharField(model_attr="name")
-    title = indexes.CharField(model_attr="title", boost=2)
-    title_sortable = indexes.CharField(indexed=False)  # Necessary for sorting
-    description = indexes.CharField(model_attr="abstract", boost=1.5)
-    owner = indexes.CharField(model_attr="owner", faceted=True, null=True)
-    modified = indexes.DateTimeField(model_attr="date")
-    category = indexes.CharField(
-        model_attr="category__identifier",
-        faceted=True,
-        null=True)
+    id = indexes.IntegerField(model_attr='resourcebase_ptr_id')
+    abstract = indexes.CharField(model_attr="abstract", boost=1.5)
+    category__gn_description = indexes.CharField(model_attr="category__gn_description", null=True)
+    csw_type = indexes.CharField(model_attr="csw_type")
+    csw_wkt_geometry = indexes.CharField(model_attr="csw_wkt_geometry")
     detail_url = indexes.CharField(model_attr="get_absolute_url")
-    bbox_left = indexes.FloatField(model_attr="bbox_x0", null=True)
-    bbox_right = indexes.FloatField(model_attr="bbox_x1", null=True)
-    bbox_bottom = indexes.FloatField(model_attr="bbox_y0", null=True)
-    bbox_top = indexes.FloatField(model_attr="bbox_y1", null=True)
-    temporal_extent_start = indexes.DateTimeField(
-        model_attr="temporal_extent_start",
-        null=True)
-    temporal_extent_end = indexes.DateTimeField(
-        model_attr="temporal_extent_end",
-        null=True)
-    keywords = indexes.MultiValueField(
-        model_attr="keyword_slug_list",
-        null=True,
-        faceted=True)
-    regions = indexes.MultiValueField(
-        model_attr="region_name_list",
-        null=True,
-        faceted=True)
+    distribution_description = indexes.CharField(model_attr="distribution_description", null=True)
+    distribution_url = indexes.CharField(model_attr="distribution_url", null=True)
+    owner = indexes.CharField(model_attr="owner", faceted=True, null=True, stored=False)
+    owner__username = indexes.CharField(model_attr="owner", faceted=True, null=True)
     popular_count = indexes.IntegerField(
         model_attr="popular_count",
         default=0,
         boost=20)
     share_count = indexes.IntegerField(model_attr="share_count", default=0)
     rating = indexes.IntegerField(null=True)
-    num_ratings = indexes.IntegerField()
-    num_comments = indexes.IntegerField()
+    srid = indexes.CharField(model_attr="srid")
+    supplemental_information = indexes.CharField(model_attr="supplemental_information", null=True)
     thumbnail_url = indexes.CharField(model_attr="thumbnail_url", null=True)
+    uuid = indexes.CharField(model_attr="uuid")
+    title = indexes.CharField(model_attr="title", boost=2)
+    date = indexes.DateTimeField(model_attr="date")
+
+    text = indexes.EdgeNgramField(document=True, use_template=True, stored=False)
+    type = indexes.CharField(faceted=True, stored=False)
+    subtype = indexes.CharField(faceted=True)
+    typename = indexes.CharField(model_attr='typename')
+    title_sortable = indexes.CharField(indexed=False, stored=False)  # Necessary for sorting
+    category = indexes.CharField(
+        model_attr="category__identifier",
+        faceted=True,
+        null=True,
+        stored=False)
+    bbox_left = indexes.FloatField(model_attr="bbox_x0", null=True, stored=False)
+    bbox_right = indexes.FloatField(model_attr="bbox_x1", null=True, stored=False)
+    bbox_bottom = indexes.FloatField(model_attr="bbox_y0", null=True, stored=False)
+    bbox_top = indexes.FloatField(model_attr="bbox_y1", null=True, stored=False)
+    temporal_extent_start = indexes.DateTimeField(
+        model_attr="temporal_extent_start",
+        null=True,
+        stored=False)
+    temporal_extent_end = indexes.DateTimeField(
+        model_attr="temporal_extent_end",
+        null=True,
+        stored=False)
+    keywords = indexes.MultiValueField(
+        model_attr="keyword_slug_list",
+        null=True,
+        faceted=True,
+        stored=False)
+    regions = indexes.MultiValueField(
+        model_attr="region_name_list",
+        null=True,
+        faceted=True,
+        stored=False)
+    num_ratings = indexes.IntegerField(stored=False)
+    num_comments = indexes.IntegerField(stored=False)
 
     def get_model(self):
         return Layer

--- a/geonode/maps/search_indexes.py
+++ b/geonode/maps/search_indexes.py
@@ -3,23 +3,41 @@ from geonode.maps.models import Map
 
 
 class MapIndex(indexes.SearchIndex, indexes.Indexable):
-    text = indexes.CharField(document=True, use_template=True)
-    title = indexes.CharField(model_attr="title", boost=2)
-    # https://github.com/toastdriven/django-haystack/issues/569 - Necessary for sorting
-    title_sortable = indexes.CharField(model_attr="title", indexed=False)
-    oid = indexes.IntegerField(model_attr='id')
-    type = indexes.CharField(faceted=True)
-    bbox_left = indexes.FloatField(model_attr="bbox_x0", null=True)
-    bbox_right = indexes.FloatField(model_attr="bbox_x1", null=True)
-    bbox_top = indexes.FloatField(model_attr="bbox_y0", null=True)
-    bbox_bottom = indexes.FloatField(model_attr="bbox_y1", null=True)
-    abstract = indexes.CharField(model_attr='abstract', boost=1.5)
-    owner = indexes.CharField(model_attr="owner", faceted=True, null=True)
-    modified = indexes.DateTimeField(model_attr="last_modified")
+    id = indexes.IntegerField(model_attr='id')
+    abstract = indexes.CharField(model_attr="abstract", boost=1.5)
+    category__gn_description = indexes.CharField(model_attr="category__gn_description", null=True)
+    csw_type = indexes.CharField(model_attr="csw_type")
+    csw_wkt_geometry = indexes.CharField(model_attr="csw_wkt_geometry")
     detail_url = indexes.CharField(model_attr="get_absolute_url")
-    popular_count = indexes.IntegerField(model_attr="popular_count", default=0)
-    keywords = indexes.MultiValueField(model_attr="keyword_list", null=True, faceted=True)
+    distribution_description = indexes.CharField(model_attr="distribution_description", null=True)
+    distribution_url = indexes.CharField(model_attr="distribution_url", null=True)
+    owner_username = indexes.CharField(model_attr="owner", faceted=True, null=True)
+    popular_count = indexes.IntegerField(
+        model_attr="popular_count",
+        default=0,
+        boost=20)
+    share_count = indexes.IntegerField(model_attr="share_count", default=0)
+    rating = indexes.IntegerField(null=True)
+    srid = indexes.CharField(model_attr="srid")
+    supplemental_information = indexes.CharField(model_attr="supplemental_information", null=True)
     thumbnail_url = indexes.CharField(model_attr="thumbnail_url", null=True)
+    uuid = indexes.CharField(model_attr="uuid")
+    title = indexes.CharField(model_attr="title", boost=2)
+    date = indexes.DateTimeField(model_attr="date")
+
+    text = indexes.CharField(document=True, use_template=True, stored=False)
+    # https://github.com/toastdriven/django-haystack/issues/569 - Necessary for sorting
+    title_sortable = indexes.CharField(model_attr="title", indexed=False, stored=False)
+    type = indexes.CharField(faceted=True)
+    bbox_left = indexes.FloatField(model_attr="bbox_x0", null=True, stored=False)
+    bbox_right = indexes.FloatField(model_attr="bbox_x1", null=True, stored=False)
+    bbox_top = indexes.FloatField(model_attr="bbox_y0", null=True, stored=False)
+    bbox_bottom = indexes.FloatField(model_attr="bbox_y1", null=True, stored=False)
+    category = indexes.CharField(
+        model_attr="category__identifier",
+        faceted=True,
+        null=True,
+        stored=False)
 
     def get_model(self):
         return Map

--- a/geonode/people/search_indexes.py
+++ b/geonode/people/search_indexes.py
@@ -3,7 +3,7 @@ from geonode.people.models import Profile
 
 
 class ProfileIndex(indexes.SearchIndex, indexes.Indexable):
-    oid = indexes.IntegerField(model_attr='id')
+    id = indexes.IntegerField(model_attr='id')
     username = indexes.CharField(model_attr='username', null=True)
     first_name = indexes.CharField(model_attr='first_name', null=True)
     last_name = indexes.CharField(model_attr='last_name', null=True)


### PR DESCRIPTION
Currently, the results returned from the search API when HAYSTACK_SEARCH = True are very different from the standard API results: some item fields are missing and others have different names.  This patch will make the result format more similar (though not identical).

