### PR TITLE
 set 600px instead of 400 for geoext frame for layers and maps templates

### DIFF
--- a/geonode/layers/templates/layers/layer_geoext_map.html
+++ b/geonode/layers/templates/layers/layer_geoext_map.html
@@ -33,7 +33,7 @@
                 
                 portalConfig: {
                     renderTo: "preview_map",
-                    height: 400 
+                    height: 600 
                 },
 
                 listeners: {

--- a/geonode/maps/templates/maps/map_include.html
+++ b/geonode/maps/templates/maps/map_include.html
@@ -26,7 +26,7 @@ Ext.onReady(function() {
 
         // tell the map viewer where and how to be rendered
         portalConfig: {
-            height: 400,
+            height: 600,
             renderTo: "the_map"
         }
     }, {{ config }});


### PR DESCRIPTION
Hi, 

This first very simple pull request is also a way to check if it is the proper way to do it through GitHub (did we fork the good base from Geonode ? Etc.). Then, we will send you our functionnalities that we developed on our website (aware.cirad.fr - development version), as Agnès Tendero told you a few days ago. As a reminder these functionalities are :  

1. Concatenating the metadata Regions in Title search fields
2. Display the full list of resources of each catalogue for every user (logged in or not)
3. List of layers/maps/documents sorted by permission : first the authorized ones, then the restricted ones.
4. Export metadata to text and HTML format
5. Restrictions for unauthenticated users : hide 'Add layer', 'Create new map', 'Add documents' options
6. Search by text (title) improved within each catalogue : search did not take into account if users are in the layers catalogue and could propose maps and documents.
7. Direct access to the layer/map/document when the Title is selected int the search fields
8. Notifications : users can manage their notifications in the menu
9. Add a button to zoom on layer extent in the geoexplorer toolbar
10. Height of the geoexplorer frame increased in the layer/map sections
11. Display/hide functionnalities depending on permissions (view resource base, add resource base)

Here, this is just a small change : increase the geoframe height. We experienced this change and we thought it was a really more comfortable to visualize resources. 

Thank you !

ARTISTS Team, CIRAD, Reunion Island
