### PR TITLE
Fix for #2222

### DIFF
--- a/geonode/layers/models.py
+++ b/geonode/layers/models.py
@@ -509,9 +509,12 @@ def post_delete_layer(instance, sender, **kwargs):
             default_style__id=instance.default_style.id).count() == 0:
         instance.default_style.delete()
 
-    if instance.upload_session:
-        for lf in instance.upload_session.layerfile_set.all():
-            lf.file.delete()
+    try:
+        if instance.upload_session:
+            for lf in instance.upload_session.layerfile_set.all():
+                lf.file.delete()
+    except UploadSession.DoesNotExist:
+        pass
 
 
 signals.pre_save.connect(pre_save_layer, sender=Layer)


### PR DESCRIPTION
uploadsession can be empty under certain circomstancies, for example when there is a layer cascade delete when removing an user