### PR TITLE
Added SRID Flag

### DIFF
--- a/geonode/base/templates/base/resourcebase_info_panel.html
+++ b/geonode/base/templates/base/resourcebase_info_panel.html
@@ -7,6 +7,11 @@
     <dd>{{ resource.title|truncatechars:80 }}</dd>
     {% endif %}
 
+    {% if resource.srid and SRID_DETAIL == 'above' %}
+    <dt>{% trans "SRID" %}</dt>
+    <dd>{{ resource.srid }}</dd>
+    {% endif %}
+
     {% if LICENSES_ENABLED and LICENSES_DETAIL == 'above' and resource.license %}
     <dt>{% trans "License" %}</dt>
     <dd>{{ resource.license.name_long }} <a href="#license-more-above" data-toggle="collapse" data-target=".license-more-above"><i class="fa fa-info-circle"></i></a></dd>
@@ -87,6 +92,11 @@
 
   <dl class="dl-horizontal">
     <div class="more collapse">
+
+    {% if resource.srid and SRID_DETAIL == 'below' %}
+    <dt>{% trans "SRID" %}</dt>
+    <dd>{{ resource.srid }}</dd>
+    {% endif %}
 
     {% if LICENSES_ENABLED and LICENSES_DETAIL == 'below' and resource.license %}
     <dt>{% trans "License" %}</dt>

--- a/geonode/context_processors.py
+++ b/geonode/context_processors.py
@@ -63,6 +63,12 @@ def resource_urls(request):
             settings,
             'CLIENT_RESULTS_LIMIT',
             10),
+        SRID_DETAIL=getattr(
+            settings,
+            'SRID',
+            dict()).get(
+            'DETAIL',
+            'never'),
         LICENSES_ENABLED=getattr(
             settings,
             'LICENSES',

--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -687,6 +687,10 @@ LICENSES = {
     'METADATA': 'verbose',
 }
 
+SRID = {
+    'DETAIL': 'never',
+}
+
 SESSION_SERIALIZER = 'django.contrib.sessions.serializers.PickleSerializer'
 
 # Require users to authenticate before using Geonode


### PR DESCRIPTION
Adds `SRID_DETAIL` flag for specifying if you want to show the SRID on a layer/map detail page above/below the fold.  Current default of not showing is maintained.