### PR TITLE
add OpenSearch autodiscovery support

### DIFF
--- a/geonode/catalogue/templates/catalogue/opensearch_description.xml
+++ b/geonode/catalogue/templates/catalogue/opensearch_description.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
+    <ShortName>{{ shortname }}</ShortName>
+    <LongName>{{ shortname }}</LongName>
+    <Description>Search {{ url }}</Description>
+    <Tags>{{ tags }}</Tags>
+    <Image height="16" width="16" type="image/vnd.microsoft.icon">{{ url }}/static/geonode/img/favicon.ico</Image>
+    <InputEncoding>UTF-8</InputEncoding>
+    <Url type="text/html" template="{{ url }}/search/?title__icontains={searchTerms}"/>
+    <Url type="application/atom+xml" template="{{ url }}/catalogue/csw?mode=opensearch&amp;service=CSW&amp;version=2.0.2&amp;request=GetRecords&amp;elementsetname=full&amp;typenames=csw:Record&amp;resulttype=results&amp;q={searchTerms?}&amp;bbox={geo:box?}&amp;time={time:start?}/{time:end?}"/>
+    <Developer>{{ developer }}</Developer>
+    <Contact>{{ contact }}</Contact>
+    <Attribution>{{ attribution }}</Attribution>
+</OpenSearchDescription>

--- a/geonode/catalogue/urls.py
+++ b/geonode/catalogue/urls.py
@@ -21,4 +21,5 @@
 from django.conf.urls import patterns, url
 
 urlpatterns = patterns('geonode.catalogue.views',
-                       url(r'^csw$', 'csw_global_dispatch', name='csw_global_dispatch'))
+                       url(r'^csw$', 'csw_global_dispatch', name='csw_global_dispatch'),
+                       url(r'^opensearch$', 'opensearch_dispatch', name='opensearch_dispatch'))

--- a/geonode/catalogue/views.py
+++ b/geonode/catalogue/views.py
@@ -48,6 +48,7 @@ def csw_global_dispatch(request):
 
     return HttpResponse(content, content_type=csw.contenttype)
 
+
 @csrf_exempt
 def opensearch_dispatch(request):
     """OpenSearch wrapper"""
@@ -62,17 +63,5 @@ def opensearch_dispatch(request):
         'url': settings.SITEURL.rstrip('/')
     }
 
-    return render_to_response('catalogue/opensearch_description.xml',
-                              ctx,
+    return render_to_response('catalogue/opensearch_description.xml', ctx,
                               content_type='application/opensearchdescription+xml')
-
-
-
-
-
-
-
-
-
-
-

--- a/geonode/catalogue/views.py
+++ b/geonode/catalogue/views.py
@@ -21,6 +21,7 @@
 import os
 from django.conf import settings
 from django.http import HttpResponse, HttpResponseRedirect
+from django.shortcuts import render_to_response
 from django.views.decorators.csrf import csrf_exempt
 from pycsw import server
 from geonode.catalogue.backends.pycsw_local import CONFIGURATION
@@ -46,3 +47,32 @@ def csw_global_dispatch(request):
     content = csw.dispatch_wsgi()
 
     return HttpResponse(content, content_type=csw.contenttype)
+
+@csrf_exempt
+def opensearch_dispatch(request):
+    """OpenSearch wrapper"""
+
+    ctx = {
+        'shortname': settings.PYCSW['CONFIGURATION']['metadata:main']['identification_title'],
+        'description': settings.PYCSW['CONFIGURATION']['metadata:main']['identification_abstract'],
+        'developer': settings.PYCSW['CONFIGURATION']['metadata:main']['contact_name'],
+        'contact': settings.PYCSW['CONFIGURATION']['metadata:main']['contact_email'],
+        'attribution': settings.PYCSW['CONFIGURATION']['metadata:main']['provider_name'],
+        'tags': settings.PYCSW['CONFIGURATION']['metadata:main']['identification_keywords'].replace(',', ' '),
+        'url': settings.SITEURL.rstrip('/')
+    }
+
+    return render_to_response('catalogue/opensearch_description.xml',
+                              ctx,
+                              content_type='application/opensearchdescription+xml')
+
+
+
+
+
+
+
+
+
+
+

--- a/geonode/templates/base.html
+++ b/geonode/templates/base.html
@@ -32,6 +32,7 @@
         }
       </style>
     <![endif]-->
+    <link rel="search" type="application/opensearchdescription+xml" href="/catalogue/opensearch" title="GeoNode Search"/>
   </head>
   
   <body class="{% block body_class %}{% endblock %}">

--- a/geonode/tests/smoke.py
+++ b/geonode/tests/smoke.py
@@ -99,6 +99,15 @@ class GeoNodeSmokeTests(TestCase):
         response = self.client.get(reverse('profile_detail', args=['norman']))
         self.failUnlessEqual(response.status_code, 200)
 
+    def test_csw_endpoint(self):
+        '''Test that the CSW endpoint is correctly configured.'''
+        response = self.client.get(reverse('csw_global_dispatch'))
+        self.failUnlessEqual(response.status_code, 200)
+
+    def test_opensearch_description(self):
+        '''Test that the local OpenSearch endpoint is correctly configured.'''
+        response = self.client.get(reverse('opensearch_dispatch'))
+        self.failUnlessEqual(response.status_code, 200)
 
 class GeoNodeUtilsTests(TestCase):
 

--- a/geonode/tests/smoke.py
+++ b/geonode/tests/smoke.py
@@ -109,6 +109,7 @@ class GeoNodeSmokeTests(TestCase):
         response = self.client.get(reverse('opensearch_dispatch'))
         self.failUnlessEqual(response.status_code, 200)
 
+
 class GeoNodeUtilsTests(TestCase):
 
     def setUp(self):


### PR DESCRIPTION
cc @pjdufour 

This PR provides [OpenSearch](http://www.opensearch.org/Home) support to GeoNode in the following areas:

- all webpages have an [autodiscovery](http://www.opensearch.org/Specifications/OpenSearch/1.1#Autodiscovery_in_HTML.2FXHTML) link in `<head>`.
- the discovery document has a link to the basic HTML search as well as a pycsw powered Atom output search.  The reason for two different endpoints in the document is because pycsw does not provide HTML output, which is an OpenSearch autodiscovery requirement for web browser based search addons