### PR TITLE
added projection option for EPSG:4326 - settings.DEFAULT_MAP_PROJECTION

### DIFF
--- a/geonode/layers/views.py
+++ b/geonode/layers/views.py
@@ -230,11 +230,9 @@ def layer_detail(request, layername, template='layers/layer_detail.html'):
     layer_bbox = layer.bbox
     bbox = [float(coord) for coord in list(layer_bbox[0:4])]
     srid = layer.srid
-
-    # Transform WGS84 to Mercator.
-    config["srs"] = srid if srid != "EPSG:4326" else "EPSG:900913"
-    config["bbox"] = llbbox_to_mercator([float(coord) for coord in bbox])
-
+    config["srs"] = getattr(settings, 'DEFAULT_MAP_CRS', 'EPSG:900913')
+    config["bbox"] = bbox if srid != "EPSG:900913" \
+        else llbbox_to_mercator([float(coord) for coord in bbox])
     config["title"] = layer.title
     config["queryable"] = True
 
@@ -263,7 +261,10 @@ def layer_detail(request, layername, template='layers/layer_detail.html'):
             id=layer.id).update(popular_count=F('popular_count') + 1)
 
     # center/zoom don't matter; the viewer will center on the layer bounds
-    map_obj = GXPMap(projection="EPSG:900913")
+    if getattr(settings, 'DEFAULT_MAP_CRS', 'EPSG:900913') == "EPSG:4326":
+        map_obj = GXPMap(projection="EPSG:4326")
+    else:
+        map_obj = GXPMap(projection="EPSG:900913")
     NON_WMS_BASE_LAYERS = [
         la for la in default_map_config()[1] if la.ows_url is None]
 

--- a/geonode/maps/models.py
+++ b/geonode/maps/models.py
@@ -230,7 +230,7 @@ class Map(ResourceBase, GXPMapBase):
         self.owner = user
         self.title = title
         self.abstract = abstract
-        self.projection = "EPSG:900913"
+        self.projection = getattr(settings, 'DEFAULT_MAP_CRS', 'EPSG:900913')
         self.zoom = 0
         self.center_x = 0
         self.center_y = 0

--- a/geonode/maps/views.py
+++ b/geonode/maps/views.py
@@ -473,7 +473,8 @@ def new_map_config(request):
 
         if 'layer' in params:
             bbox = None
-            map_obj = Map(projection="EPSG:900913")
+            map_obj = Map(projection=getattr(settings, 'DEFAULT_MAP_CRS',
+                          'EPSG:900913'))
             layers = []
             for layer_name in params.getlist('layer'):
                 try:
@@ -503,8 +504,18 @@ def new_map_config(request):
                 # Add required parameters for GXP lazy-loading
                 config["title"] = layer.title
                 config["queryable"] = True
-                config["srs"] = layer.srid if layer.srid != "EPSG:4326" else "EPSG:900913"
-                config["bbox"] = llbbox_to_mercator([float(coord) for coord in bbox])
+                if getattr(
+                           settings,
+                           'DEFAULT_MAP_CRS',
+                           'EPSG:900913') == "EPSG:4326":
+                    config["srs"] = layer.srid if \
+                        layer.srid != "EPSG:900913" else "EPSG:4326"
+                    config["bbox"] = bbox
+                else:
+                    config["srs"] = layer.srid if \
+                        layer.srid != "EPSG:4326" else "EPSG:900913"
+                    config["bbox"] = llbbox_to_mercator([float(coord) for
+                                                        coord in bbox])
 
                 if layer.storeType == "remoteStore":
                     service = layer.service

--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -594,6 +594,10 @@ PYCSW = {
 
 # GeoNode javascript client configuration
 
+# default map projection
+# Note: If set to EPSG:4326, then only EPSG:4326 basemaps will work.
+DEFAULT_MAP_CRS = "EPSG:900913"
+
 # Where should newly created maps be focused?
 DEFAULT_MAP_CENTER = (0, 0)
 
@@ -670,7 +674,7 @@ CKAN_ORIGINS = [{
 # Be sure to replace @GeoNode with your organization or site's twitter handle.
 TWITTER_CARD = True
 TWITTER_SITE = '@GeoNode'
-TWITTER_HASHTAGS = ['geonode'] 
+TWITTER_HASHTAGS = ['geonode']
 
 OPENGRAPH_ENABLED = True
 

--- a/geonode/tests/integration.py
+++ b/geonode/tests/integration.py
@@ -976,7 +976,7 @@ class GeoNodeMapPrintTest(TestCase):
                 'layout': 'A4 portrait',
                 'mapTitle': 'test',
                 'outputFilename': 'print',
-                'srs': 'EPSG:900913',
+                'srs': getattr(settings, 'DEFAULT_MAP_CRS', 'EPSG:900913'),
                 'units': 'm'}
 
             self.client.post(print_url, post_payload)

--- a/geonode/utils.py
+++ b/geonode/utils.py
@@ -415,12 +415,15 @@ class GXPLayer(GXPLayerBase):
 
 
 def default_map_config():
-    _DEFAULT_MAP_CENTER = forward_mercator(settings.DEFAULT_MAP_CENTER)
+    if getattr(settings, 'DEFAULT_MAP_CRS', 'EPSG:900913') == "EPSG:4326":
+        _DEFAULT_MAP_CENTER = inverse_mercator(settings.DEFAULT_MAP_CENTER)
+    else:
+        _DEFAULT_MAP_CENTER = forward_mercator(settings.DEFAULT_MAP_CENTER)
 
     _default_map = GXPMap(
         title=DEFAULT_TITLE,
         abstract=DEFAULT_ABSTRACT,
-        projection="EPSG:900913",
+        projection=getattr(settings, 'DEFAULT_MAP_CRS', 'EPSG:900913'),
         center_x=_DEFAULT_MAP_CENTER[0],
         center_y=_DEFAULT_MAP_CENTER[1],
         zoom=settings.DEFAULT_MAP_ZOOM


### PR DESCRIPTION
Added DEFAULT_MAP_CRS as a variable in settings.py and modified hard coded value for EPSG:900913.

Note: If this is set to EPSG:4326 the basemap must be EPSG:4326

Add the following to local_settings.py to test with EPSG:4326 basemap

DEFAULT_MAP_CRS = "EPSG:4326"

MAP_BASELAYERS = [{
    "source": {"ptype": "gxp_olsource"},
    "type": "OpenLayers.Layer",
    "args": ["No background"],
    "visibility": False,
    "fixed": True,
    "group":"background"
}, {
    "source": {"ptype": "gxp_olsource"},
    "type": "OpenLayers.Layer.WMS",
    "args": ["World map", "http://vmap0.tiles.osgeo.org/wms/vmap0", {"layers": 'basic'}],
    "visibility": True,
    "fixed": True,
    "group": "background"
}