### PR TITLE
fix #2381

### DIFF
--- a/geonode/documents/admin.py
+++ b/geonode/documents/admin.py
@@ -7,6 +7,9 @@ class DocumentAdminForm(ResourceBaseAdminForm):
 
     class Meta:
         model = Document
+        exclude = (
+            'resource',
+        )
 
 
 class DocumentAdmin(MediaTranslationAdmin):


### PR DESCRIPTION
With our current version of the django-autocomplete-light (2.2.10) the genericForeignKey from the ContentTypes framework is not supported (https://docs.djangoproject.com/en/1.9/ref/contrib/contenttypes/).

We have excluded it, until we upgrade it to the latest django-autocomplete-light, which supports it (v3 >).