### PR TITLE
Case insensitive search on GeoExplorer Find Layers

### DIFF
--- a/geonode/static/geonode/js/extjs/Geonode-CatalogueApiSearch.js
+++ b/geonode/static/geonode/js/extjs/Geonode-CatalogueApiSearch.js
@@ -139,7 +139,7 @@ gxp.plugins.GeoNodeAPICatalogueSource = Ext.extend(gxp.plugins.CatalogueSource, 
             }
         }
         Ext.apply(this.store.baseParams, {
-            'title__contains': options.queryString
+            'title__icontains': options.queryString
         });
         if (options.limit !== undefined) {
             Ext.apply(this.store.baseParams, {


### PR DESCRIPTION
this patch performs a more useful search on "title" field. The issue does not occur in developing mode due to a counter-intuitive behavior of the django SQLite backend [1].

[1] https://docs.djangoproject.com/en/1.8/ref/databases/#sqlite-string-matching