### PR TITLE
Fix Haystack search issue with regions containing spaces.

### DIFF
--- a/geonode/api/resourcebase_api.py
+++ b/geonode/api/resourcebase_api.py
@@ -253,7 +253,7 @@ class CommonModelApi(ModelResource):
             for region in regions:
                 sqs = (
                     SearchQuerySet() if sqs is None else sqs).filter_or(
-                    regions_exact=region)
+                    regions_exact__exact=region)
 
         # filter by owner
         if owner:


### PR DESCRIPTION
From haystack documentation: "If you want to match a phrase, you should use either the __exact filter type or the Exact input type"