### PR TITLE
added additonal api basemaps functionality

### DIFF
--- a/geonode/contrib/api_basemaps/__init__.py
+++ b/geonode/contrib/api_basemaps/__init__.py
@@ -1,3 +1,4 @@
+# flake8: noqa
 # -*- coding: utf-8 -*-
 #########################################################################
 #
@@ -17,3 +18,48 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 #########################################################################
+
+from geonode.settings import (
+    ALT_OSM_BASEMAPS,
+    CARTODB_BASEMAPS,
+    STAMEN_BASEMAPS,
+    THUNDERFOREST_BASEMAPS,
+    MAPBOX_ACCESS_TOKEN,
+    BING_API_KEY,
+)
+
+if ALT_OSM_BASEMAPS:
+    try:
+        from osm import *
+    except ImportError:
+        pass
+
+if CARTODB_BASEMAPS:
+    try:
+        from cartodb import *
+    except ImportError:
+        pass
+
+if STAMEN_BASEMAPS:
+    try:
+        from stamen import *
+    except ImportError:
+        pass
+
+if THUNDERFOREST_BASEMAPS:
+    try:
+        from thunderforest import *
+    except ImportError:
+        pass
+
+if BING_API_KEY is not None:
+    try:
+        from bing import *
+    except ImportError:
+        pass
+
+if MAPBOX_ACCESS_TOKEN is not None:
+    try:
+        from mapbox import *
+    except ImportError:
+        pass

--- a/geonode/contrib/api_basemaps/cartodb.py
+++ b/geonode/contrib/api_basemaps/cartodb.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+#########################################################################
+#
+# Copyright (C) 2016 OSGeo
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#########################################################################
+
+from geonode.settings import MAP_BASELAYERS
+CARTODB = {
+    'maps': {
+        'light_all': {
+            'enabled': True,
+            'name': 'CartoDB Positron',
+            'visibility': False,
+        },
+        'dark_all': {
+            'enabled': True,
+            'name': 'CartoDB Dark Matter',
+            'visibility': False,
+        }
+    }
+}
+ATTRIBUTION = ('&copy; <a href="http://www.openstreetmap.org/copyright">OpenSt'
+               'reetMap</a> contributors, &copy; <a href="http://cartodb.com/a'
+               'ttributions">CartoDB</a>')
+for k, v in CARTODB['maps'].items():
+    URL = 'https://s.basemaps.cartocdn.com/%s/${z}/${x}/${y}.png' % k
+    if v['enabled']:
+        BASEMAP = {
+            'source': {
+                'ptype': 'gxp_olsource'
+            },
+            'type': 'OpenLayers.Layer.XYZ',
+            "args": [
+                '%s' % v['name'],
+                [URL],
+                {
+                    'transitionEffect': 'resize',
+                    'attribution': '%s' % ATTRIBUTION,
+                }
+            ],
+            'fixed': True,
+            'visibility': v['visibility'],
+            'group': 'background'
+        }
+        MAP_BASELAYERS.append(BASEMAP)

