### PR TITLE
Exif Support

### DIFF
--- a/docs/reference/developers/settings.txt
+++ b/docs/reference/developers/settings.txt
@@ -525,4 +525,11 @@ Default::
         'JPEG', 'PDF', 'PNG' 'Tiles',
     ]
 
+Contrib settings
+=================
 
+EXIF_ENABED
+...........
+Default: ``False``
+
+A boolean that specifies whether the Exif contrib app is enabled.  If enabled, metadata is generated from Exif tags when documents are uploaded.

--- a/geonode/context_processors.py
+++ b/geonode/context_processors.py
@@ -90,6 +90,10 @@ def resource_urls(request):
         USE_NOTIFICATIONS=('notification' in settings.INSTALLED_APPS),
         DEFAULT_ANONYMOUS_VIEW_PERMISSION=getattr(settings, 'DEFAULT_ANONYMOUS_VIEW_PERMISSION', False),
         DEFAULT_ANONYMOUS_DOWNLOAD_PERMISSION=getattr(settings, 'DEFAULT_ANONYMOUS_DOWNLOAD_PERMISSION', False),
+        EXIF_ENABLED=getattr(
+            settings,
+            "EXIF_ENABLED",
+            False),
     )
 
     return defaults

--- a/geonode/contrib/exif/templates/exif/_exif_document_detail.html
+++ b/geonode/contrib/exif/templates/exif/_exif_document_detail.html
@@ -1,0 +1,26 @@
+{% load i18n %}
+
+{% block exif_tags %}
+  <article class="tab-pane" id="exif">
+    <dl class="dl-horizontal">
+      <dt>{% trans 'Width' %}</dt>
+      <dd>{{ exif_data.width }}</dd>
+      <dt>{% trans 'Height' %}</dt>
+      <dd>{{ exif_data.height }}</dd>
+      <dt>{% trans 'Make' %}</dt>
+      <dd>{{ exif_data.make }}</dd>
+      <dt>{% trans 'Model' %}</dt>
+      <dd>{{ exif_data.model }}</dd>
+      <dt>{% trans 'Date' %}</dt>
+      <dd>{{ exif_data.date }}</dd>
+      <dt>{% trans 'Latitude' %}</dt>
+      <dd>{% if exif_data.lat %}{{ exif_data.lat }}{% else %}{% trans 'Not specified' %}{% endif %}</dd>
+      <dt>{% trans 'Longitude' %}</dt>
+      <dd>{% if exif_data.lon %}{{ exif_data.lon }}{% else %}{% trans 'Not specified' %}{% endif %}</dd>
+      <dt>{% trans 'Flash' %}</dt>
+      <dd>{% if exif_data.flash %}{% trans 'True' %}{% else %}{% trans 'False'%}{% endif %}</dd>
+      <dt>{% trans 'Speed Rating' %}</dt>
+      <dd>{{ exif_data.speed }}</dd>
+    </dl>
+  </article>
+{% endblock %}

--- a/geonode/contrib/exif/utils.py
+++ b/geonode/contrib/exif/utils.py
@@ -62,6 +62,69 @@ def convertExifLocationToDecimalDegrees(location, direction):
         return None
 
 
