### PR TITLE
Intitial NLP Support

### DIFF
--- a/docs/reference/developers/settings.txt
+++ b/docs/reference/developers/settings.txt
@@ -558,6 +558,30 @@ Default: ``False``
 
 A boolean that specifies whether the Exif contrib app is enabled.  If enabled, metadata is generated from Exif tags when documents are uploaded.
 
+NLP_ENABED
+...........
+Default: ``False``
+
+A boolean that specifies whether the NLP (Natural Language Processing) contrib app is enabled.  If enabled, NLP (specifically MITIE) is used to infer additional metadata from uploaded documents to help fill metadata gaps.
+
+NLP_LOCATION_THRESHOLD
+-------------------
+Default: ``1.0``
+
+A float that specifies the threshold for location matches.
+
+NLP_LIBRARY_PATH
+--------------
+Default:: ``'/opt/MITIE/mitielib'``
+
+A string that specifies the location of the MITIE library
+
+NLP_MODEL_PATH
+--------------
+Default:: ``'/opt/MITIE/MITIE-models/english/ner_model.dat'``
+
+A string that specifies the location of the NER (Named Entity Resolver).  MITIE comes with English and Spanish NER models.  Other models can be trained.
+
 SLACK_ENABED
 ...........
 Default: ``False``

--- a/geonode/context_processors.py
+++ b/geonode/context_processors.py
@@ -110,6 +110,10 @@ def resource_urls(request):
             settings,
             "EXIF_ENABLED",
             False),
+        NLP_ENABLED=getattr(
+            settings,
+            "NLP_ENABLED",
+            False),
         SEARCH_FILTERS=getattr(
             settings,
             'SEARCH_FILTERS',

--- a/geonode/contrib/nlp/utils.py
+++ b/geonode/contrib/nlp/utils.py
@@ -1,0 +1,141 @@
+# -*- coding: utf-8 -*-
+#########################################################################
+#
+# Copyright (C) 2012 OpenPlans
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#########################################################################
+
+import os
+import sys
+
+from django.conf import settings
+
+from taggit.models import Tag
+
+from geonode.base.models import Region
+
+global ner
+ner = None
+
+
+def _load_ner():
+    global ner
+    if settings.NLP_ENABLED:
+        try:
+            if not (settings.NLP_LIBRARY_PATH in sys.path):
+                sys.path.append(settings.NLP_LIBRARY_PATH)
+            if not ner:
+                from mitie import named_entity_extractor
+                ner = named_entity_extractor(settings.NLP_MODEL_PATH)
+        except:
+            print "Could not load the NLP NER"
+
+
+_load_ner()
+
+
+def removeDuplicateEntities(entities):
+    seen = set()
+    out = []
+    for e in entities:
+        text, score = e
+        if text not in seen:
+            seen.add(text)
+            out.append(e)
+    return out
+
+
+def nlp_extract_metadata_doc(doc):
+
+    if not doc:
+        return None
+
+    if not doc.doc_file:
+        return None
+
+    if os.path.splitext(doc.doc_file.name)[1].lower()[1:] in ["txt", "log", "sld", "xml"]:
+        text = None
+        with open(doc.doc_file.path, "r") as f:
+            text = f.read()
+        return _nlp_extract_metadata_core(text=text)
+    else:
+        return None
+
+
+def nlp_extract_metadata_dict(d):
+
+    m = {'keywords': set(), 'regions': set()}
+    for key in d:
+        if d[key]:
+            new_metadata = _nlp_extract_metadata_core(d[key])
+            m['keywords'] = m['keywords'] + set(new_metadata['keywords'])
+            m['regions'] = m['regions'] + set(new_metadata['regions'])
+
+    return {'keywords': list(m['keywords']), 'regions': list(m['regions'])}
+
+
+def _nlp_extract_metadata_core(text=None):
+
+    if text:
+        global ner
+        from mitie import tokenize
+
+        tokens = tokenize(text)
+        entities = ner.extract_entities(tokens)
+        locations = []
+        organizations = []
+        for e in entities:
+            range = e[0]
+            tag = e[1]
+            score = e[2]
+            # score_text = "{:0.3f}".format(score)
+            entity_text = " ".join(tokens[i] for i in range)
+            if tag == "LOCATION":
+                locations.append((entity_text, score))
+            elif tag == "ORGANIZATION":
+                organizations.append((entity_text, score))
+
+        # Remove Duplicates
+        locations = removeDuplicateEntities(locations)
+        organizations = removeDuplicateEntities(organizations)
+
+        # Resolve Locations to Regions
+        regions = []
+        for location in locations:
+            location_text, score = location
+            if score > settings.NLP_LOCATION_THRESHOLD:
+                try:
+                    region = Region.objects.get(name__iexact=location_text)
+                    if region:
+                        regions.append(region)
+                except:
+                    pass
+
+        # Resolve organizations to Keywords/Tags
+        keywords = []
+        for organization in organizations:
+            organization_text, score = organization
+            try:
+                keyword = Tag.objects.get(name__iexact=organization_text)
+                if keyword:
+                    keywords.append(keyword.name)
+            except:
+                pass
+
+        return {'regions': regions, 'keywords': keywords}
+
+    else:
+        return None

--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -797,6 +797,12 @@ RESOURCE_PUBLISHING = False
 # Settings for EXIF contrib app
 EXIF_ENABLED = False
 
+# Settings for NLP contrib app
+NLP_ENABLED = False
+NLP_LOCATION_THRESHOLD = 1.0
+NLP_LIBRARY_PATH = "/opt/MITIE/mitielib"
+NLP_MODEL_PATH = "/opt/MITIE/MITIE-models/english/ner_model.dat"
+
 # Settings for Slack contrib app
 SLACK_ENABLED = False
 SLACK_WEBHOOK_URLS = [


### PR DESCRIPTION
This PR add a `nlp` contrib app.  This app is disabled by default.  If enabled by the `NLP_ENABLED` settings flag, the app will use [MITIE](https://github.com/mit-nlp/MITIE) and natural language processing (NLP) techniques to infer additional metadata from the raw contents of new text documents.  This contrib app will help fill key metadata gaps.

Specifically, the app will identify locations mentioned within the document and crosscheck them against regions (https://github.com/GeoNode/geonode/blob/master/geonode/base/models.py#L117) to autofill the regions metadata field.  Keywords are generated for identified organizations but only if they match "existing" keywords.

In the future this app can be enhanced in a few ways.  Additional structured metadata could be inferred for layers by reading in the abstract, title, and purpose from a metadata file.  The remote services feature could use the nlp app to fill in structured metadata for remote services that have none or little to begin with.  Lastly, a separate library agnostic to GeoNode's models should be built outside of the core so [CKAN](https://github.com/CKAN/ckan) and other platforms can reuse some of the opensource code.