### PR TITLE
Modal user menu Help link fix.

### DIFF
--- a/geonode/templates/base.html
+++ b/geonode/templates/base.html
@@ -229,7 +229,7 @@
               {% block extra_user_menu %}
               {% endblock %}
               <li class="modal-divider"></li>
-              <li><a title="Help" rel="tooltip" href="/help/"><i class="fa fa-question-circle"></i> {% trans "Help" %}</a></li>
+              <li><a title="Help" rel="tooltip" href="{% url "help" %}"><i class="fa fa-question-circle"></i> {% trans "Help" %}</a></li>
             </ul>
           </div>
           <div class="modal-footer">


### PR DESCRIPTION
Changed to Django template tag. It was just hard string. Now You can change help URL in urls.py, like I needed to.