### PR TITLE
Fix Travis CI/paver sync error during migration

### DIFF
--- a/pavement.py
+++ b/pavement.py
@@ -210,8 +210,7 @@ def sync(options):
     """
     Run the syncdb and migrate management commands to create and migrate a DB
     """
-    sh("python manage.py syncdb --noinput")
-    # sh("python manage.py migrate --noinput")
+    sh("python manage.py migrate --noinput")
     sh("python manage.py loaddata sample_admin.json")
 
 

--- a/pavement.py
+++ b/pavement.py
@@ -210,10 +210,6 @@ def sync(options):
     """
     Run the syncdb and migrate management commands to create and migrate a DB
     """
-    try:
-        sh("python manage.py migrate auth --fake-initial")
-    except:
-        pass
     sh("python manage.py syncdb --noinput")
     # sh("python manage.py migrate --noinput")
     sh("python manage.py loaddata sample_admin.json")


### PR DESCRIPTION
*Note: I'm raising this PR partly for discussion; feel free to close if preferred.*

I noticed that Travis CI is erroring (non-fatally; tests & linting do still run) during the initial migration step, e.g., https://travis-ci.org/GeoNode/geonode/builds/137479227#L2473:
```
...
django.db.utils.OperationalError: no such table: django_site
```
It looks like this exception started being thrown after [this commit](https://github.com/GeoNode/geonode/commit/a39176fa4f469f00e53a065533d205b2211f7f1d) happened - related Travis build [here](https://travis-ci.org/GeoNode/geonode/builds/126400625#L2301) is the first instance of this particular error.

Testing `paver sync` locally reproduces the error Travis is getting; reverting that commit resolves it. However I'm hesitant to revert without clarity on what "migration issue" that particular commit was intending to fix... thoughts? 
