### PR TITLE
fix encoding problem when using Spanish lang (accents)

### DIFF
--- a/geonode/catalogue/backends/generic.py
+++ b/geonode/catalogue/backends/generic.py
@@ -154,7 +154,7 @@ class Catalogue(CatalogueServiceWeb):
 
     def csw_request(self, layer, template):
 
-        md_doc = self.csw_gen_xml(layer, template)
+        md_doc = self.csw_gen_xml(layer, template).encode('utf-8')
 
         if self.type == 'geonetwork':
             headers = {


### PR DESCRIPTION
When you set GeoNetwork as the CSW backend and Spanish language, it crashes with error:

`UnicodeDecodeError: 'ascii' codec can't decode byte 0xf3 in position ##: ordinal not in range(128)`

I found that the problem were the accents included in the metadata content.