### PR TITLE
Metadata read button

### DIFF
--- a/geonode/documents/templates/documents/document_detail.html
+++ b/geonode/documents/templates/documents/document_detail.html
@@ -84,6 +84,12 @@
 
   <div class="col-md-4">
 
+    <li class="list-group-item">
+        <a href="{% url "document_metadata_detail" resource.id %}">
+            <button class="btn btn-primary btn-md btn-block">{% trans "Metadata Detail" %}</button>
+        </a>
+    </li> 
+
     <ul class="list-group">
       <li class="list-group-item">
       {% if "download_resourcebase" in perms_list %}

--- a/geonode/documents/templates/documents/document_metadata_detail.html
+++ b/geonode/documents/templates/documents/document_metadata_detail.html
@@ -1,0 +1,1 @@
+{% extends "metadata_detail.html" %}

--- a/geonode/documents/urls.py
+++ b/geonode/documents/urls.py
@@ -38,5 +38,7 @@ urlpatterns = patterns('geonode.documents.views',
                        url(r'^(?P<docid>\d+)/remove$', 'document_remove', name="document_remove"),
                        url(r'^upload/?$', login_required(DocumentUploadView.as_view()), name='document_upload'),
                        url(r'^search/?$', 'document_search_page', name='document_search_page'),
+                       url(r'^(?P<docid>[^/]*)/metadata_detail$', 'document_metadata_detail',
+                           name='document_metadata_detail'),
                        url(r'^(?P<docid>\d+)/metadata$', 'document_metadata', name='document_metadata'),
                        )

--- a/geonode/documents/views.py
+++ b/geonode/documents/views.py
@@ -449,3 +449,16 @@ def document_remove(request, docid, template='documents/document_remove.html'):
             content_type="text/plain",
             status=401
         )
+
+
+def document_metadata_detail(request, docid, template='documents/document_metadata_detail.html'):
+    document = _resolve_document(
+        request,
+        docid,
+        'view_resourcebase',
+        _PERMISSION_MSG_METADATA)
+    return render_to_response(template, RequestContext(request, {
+        "layer": document,
+        "docid": docid,
+        'SITEURL': settings.SITEURL[:-1]
+    }))

--- a/geonode/layers/templates/layers/layer_detail.html
+++ b/geonode/layers/templates/layers/layer_detail.html
@@ -175,6 +175,13 @@
     {% if GEOSERVER_BASE_URL %}
       {% get_obj_perms request.user for resource.layer as "layer_perms" %}
     {% endif %}
+
+    <li class="list-group-item"> 
+      <a href="{% url "layer_metadata_detail" resource.typename %}">
+        <button class="btn btn-primary btn-md btn-block">{% trans "Metadata Detail" %}</button> 
+      </a>    
+    </li>
+
     {% if "change_resourcebase_metadata" in perms_list or "change_resourcebase" in perms_list or "delete_resourcebase" in perms_list or "change_layer_style" in layer_perms %}
     <li class="list-group-item"> 
       <button class="btn btn-primary btn-md btn-block" data-toggle="modal" data-target="#edit-layer">{% trans "Edit Layer" %}</button>

--- a/geonode/layers/templates/layers/layer_metadata_detail.html
+++ b/geonode/layers/templates/layers/layer_metadata_detail.html
@@ -1,0 +1,1 @@
+{% extends "metadata_detail.html" %}

--- a/geonode/layers/urls.py
+++ b/geonode/layers/urls.py
@@ -35,6 +35,7 @@ urlpatterns = patterns(
     url(r'^(?P<layername>[^/]*)/remove$', 'layer_remove', name="layer_remove"),
     url(r'^(?P<layername>[^/]*)/replace$', 'layer_replace', name="layer_replace"),
     url(r'^(?P<layername>[^/]*)/thumbnail$', 'layer_thumbnail', name='layer_thumbnail'),
+    url(r'^(?P<layername>[^/]*)/metadata_detail$', 'layer_metadata_detail', name='layer_metadata_detail'),
 
     # url(r'^api/batch_permissions/?$', 'batch_permissions',
     #    name='batch_permssions'),

--- a/geonode/layers/views.py
+++ b/geonode/layers/views.py
@@ -581,3 +581,11 @@ def layer_thumbnail(request, layername):
                 status=500,
                 content_type='text/plain'
             )