--- a/geonode/contrib/api_basemaps/osm.py
+++ b/geonode/contrib/api_basemaps/osm.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+#########################################################################
+#
+# Copyright (C) 2016 OSGeo
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#########################################################################
+
+from geonode.settings import MAP_BASELAYERS
+OSM = {
+    'maps': {
+        'de': {
+            'enabled': True,
+            'name': 'OSM DE',
+            'visibility': False,
+            'url': ('http://a.tile.openstreetmap.de/tiles/osmde/${z}/${x}/${y}'
+                    '.png'),
+            'attribution': ('&copy; <a href="http://www.openstreetmap.org/copy'
+                            'right">OpenStreetMap</a>')
+        },
+        'france': {
+            'enabled': True,
+            'name': 'OSM France',
+            'visibility': False,
+            'url': ('http://a.tile.openstreetmap.fr/osmfr/${z}/${x}/${y}.png'),
+            'attribution': ('&copy; Openstreetmap France | &copy; <a href="htt'
+                            'p://www.openstreetmap.org/copyright">OpenStreetMa'
+                            'p</a>')
+        },
+        'hot': {
+            'enabled': True,
+            'name': 'OSM HOT',
+            'visibility': False,
+            'url': ('http://a.tile.openstreetmap.fr/hot/${z}/${x}/${y}.png'),
+            'attribution': ('&copy; <a href="http://www.openstreetmap.org/copy'
+                            'right">OpenStreetMap</a>, Tiles courtesy of <a hr'
+                            'ef="http://hot.openstreetmap.org/" target="_blank'
+                            '">Humanitarian OpenStreetMap Team</a>')
+        }
+    }
+}
+
+for k, v in OSM['maps'].items():
+    if v['enabled']:
+        BASEMAP = {
+            'source': {
+                'ptype': 'gxp_olsource'
+            },
+            'type': 'OpenLayers.Layer.XYZ',
+            "args": [
+                '%s' % v['name'],
+                [v['url']],
+                {
+                    'transitionEffect': 'resize',
+                    'attribution': '%s' % v['attribution'],
+                }
+            ],
+            'fixed': True,
+            'visibility': v['visibility'],
+            'group': 'background'
+        }
+        MAP_BASELAYERS.append(BASEMAP)

--- a/geonode/contrib/api_basemaps/stamen.py
+++ b/geonode/contrib/api_basemaps/stamen.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+#########################################################################
+#
+# Copyright (C) 2016 OSGeo
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#########################################################################
+
+from geonode.settings import MAP_BASELAYERS
+STAMEN = {
+    'maps': {
+        'toner': {
+            'enabled': True,
+            'name': 'Stamen Toner',
+            'visibility': False,
+        },
+        'toner-lite': {
+            'enabled': True,
+            'name': 'Stamen Toner Lite',
+            'visibility': False,
+        },
+        'watercolor': {
+            'enabled': True,
+            'name': 'Stamen Watercolor',
+            'visibility': False,
+        }
+    }
+}
+ATTRIBUTION = ('Map tiles by <a href="http://stamen.com">Stamen Design</a>, <a'
+               ' href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</'
+               'a> &mdash; Map data &copy; <a href="http://www.openstreetmap.o'
+               'rg/copyright">OpenStreetMap</a>')
+for k, v in STAMEN['maps'].items():
+    URL = 'http://stamen-tiles-a.a.ssl.fastly.net/%s/${z}/${x}/${y}.png' % k
+    if v['enabled']:
+        BASEMAP = {
+            'source': {
+                'ptype': 'gxp_olsource'
+            },
+            'type': 'OpenLayers.Layer.XYZ',
+            "args": [
+                '%s' % v['name'],
+                [URL],
+                {
+                    'transitionEffect': 'resize',
+                    'attribution': '%s' % ATTRIBUTION,
+                }
+            ],
+            'fixed': True,
+            'visibility': v['visibility'],
+            'group': 'background'
+        }
+        MAP_BASELAYERS.append(BASEMAP)

