### PR TITLE
(Hold for 2.5.x) add support for preserving XML metadata with upload (#2250)

### DIFF
--- a/geonode/base/models.py
+++ b/geonode/base/models.py
@@ -322,6 +322,7 @@ class ResourceBase(PolymorphicModel, PermissionLevelMixin):
 
     # metadata XML specific fields
     metadata_uploaded = models.BooleanField(default=False)
+    metadata_uploaded_preserve = models.BooleanField(default=False)
     metadata_xml = models.TextField(null=True,
                                     default='<gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd"/>',
                                     blank=True)

--- a/geonode/catalogue/models.py
+++ b/geonode/catalogue/models.py
@@ -22,6 +22,7 @@ import logging
 
 from django.conf import settings
 from django.db.models import signals
+from lxml import etree
 from geonode.layers.models import Layer
 from geonode.documents.models import Document
 from geonode.catalogue import get_catalogue
@@ -71,7 +72,10 @@ def catalogue_post_save(instance, sender, **kwargs):
                                    )
 
     # generate an XML document (GeoNode's default is ISO)
-    md_doc = catalogue.catalogue.csw_gen_xml(instance, 'catalogue/full_metadata.xml')
+    if instance.metadata_uploaded and instance.metadata_uploaded_preserve:
+        md_doc = etree.tostring(etree.fromstring(instance.metadata_xml))
+    else:
+        md_doc = catalogue.catalogue.csw_gen_xml(instance, 'catalogue/full_metadata.xml')
 
     csw_anytext = catalogue.catalogue.csw_gen_anytext(md_doc)
 

--- a/geonode/layers/forms.py
+++ b/geonode/layers/forms.py
@@ -64,6 +64,7 @@ class LayerUploadForm(forms.Form):
     xml_file = forms.FileField(required=False)
 
     charset = forms.CharField(required=False)
+    metadata_uploaded_preserve = forms.BooleanField(required=False)
 
     spatial_files = (
         "base_file",
@@ -167,6 +168,7 @@ class NewLayerUploadForm(LayerUploadForm):
     layer_title = forms.CharField(required=False)
     permissions = JSONField()
     charset = forms.CharField(required=False)
+    metadata_uploaded_preserve = forms.BooleanField(required=False)
 
     spatial_files = (
         "base_file",

--- a/geonode/layers/management/commands/importlayers.py
+++ b/geonode/layers/management/commands/importlayers.py
@@ -28,7 +28,7 @@ import datetime
 class Command(BaseCommand):
     help = ("Brings a data file or a directory full of data files into a"
             " GeoNode site.  Layers are added to the Django database, the"
-            " GeoServer configuration, and the GeoNetwork metadata index.")
+            " GeoServer configuration, and the pycsw metadata index.")
 
     args = 'path [path...]'
 
@@ -96,6 +96,14 @@ class Command(BaseCommand):
             default=False,
             action="store_true",
             help="Make layer viewable only to owner"
+        ),
+        make_option(
+            '-m',
+            '--metadata_uploaded_preserve',
+            dest='metadata_uploaded_preserve',
+            default=False,
+            action="store_true",
+            help="Force metadata XML to be preserved"
         )
     )
 
@@ -108,6 +116,8 @@ class Command(BaseCommand):
         category = options.get('category', None)
         private = options.get('private', False)
         title = options.get('title', None)
+        metadata_uploaded_preserve = options.get('metadata_uploaded_preserve',
+                                                 False)
 
         if verbosity > 0:
             console = self.stdout
@@ -143,7 +153,9 @@ class Command(BaseCommand):
                 category=category,
                 regions=regions,
                 title=title,
