### PR TITLE
Extract regions from ISO metadata

### DIFF
--- a/geonode/layers/metadata.py
+++ b/geonode/layers/metadata.py
@@ -55,23 +55,24 @@ def set_metadata(xml):
         tagname = get_tagname(exml)
 
     if tagname == 'MD_Metadata':  # ISO
-        vals, keywords = iso2dict(exml)
+        vals, regions, keywords = iso2dict(exml)
     elif tagname == 'metadata':  # FGDC
-        vals, keywords = fgdc2dict(exml)
+        vals, regions, keywords = fgdc2dict(exml)
     elif tagname == 'Record':  # Dublin Core
-        vals, keywords = dc2dict(exml)
+        vals, regions, keywords = dc2dict(exml)
     else:
         raise RuntimeError('Unsupported metadata format')
     if not vals.get("date"):
         vals["date"] = datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
 
-    return [vals, keywords]
+    return [vals, regions, keywords]
 
 
 def iso2dict(exml):
     """generate dict of properties from gmd:MD_Metadata"""
 
     vals = {}
+    regions = []
     keywords = []
 
     mdata = MD_Metadata(exml)
@@ -97,9 +98,11 @@ def iso2dict(exml):
 
         if (hasattr(mdata.identification, 'keywords') and
                 len(mdata.identification.keywords) > 0):
-            if None not in mdata.identification.keywords[0]['keywords']:
-                keywords = mdata.identification.keywords[0]['keywords']
-
+            for kw in mdata.identification.keywords:
+                if kw['type'] == "theme":
+                    keywords.extend(kw['keywords'])
+                elif kw['type'] == "place":
+                    regions.extend(kw['keywords'])
         if len(mdata.identification.securityconstraints) > 0:
             vals['constraints_use'] = \
                 mdata.identification.securityconstraints[0]
@@ -112,13 +115,14 @@ def iso2dict(exml):
     if mdata.dataquality is not None:
         vals['data_quality_statement'] = mdata.dataquality.lineage
 
-    return [vals, keywords]
+    return [vals, regions, keywords]
 
 
 def fgdc2dict(exml):
     """generate dict of properties from FGDC metadata"""
 
     vals = {}
+    regions = []
     keywords = []
 
     mdata = Metadata(exml)
@@ -168,13 +172,14 @@ def fgdc2dict(exml):
     if raw_date is not None:
         vals['date'] = sniff_date(raw_date)
 
-    return [vals, keywords]
+    return [vals, regions, keywords]
 
 
 def dc2dict(exml):
     """generate dict of properties from csw:Record"""
 
     vals = {}
+    regions = []
     keywords = []
 
     mdata = CswRecord(exml)
@@ -188,7 +193,7 @@ def dc2dict(exml):
     vals['title'] = mdata.title
     vals['abstract'] = mdata.abstract
 
-    return [vals, keywords]
+    return [vals, regions, keywords]
 
 
 def sniff_date(datestr):

--- a/geonode/upload/upload.py
+++ b/geonode/upload/upload.py
@@ -31,7 +31,7 @@ or return response objects.
 State is stored in a UploaderSession object stored in the user's session.
 This needs to be made more stateful by adding a model.
 """
-from geonode.layers.utils import get_valid_layer_name
+from geonode.layers.utils import get_valid_layer_name, resolve_regions
 from geonode.layers.metadata import set_metadata
 from geonode.layers.models import Layer
 from geonode import GeoNodeException
@@ -588,9 +588,19 @@ def final_step(upload_session, user):
     if xml_file:
         saved_layer.metadata_uploaded = True
         # get model properties from XML
-        vals, keywords = set_metadata(open(xml_file[0]).read())
+        vals, regions, keywords = set_metadata(open(xml_file[0]).read())
+
+        regions_resolved, regions_unresolved = resolve_regions(regions)
+        keywords.extend(regions_unresolved)
+
+        # set regions
+        regions_resolved = list(set(regions_resolved))
+        if regions:
+            if len(regions) > 0:
+                saved_layer.regions.add(*regions_resolved)
 
         # set taggit keywords
+        keywords = list(set(keywords))
         saved_layer.keywords.add(*keywords)
 
         # set model properties


### PR DESCRIPTION
This PR references #2237.  On layer upload, regions are extracted from attached ISO XML.  If GeoNode can't resolve the place keyword to a Region object, then it adds the region name as a keyword/tag.

@tomkralidis 