### PR TITLE
Support GeoJSON uploads through the importer backend.

### DIFF
--- a/geonode/static/geonode/js/upload/FileTypes.js
+++ b/geonode/static/geonode/js/upload/FileTypes.js
@@ -34,6 +34,12 @@ define(['./FileType'], function (FileType) {
             main: 'kml',
             requires: ['kml']
         }),
+        GEOJSON: new FileType({
+            name: gettext('GeoJSON'),
+            format: 'vector',
+            main: 'geojson',
+            requires: ['geojson']
+        }),
         ZIP: new FileType({
             name: gettext('Zip Archives'),
             format: 'archive',

--- a/geonode/upload/files.py
+++ b/geonode/upload/files.py
@@ -129,6 +129,7 @@ types = [
     FileType("JPG", "jpg", raster,
              auxillary_file_exts=('prj',)),
     FileType("CSV", "csv", vector),
+    FileType("GeoJSON", "geojson", vector),
     FileType("KML", "kml", vector,
              aliases=('kmz',)),
 ]

--- a/geonode/upload/views.py
+++ b/geonode/upload/views.py
@@ -522,6 +522,7 @@ _pages = {
     'tif': ('time', 'run', 'final'),
     'kml': ('run', 'final'),
     'csv': ('csv', 'time', 'run', 'final'),
+    'geojson': ('run', 'final')
 }
 
 if not _ALLOW_TIME_STEP:


### PR DESCRIPTION
This PR provides GeoJSON support when using the importer backend.  

**Notes**: 
* GeoJSON uploads will not work for users who use the rest uploader backend.
* Relies on 2.6+ fix https://github.com/geoserver/geoserver/commit/a7efe793d3b1025eceb41c899f381a5b16df5b9b.