### PR TITLE
Keywords not restricted by type

### DIFF
--- a/geonode/layers/metadata.py
+++ b/geonode/layers/metadata.py
@@ -100,10 +100,10 @@ def iso2dict(exml):
         if (hasattr(mdata.identification, 'keywords') and
                 len(mdata.identification.keywords) > 0):
             for kw in mdata.identification.keywords:
-                if kw['type'] == "theme":
-                    keywords.extend(kw['keywords'])
-                elif kw['type'] == "place":
+                if kw['type'] == "place":
                     regions.extend(kw['keywords'])
+                else:
+                    keywords.extend(kw['keywords'])
         if len(mdata.identification.otherconstraints) > 0:
             vals['constraints_other'] = \
                 mdata.identification.otherconstraints[0]


### PR DESCRIPTION
Changes proposed on #2388, allowing the upload of metadata with keywords of types other than 'place' or 'theme', in conformity with the ISO 19115 [codelist](http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_KeywordTypeCode).