### PR TITLE
Update to how thumbnails are saved

### DIFF
--- a/geonode/base/models.py
+++ b/geonode/base/models.py
@@ -35,7 +35,8 @@ from django.contrib.staticfiles.templatetags import staticfiles
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.auth import get_user_model
 from django.db.models import signals
-from django.core.files import File
+from django.core.files.storage import default_storage as storage
+from django.core.files.base import ContentFile
 
 from mptt.models import MPTTModel, TreeForeignKey
 
@@ -570,16 +571,17 @@ class ResourceBase(PolymorphicModel, PermissionLevelMixin):
         return self.link_set.filter(name='Thumbnail').exists()
 
     def save_thumbnail(self, filename, image):
-        thumb_folder = 'thumbs'
-        upload_path = os.path.join(settings.MEDIA_ROOT, thumb_folder)
-        if not os.path.exists(upload_path):
-            os.makedirs(upload_path)
+        upload_to = 'thumbs/'
+        upload_path = os.path.join('thumbs/', filename)
 
-        with open(os.path.join(upload_path, filename), 'wb') as f:
-            thumbnail = File(f)
-            thumbnail.write(image)
+        if storage.exists(upload_path):
+            # Delete if exists otherwise the (FileSystemStorage) implementation
+            # will create a new file with a unique name
+            storage.delete(os.path.join(upload_path))
 
-        url_path = os.path.join(settings.MEDIA_URL, thumb_folder, filename).replace('\\', '/')
+        storage.save(upload_path, ContentFile(image))
+
+        url_path = os.path.join(settings.MEDIA_URL, upload_to, filename).replace('\\', '/')
         url = urljoin(settings.SITEURL, url_path)
 
         Link.objects.get_or_create(resource=self,

--- a/geonode/layers/utils.py
+++ b/geonode/layers/utils.py
@@ -35,6 +35,7 @@ from osgeo import gdal
 from django.contrib.auth import get_user_model
 from django.template.defaultfilters import slugify
 from django.core.exceptions import ObjectDoesNotExist
+from django.core.files.storage import default_storage as storage
 from django.core.files import File
 from django.conf import settings
 from django.db.models import Q
@@ -659,7 +660,7 @@ def create_thumbnail(instance, thumbnail_remote_url, thumbnail_create_url=None,
     thumbnail_name = 'layer-%s-thumb.png' % instance.uuid
     thumbnail_path = os.path.join(thumbnail_dir, thumbnail_name)
 
-    if overwrite is True or os.path.isfile(thumbnail_path) is False:
+    if overwrite is True or storage.exists(thumbnail_path) is False:
         if not ogc_client:
             ogc_client = http_client
         BBOX_DIFFERENCE_THRESHOLD = 1e-5


### PR DESCRIPTION
Refactor thumbnail files to be stored in the location configured for media storage so that whether uploaded or auto-generated, the locations are consistent when the application is configured for remote storage.