### PR TITLE
Improve WGS84 support

### DIFF
--- a/geonode/maps/views.py
+++ b/geonode/maps/views.py
@@ -537,7 +537,11 @@ def new_map_config(request):
                 x = (minx + maxx) / 2
                 y = (miny + maxy) / 2
 
-                center = list(forward_mercator((x, y)))
+                if getattr(settings, 'DEFAULT_MAP_CRS', 'EPSG:900913') == "EPSG:4326":
+                    center = list((x, y))
+                else:
+                    center = list(forward_mercator((x, y)))
+
                 if center[1] == float('-inf'):
                     center[1] = 0
 


### PR DESCRIPTION
To resolve issue https://github.com/GeoNode/geonode/issues/2432.

_(Issue: If a map contains a layer with a bounding box, the map's center value is forced to Web Mercator, regardless of the DEFAULT_MAP_CRS value in settings.py.)_

Rewritten so that the map's center point is returned in coordinates if DEFAULT_MAP_CRS is EPSG:4326; otherwise, it defaults to Web Mercator.
