### PR TITLE
API_INCLUDE_REGIONS_COUNT setting to enable region facets

### DIFF
--- a/docs/reference/developers/settings.txt
+++ b/docs/reference/developers/settings.txt
@@ -342,6 +342,21 @@ Default: ``10``
 
 An integer that specifies the default search size when using ``geonode.search`` for querying data.
 
+API settings
+============
+
+API_LIMIT_PER_PAGE
+------------------
+Default: ``0``
+
+Number of items returned by the API. 0 equals no limit
+
+API_INCLUDE_REGIONS_COUNT
+-------------------------
+Default: ``False``
+
+Specifies if to include facets count for regions.
+
 Security settings
 =================
 

--- a/geonode/api/api.py
+++ b/geonode/api/api.py
@@ -134,9 +134,10 @@ class RegionResource(TypeFilteredResource):
         allowed_methods = ['get']
         filtering = {
             'name': ALL,
+            'code': ALL,
         }
-        # To activate the counts on regions uncomment the following line
-        # serializer = CountJSONSerializer()
+        if settings.API_INCLUDE_REGIONS_COUNT:
+            serializer = CountJSONSerializer()
 
 
 class TopicCategoryResource(TypeFilteredResource):

--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -765,6 +765,7 @@ CLIENT_RESULTS_LIMIT = 100
 
 # Number of items returned by the apis 0 equals no limit
 API_LIMIT_PER_PAGE = 0
+API_INCLUDE_REGIONS_COUNT = False
 
 LEAFLET_CONFIG = {
     'TILES': [


### PR DESCRIPTION
Includes a API_INCLUDE_REGIONS_COUNT setting to enable region facets count. It also add region code to the api filtering fields