+def exif_extract_dict(doc):
+
+    if not doc:
+        return None
+
+    if not doc.doc_file:
+        return None
+
+
+    if os.path.splitext(doc.doc_file.name)[1].lower()[1:] in ["jpg", "jpeg"]:
+        from PIL import Image, ExifTags
+        img = Image.open(doc.doc_file.path)
+        exif_data = {
+            ExifTags.TAGS[k]: v
+            for k, v in img._getexif().items() if k in ExifTags.TAGS
+        }
+
+        exif_dict = {
+            'width': exif_data.get('ExifImageWidth', None),
+            'height': exif_data.get('ExifImageHeight', None),
+            'make': exif_data.get('Make', None),
+            'model': exif_data.get('Model', None),
+            'date': None,
+            'lat': None,
+            'lon': None,
+            'flash': exif_data.get('Flash', 0),
+            'speed': exif_data.get('ISOSpeedRatings', 0)
+        }
+
+        date = None
+        if "DateTime" in exif_data:
+            date = exif_data["DateTime"]
+        elif "DateTimeOriginal" in exif_data:
+            date = exif_data["DateTimeOriginal"]
+        elif "DateTimeDigitized" in exif_data:
+            date = exif_data["DateTimeDigitized"]
+
+        if date:
+            try:
+                date = convertExifDateToDjangoDate(date)
+            except:
+                print "Could not parse exif date"
+                date = None
+
+        if date:
+            exif_dict['date'] = date
+
+        if "GPSInfo" in exif_data:
+            gpsinfo = {}
+            for key in exif_data["GPSInfo"].keys():
+                decode = ExifTags.GPSTAGS.get(key, key)
+                gpsinfo[decode] = exif_data["GPSInfo"][key]
+            if "GPSLatitude" in gpsinfo and "GPSLongitude" in gpsinfo:
+                lat = convertExifLocationToDecimalDegrees(gpsinfo["GPSLatitude"], gpsinfo.get('GPSLatitudeRef', 'N'))
+                lon = convertExifLocationToDecimalDegrees(gpsinfo["GPSLongitude"], gpsinfo.get('GPSLongitudeRef', 'E'))
+                exif_dict['lat'] = lat
+                exif_dict['lon'] = lon
+
+        return exif_dict
+
+    else:
+        return None
+
 def exif_extract_metadata_doc(doc):
 
     if not doc:
@@ -112,9 +175,10 @@ def exif_extract_metadata_doc(doc):
             for key in exif_data["GPSInfo"].keys():
                 decode = ExifTags.GPSTAGS.get(key, key)
                 gpsinfo[decode] = exif_data["GPSInfo"][key]
-            lat = convertExifLocationToDecimalDegrees(gpsinfo["GPSLatitude"], gpsinfo.get('GPSLatitudeRef', 'N'))
-            lon = convertExifLocationToDecimalDegrees(gpsinfo["GPSLongitude"], gpsinfo.get('GPSLongitudeRef', 'E'))
-            bbox = (lon, lon, lat, lat)
+            if "GPSLatitude" in gpsinfo and "GPSLongitude" in gpsinfo:
+                lat = convertExifLocationToDecimalDegrees(gpsinfo["GPSLatitude"], gpsinfo.get('GPSLatitudeRef', 'N'))
+                lon = convertExifLocationToDecimalDegrees(gpsinfo["GPSLongitude"], gpsinfo.get('GPSLongitudeRef', 'E'))
+                bbox = (lon, lon, lat, lat)
 
         abstract = exif_build_abstract(model=model, date=date, lat=lat, lon=lon)
 

