### PR TITLE
Fixes #2175

### DIFF
--- a/geonode/base/models.py
+++ b/geonode/base/models.py
@@ -720,8 +720,12 @@ def resourcebase_post_save(instance, *args, **kwargs):
 
     # we need to remove stale links
     for link in instance.link_set.all():
-        if urlsplit(settings.SITEURL).hostname not in link.url:
-            link.delete()
+        if link.name == "External Document":
+            if link.resource.doc_url != link.url:
+                link.delete()
+        else:
+            if urlsplit(settings.SITEURL).hostname not in link.url:
+                link.delete()
 
 
 def rating_post_save(instance, *args, **kwargs):

--- a/geonode/documents/enumerations.py
+++ b/geonode/documents/enumerations.py
@@ -1,0 +1,61 @@
+# DOCUMENT_TYPE_MAP and DOCUMENT_MIMETYPE_MAP
+# match values in settings.ALLOWED_DOCUMENT_TYPES
+
+DOCUMENT_TYPE_MAP = {
+    'txt': 'text',
+    'log': 'text',
+    'doc': 'text',
+    'docx': 'text',
+    'ods': 'text',
+    'odt': 'text',
+    'sld': 'text',
+    'xls': 'text',
+    'xlsx': 'text',
+    'xml': 'text',
+
+    'gif': 'image',
+    'jpg': 'image',
+    'jpeg': 'image',
+    'png': 'image',
+    'tif': 'image',
+    'tiff': 'image',
+
+    'odp': 'presentation',
+    'ppt': 'presentation',
+    'pptx': 'presentation',
+    'pdf': 'presentation',
+
+    'rar': 'archive',
+    'gz': 'archive',
+    'zip': 'archive',
+}
+
+
+DOCUMENT_MIMETYPE_MAP = {
+    'txt': 'text/plain',
+    'log': 'text/plain',
+    'doc': 'text/plain',
+    'docx': 'text/plain',
+    'ods': 'text/plain',
+    'odt': 'text/plain',
+    'sld': 'text/plain',
+    'xls': 'text/plain',
+    'xlsx': 'text/plain',
+    'xml': 'text/xml',
+
+    'gif': 'image/gif',
+    'jpg': 'image/jpeg',
+    'jpeg': 'image/jpeg',
+    'png': 'image/png',
+    'tif': 'image/tiff',
+    'tiff': 'image/tiff',
+
+    'odp': 'text/plain',
+    'ppt': 'text/plain',
+    'pptx': 'text/plain',
+    'pdf': 'application/pdf',
+
+    'rar': 'application/x-rar-compressed',
+    'gz': 'application/x-gzip',
+    'zip': 'application/zip',
+}

--- a/geonode/documents/models.py
+++ b/geonode/documents/models.py
@@ -12,7 +12,8 @@ from django.contrib.staticfiles import finders
 from django.utils.translation import ugettext_lazy as _
 
 from geonode.layers.models import Layer
-from geonode.base.models import ResourceBase, resourcebase_post_save
+from geonode.base.models import ResourceBase, resourcebase_post_save, Link
+from geonode.documents.enumerations import DOCUMENT_TYPE_MAP, DOCUMENT_MIMETYPE_MAP
 from geonode.maps.signals import map_changed_signal
 from geonode.maps.models import Map
 from geonode.security.models import remove_object_permissions
@@ -129,7 +130,7 @@ def pre_save_document(instance, sender, **kwargs):
     if instance.doc_file:
         base_name, extension = os.path.splitext(instance.doc_file.name)
         instance.extension = extension[1:]
-        doc_type_map = settings.DOCUMENT_TYPE_MAP
+        doc_type_map = DOCUMENT_TYPE_MAP
         if doc_type_map is None:
             doc_type = 'other'
         else:
@@ -167,6 +168,34 @@ def pre_save_document(instance, sender, **kwargs):
         instance.bbox_y1 = 90
 
 
+def post_save_document(instance, *args, **kwargs):
+
+    name = None
+    ext = instance.extension
+    mime = DOCUMENT_MIMETYPE_MAP[ext]
+    url = None
+
+    if instance.doc_file:
+        name = "Hosted Document"
+        url = '%s%s' % (
+            settings.SITEURL[:-1],
+            reverse('document_download', args=(instance.id,)))
+    elif instance.doc_url:
+        name = "External Document"
+        url = instance.doc_url
+
+    if name and url:
+        Link.objects.get_or_create(
+            resource=instance.resourcebase_ptr,
+            url=url,
+            defaults=dict(
+                extension=ext,
+                name=name,
+                mime=mime,
+                url=url,
+                link_type='data',))
+
+
 def create_thumbnail(sender, instance, created, **kwargs):
     from geonode.tasks.update import create_document_thumbnail
 
