### PR TITLE
Fix to Exif Contrib App

### DIFF
--- a/geonode/contrib/exif/templates/exif/_exif_document_detail.html
+++ b/geonode/contrib/exif/templates/exif/_exif_document_detail.html
@@ -1,6 +1,5 @@
 {% load i18n %}
 
-{% block exif_tags %}
   <article class="tab-pane" id="exif">
     <dl class="dl-horizontal">
       <dt>{% trans 'Width' %}</dt>
@@ -23,4 +22,3 @@
       <dd>{{ exif_data.speed }}</dd>
     </dl>
   </article>
-{% endblock %}

--- a/geonode/documents/templates/documents/document_detail.html
+++ b/geonode/documents/templates/documents/document_detail.html
@@ -75,9 +75,9 @@
       </article>
 
       {% if EXIF_ENABLED and exif_data %}
-        {% block exif %}
-          {% include "exif/_exif_document_detail.html" %}
-        {% endblock %}
+        {% with "exif/_exif_document_detail.html" as exif_template %}
+            {% include exif_template %}
+        {% endwith %}
       {% endif %}
     </div>
   </div>

--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -246,6 +246,9 @@ GEONODE_CONTRIB_APPS = (
     'geonode.contrib.slack'
 )
 
+# Uncomment the following line to enable contrib apps
+# GEONODE_APPS = GEONODE_APPS + GEONODE_CONTRIB_APPS
+
 INSTALLED_APPS = (
 
     # Boostrap admin theme


### PR DESCRIPTION
Fix to [exif contrib app](https://github.com/GeoNode/geonode/tree/master/geonode/contrib/exif) so that it passes tests when not included in `settings.INSTALLED_APPS`.  Switched to using `with` for including contrib templates in core templates.

Hold for Travis-CI test.