### PR TITLE
added mapbox api basemaps functionality

### DIFF
--- a/geonode/contrib/api_basemaps/__init__.py
+++ b/geonode/contrib/api_basemaps/__init__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+#########################################################################
+#
+# Copyright (C) 2016 OSGeo
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#########################################################################

--- a/geonode/contrib/api_basemaps/bing.py
+++ b/geonode/contrib/api_basemaps/bing.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+#########################################################################
+#
+# Copyright (C) 2016 OSGeo
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#########################################################################
+
+from geonode.settings import MAP_BASELAYERS, BING_API_KEY
+BASEMAP = {
+    'source': {
+        'ptype': 'gxp_bingsource',
+        'apiKey': BING_API_KEY
+    },
+    'name': 'AerialWithLabels',
+    'fixed': True,
+    'visibility': False,
+    'group': 'background'
+}
+MAP_BASELAYERS.append(BASEMAP)

--- a/geonode/contrib/api_basemaps/mapbox.py
+++ b/geonode/contrib/api_basemaps/mapbox.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+#########################################################################
+#
+# Copyright (C) 2016 OSGeo
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#########################################################################
+
+from geonode.settings import MAP_BASELAYERS, MAPBOX_ACCESS_TOKEN
+MAPBOX_API = {
+    'styles': {
+        'streets-v9': {
+            'enabled': True,
+            'name': 'Mapbox Streetmap',
+            'attribution': '© Mapbox © OpenStreetMap',
+            'visibility': False,
+        },
+        'outdoors-v9': {
+            'enabled': True,
+            'name': 'Mapbox Outdoors',
+            'attribution': '© Mapbox © OpenStreetMap',
+            'visibility': False,
+        },
+        'dark-v9': {
+            'enabled': True,
+            'name': 'Mapbox Dark',
+            'attribution': '© Mapbox © OpenStreetMap',
+            'visibility': False,
+        },
+        'light-v9': {
+            'enabled': True,
+            'name': 'Mapbox Light',
+            'attribution': '© Mapbox © OpenStreetMap',
+            'visibility': False,
+        },
+        'satellite-v9': {
+            'enabled': True,
+            'name': 'Mapbox Satellite',
+            'attribution': '© Mapbox © DigitalGlobe',
+            'visibility': False,
+        },
+        'satellite-streets-v9': {
+            'enabled': True,
+            'name': 'Mapbox Satellite Streets',
+            'attribution': '© Mapbox © OpenStreetMap © DigitalGlobe',
+            'visibility': False,
+        },
+    }
+}
+
+for k, v in MAPBOX_API['styles'].items():
+    URL = ('https://api.mapbox.com/styles/v1/mapbox/%s/tiles/${z}/${x}/${y}'
+           '?access_token=%s') % (k, MAPBOX_ACCESS_TOKEN)
+    if v['enabled']:
+        BASEMAP = {
+            'source': {
+                'ptype': 'gxp_olsource'
+            },
+            'type': 'OpenLayers.Layer.XYZ',
+            "args": [
+                '%s' % v['name'],
+                [URL],
+                {
+                    'transitionEffect': 'resize',
+                    'attribution': '%s' % v['attribution']
+                }
+            ],
+            'fixed': True,
+            'visibility': v['visibility'],
+            'group': 'background'
+        }
+        MAP_BASELAYERS.append(BASEMAP)

--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -256,9 +256,9 @@ GEONODE_CONTRIB_APPS = (
 # GEONODE_APPS = GEONODE_APPS + GEONODE_CONTRIB_APPS
 
 INSTALLED_APPS = (
-    
+
     'modeltranslation',
-    
+
     # Boostrap admin theme
     # 'django_admin_bootstrapped.bootstrap3',
     # 'django_admin_bootstrapped',
@@ -307,7 +307,7 @@ INSTALLED_APPS = (
     'tastypie',
     'polymorphic',
     'guardian',
-    
+
 ) + GEONODE_APPS
 
 LOGGING = {
@@ -639,10 +639,10 @@ MAP_BASELAYERS = [{
     "name": "naip",
     "group": "background",
     "visibility": False
-}, 
-{
-    "source": {"ptype": "gxp_mapboxsource"},
 }]
+
+MAPBOX_ACCESS_TOKEN = os.environ.get('MAPBOX_ACCESS_TOKEN', None)
+BING_API_KEY = os.environ.get('BING_API_KEY', None)
 
 SOCIAL_BUTTONS = True
 
@@ -892,21 +892,17 @@ try:
 except ImportError:
     pass
 
-try:
-    BING_LAYER = {    
-        "source": {
-            "ptype": "gxp_bingsource",
-            "apiKey": BING_API_KEY
-        },
-        "name": "AerialWithLabels",
-        "fixed": True,
-        "visibility": False,
-        "group": "background"
-    }
-    MAP_BASELAYERS.append(BING_LAYER)
-except NameError:
-    #print "Not enabling BingMaps base layer as a BING_API_KEY is not defined in local_settings.py file."
-    pass
+if MAPBOX_ACCESS_TOKEN is not None:
+    try:
+        from contrib.api_basemaps.mapbox import *
+    except ImportError:
+        pass
+
+if BING_API_KEY is not None:
+    try:
+        from contrib.api_basemaps.bing import *
+    except ImportError:
+        pass
 
 # Require users to authenticate before using Geonode
 if LOCKDOWN_GEONODE:


### PR DESCRIPTION
Added mapbox api basemaps functionality if MAPBOX_ACCESS_TOKEN is set.

fix for #2478 

- created an api_basemaps app under geonode.contrib
- moved bing basemap to api_basemaps
- set default value for both to None and check for os.environ for both