-                private=private)
+                private=private,
+                metadata_uploaded_preserve=metadata_uploaded_preserve)
+
             output.extend(out)
 
         updated = [dict_['file']

--- a/geonode/layers/metadata.py
+++ b/geonode/layers/metadata.py
@@ -55,17 +55,17 @@ def set_metadata(xml):
         tagname = get_tagname(exml)
 
     if tagname == 'MD_Metadata':  # ISO
-        vals, regions, keywords = iso2dict(exml)
+        identifier, vals, regions, keywords = iso2dict(exml)
     elif tagname == 'metadata':  # FGDC
-        vals, regions, keywords = fgdc2dict(exml)
+        identifier, vals, regions, keywords = fgdc2dict(exml)
     elif tagname == 'Record':  # Dublin Core
-        vals, regions, keywords = dc2dict(exml)
+        identifier, vals, regions, keywords = dc2dict(exml)
     else:
         raise RuntimeError('Unsupported metadata format')
     if not vals.get("date"):
         vals["date"] = datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
 
-    return [vals, regions, keywords]
+    return [identifier, vals, regions, keywords]
 
 
 def iso2dict(exml):
@@ -76,6 +76,7 @@ def iso2dict(exml):
     keywords = []
 
     mdata = MD_Metadata(exml)
+    identifier = mdata.identifier
     vals['language'] = mdata.language or mdata.languagecode or 'eng'
     vals['spatial_representation_type'] = mdata.hierarchy
     vals['date'] = sniff_date(mdata.datestamp)
@@ -115,7 +116,7 @@ def iso2dict(exml):
     if mdata.dataquality is not None:
         vals['data_quality_statement'] = mdata.dataquality.lineage
 
-    return [vals, regions, keywords]
+    return [identifier, vals, regions, keywords]
 
 
 def fgdc2dict(exml):
@@ -126,7 +127,7 @@ def fgdc2dict(exml):
     keywords = []
 
     mdata = Metadata(exml)
-
+    identifier = mdata.idinfo.datasetid
     if hasattr(mdata.idinfo, 'citation'):
         if hasattr(mdata.idinfo.citation, 'citeinfo'):
             vals['spatial_representation_type'] = \
@@ -177,7 +178,7 @@ def fgdc2dict(exml):
     if raw_date is not None:
         vals['date'] = sniff_date(raw_date)
 
-    return [vals, regions, keywords]
+    return [identifier, vals, regions, keywords]
 
 
 def dc2dict(exml):
@@ -188,6 +189,7 @@ def dc2dict(exml):
     keywords = []
 
     mdata = CswRecord(exml)
+    identifier = mdata.identifier
     vals['language'] = mdata.language
     vals['spatial_representation_type'] = mdata.type
     keywords = mdata.subjects
@@ -199,7 +201,7 @@ def dc2dict(exml):
     vals['title'] = mdata.title
     vals['abstract'] = mdata.abstract
 
-    return [vals, regions, keywords]
+    return [identifier, vals, regions, keywords]
 
 
 def sniff_date(datestr):

--- a/geonode/layers/templates/layers/layer_metadata.html
+++ b/geonode/layers/templates/layers/layer_metadata.html
@@ -18,9 +18,12 @@
         Editing details for {{ layer_title }}
       {% endblocktrans %}
     </p>
-    <form class="form-horizontal" action="{% url "layer_metadata" layer.service_typename %}" method="POST">
-      {% if layer.metadata_uploaded %}
-    	<p class="bg-warning">{% blocktrans %}Note: this layer's orginal metadata was populated by importing a metadata XML file.
+    <form id="layer_metadata_update" class="form-horizontal" action="{% url "layer_metadata" layer.service_typename %}" method="POST">
+      {% if layer.metadata_uploaded_preserve %}
+        <p class="bg-warning">{% blocktrans %}Note: this layer's orginal metadata was populated and preserved by importing a metadata XML file.
+          This metadata cannot be edited.{% endblocktrans %}</p>
+      {% elif layer.metadata_uploaded %}
+        <p class="bg-warning">{% blocktrans %}Note: this layer's orginal metadata was populated by importing a metadata XML file.
           GeoNode's metadata import supports a subset of ISO, FGDC, and Dublin Core metadata elements.
           Some of your original metadata may have been lost.{% endblocktrans %}</p>
       {% endif %}
@@ -55,9 +58,11 @@
           </ul>
         {% endif %}
 
+        {% if not layer.metadata_uploaded_preserve %}
         <div class="form-actions">
           <input type="submit" class="btn btn-primary" value="{% trans "Update" %}"/>
         </div>
+        {% endif %}
 
 
         {% csrf_token %}
@@ -114,9 +119,11 @@
               <button type='button' class="modal-cloose-btn btn btn-primary">Done</button>
             </fieldset>
 
+            {% if not layer.metadata_uploaded_preserve %}
             <div class="form-actions">
               <input type="submit" class="btn btn-primary" value="{% trans "Update" %}"/>
             </div>
+            {% endif %}
           </div>
         </div>
       </form>

--- a/geonode/layers/templates/upload/layer_upload.html
+++ b/geonode/layers/templates/upload/layer_upload.html
@@ -67,6 +67,9 @@
       <ul id="global-errors"></ul>
       <h4>{% trans "Files to be uploaded" %}</h4>
       <div id="file-queue"></div>
+      <div class="checkbox" style="display:none;" id="metadata_uploaded_preserve_check">
+          Preserve Metadata XML <input type="checkbox" name="metadata_uploaded_preserve" id="id_metadata_uploaded_preserve"/>
+      </div>
     </section>
 
     <section class="charset">

--- a/geonode/layers/utils.py
+++ b/geonode/layers/utils.py
@@ -355,7 +355,8 @@ def extract_tarfile(upload_file, extension='.shp', tempdir=None):
 
 def file_upload(filename, name=None, user=None, title=None, abstract=None,
                 keywords=[], category=None, regions=[],
-                skip=True, overwrite=False, charset='UTF-8'):
+                skip=True, overwrite=False, charset='UTF-8',
+                metadata_uploaded_preserve=False):
     """Saves a layer in GeoNode asking as little information as possible.
        Only filename is required, user and title are optional.
     """
