### PR TITLE
More resilient layer delete

### DIFF
--- a/geonode/geoserver/signals.py
+++ b/geonode/geoserver/signals.py
@@ -32,7 +32,8 @@ def geoserver_pre_delete(instance, sender, **kwargs):
     # ogc_server_settings.BACKEND_WRITE_ENABLED == True
     if getattr(ogc_server_settings, "BACKEND_WRITE_ENABLED", True):
         if not getattr(instance, "service", None):
-            cascading_delete(gs_catalog, instance.typename)
+            if instance.typename:
+                cascading_delete(gs_catalog, instance.typename)
 
 
 def geoserver_pre_save(instance, sender, **kwargs):

--- a/geonode/layers/models.py
+++ b/geonode/layers/models.py
@@ -492,18 +492,20 @@ def post_delete_layer(instance, sender, **kwargs):
     Remove the layer default style.
     """
     from geonode.maps.models import MapLayer
-    logger.debug(
-        "Going to delete associated maplayers for [%s]",
-        instance.typename.encode('utf-8'))
-    MapLayer.objects.filter(
-        name=instance.typename,
-        ows_url=instance.ows_url).delete()
+    if instance.typename:
+        logger.debug(
+            "Going to delete associated maplayers for [%s]",
+            instance.typename.encode('utf-8'))
+        MapLayer.objects.filter(
+            name=instance.typename,
+            ows_url=instance.ows_url).delete()
 
     if instance.service:
         return
-    logger.debug(
-        "Going to delete the default style for [%s]",
-        instance.typename.encode('utf-8'))
+    if instance.typename:
+        logger.debug(
+            "Going to delete the default style for [%s]",
+            instance.typename.encode('utf-8'))
 
     if instance.default_style and Layer.objects.filter(
             default_style__id=instance.default_style.id).count() == 0:


### PR DESCRIPTION
Currently if you try to delete a layer in GeoNode but its missing in GeoServer, GeoNode will error out and prevent the deletion.  This PR helps GeoNode avoid those errors, so it'll delete the layers even if GeoNode and GeoServer fall our of sync for some reason, which can easily happen when adding some layers automatically via scripting.