### PR TITLE
DateTimeFields not accepting PM datetimes

### DIFF
--- a/geonode/base/forms.py
+++ b/geonode/base/forms.py
@@ -80,19 +80,19 @@ class ResourceBaseForm(TranslationModelForm):
         }
     date = forms.DateTimeField(
         localize=True,
-        input_formats = ['%Y-%m-%d %I:%M %p', ],
+        input_formats=['%Y-%m-%d %I:%M %p'],
         widget=DateTimePicker(**_date_widget_options)
     )
     temporal_extent_start = forms.DateTimeField(
         required=False,
         localize=True,
-        input_formats = ['%Y-%m-%d %I:%M %p', ],
+        input_formats=['%Y-%m-%d %I:%M %p'],
         widget=DateTimePicker(**_date_widget_options)
     )
     temporal_extent_end = forms.DateTimeField(
         required=False,
         localize=True,
-        input_formats = ['%Y-%m-%d %I:%M %p', ],
+        input_formats=['%Y-%m-%d %I:%M %p'],
         widget=DateTimePicker(**_date_widget_options)
     )
 

--- a/geonode/base/forms.py
+++ b/geonode/base/forms.py
@@ -70,7 +70,7 @@ class ResourceBaseForm(TranslationModelForm):
     _date_widget_options = {
         "icon_attrs": {"class": "fa fa-calendar"},
         "attrs": {"class": "form-control input-sm"},
-        "format": "%Y-%m-%d %H:%M",
+        "format": "%Y-%m-%d %I:%M %p",
         # Options for the datetimepickers are not set here on purpose.
         # They are set in the metadata_form_js.html template because
         # bootstrap-datetimepicker uses jquery for its initialization
@@ -80,16 +80,19 @@ class ResourceBaseForm(TranslationModelForm):
         }
     date = forms.DateTimeField(
         localize=True,
+        input_formats = ['%Y-%m-%d %I:%M %p', ],
         widget=DateTimePicker(**_date_widget_options)
     )
     temporal_extent_start = forms.DateTimeField(
         required=False,
         localize=True,
+        input_formats = ['%Y-%m-%d %I:%M %p', ],
         widget=DateTimePicker(**_date_widget_options)
     )
     temporal_extent_end = forms.DateTimeField(
         required=False,
         localize=True,
+        input_formats = ['%Y-%m-%d %I:%M %p', ],
         widget=DateTimePicker(**_date_widget_options)
     )
 

--- a/geonode/templates/metadata_form_js.html
+++ b/geonode/templates/metadata_form_js.html
@@ -6,7 +6,7 @@
 {% autoescape off %}
     $(function() {
       var pickerOptions = {
-          format: 'YYYY-MM-DD hh:mm',
+          format: 'YYYY-MM-DD hh:mm A',
           pickDate: true,
           pickTime: true,
           language: 'en',


### PR DESCRIPTION
DateTimeFields for the metadata were not accepting datetime instances in the PM range, messing with the listing of layers when sorted by latest. This PR provides a fix for this issue.