### PR TITLE
port existing MapStory Favorites feature to GeoNode as optional module.

### DIFF
--- a/geonode/contrib/favorite/models.py
+++ b/geonode/contrib/favorite/models.py
@@ -1,0 +1,81 @@
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.contrib.contenttypes.models import ContentType
+from django.contrib.contenttypes import generic
+from django.db import models
+
+from geonode.documents.models import Document
+from geonode.layers.models import Layer
+from geonode.maps.models import Map
+
+
+class FavoriteManager(models.Manager):
+    def favorites_for_user(self, user):
+        return self.filter(user=user)
+
+    def _favorite_ct_for_user(self, user, model):
+        content_type = ContentType.objects.get_for_model(model)
+        return self.favorites_for_user(user).filter(content_type=content_type).prefetch_related('content_object')
+
+    def favorite_documents_for_user(self, user):
+        return self._favorite_ct_for_user(user, Document)
+
+    def favorite_maps_for_user(self, user):
+        return self._favorite_ct_for_user(user, Map)
+
+    def favorite_layers_for_user(self, user):
+        return self._favorite_ct_for_user(user, Layer)
+
+    def favorite_users_for_user(self, user):
+        return self._favorite_ct_for_user(user, get_user_model())
+
+    def favorite_for_user_and_content_object(self, user, content_object):
+        """
+        if Favorite exists for input user and type and pk of the input
+        content_object, return it.  else return None.
+        impl note: can only be 0 or 1, per the class's unique_together.
+        """
+        content_type = ContentType.objects.get_for_model(type(content_object))
+        result = self.filter(user=user, content_type=content_type, object_id=content_object.pk)
+
+        if len(result) > 0:
+            return result[0]
+        else:
+            return None
+
+    def bulk_favorite_objects(self, user):
+        'get the actual favorite objects for a user as a dict by content_type'
+        favs = {}
+        for m in (Document, Map, Layer, get_user_model()):
+            ct = ContentType.objects.get_for_model(m)
+            f = self.favorites_for_user(user).filter(content_type=ct)
+            favs[ct.name] = m.objects.filter(id__in=f.values('object_id'))
+        return favs
+
+    def create_favorite(self, content_object, user):
+        content_type = ContentType.objects.get_for_model(type(content_object))
+        favorite, _ = self.get_or_create(
+            user=user,
+            content_type=content_type,
+            object_id=content_object.pk,
+            )
+        return favorite
+
+
+class Favorite(models.Model):
+    user = models.ForeignKey(settings.AUTH_USER_MODEL)
+    content_type = models.ForeignKey(ContentType)
+    object_id = models.PositiveIntegerField()
+    content_object = generic.GenericForeignKey('content_type', 'object_id')
+
+    created_on = models.DateTimeField(auto_now_add=True)
+
+    objects = FavoriteManager()
+
+    class Meta:
+        verbose_name = 'favorite'
+        verbose_name_plural = 'favorites'
+        unique_together = (('user', 'content_type', 'object_id'),)
+
+    def __unicode__(self):
+        return "Favorite: {}, {}, {}".format(self.content_object.title, self.content_type, self.user)

