### PR TITLE
Message posted to Slack after layer upload

### DIFF
--- a/geonode/contrib/slack/utils.py
+++ b/geonode/contrib/slack/utils.py
@@ -59,7 +59,9 @@ def _build_state_layer(layer):
 
     state = _build_state_resourcebase(layer)
 
-    url_detail = "{base}{context}".format(base=settings.SITEURL[:-1], context=layer.detail_url)
+    url_detail = "{base}{context}".format(
+        base=settings.SITEURL[:-1],
+        context=reverse('layer_detail', args=(layer.service_typename,)))
     link_shp = Link.objects.get(resource=layer.get_self_resource(), name='Zipped Shapefile')
     link_geojson = Link.objects.get(resource=layer.get_self_resource(), name='GeoJSON')
     link_netkml = Link.objects.get(resource=layer.get_self_resource(), name='View in Google Earth')

--- a/geonode/layers/utils.py
+++ b/geonode/layers/utils.py
@@ -598,6 +598,16 @@ def upload(incoming, user=None, overwrite=False,
                                                            "delete_resourcebase", "change_resourcebase_permissions",
                                                            "publish_resourcebase"]}, "groups": {}}
                     layer.set_permissions(perm_spec)
+
+                if getattr(settings, 'SLACK_ENABLED', False):
+                    try:
+                        from geonode.contrib.slack.utils import build_slack_message_layer, send_slack_messages
+                        send_slack_messages(build_slack_message_layer(
+                            ("layer_new" if status == "created" else "layer_edit"),
+                            layer))
+                    except:
+                        print "Could not send slack message."
+
             except Exception as e:
                 if ignore_errors:
                     status = 'failed'


### PR DESCRIPTION
Slack enhancement, related to #2229.

GeoNode will now send a notification via slack when a new layer has been uploaded via importlayers or the user interface.