### PR TITLE
Clarify origin of datastore identifier.

### DIFF
--- a/geonode/local_settings.py.sample
+++ b/geonode/local_settings.py.sample
@@ -59,7 +59,7 @@ OGC_SERVER = {
         'BACKEND_WRITE_ENABLED': True,
         'WPS_ENABLED' : False,
         'LOG_FILE': '%s/geoserver/data/logs/geoserver.log' % os.path.abspath(os.path.join(PROJECT_ROOT, os.pardir)),
-        # Set to name of database in DATABASES dictionary to enable
+        # Set to dictionary identifier of database containing spatial data in DATABASES dictionary to enable
         'DATASTORE': '', #'datastore',
     }
 }


### PR DESCRIPTION
As it is currently written it is too easy to confuse with the 'NAME' of the postgis DB.