### PR TITLE
Fixed checking for keywords

### DIFF
--- a/geonode/base/templates/base/resourcebase_info_panel.html
+++ b/geonode/base/templates/base/resourcebase_info_panel.html
@@ -35,7 +35,7 @@
     <dd>{{ resource.display_type }}</dd>
     {% endif %}
 
-    {% if resource.keywords %}
+    {% if resource.keywords.count > 0 %}
     <dt>{% trans "Keywords" %}</dt>
     <dd>
       {% for keyword in resource.keywords.all %}


### PR DESCRIPTION
This fixes the shift in category and owner values when keywords are empty (Resource details).