@@ -423,10 +424,17 @@ def file_upload(filename, name=None, user=None, title=None, abstract=None,
 
     # set metadata
     if 'xml' in files:
-        xml_file = open(files['xml'])
+        with open(files['xml']) as f:
+            xml_file = f.read()
         defaults['metadata_uploaded'] = True
+        defaults['metadata_uploaded_preserve'] = metadata_uploaded_preserve
+
         # get model properties from XML
-        vals, regions, keywords = set_metadata(xml_file.read())
+        identifier, vals, regions, keywords = set_metadata(xml_file)
+
+        if defaults['metadata_uploaded_preserve']:
+            defaults['metadata_xml'] = xml_file
+            defaults['uuid'] = identifier
 
         for key, value in vals.items():
             if key == 'spatial_representation_type':
@@ -500,7 +508,8 @@ def file_upload(filename, name=None, user=None, title=None, abstract=None,
 def upload(incoming, user=None, overwrite=False,
            keywords=(), category=None, regions=(),
            skip=True, ignore_errors=True,
-           verbosity=1, console=None, title=None, private=False):
+           verbosity=1, console=None, title=None, private=False,
+           metadata_uploaded_preserve=False):
     """Upload a directory of spatial data files to GeoNode
 
        This function also verifies that each layer is in GeoServer.
@@ -585,7 +594,8 @@ def upload(incoming, user=None, overwrite=False,
                                     keywords=keywords,
                                     category=category,
                                     regions=regions,
-                                    title=title
+                                    title=title,
+                                    metadata_uploaded_preserve=metadata_uploaded_preserve
                                     )
                 if not existed:
                     status = 'created'

--- a/geonode/layers/views.py
+++ b/geonode/layers/views.py
@@ -74,6 +74,9 @@ MAX_SEARCH_BATCH_SIZE = 25
 GENERIC_UPLOAD_ERROR = _("There was an error while attempting to upload your data. \
 Please try again, or contact and administrator if the problem continues.")
 
+METADATA_UPLOADED_PRESERVE_ERROR = _("Note: this layer's orginal metadata was \
+populated and preserved by importing a metadata XML file. This metadata cannot be edited.")
+
 _PERMISSION_MSG_DELETE = _("You are not permitted to delete this layer")
 _PERMISSION_MSG_GENERIC = _('You do not have permissions for this layer.')
 _PERMISSION_MSG_MODIFY = _("You are not permitted to modify this layer")
@@ -173,6 +176,7 @@ def layer_upload(request, template='upload/layer_upload.html'):
                     category=topic_category,
                     abstract=form.cleaned_data["abstract"],
                     title=form.cleaned_data["layer_title"],
+                    metadata_uploaded_preserve=form.cleaned_data["metadata_uploaded_preserve"]
                 )
                 Layer.objects.filter(name=name).update(
                     category=topic_category
@@ -329,6 +333,16 @@ def layer_metadata(request, layername, template='layers/layer_metadata.html'):
     metadata_author = layer.metadata_author
 
     if request.method == "POST":
+        if layer.metadata_uploaded_preserve:  # layer metadata cannot be edited
+            out = {
+                'success': False,
+                'errors': METADATA_UPLOADED_PRESERVE_ERROR
+            }
+            return HttpResponse(
+                json.dumps(out),
+                mimetype='application/json',
+                status=400)
+
         layer_form = LayerForm(request.POST, instance=layer, prefix="resource")
         attribute_form = layer_attribute_set(
             request.POST,

--- a/geonode/static/geonode/js/upload/LayerInfo.js
+++ b/geonode/static/geonode/js/upload/LayerInfo.js
@@ -177,6 +177,9 @@ define(function (require, exports) {
         }
 
         form_data.append('charset', $('#charset').val());
+        if ($('#id_metadata_uploaded_preserve').prop('checked')) {
+             form_data.append('metadata_uploaded_preserve', true);
+        }
         return form_data;
     };
 
@@ -522,10 +525,15 @@ define(function (require, exports) {
         ul.empty();
 
         $.each(this.files, function (idx, file) {
+            var file_ext = file.name.substr(file.name.lastIndexOf('.') + 1);
+
             var li = $('<li/>').appendTo(ul),
                 p = $('<p/>', {text: file.name}).appendTo(li),
                 a  = $('<a/>', {text: ' ' + gettext('Remove')});
 
+            if (file_ext === 'xml') {
+                $('#metadata_uploaded_preserve_check').show();
+            }
             a.data('layer', self.name);
             a.data('file',  file.name);
             a.appendTo(p);
@@ -535,6 +543,9 @@ define(function (require, exports) {
                     layer_name = target.data('layer'),
                     file_name  = target.data('file');
                 self.removeFile(file_name);
+                if (file_ext === 'xml') {
+                    $('#metadata_uploaded_preserve_check').hide();
+                }
                 self.displayRefresh();
             });
         });

--- a/geonode/templates/metadata_form_js.html
+++ b/geonode/templates/metadata_form_js.html
@@ -42,6 +42,9 @@
     });
 
     $(document).ready(function() {
+        {% if layer.metadata_uploaded_preserve %}
+        $('#layer_metadata_update :input').attr('readonly','readonly');
+        {% endif %}
         $('.has-popover').popover({'trigger':'hover'});
     });
 {% endautoescape %}

--- a/geonode/upload/forms.py
+++ b/geonode/upload/forms.py
@@ -49,6 +49,8 @@ class LayerUploadForm(forms.Form):
     layer_title = forms.CharField(required=False)
     permissions = JSONField()
 
+    metadata_uploaded_preserve = forms.BooleanField(required=False)
+
     spatial_files = (
         "base_file",
         "dbf_file",


### PR DESCRIPTION
(this is a resubmit of #2294)

## Overview

Implements #2250 

## Workflow Changes
- layer upload: when a metadata XML file is provided, present checkbox to enable preservation of metadata
- layer metadata editing: when metadata is to be preserved, switch the UI form to readonly and hide all submit buttons.  In addition, `POST` requests will in the same situation (i.e. bypassing the UI) will throw 400 with a JSON exception
- `importlayers` adds a `-m` /  `--metadata_uploaded_preserve` boolean flag for backend workflows

## Backwards Compatibility
This PR introduces a new field `metadata_uploaded_preserve` (boolean, `default=False`) in `geonode.base.models.ResourceBase`.  Migration is required (but not provided here).