+
+
+def layer_metadata_detail(request, layername, template='layers/layer_metadata_detail.html'):
+    layer = _resolve_layer(request, layername, 'view_resourcebase', _PERMISSION_MSG_METADATA)
+    return render_to_response(template, RequestContext(request, {
+        "layer": layer,
+        'SITEURL': settings.SITEURL[:-1]
+    }))

--- a/geonode/maps/templates/maps/map_detail.html
+++ b/geonode/maps/templates/maps/map_detail.html
@@ -72,6 +72,13 @@
           <button class="btn btn-primary btn-md btn-block" data-toggle="modal" data-target="#download-map">{% trans "Download Map" %}</button>
         </li>
         {% endif %}
+
+        <li class="list-group-item">
+           <a href="{% url "map_metadata_detail" resource.id %}">
+               <button class="btn btn-primary btn-md btn-block" >{% trans "Metadata Detail" %}</button>
+           </a>
+        </li>  
+
         <div class="modal fade" id="download-map" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
           <div class="modal-dialog">
             <div class="modal-content">

--- a/geonode/maps/templates/maps/map_metadata_detail.html
+++ b/geonode/maps/templates/maps/map_metadata_detail.html
@@ -1,0 +1,1 @@
+{% extends "metadata_detail.html" %}

--- a/geonode/maps/urls.py
+++ b/geonode/maps/urls.py
@@ -48,6 +48,7 @@ urlpatterns = patterns('geonode.maps.views',
                        url(r'^(?P<mapid>[^/]+)/(?P<snapshot>[A-Za-z0-9_\-]+)/data$', 'map_json', name='map_json'),
                        url(r'^check/$', 'map_download_check', name='map_download_check'),
                        url(r'^embed/$', 'map_embed', name='map_embed'),
+                       url(r'^(?P<mapid>[^/]*)/metadata_detail$', 'map_metadata_detail', name='map_metadata_detail'),
                        url(r'^(?P<layername>[^/]*)/attributes', 'maplayer_attributes', name='maplayer_attributes'),
                        # url(r'^change-poc/(?P<ids>\w+)$', 'change_poc', name='maps_change_poc'),
                        )

--- a/geonode/maps/views.py
+++ b/geonode/maps/views.py
@@ -880,3 +880,12 @@ def map_thumbnail(request, mapid):
                 status=500,
                 content_type='text/plain'
             )
+
+
+def map_metadata_detail(request, mapid, template='maps/map_metadata_detail.html'):
+    map_obj = _resolve_map(request, mapid, 'view_resourcebase')
+    return render_to_response(template, RequestContext(request, {
+        "layer": map_obj,
+        "mapid": mapid,
+        'SITEURL': settings.SITEURL[:-1]
+    }))

