### PR TITLE
Added NLP hook for layer upload

### DIFF
--- a/geonode/contrib/nlp/utils.py
+++ b/geonode/contrib/nlp/utils.py
@@ -81,8 +81,8 @@ def nlp_extract_metadata_dict(d):
     for key in d:
         if d[key]:
             new_metadata = _nlp_extract_metadata_core(d[key])
-            m['keywords'] = m['keywords'] + set(new_metadata['keywords'])
-            m['regions'] = m['regions'] + set(new_metadata['regions'])
+            m['keywords'] = m['keywords'].union(set(new_metadata['keywords']))
+            m['regions'] = m['regions'].union(set(new_metadata['regions']))
 
     return {'keywords': list(m['keywords']), 'regions': list(m['regions'])}
 
@@ -107,6 +107,7 @@ def _nlp_extract_metadata_core(text=None):
                 locations.append((entity_text, score))
             elif tag == "ORGANIZATION":
                 organizations.append((entity_text, score))
+            # print tag+" : "+entity_text+" : "+score_text
 
         # Remove Duplicates
         locations = removeDuplicateEntities(locations)


### PR DESCRIPTION
Continuation of #2230 to extend NLP to shapefile metadata.  When a shapefile is uploaded, the keywords (and regions) from the metadata xml (if it is included) are extended with keywords and region inferred by the [nlp contrib app](https://github.com/GeoNode/geonode/tree/master/geonode/contrib/nlp).  The NLP contrib app parses the title, abstract, and purpose looking for regions and keywords.

Unfortunately the nlp contrib app still misses many regions.  Until a region refractor (#2232) that incorporates a "geographic thesaurus" with multiple names we'll have a hard time matching the text "Syria" in the abstract to "Syrian Arab Republic", etc.
