### PR TITLE
use absolute path to data file to avoid IOError

### DIFF
--- a/geonode/base/migrations/0002_topiccategory_fa_class.py
+++ b/geonode/base/migrations/0002_topiccategory_fa_class.py
@@ -21,6 +21,7 @@
 from __future__ import unicode_literals
 
 import json
+import os
 
 from django.db import migrations, models
 
@@ -42,7 +43,12 @@ class Migration(migrations.Migration):
         )
     ]
 
-    with open('geonode/base/fixtures/initial_data.json') as data_file:
+    current = os.path.dirname(os.path.abspath(__file__))
+    parent = os.path.abspath(os.path.join(current, os.pardir))
+    fixture = os.path.join(parent, 'fixtures/initial_data.json')
+    # geonode/base/fixtures/initial_data.json
+
+    with open(fixture) as data_file:
         data = json.load(data_file)
 
         for record in data:


### PR DESCRIPTION
On some platforms, a relative reference to a file in `geonode/base/fixtures` throws an IOError:

```
class Migration(migrations.Migration):
  File "/vagrant/.venv/src/geonode/geonode/base/migrations/0002_topiccategory_fa_class.py", line 45, in Migration
    
with open('geonode/base/fixtures/initial_data.json') as data_file:
IOError
 
[Errno 2] No such file or directory: u'geonode/base/fixtures/initial_data.json'
```

Using the absolute path fixes this.