--- a/geonode/templates/metadata_detail.html
+++ b/geonode/templates/metadata_detail.html
@@ -1,0 +1,373 @@
+{% extends "layers/layer_base.html" %}
+{% load i18n %}
+{% load bootstrap_tags %}
+
+{% block title %}{{ layer.typename }} — {{ block.super }}{% endblock %}
+
+{% block body_class %}data{% endblock %}
+
+{% block body_outer %}
+
+<style>
+
+    .subtitle {
+        font-size:16px;
+        color: #428bca;
+    }
+
+    .sep_title hr {
+        margin-top: 2px;
+    }
+
+</style>
+
+<div class="page-header">
+    {% if layer.doc_file %}
+    <a href="{% url 'document_detail' docid=docid %}" class="btn btn-primary pull-right">{% trans "Return to Document" %}</a>
+    {% else %}
+    <a href="{% url 'layer_detail' layername=layer.typename %}" class="btn btn-primary pull-right">{% trans "Return to Layer" %}</a>
+    {% endif %}
+    <h2 class="page-title">{% trans "Metadata" %} : {{ layer.title }}</h2>
+</div>
+
+
+<article class="description tab-pane active" id="info">
+
+    <span class="subtitle">{% trans "Identification" %}</span>
+    <div class="sep_title"><hr></div>
+
+    <dl class="dl-horizontal">
+        {% if layer.title %}
+        <dt>{% trans "Title" %}</dt>
+        <dd>{{ layer.title|truncatechars:80 }}</dd>
+        {% endif %}
+
+        {% if layer.abstract %}
+        <dt>{% trans "Abstract" %}</dt>
+        <dd>{{ layer.abstract|escape|urlize|linebreaks|safe|truncatechars:1000 }}</dd>
+        {% endif %}
+
+    </dl>    
+
+    <dl class="dl-horizontal">   
+
+        {% if LICENSES_ENABLED and LICENSES_DETAIL == 'above' and layer.license %}
+        <dt>{% trans "License" %}</dt>
+        <dd>{{ layer.license.name_long }} <a href="#license-more-above" data-toggle="collapse" data-target=".license-more-above"><i class="fa fa-info-circle"></i></a></dd>
+        {% endif %}
+        <dd class="license-more-above collapse">
+            {% for bullet in layer.license.description_bullets %}
+            {{ bullet }}<br/><br/>
+            {% endfor %}
+            {% if layer.license.url %}
+            + For more info see <a href="{{ layer.license.url }}">{{ layer.license.url }}</a>.
+            {% endif %}
+        </dd>
+
+
+        {% if layer.date %}
+        <dt>{% trans layer.date_type|title %} {% trans "Date" %}</dt>
+        <dd>{{ layer.date }}</dd>
+        {% endif %}
+
+        {% if layer.display_type %}
+        <dt>{% trans "Type" %}</dt>
+        <dd>{{ layer.display_type }}</dd>
+        {% endif %}
+
+        {% if layer.keyword_list %}
+        <dt>{% trans "Keywords" %}</dt>
+        <dd>{% for keyword in layer.keyword_list %}
+            {{ keyword }}
+            {% endfor %}</dd>
+        {% endif %}
+
+        {% if layer.category %}
+        <dt>{% trans "Category" %}</dt>
+        <dd><a href="/search/?category__identifier__in={{ layer.category.identifier }}">{{ layer.category }}</a> {% if layer.category.description %}<a href="#category-more" data-toggle="collapse" data-target=".category-more"><i class="fa fa-info-circle"></i></a>{% endif %}</dd>
+        {% if layer.category.description %}
+        <dd class="category-more collapse">
+            {{ layer.category.description }}
+        </dd>
+        {% endif %}
+        {% endif %}
+
+        {% if layer.regions.all %}
+        <dt>{% trans "Regions" %}</dt>
+        <dd>{{ layer.regions.all|join:", " }}</dd>
+        {% endif %}
+
+        <dt>{% trans "Published" %}</dt>
+        <dd>{% if layer.is_published %} {% trans "Yes" %} {% else %} {% trans "No" %} {% endif %}</dd>
+
+        <dt>{% trans "Featured" %}</dt>
+        <dd>{% if layer.featured %} {% trans "Yes" %} {% else %} {% trans "No" %} {% endif %}</dd>
+
+
+    </dl>
+
+
+    <span class="subtitle">{% trans "Owner" %}</span>
+    <div class="sep_title"><hr></div>
+
+    <dl class="dl-horizontal">
+
+        {% if layer.owner %}
+        {% with layer.owner as poc %}
+
+        <dt>{% trans "Name" %}</dt>
+        <dd>{{ poc.name_long }}</dd>
+
+        <dt>{% trans "email" %}</dt>
+        <dd>{{ poc.email }}</dd>
+
+        <dt>{% trans "Position" %}</dt>
+        <dd>{{ poc.position }}</dd>
+
+        <dt>{% trans "Organization" %}</dt>
+        <dd>{{ poc.organization }}</dd>
+
+        <dt>{% trans "Location" %}</dt>
+        <dd>{{ poc.location }}</dd>
+
+        <dt>{% trans "Voice" %}</dt>
+        <dd>{{ poc.voice }}</dd>
+
+        <dt>{% trans "Fax" %}</dt>
+        <dd>{{ poc.fax }}</dd>
+
+        {% if poc.keyword_list %}
+        <dt>{% trans "Keywords" %}</dt>
+        <dd>{% for keyword in poc.keyword_list %}
+            {{ keyword }}
+            {% endfor %}</dd>
+        {% endif %}
+
+        {% endwith %} 
+        {% endif %}
+
+    </dl>
+
+    <span class="subtitle">{% trans "Information of Layer" %}</span>
+    <div class="sep_title"><hr></div>
+
+    <dl class="dl-horizontal">
+
+        <dt>{% trans "Identification Image" %}</dt>
+        <dd>
+            <a href="{{ layer.get_thumbnail_url }}"><img ng-src="{{ layer.get_thumbnail_url }}" src="{{ layer.get_thumbnail_url }}"></a>
+        </dd>
+
+    </dl>
+
+    <dl class="dl-horizontal">
+
+        <dt>{% trans "Spatial Resolution" %}</dt>
+        <dd>{% if layer.scale %} {{ layer.scale }} {% else %} --- {% endif %}</dd>
+
+        <dt>{% trans "Projetion System" %}</dt>
+        <dd>{{ layer.srid }}</dd>
+
+        <dt>{% trans "Extension x0" %}</dt>
+        <dd>{{layer.bbox_x0}}</dd>
+
+        <dt>{% trans "Extension x1" %}</dt>
+        <dd>{{layer.bbox_x1}}</dd>
+
+        <dt>{% trans "Extension y0" %}</dt>
+        <dd>{{layer.bbox_y0}}</dd>
+
+        <dt>{% trans "Extension y1" %}</dt>
+        <dd>{{layer.bbox_y1}}</dd>
+
+    </dl>
+
+    <span class="subtitle">{% trans "Features" %}</span>
+    <div class="sep_title"><hr></div>
+
+    <dl class="dl-horizontal">
+
+        {% if LICENSES_ENABLED and LICENSES_DETAIL == 'below' and layer.license %}
+        <dt>{% trans "License" %}</dt>
+        <dd>{{ layer.license.name_long }} <a href="#license-more-below" data-toggle="collapse" data-target=".license-more-below"><i class="fa fa-info-circle"></i></a></dd>
+        <dd class="license-more-below collapse">
+            {% for bullet in layer.license.description_bullets %}
+            {{ bullet }}<br/><br/>
+            {% endfor %}
+            {% if layer.license.url %}
+            + For more info see <a href="{{ layer.license.url }}">{{ layer.license.url }}</a>.
+            {% endif %}
+        </dd>
+        {% endif %}
+
+        {% if layer.maintenance_frequency %}
+        <dt>{% trans "Maintenance Frequency" %}</dt>
+        <dd>{{ layer.maintenance_frequency_title }}</dd>
+        {% endif %}
+
+        {% if layer.restriction_code_type or layer.constraints_other %}
+        <dt>{% trans "Restrictions" %}</dt>
+        <dd>{% if layer.constraints_other %}
+            {{ layer.constraints_other }}
+            {% else %}
+            {{ layer.restriction_code_type }}
+            {% endif %}</dd>
+        {% endif %}
+
+        {% if layer.edition %}
+        <dt>{% trans "Edition" %}</dt>
+        <dd>{{ layer.edition}}</dd>
+        {% endif %}
+
+        {% if layer.purpose %}
+        <dt>{% trans "Purpose" %}</dt>
+        <dd>{{ layer.purpose|escape|urlize|linebreaks|safe|truncatechars:160 }}</dd>
+        {% endif %}
+
+        {% if layer.language %}
+        <dt>{% trans "Language" %}</dt>
+        <dd>{{ layer.language_title }}</dd>
+        {% endif %}
+
+        {% if layer.temporal_extent_start and layer.temporal_extent_end %}
+        <dt>{% trans "Temporal Extent" %}</dt>
+        <dd>{{ layer.temporal_extent_start }} - {{ layer.temporal_extent_end }}</dd>
+        {% endif %}
+
+        {% if layer.data_quality_statement %}
+        <dt>{% trans "Data Quality" %}</dt>
+        <dd>{{ layer.data_quality_statement }}</dd>
+        {% endif %}
+
+        {% if layer.supplemental_information %}
+        <dt>{% trans "Supplemental Information" %}</dt>
+        <dd>{{ layer.supplemental_information|truncatechars:160|escape|urlize|linebreaks|safe }}</dd>
+        {% endif %}
+
+        {% if layer.spatial_representation_type %}
+        <dt>{% trans "Spatial Representation Type" %}</dt>
+        <dd>{{ layer.spatial_representation_type }}</dd>
+        {% endif %}
+
+    </dl>
+    
+    {% if layer.poc %}   
+    <span class="subtitle">{% trans "Contact Points" %}</span>
+    <div class="sep_title"><hr></div>
+    
+    <dl class="dl-horizontal">
+
+        <dt>{% trans "Name" %}</dt>
+        <dd>{{ layer.poc.name_long }}</dd>
+
+        <dt>{% trans "email" %}</dt>
+        <dd>{{ layer.poc.email }}</dd>
+
+        <dt>{% trans "Position" %}</dt> 
+        <dd>{{ layer.poc.position }}</dd>
+
+        <dt>{% trans "Organization" %}</dt>
+        <dd>{{ layer.poc.organization }}</dd>
+
+        <dt>{% trans "Location" %}</dt>
+        <dd>{{ layer.poc.location }}</dd>
+
+        <dt>{% trans "Voice" %}</dt>
+        <dd>{{ layer.poc.voice }}</dd>
+
+        <dt>{% trans "Fax" %}</dt>
+        <dd>{{ layer.poc.fax }}</dd>
+
+        {% if poc.keyword_list %}
+        <dt>{% trans "Keywords" %}</dt>
+        <dd>{% for keyword in layer.poc.keyword_list %}
+            {{ keyword }}
+            {% endfor %}</dd>
+        {% endif %}
+        
+        <hr>
+
+    </dl>
+    
+    
+    
+    {% endif %}
+
+    <span class="subtitle">{% trans "References" %}</span>
+    <div class="sep_title"><hr></div>
+
+    <dl class="dl-horizontal">
+
+        <dt>{% trans "Link Online" %}</dt>
+        <dd><a href="{{ layer.get_absolute_url }}">{{ layer.get_absolute_url }}</a></dd>
+
+        <dt>{% trans "Metadata Page" %}</dt>
+        <dd><a href="{{ layer.get_absolute_url }}/metadata_detail">{{ layer.get_absolute_url }}/metadata_detail</a></dd>
+
+        {% if layer.doc_file %}
+        <dt>{% trans "Online Link" %}</dt>
+        <dd><a href="{{ layer.get_absolute_url }}/download">{{ layer.get_absolute_url }}/download</a></dd>
+        {% endif %}
+
+        <hr>
+
+        {% for link in layer.link_set.download %}
+        <dt>{{link.name}}</dt>
+        <dd><a href="{{link.url}}">{{layer.name}}.{{link.extension}}</a></dd> 
+        {% endfor %}
+
+        <hr>
+
+        {% for link in layer.link_set.ows %}
+        <dt>{{link.name}}</dt>
+        <dd><a href="{{link.url}}">Geoservice {{link.link_type}}</a></dd>
+        {% endfor %}
+
+    </dl>
+
+    {% if layer.metadata_author %}
+    <span class="subtitle">{% trans "Metadata Author" %}</span>
+    <div class="sep_title"><hr></div>
+
+    <dl class="dl-horizontal">
+
+        {% with layer.metadata_author as poc %}
+
+        <dt>{% trans "Name" %}</dt>
+        <dd>{{ poc.name_long }}</dd>
+
+        <dt>{% trans "email" %}</dt>
+        <dd>{{ poc.email }}</dd>
+
+        <dt>{% trans "Position" %}</dt>
+        <dd>{{ poc.position }}</dd>
+
+        <dt>{% trans "Organization" %}</dt>
+        <dd>{{ poc.organization }}</dd>
+
+        <dt>{% trans "Location" %}</dt>
+        <dd>{{ poc.location }}</dd>
+
+        <dt>{% trans "Voice" %}</dt>
+        <dd>{{ poc.voice }}</dd>
+
+        <dt>{% trans "Fax" %}</dt>
+        <dd>{{ poc.fax }}</dd>
+
+        {% if poc.keyword_list %}
+        <dt>{% trans "Keywords" %}</dt>
+        <dd>{% for keyword in poc.keyword_list %}
+            {{ keyword }}
+            {% endfor %}</dd>
+        {% endif %}
+
+        {% endwith %} 
+
+    </dl>
+    {% endif %}
+
+
+</article>
+
+
+{% endblock %}


### PR DESCRIPTION
I would like to contribute to the project by providing a solution that tested here in my organization.

We concluded that for the processing and visualization of metadata we should get rid of the dependence of use of Geonetwork. For this thought to implement a specific page for metadata visualization. The idea was to provide more this feature within the GeoNode so that users could enjoy a complete interface to interact with the metadata (editing and reading).

The implementation covers the inclusion of a specific button for access to a page that displays metadata of a layer, or map, or document.

While the display is functioning in most cases, the metadata display page still has some bugs related to the layout, which may appear depending on the registered data, but I think this kind of correction can be easy for experts in CSS and HTML.

Anyway, I hope this suggestion will be useful for the project.

David.

Related Issue :  #2443 