--- a/geonode/contrib/exif/utils.py
+++ b/geonode/contrib/exif/utils.py
@@ -1,0 +1,138 @@
+# -*- coding: utf-8 -*-
+#########################################################################
+#
+# Copyright (C) 2012 OpenPlans
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#########################################################################
+
+import os
+
+from slugify import Slugify
+from datetime import datetime
+
+custom_slugify = Slugify(separator='_')
+
+ABSTRACT_TEMPLATE_MODEL_DATE_LATLON = "Image shot by {model} on {date} at {lat}, {lon} (latitude, longitude)"
+ABSTRACT_TEMPLATE_MODEL_DATE = "Image shot by {model} on {date}"
+ABSTRACT_TEMPLATE_MODEL = "Image shot by {model}"
+ABSTRACT_TEMPLATE_DATE = "Image shot on {date}"
+
+
+def convertExifDateToDjangoDate(date):
+    a = list(date.replace(" ", "T"))
+    a[4] = "-"
+    a[7] = "-"
+    a[10] = "T"
+
+    return datetime(
+        int("".join(a[0:4])),
+        int("".join(a[5:7])),
+        int("".join(a[8:10])),
+        int("".join(a[11:13])),
+        int("".join(a[14:16]))
+    )
+
+
+def convertExifLocationToDecimalDegrees(location, direction):
+    if location:
+        dd = 0.0
+        d, m, s = location
+        dd += float(d[0]) / float(d[1])
+        dd += (float(m[0]) / float(m[1])) / 60.0
+        dd += (float(s[0]) / float(s[1])) / 3600.0
+
+        if direction:
+            if direction.lower() == 's' or direction.lower() == 'w':
+                dd = dd * -1.0
+        return dd
+    else:
+        return None
+
+
+def exif_extract_metadata_doc(doc):
+
+    if not doc:
+        return None
+
+    if not doc.doc_file:
+        return None
+
+    if os.path.splitext(doc.doc_file.name)[1].lower()[1:] in ["jpg", "jpeg"]:
+        from PIL import Image, ExifTags
+        img = Image.open(doc.doc_file.path)
+        exif_data = {
+            ExifTags.TAGS[k]: v
+            for k, v in img._getexif().items() if k in ExifTags.TAGS
+        }
+
+        model = None
+        date = None
+        keywords = []
+        bbox = None
+        lat = None
+        lon = None
+        abstract = None
+
+        if "DateTime" in exif_data:
+            date = exif_data["DateTime"]
+        elif "DateTimeOriginal" in exif_data:
+            date = exif_data["DateTimeOriginal"]
+        elif "DateTimeDigitized" in exif_data:
+            date = exif_data["DateTimeDigitized"]
+
+        if date:
+            try:
+                date = convertExifDateToDjangoDate(date)
+            except:
+                print "Could not parse exif date"
+                date = None
+
+        if "Make" in exif_data:
+            keywords.append(custom_slugify(exif_data["Make"]))
+
+        if "Model" in exif_data:
+            model = exif_data.get("Model", None)
+            keywords.append(custom_slugify(model))
+
+        if "GPSInfo" in exif_data:
+            gpsinfo = {}
+            for key in exif_data["GPSInfo"].keys():
+                decode = ExifTags.GPSTAGS.get(key, key)
+                gpsinfo[decode] = exif_data["GPSInfo"][key]
+            lat = convertExifLocationToDecimalDegrees(gpsinfo["GPSLatitude"], gpsinfo.get('GPSLatitudeRef', 'N'))
+            lon = convertExifLocationToDecimalDegrees(gpsinfo["GPSLongitude"], gpsinfo.get('GPSLongitudeRef', 'E'))
+            bbox = (lon, lon, lat, lat)
+
+        abstract = exif_build_abstract(model=model, date=date, lat=lat, lon=lon)
+
+        return {'date': date, 'keywords': keywords, 'bbox': bbox, 'abstract': abstract}
+
+    else:
+        return None
+
+
+def exif_build_abstract(model=None, date=None, lat=None, lon=None):
+
+    if model and date and lat and lon:
+        return ABSTRACT_TEMPLATE_MODEL_DATE_LATLON.format(model=model, date=date, lat=lat, lon=lon)
+    elif model and date:
+        return ABSTRACT_TEMPLATE_MODEL_DATE.format(model=model, date=date)
+    elif model:
+        return ABSTRACT_TEMPLATE_MODEL.format(model=model)
+    elif date:
+        return ABSTRACT_TEMPLATE_DATE.format(date=date)
+    else:
+        return None

--- a/geonode/contrib/exif/utils.py
+++ b/geonode/contrib/exif/utils.py
@@ -70,7 +70,6 @@ def exif_extract_dict(doc):
     if not doc.doc_file:
         return None
 
-
     if os.path.splitext(doc.doc_file.name)[1].lower()[1:] in ["jpg", "jpeg"]:
         from PIL import Image, ExifTags
         img = Image.open(doc.doc_file.path)
@@ -124,6 +123,7 @@ def exif_extract_dict(doc):
 
     else:
         return None
+
 
 def exif_extract_metadata_doc(doc):
 

--- a/geonode/documents/templates/documents/document_detail.html
+++ b/geonode/documents/templates/documents/document_detail.html
@@ -76,10 +76,11 @@
         <!-- TODO: Add display of who gave what rating based -->
       </article>
 