--- a/geonode/contrib/api_basemaps/thunderforest.py
+++ b/geonode/contrib/api_basemaps/thunderforest.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+#########################################################################
+#
+# Copyright (C) 2016 OSGeo
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#########################################################################
+
+from geonode.settings import MAP_BASELAYERS
+THUNDERFOREST = {
+    'maps': {
+        'cycle': {
+            'enabled': True,
+            'name': 'Thunderforest OpenCycleMap',
+            'visibility': False,
+        },
+        'transport': {
+            'enabled': True,
+            'name': 'Thunderforest Transport',
+            'visibility': False,
+        },
+        'transport-dark': {
+            'enabled': True,
+            'name': 'Thunderforest Transport Dark',
+            'visibility': False,
+        },
+        'spinal-map': {
+            'enabled': True,
+            'name': 'Thunderforest Spinal Map',
+            'visibility': False,
+        },
+        'landscape': {
+            'enabled': True,
+            'name': 'Thunderforest Landscape',
+            'visibility': False,
+        },
+        'outdoors': {
+            'enabled': True,
+            'name': 'Thunderforest Outdoors',
+            'visibility': False,
+        },
+        'pioneer': {
+            'enabled': True,
+            'name': 'Thunderforest Pioneer',
+            'visibility': False,
+        }
+    }
+}
+ATTRIBUTION = ('&copy; <a href="http://www.thunderforest.com/">Thunderforest</'
+               'a>, &copy; <a href="http://www.openstreetmap.org/copyright">Op'
+               'enStreetMap</a>')
+for k, v in THUNDERFOREST['maps'].items():
+    URL = 'http://a.tile.thunderforest.com/%s/${z}/${x}/${y}.png' % k
+    if v['enabled']:
+        BASEMAP = {
+            'source': {
+                'ptype': 'gxp_olsource'
+            },
+            'type': 'OpenLayers.Layer.XYZ',
+            "args": [
+                '%s' % v['name'],
+                [URL],
+                {
+                    'transitionEffect': 'resize',
+                    'attribution': '%s' % ATTRIBUTION,
+                }
+            ],
+            'fixed': True,
+            'visibility': v['visibility'],
+            'group': 'background'
+        }
+        MAP_BASELAYERS.append(BASEMAP)

--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -615,6 +615,13 @@ DEFAULT_MAP_CENTER = (0, 0)
 # maximum zoom is between 12 and 15 (for Google Maps, coverage varies by area)
 DEFAULT_MAP_ZOOM = 0
 
+ALT_OSM_BASEMAPS = os.environ.get('ALT_OSM_BASEMAPS', False)
+CARTODB_BASEMAPS = os.environ.get('CARTODB_BASEMAPS', False)
+STAMEN_BASEMAPS = os.environ.get('STAMEN_BASEMAPS', False)
+THUNDERFOREST_BASEMAPS = os.environ.get('THUNDERFOREST_BASEMAPS', False)
+MAPBOX_ACCESS_TOKEN = os.environ.get('MAPBOX_ACCESS_TOKEN', None)
+BING_API_KEY = os.environ.get('BING_API_KEY', None)
+
 MAP_BASELAYERS = [{
     "source": {"ptype": "gxp_olsource"},
     "type": "OpenLayers.Layer",
@@ -626,23 +633,10 @@ MAP_BASELAYERS = [{
     "source": {"ptype": "gxp_osmsource"},
     "type": "OpenLayers.Layer.OSM",
     "name": "mapnik",
-    "visibility": False,
+    "visibility": True,
     "fixed": True,
     "group": "background"
-}, {
-    "source": {"ptype": "gxp_mapquestsource"},
-    "name": "osm",
-    "group": "background",
-    "visibility": True
-}, {
-    "source": {"ptype": "gxp_mapquestsource"},
-    "name": "naip",
-    "group": "background",
-    "visibility": False
 }]
-
-MAPBOX_ACCESS_TOKEN = os.environ.get('MAPBOX_ACCESS_TOKEN', None)
-BING_API_KEY = os.environ.get('BING_API_KEY', None)
 
 SOCIAL_BUTTONS = True
 
@@ -892,17 +886,10 @@ try:
 except ImportError:
     pass
 
-if MAPBOX_ACCESS_TOKEN is not None:
-    try:
-        from contrib.api_basemaps.mapbox import *
-    except ImportError:
-        pass
-
-if BING_API_KEY is not None:
-    try:
-        from contrib.api_basemaps.bing import *
-    except ImportError:
-        pass
+try:
+    from geonode.contrib.api_basemaps import *
+except ImportError:
+    pass
 
 # Require users to authenticate before using Geonode
 if LOCKDOWN_GEONODE:


### PR DESCRIPTION
- removed mapquest basemaps (will add when setup api key is identified)
- added cartodb basemaps
- added stamen basemaps
- added thunderforest basemaps
- added alternate osm basemaps

Each on is configurable with = True, by default they are set to False

migrated basemap variable checks to geonode.contrib.api_basemap to clear up settings.py