@@ -186,6 +215,7 @@ def pre_delete_document(instance, sender, **kwargs):
 
 signals.pre_save.connect(pre_save_document, sender=Document)
 signals.post_save.connect(create_thumbnail, sender=Document)
+signals.post_save.connect(post_save_document, sender=Document)
 signals.post_save.connect(resourcebase_post_save, sender=Document)
 signals.pre_delete.connect(pre_delete_document, sender=Document)
 map_changed_signal.connect(update_documents_extent)

--- a/geonode/documents/models.py
+++ b/geonode/documents/models.py
@@ -131,13 +131,11 @@ def pre_save_document(instance, sender, **kwargs):
         base_name, extension = os.path.splitext(instance.doc_file.name)
         instance.extension = extension[1:]
         doc_type_map = DOCUMENT_TYPE_MAP
+        doc_type_map.update(getattr(settings, 'DOCUMENT_TYPE_MAP', {}))
         if doc_type_map is None:
             doc_type = 'other'
         else:
-            if instance.extension in doc_type_map:
-                doc_type = doc_type_map[''+instance.extension]
-            else:
-                doc_type = 'other'
+            doc_type = doc_type_map.get(instance.extension, 'other')
         instance.doc_type = doc_type
 
     elif instance.doc_url:
@@ -172,7 +170,9 @@ def post_save_document(instance, *args, **kwargs):
 
     name = None
     ext = instance.extension
-    mime = DOCUMENT_MIMETYPE_MAP[ext]
+    mime_type_map = DOCUMENT_MIMETYPE_MAP
+    mime_type_map.update(getattr(settings, 'DOCUMENT_MIMETYPE_MAP', {}))
+    mime = mime_type_map.get(ext, 'text/plain')
     url = None
 
     if instance.doc_file:

--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -200,37 +200,9 @@ LOGOUT_URL = '/account/logout/'
 # Documents application
 ALLOWED_DOCUMENT_TYPES = [
     'doc', 'docx', 'gif', 'jpg', 'jpeg', 'ods', 'odt', 'odp', 'pdf', 'png', 'ppt',
-    'pptx', 'rar', 'tif', 'tiff', 'txt', 'xls', 'xlsx', 'xml', 'zip', 'gz'
+    'pptx', 'rar', 'sld', 'tif', 'tiff', 'txt', 'xls', 'xlsx', 'xml', 'zip', 'gz'
 ]
 MAX_DOCUMENT_SIZE = 2  # MB
-DOCUMENT_TYPE_MAP = {
-    'txt': 'text',
-    'log': 'text',
-    'doc': 'text',
-    'docx': 'text',
-    'ods': 'text',
-    'odt': 'text',
-    'xls': 'text',
-    'xlsx': 'text',
-    'xml': 'text',
-
-    'gif': 'image',
-    'jpg': 'image',
-    'jpeg': 'image',
-    'png': 'image',
-    'tif': 'image',
-    'tiff': 'image',
-
-    'odp': 'presentation',
-    'ppt': 'presentation',
-    'pptx': 'presentation',
-    'pdf': 'presentation',
-
-    'rar': 'archive',
-    'gz': 'archive',
-    'zip': 'archive',
-}
-
 
 GEONODE_APPS = (
 

--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -204,6 +204,14 @@ ALLOWED_DOCUMENT_TYPES = [
 ]
 MAX_DOCUMENT_SIZE = 2  # MB
 
+# DOCUMENT_TYPE_MAP and DOCUMENT_MIMETYPE_MAP update enumerations in
+# documents/enumerations.py and should only
+# need to be uncommented if adding other types
+# to settings.ALLOWED_DOCUMENT_TYPES
+
+# DOCUMENT_TYPE_MAP = {}
+# DOCUMENT_MIMETYPE_MAP = {}
+
 GEONODE_APPS = (
 
 


### PR DESCRIPTION
Fixes #2175.  For CSW, adds link for documents to point to the download url.

Generates ISO XML like:

```
<gmd:onLine>
  <gmd:CI_OnlineResource>
    <gmd:linkage>
      <gmd:URL>http://localhost:8000/documents/1/download</gmd:URL>
    </gmd:linkage>
    <gmd:protocol>
      <gco:CharacterString>WWW:DOWNLOAD-1.0-http--download</gco:CharacterString>
    </gmd:protocol>
    <gmd:name>
      <gco:CharacterString>.jpg</gco:CharacterString>
    </gmd:name>
    <gmd:description>
      <gco:CharacterString>Test.jpg (Hosted Document Format)</gco:CharacterString>
    </gmd:description>
  </gmd:CI_OnlineResource>
</gmd:onLine>
```