### PR TITLE
Satisfy Django with OneToOneField instead of FK where unique=True

### DIFF
--- a/geonode/services/migrations/0001_initial.py
+++ b/geonode/services/migrations/0001_initial.py
@@ -126,7 +126,7 @@ class Migration(migrations.Migration):
                     models.CharField(
                         default=b'pending', max_length=10,
                         choices=[(b'pending', b'pending'), (b'failed', b'failed'), (b'process', b'process')])),
-                ('service', models.ForeignKey(to='services.Service', unique=True)),
+                ('service', models.OneToOneField(to='services.Service')),
             ],
         ),
         migrations.CreateModel(

--- a/geonode/services/models.py
+++ b/geonode/services/models.py
@@ -116,7 +116,7 @@ class ServiceLayer(models.Model):
 
 
 class WebServiceHarvestLayersJob(models.Model):
-    service = models.ForeignKey(Service, blank=False, null=False, unique=True)
+    service = models.OneToOneField(Service, blank=False, null=False)
     status = models.CharField(choices=[(
         x, x) for x in STATUS_VALUES], max_length=10, blank=False, null=False, default='pending')
 


### PR DESCRIPTION
Ref: https://github.com/GeoNode/geonode/issues/2501

Django recommends a `OneToOneField` over `ForeignKey(unique=True)`; in Django 1.8 this generates a warning at runtime.

In practice, the behavior should be equivalent with this change: the only difference would be how relationship reversal is handled, but I did not find any existing references to `WebServiceHarvestLayersJob` from the `Service` side of the relationship, so this shouldn't affect GeoNode's current behavior.

See also: https://docs.djangoproject.com/en/1.8/ref/models/fields/#django.db.models.OneToOneField