### PR TITLE
Use DjangoJSONEncoder when we need to handle Decimal types

### DIFF
--- a/geonode/maps/views.py
+++ b/geonode/maps/views.py
@@ -25,6 +25,7 @@ from guardian.shortcuts import get_perms
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.urlresolvers import reverse
+from django.core.serializers.json import DjangoJSONEncoder
 from django.http import HttpResponse, HttpResponseRedirect, HttpResponseNotAllowed, HttpResponseServerError
 from django.shortcuts import render_to_response, get_object_or_404
 from django.conf import settings
@@ -531,7 +532,8 @@ def new_map_config(request):
                         map=map_obj,
                         name=layer.typename,
                         ows_url=layer.ows_url,
-                        layer_params=json.dumps(config),
+                        # use DjangoJSONEncoder to handle Decimal values
+                        layer_params=json.dumps(config, cls=DjangoJSONEncoder),
                         visibility=True
                     )
 


### PR DESCRIPTION
*Related: https://github.com/GeoNode/geonode/issues/2430*

Django 1.7+ dropped simplejson in favor of vanilla json -- this is mostly fine, except in some edge cases. One such case is `decimal.Decimal` types: standard library json doesn't handle serializing these by default.

DjangoJSONEncoder covers this, and using it where needed fixes the problem. The encoder+decimal handling [exists in Django 1.6](https://github.com/django/django/blob/stable/1.6.x/django/core/serializers/json.py#L101-102) so users on an old version should still be fine.