--- a/geonode/contrib/favorite/readme.txt
+++ b/geonode/contrib/favorite/readme.txt
@@ -1,0 +1,76 @@
+This GeoNode contrib module was contributed by the MapStory project.
+
+Function of the module:
+Allow user to favorite content in Document, Layer, Map detail pages.
+  - If user is not logged in, tell them to log in if want to use favorites.
+  - If user is logged in, provide an 'Add Favorite' button, or a 'Delete Favorite' button.
+Allow user to view a favorites list page with delete link for each.
+Allow user to link to user favorites list page from each detail and user profile page and user modal list.
+
+-----
+
+To enable the module:
+This contribution was initially contributed with hooks in the core GeoNode code so that enabling this module involved only one change in settings.py file.
+Per GeoNode developer input, the core hooks have been removed and these instructions have been added.
+It is up to the installing developer to add these to enable this module.
+
+Steps to enable Favorites in GeoNode:
+
+1. add the module to the geonode.settings.py file.
+
+    # GeoNode Contrib Apps
+    # 'geonode.contrib.dynamic',
+    'geonode.contrib.favorite',
+
+2. add Favorites urls to the geonode/urls.py.
+
+    urlpatterns += patterns('',
+                            (r'^favorite/', include('geonode.contrib.favorite.urls')),
+                            )
+
+3. to show Favorites on a detail page, make these additions to the View and the corresponding template files.
+
+3a. template - add link to the Favorite tab on the 'tab switcher' on geonode/templates/_actions.html:
+(this single change gets included on each detail pages)
+
+    after GeoGig, approx ln 15, add:
+
+    <li><a href="#favorite" data-toggle="tab"><i class="fa fa-star"></i>{% trans "Favorite" %}</a></li>
+
+3b. view - add an import and a code block to <model>_detail method.  Using Map as example, geonode/maps/views.py:
+(repeat 3b and 3c for each detail page)
+
+    in imports:
+    from geonode.contrib.favorite.utils import get_favorite_info
+
+    in map_detail method:
+    if request.user.is_authenticated():
+        context_dict["favorite_info"] = get_favorite_info(request.user, layer)
+
+3c. template - include the Favorite html and js.  Using Map as example, geonode/maps/templates/maps/map_detail.html: 
+
+    after the social_links block for map (or after ratings block for document/layer), add:
+
+    <article class="tab-pane" id="favorite">
+      {% include "favorite/_favorite.html" %}
+    </article>
+
+    in the {% block extra_script %}, add:
+
+    {% include "favorite/-favorite_js.html" %}
+
+
+4. Add link to Favorites list from user profile page, geonode/templates/people/profile_detail.html:
+
+    after My Activities, approx ln 95, add:
+
+    <ul class="list-group">
+        <li class="list-group-item"><a href="{% url "favorite_list" %}"><i class="fa fa-star"></i> {% trans "Favorites" %}</a></li>
+    </ul>
+
+
+5. Add link to Favorites list from user modal, geonode/templates/base.html:
+
+    after notifications, approx ln 216, add:
+
+    <li><a href="{% url "favorite_list" %}"><i class="fa fa-star"></i> {% trans "Favorites" %}</a></li> 

--- a/geonode/contrib/favorite/templates/favorite/_favorite.html
+++ b/geonode/contrib/favorite/templates/favorite/_favorite.html
@@ -1,0 +1,20 @@
+{% load i18n %}
+
+<div id="favorite">
+    <header>
+        <h4>{% trans 'Favorite' %}</h4>
+    </header>
+
+    {% if user.is_authenticated %}
+    <div class="clearfix">
+        <button id="favoriteLink" class="btn btn-primary">Add to Favorites</button>
+        <br/><br/>
+        <div><a href="{% url "favorite_list" %}">Go to Favorites</a></div>
+    </div>
+
+    {% else %}
+    <div class="clearfix">
+        <p class="pull-right">{% trans 'Log in to add/delete Favorites.' %}</p>
+    </div>
+    {% endif %}
+</div>

--- a/geonode/contrib/favorite/templates/favorite/_favorite_js.html
+++ b/geonode/contrib/favorite/templates/favorite/_favorite_js.html
@@ -1,0 +1,34 @@
+{% load i18n %}
+
+{% if request.user.is_authenticated %}
+<script type="text/javascript">
+    // set on page load, does not vary with button state.
+    var favoriteAddUrl = "{{ favorite_info.add_url }}"
+
+    // varies with button state.
+    var favoriteCurrentUrl = null;
+
+    // add click behavior to the Add/Delete Favorite button.
+    $("#favoriteLink").click(function(event) {
+        $.post(
+            favoriteCurrentUrl,
+            function(data) {
+                setFavoriteButton(data.has_favorite, data.delete_url);
+        });
+    });
+
+    // set button text and url based on whether user has favorite.
+    function setFavoriteButton(hasFavorite, deleteUrl) {
+        if (hasFavorite == "true") {
+            $("#favoriteLink").html("{% trans "Delete from Favorites" %}");
+            favoriteCurrentUrl = deleteUrl;
+        } else {
+            $("#favoriteLink").html("{% trans "Add to Favorites" %}");
+            favoriteCurrentUrl = favoriteAddUrl;
+        }
+    }
+
+    setFavoriteButton("{{ favorite_info.has_favorite }}","{{ favorite_info.delete_url }}" );
+
+</script>
+{% endif %}

