### PR TITLE
Add TIME param to thumbnail request

### DIFF
--- a/geonode/geoserver/signals.py
+++ b/geonode/geoserver/signals.py
@@ -371,6 +371,8 @@ def geoserver_post_save(instance, sender, **kwargs):
         'format': 'image/png8',
         'width': 200,
         'height': 150,
+        'TIME': '-99999999999-01-01T00:00:00.0Z/99999999999-01-01T00:00:00.0Z'
+
     }
 
     # Avoid using urllib.urlencode here because it breaks the url.


### PR DESCRIPTION
This PR adds the TIME param to allow thumbnails generated for time enabled layers to include all features. Without this change, the thumbnail would only include features from the first time instance which could be blank
<img width="222" alt="screen shot 2016-06-20 at 10 33 58 am" src="https://cloud.githubusercontent.com/assets/947403/16200358/9db19048-36d2-11e6-9abf-4a9272357598.png">
<img width="225" alt="screen shot 2016-06-20 at 10 34 11 am" src="https://cloud.githubusercontent.com/assets/947403/16200356/9dac1bea-36d2-11e6-97b1-63ed7ced1539.png">
<img width="370" alt="screen shot 2016-06-20 at 10 34 27 am" src="https://cloud.githubusercontent.com/assets/947403/16200357/9dae284a-36d2-11e6-89e7-e060490f4aae.png">


.