### PR TITLE
'null' has no effect on a ManyToManyField; removed 

### DIFF
--- a/geonode/base/migrations/0001_initial.py
+++ b/geonode/base/migrations/0001_initial.py
@@ -379,7 +379,7 @@ class Migration(migrations.Migration):
             name='regions',
             field=models.ManyToManyField(
                 help_text='keyword identifies a location', to='base.Region',
-                null=True, verbose_name='keywords region', blank=True),
+                verbose_name='keywords region', blank=True),
         ),
         migrations.AddField(
             model_name='resourcebase',

--- a/geonode/base/models.py
+++ b/geonode/base/models.py
@@ -269,7 +269,7 @@ class ResourceBase(PolymorphicModel, PermissionLevelMixin):
                                              blank=True, null=True, help_text=maintenance_frequency_help_text)
 
     keywords = TaggableManager(_('keywords'), blank=True, help_text=keywords_help_text)
-    regions = models.ManyToManyField(Region, verbose_name=_('keywords region'), blank=True, null=True,
+    regions = models.ManyToManyField(Region, verbose_name=_('keywords region'), blank=True,
                                      help_text=regions_help_text)
 
     restriction_code_type = models.ForeignKey(RestrictionCodeType, verbose_name=_('restrictions'),


### PR DESCRIPTION
Ref: https://github.com/GeoNode/geonode/issues/2501

Including `null=True` does nothing for a ManyToManyField; Django's system checker throws a warning on this one. Removing the null arg but leaving `blank=True` keeps the expected behavior.

See also: https://docs.djangoproject.com/en/1.8/ref/models/fields/#manytomany-arguments