-      {% block exif %}
-        {% include "exif/_exif_document_detail.html" %}
-      {% endblock %}
-
+      {% if EXIF_ENABLED and exif_data %}
+        {% block exif %}
+          {% include "exif/_exif_document_detail.html" %}
+        {% endblock %}
+      {% endif %}
     </div>
   </div>
 

--- a/geonode/documents/templates/documents/document_detail.html
+++ b/geonode/documents/templates/documents/document_detail.html
@@ -75,6 +75,11 @@
         <div class="overall_rating" style="float:left" data-score="{{ document_rating }}"></div> ({{num_votes}})
         <!-- TODO: Add display of who gave what rating based -->
       </article>
+
+      {% block exif %}
+        {% include "exif/_exif_document_detail.html" %}
+      {% endblock %}
+
     </div>
   </div>
 

--- a/geonode/documents/views.py
+++ b/geonode/documents/views.py
@@ -99,6 +99,15 @@ def document_detail(request, docid):
         if settings.SOCIAL_ORIGINS:
             context_dict["social_links"] = build_social_links(request, document)
 
+        if getattr(settings, 'EXIF_ENABLED', False):
+            try:
+                from geonode.contrib.exif.utils import exif_extract_dict
+                exif = exif_extract_dict(document)
+                if exif:
+                    context_dict['exif_data'] = exif
+            except Exception, e:
+                print "Exif extraction failed."
+
         return render_to_response(
             "documents/document_detail.html",
             RequestContext(request, context_dict))
@@ -162,7 +171,6 @@ class DocumentUploadView(CreateView):
                     abstract = exif_metadata.get('abstract', None)
             except Exception, e:
                 print "Exif extraction failed."
-                raise e
 
         if abstract:
             self.object.abstract = abstract

--- a/geonode/documents/views.py
+++ b/geonode/documents/views.py
@@ -105,7 +105,7 @@ def document_detail(request, docid):
                 exif = exif_extract_dict(document)
                 if exif:
                     context_dict['exif_data'] = exif
-            except Exception, e:
+            except:
                 print "Exif extraction failed."
 
         return render_to_response(
@@ -169,7 +169,7 @@ class DocumentUploadView(CreateView):
                     keywords.extend(exif_metadata.get('keywords', []))
                     bbox = exif_metadata.get('bbox', None)
                     abstract = exif_metadata.get('abstract', None)
-            except Exception, e:
+            except:
                 print "Exif extraction failed."
 
         if abstract:

--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -783,6 +783,9 @@ LEAFLET_CONFIG = {
 # option to enable/disable resource unpublishing for administrators
 RESOURCE_PUBLISHING = False
 
+# Settings for EXIF contrib app
+EXIF_ENABLED = False
+
 CACHES = {
     # DUMMY CACHE FOR DEVELOPMENT
     'default': {

--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -232,6 +232,7 @@ GEONODE_APPS = (
     # GeoNode Contrib Apps
 
     # 'geonode.contrib.dynamic',
+    'geonode.contrib.exif',
 
     # GeoServer Apps
     # Geoserver needs to come last because

--- a/geonode/templates/_actions.html
+++ b/geonode/templates/_actions.html
@@ -12,4 +12,7 @@
   {% if GEOGIG_ENABLED and resource.link_set.geogig %}
   <li><a href="#geogig" data-toggle="tab"><i class="fa fa-code-fork"></i> {% trans "GeoGig" %}</a></li>
   {% endif %}
+  {% if EXIF_ENABLED and resource.polymorphic_ctype.name == 'document' and exif_data %}
+  <li><a href="#exif" data-toggle="tab"><i class="fa fa-photo"></i> {% trans "Exif" %}</a></li>
+  {% endif %}
 </ul>


### PR DESCRIPTION
This PR adds an Exif contrib app.  This app is disabled by default.  If enabled by the `EXIF_ENABLED` settings flag, this app parses Exif tags from JPEGs uploaded as documents and automatically generates metadata, including date, keywords, and a brief abstract.  It uses `from PIL import Image, ExifTags`, so doesn't require any changes to dependencies.