### PR TITLE
added german as language

### DIFF
--- a/geonode/base/enumerations.py
+++ b/geonode/base/enumerations.py
@@ -348,6 +348,7 @@ ALL_LANGUAGES = (
     ('fin', 'Finnish'),
     ('fry', 'Frisian'),
     ('glg', 'Gallegan'),
+    ('ger', 'German'),
     ('kal', 'Greenlandic'),
     ('grn', 'Guarani'),
     ('guj', 'Gujarati'),


### PR DESCRIPTION
German was missing as possible language for metadata information. As mentioned by 
Jeffrey Johnson <ortelius@gmail.com>
I have added it to the list and created this pull request.