### PR TITLE
add mapbox satellite and streets in the MAP_BASELAYERS

### DIFF
--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -639,9 +639,26 @@ MAP_BASELAYERS = [{
     "name": "naip",
     "group": "background",
     "visibility": False
-}, 
+},
 {
-    "source": {"ptype": "gxp_mapboxsource"},
+    "source": {"ptype": "gxp_olsource"},
+    "type":"OpenLayers.Layer.XYZ",
+    "args":[
+  "Mapbox Satellite", ["https://api.mapbox.com/v4/mapbox.satellite/${z}/${x}/${y}.png?access_token=<your access token here>"],
+        {"transitionEffect": "resize","attribution": "© Mapbox © OpenStreetMap © DigitalGlobe"}],
+    "visibility": False,
+    "fixed": True,
+    "group":"background"
+},
+{
+    "source": {"ptype": "gxp_olsource"},
+    "type":"OpenLayers.Layer.XYZ",
+    "args":[
+  "Mapbox Streets", ["https://api.mapbox.com/styles/v1/mapbox/streets-v9/tiles/${z}/${x}/${y}?access_token=<your access token here>"],
+        {"transitionEffect": "resize","attribution": "© Mapbox © OpenStreetMap"}],
+    "visibility": False,
+    "fixed": True,
+    "group":"background"
 }]
 
 SOCIAL_BUTTONS = True


### PR DESCRIPTION
Related to #2478, this adds Mapbox Satellite and Streets with [Openlayers](https://www.mapbox.com/help/mapbox-with-openlayers/).  

After installing geonode, you have to copy the code to your local_settings.py based on [this instructions](https://geonode.readthedocs.io/en/1.2/deploy/customize.html#changing-the-default-basemap) and include your Mapbox access token.

Ideally, access token should be provided during the post-install setup. Any idea how to to do this?

![geonode-compressor](https://cloud.githubusercontent.com/assets/353700/15573363/24633e0c-2364-11e6-9f8d-ea20aaefe9f1.gif)

Tested on geonode 2.4