--- a/geonode/contrib/favorite/templates/favorite/favorite_list.html
+++ b/geonode/contrib/favorite/templates/favorite/favorite_list.html
@@ -1,0 +1,55 @@
+{% extends "site_base.html" %}
+{% load i18n %}
+
+{% block title %} Favorites -- {{ block.super }} {% endblock %}
+
+{% block body_outer %}
+<div class="page-header">
+    <h2>{% trans "Favorites for" %} {{ user.username }}</h2>
+</div>
+
+{# list of user's current favorites #}
+<div class="twocol">
+    {% if favorites %}
+    <table id="favoritesListId" class="table">
+        <thead>
+            <th>Item</th>
+            <th>Type</th>
+            <th>&nbsp;</th>
+        </thead>
+        {% for favorite in favorites %}
+        <tr>
+            <td><a href='{{ favorite.content_object.detail_url }}' >{{ favorite.content_object.title }}</a></td>
+            <td>{{ favorite.content_type }}</td>
+            <td><button data-url="{% url 'delete_favorite' favorite.pk %}" class="btn btn-primary delete-btn">Delete from Favorites</button></td>
+        </tr>
+        {% endfor %}
+    </table>
+    {% else %}
+    <h4>No favorites</h4>
+    {% endif %}
+</div>
+{% endblock %}
+
+{% block extra_script %}
+<script type="text/javascript">
+    // add click behavior to the Delete Favorite button.
+    // ajax call to delete favorite and remove row on success.
+    $("#favoritesListId .delete-btn").click(function(event) {
+        var deleteUrl = this.dataset.url;
+        var tr = $(this).closest('tr');
+        $.post(
+            deleteUrl,
+            function(data) {
+                removeDomElementWithFade(tr);
+        });
+    });
+
+    function removeDomElementWithFade(elem) {
+        elem.fadeOut(800, function(){
+            elem.remove();
+        });
+    }
+</script>
+{% endblock extra_script %}
+

--- a/geonode/contrib/favorite/tests.py
+++ b/geonode/contrib/favorite/tests.py
@@ -1,0 +1,182 @@
+import json
+
+from django.contrib.auth import get_user_model
+from django.contrib.contenttypes.models import ContentType
+from django.core.urlresolvers import reverse
+from django.db.models import Max
+from django.test import TestCase
+
+from .models import Favorite
+from geonode.base.populate_test_data import create_models
+from geonode.documents.models import Document
+
+
+class FavoriteTest(TestCase):
+    """
+    Tests geonode.contrib.favorite app/module
+    """
+    def setUp(self):
+        self.adm_un = "admin"
+        self.adm_pw = "admin"
+        create_models(type="document")
+
+    # tests of Favorite and FavoriteManager methods.
+    def test_favorite(self):
+        # assume we created at least one User and two Documents in setUp.
+        test_user = get_user_model().objects.get(id=1)
+        test_document_1 = Document.objects.get(id=1)
+        test_document_2 = Document.objects.get(id=2)
+
+        # test create favorite.
+        Favorite.objects.create_favorite(test_document_1, test_user)
+        Favorite.objects.create_favorite(test_document_2, test_user)
+        favorites = Favorite.objects.all()
+        self.assertEqual(favorites.count(), 2)
+        ct = ContentType.objects.get_for_model(test_document_1)
+        self.assertEqual(favorites[0].content_type, ct)
+
+        # test all favorites for specific user.
+        favorites_for_user = Favorite.objects.favorites_for_user(test_user)
+        self.assertEqual(favorites_for_user.count(), 2)
+
+        # test document favorites for user.
+        document_favorites = Favorite.objects.favorite_documents_for_user(test_user)
+        self.assertEqual(document_favorites.count(), 2)
+
+        # test layer favorites for user.
+        layer_favorites = Favorite.objects.favorite_layers_for_user(test_user)
+        self.assertEqual(layer_favorites.count(), 0)
+
+        # test map favorites for user.
+        map_favorites = Favorite.objects.favorite_maps_for_user(test_user)
+        self.assertEqual(map_favorites.count(), 0)
+
+        # test user favorites for user.
+        user_favorites = Favorite.objects.favorite_users_for_user(test_user)
+        self.assertEqual(user_favorites.count(), 0)
+
+        # test favorite for user and a specific content object.
+        user_content_favorite = Favorite.objects.favorite_for_user_and_content_object(test_user, test_document_1)
+        self.assertEqual(user_content_favorite.object_id, test_document_1.id)
+
+        # test bulk favorites.
+        bulk_favorites = Favorite.objects.bulk_favorite_objects(test_user)
+        self.assertEqual(len(bulk_favorites[ct.name]), 2)
+        self.assertEqual(len(bulk_favorites["layer"]), 0)
+        self.assertEqual(len(bulk_favorites["map"]), 0)
+        self.assertEqual(len(bulk_favorites["user"]), 0)
+
+    # tests of view methods.
+    def test_create_favorite_view(self):
+        """
+        call create view with valid user and content.
+        then call again to check for idempotent.
+        """
+        self.client.login(username=self.adm_un, password=self.adm_pw)
+        response = self._get_response("add_favorite_document", ("1",))
+
+        # check persisted.
+        favorites = Favorite.objects.all()
+        self.assertEqual(favorites.count(), 1)
+        ct = ContentType.objects.get_for_model(Document)
+        self.assertEqual(favorites[0].content_type, ct)
+
+        # check response.
+        self.assertEqual(response.status_code, 200)
+        json_content = json.loads(response.content)
+        self.assertEqual(json_content["has_favorite"], "true")
+        expected_delete_url = reverse("delete_favorite", args=[favorites[0].pk])
+        self.assertEqual(json_content["delete_url"], expected_delete_url)
+
+        # call method again, check for idempotent.
+        response2 = self._get_response("add_favorite_document", ("1",))
+
+        # check still one only persisted, same as before second call.
+        favorites2 = Favorite.objects.all()
+        self.assertEqual(favorites2.count(), 1)
+        self.assertEqual(favorites2[0].content_type, ct)
+
+        # check second response.
+        self.assertEqual(response2.status_code, 200)
+        json_content2 = json.loads(response2.content)
+        self.assertEqual(json_content2["has_favorite"], "true")
+        self.assertEqual(json_content2["delete_url"], expected_delete_url)
+
+    def test_create_favorite_view_login_required(self):
+        """
+        call create view, not logged in.
+        expect a redirect to login page.
+        """
+        response = self._get_response("add_favorite_document", ("1",))
+        self.assertEqual(response.status_code, 302)
+
+    def test_create_favorite_view_id_not_found(self):
+        """
+        call create view with object id that does not exist.
+        expect not found.
+        """
+        # get a pk that is not in the db for Document object.
+        max_document_pk = Document.objects.aggregate(Max("pk"))
+        pk_not_in_db = str(max_document_pk["pk__max"] + 1)
+
+        self.client.login(username=self.adm_un, password=self.adm_pw)
+        response = self._get_response("add_favorite_document", (pk_not_in_db,))
+        self.assertEqual(response.status_code, 404)
+
+    def test_delete_favorite_view(self):
+        """
+        call delete view with valid user and favorite id.
+        then call again to check for idempotent.
+        """
+        self.client.login(username=self.adm_un, password=self.adm_pw)
+
+        # first, add one to delete.
+        response = self._get_response("add_favorite_document", ("1",))
+
+        # check persisted.
+        favorites = Favorite.objects.all()
+        self.assertEqual(favorites.count(), 1)
+        ct = ContentType.objects.get_for_model(Document)
+        self.assertEqual(favorites[0].content_type, ct)
+        favorite_pk = favorites[0].pk
+
+        # call delete method.
+        response = self._get_response("delete_favorite", (favorite_pk,))
+
+        # check no longer persisted.
+        favorites = Favorite.objects.all()
+        self.assertEqual(favorites.count(), 0)
+
+        # check response.
+        self.assertEqual(response.status_code, 200)
+        json_content = json.loads(response.content)
+        self.assertEqual(json_content["has_favorite"], "false")
+
+        # call method again, check for idempotent.
+        response2 = self._get_response("delete_favorite", (favorite_pk,))
+
+        # check still none persisted, same as before second call.
+        favorites2 = Favorite.objects.all()
+        self.assertEqual(favorites2.count(), 0)
+
+        # check second response.
+        self.assertEqual(response2.status_code, 200)
+        json_content2 = json.loads(response2.content)
+        self.assertEqual(json_content2["has_favorite"], "false")
+
+    def test_delete_favorite_view_login_required(self):
+        """
+        call delete view, not logged in.
+        expect a redirect to login page.
+        """
+        response = self._get_response("delete_favorite", ("1",))
+        self.assertEqual(response.status_code, 302)
+
+    def _get_response(self, input_url, input_args):
+        return self.client.post(
+            reverse(
+                input_url,
+                args=input_args
+            ),
+            content_type="application/json"
+        )

--- a/geonode/contrib/favorite/urls.py
+++ b/geonode/contrib/favorite/urls.py
@@ -1,0 +1,11 @@
+from django.conf.urls import patterns, url
+
+urlpatterns = patterns(
+    'geonode.contrib.favorite.views',
+    url(r'^document/(?P<id>\d+)$', 'favorite', {'subject': 'document'}, name='add_favorite_document'),
+    url(r'^map/(?P<id>\d+)$', 'favorite', {'subject': 'map'}, name='add_favorite_map'),
+    url(r'^layer/(?P<id>\d+)$', 'favorite', {'subject': 'layer'}, name='add_favorite_layer'),
+    url(r'^user/(?P<id>\d+)$', 'favorite', {'subject': 'user'}, name='add_favorite_user'),
+    url(r'^(?P<id>\d+)/delete$', 'delete_favorite', name='delete_favorite'),
+    url(r'^list/$', 'get_favorites', name='favorite_list'),
+    )

--- a/geonode/contrib/favorite/utils.py
+++ b/geonode/contrib/favorite/utils.py
@@ -1,0 +1,25 @@
+from django.core.urlresolvers import reverse
+import models
+
+
+def get_favorite_info(user, content_object):
+    """
+    return favorite info dict containing:
+        a. an add favorite url for the input parameters.
+        b. whether there is an existing Favorite for the input parameters.
+        c. a delete url (if there is an existing Favorite).
+    """
+    result = {}
+
+    url_content_type = type(content_object).__name__.lower()
+    result["add_url"] = reverse("add_favorite_{}".format(url_content_type), args=[content_object.pk])
+
+    existing_favorite = models.Favorite.objects.favorite_for_user_and_content_object(user, content_object)
+
+    if existing_favorite:
+        result["has_favorite"] = "true"
+        result["delete_url"] = reverse("delete_favorite", args=[existing_favorite.pk])
+    else:
+        result["has_favorite"] = "false"
+
+    return result

--- a/geonode/contrib/favorite/views.py
+++ b/geonode/contrib/favorite/views.py
@@ -1,0 +1,69 @@
+import json
+
+from django.conf import settings
+from django.contrib.auth.decorators import login_required
+from django.core.exceptions import ObjectDoesNotExist
+from django.core.urlresolvers import reverse
+from django.http import HttpResponse
+from django.shortcuts import get_object_or_404
+from django.shortcuts import render_to_response
+from django.template import RequestContext
+
+from geonode.documents.models import Document
+from geonode.layers.models import Layer
+from geonode.maps.models import Map
+import models
+
+
+@login_required
+def favorite(req, subject, id):
+    """
+    create favorite and put favorite_info object in response.
+    method is idempotent, Favorite's create_favorite method
+    only creates if does not already exist.
+    """
+    if subject == 'document':
+        obj = get_object_or_404(Document, pk=id)
+    elif subject == 'map':
+        obj = get_object_or_404(Map, pk=id)
+    elif subject == 'layer':
+        obj = get_object_or_404(Layer, pk=id)
+    elif subject == 'user':
+        obj = get_object_or_404(settings.AUTH_USER_MODEL, pk=id)
+
+    favorite = models.Favorite.objects.create_favorite(obj, req.user)
+    delete_url = reverse("delete_favorite", args=[favorite.pk])
+    response = {"has_favorite": "true", "delete_url": delete_url}
+
+    return HttpResponse(json.dumps(response), content_type="application/json", status=200)
+
+
+@login_required
+def delete_favorite(req, id):
+    """
+    delete favorite and put favorite_info object in response.
+    method is idempotent, if favorite does not exist, just return favorite_info.
+    """
+    try:
+        favorite = models.Favorite.objects.get(user=req.user, pk=id)
+        favorite.delete()
+    except ObjectDoesNotExist:
+        pass
+
+    response = {"has_favorite": "false"}
+
+    return HttpResponse(json.dumps(response), content_type="application/json", status=200)
+
+
+@login_required
+def get_favorites(req):
+    """
+    Display the request user's favorites.
+    """
+    return render_to_response(
+        "favorite/favorite_list.html",
+        RequestContext(
+            req,
+            {'favorites': models.Favorite.objects.favorites_for_user(req.user), }
+        )
+    )


### PR DESCRIPTION
Uncomment 'geonode.contrib.favorite' entry in settings.py to enable.
Once enabled, UI allows authenticated user to favorite Document, Layer and Map.
