### PR TITLE
Enable search according to catalogue

### DIFF
--- a/geonode/base/autocomplete_light_registry.py
+++ b/geonode/base/autocomplete_light_registry.py
@@ -24,12 +24,18 @@ from taggit.models import Tag
 from models import ResourceBase, Region
 
 
+class ResourceBaseAutocomplete(autocomplete_light.AutocompleteModelTemplate):
+    choice_template = 'autocomplete_response.html'
+
 autocomplete_light.register(Region,
                             search_fields=['name'],
                             autocomplete_js_attributes={'placeholder': 'Region/Country ..', },)
 
 autocomplete_light.register(ResourceBase,
+                            ResourceBaseAutocomplete,
                             search_fields=['title'],
+                            order_by=['title'],
+                            limit_choices=100,
                             autocomplete_js_attributes={'placeholder': 'Resource name..', },)
 
 autocomplete_light.register(Tag,

--- a/geonode/base/templatetags/base_tags.py
+++ b/geonode/base/templatetags/base_tags.py
@@ -113,3 +113,25 @@ def facets(context):
                 facets['vector'] + facets['remote'] + facets['wms']
 
     return facets
+
+
+@register.assignment_tag(takes_context=True)
+def get_current_path(context):
+    request = context['request']
+    return request.get_full_path()
+
+
+@register.assignment_tag(takes_context=True)
+def get_context_resourcetype(context):
+    c_path = get_current_path(context)
+    if c_path.find('/layers/') > - 1:
+        return 'layers'
+    elif c_path.find('/maps/') > - 1:
+        return 'maps'
+    elif c_path.find('/documents/') > - 1:
+        return 'documents'
+    elif c_path.find('/search/') > - 1:
+        return 'search'
+    else:
+        return 'error'
+    return get_current_path(context)

--- a/geonode/documents/autocomplete_light_registry.py
+++ b/geonode/documents/autocomplete_light_registry.py
@@ -21,9 +21,16 @@
 import autocomplete_light
 from models import Document
 
+
+class DocumentAutocomplete(autocomplete_light.AutocompleteModelTemplate):
+    choice_template = 'autocomplete_response.html'
+
 autocomplete_light.register(
     Document,
-    search_fields=['^title'],
+    DocumentAutocomplete,
+    search_fields=['title'],
+    order_by=['title'],
+    limit_choices=100,
     autocomplete_js_attributes={
         'placeholder': 'Document name..',
     },

--- a/geonode/layers/autocomplete_light_registry.py
+++ b/geonode/layers/autocomplete_light_registry.py
@@ -21,11 +21,18 @@
 import autocomplete_light
 from models import Layer
 
+
+class LayerAutocomplete(autocomplete_light.AutocompleteModelTemplate):
+    choice_template = 'autocomplete_response.html'
+
 autocomplete_light.register(
     Layer,
+    LayerAutocomplete,
     search_fields=[
-        '^title',
+        'title',
         '^typename'],
+    order_by=['title'],
+    limit_choices=100,
     autocomplete_js_attributes={
         'placeholder': 'Layer name..',
     },

--- a/geonode/maps/autocomplete_light_registry.py
+++ b/geonode/maps/autocomplete_light_registry.py
@@ -21,9 +21,16 @@
 import autocomplete_light
 from models import Map
 
+
+class MapAutocomplete(autocomplete_light.AutocompleteModelTemplate):
+    choice_template = 'autocomplete_response.html'
+
 autocomplete_light.register(
     Map,
-    search_fields=['^title'],
+    MapAutocomplete,
+    search_fields=['title'],
+    order_by=['title'],
+    limit_choices=100,
     autocomplete_js_attributes={
         'placeholder': 'Map name..',
     },

--- a/geonode/templates/autocomplete_response.html
+++ b/geonode/templates/autocomplete_response.html
@@ -1,0 +1,4 @@
+<span class="div" data-value="{{choice.pk}}" style="cursor:pointer;font-size:14px;" onclick="window.location.href='{{choice.detail_url}}'">
+{{ choice }}
+</span>
+

--- a/geonode/templates/search/search_scripts.html
+++ b/geonode/templates/search/search_scripts.html
@@ -1,3 +1,4 @@
+{% load base_tags %}
 {% if DEBUG_STATIC %}
 <script src="{{ STATIC_URL }}lib/js/bootstrap-datepicker.js?v={{ VERSION }}" type="text/javascript"></script>
 <script src="{{ STATIC_URL }}lib/js/angular.js?v={{ VERSION }}"></script>
@@ -26,7 +27,18 @@
   HAYSTACK_SEARCH = "{{ HAYSTACK_SEARCH }}".toLowerCase() === "true";
   HAYSTACK_FACET_COUNTS = "{{ HAYSTACK_FACET_COUNTS }}".toLowerCase() === "true";
   CLIENT_RESULTS_LIMIT = {{ CLIENT_RESULTS_LIMIT }};
-  AUTOCOMPLETE_URL_RESOURCEBASE = '{% url "autocomplete_light_autocomplete" "ResourceBaseAutocomplete" %}';
+  {% get_context_resourcetype as pathc %}
+        {% if pathc == "layers" %}
+                AUTOCOMPLETE_URL_RESOURCEBASE = '{% url "autocomplete_light_autocomplete" "LayerAutocomplete" %}';
+        {% elif pathc == "maps" %}
+                AUTOCOMPLETE_URL_RESOURCEBASE = '{% url "autocomplete_light_autocomplete" "MapAutocomplete" %}';
+        {% elif pathc == "documents" %}
+                AUTOCOMPLETE_URL_RESOURCEBASE = '{% url "autocomplete_light_autocomplete" "DocumentAutocomplete" %}';
+        {% elif pathc == "search" %}
+                AUTOCOMPLETE_URL_RESOURCEBASE = '{% url "autocomplete_light_autocomplete" "ResourceBaseAutocomplete" %}';
+        {% else %}
+                AUTOCOMPLETE_URL_RESOURCEBASE = '{% url "autocomplete_light_autocomplete" "ResourceBaseAutocomplete" %}';
+        {% endif %}
   AUTOCOMPLETE_URL_REGION = '{% url "autocomplete_light_autocomplete" "RegionAutocomplete" %}';
 
   var module = angular.module('search', ['geonode_main_search', 'cart']);


### PR DESCRIPTION
These additions enable to search according the catalogue where the user is. 
If the user is in the "Layers" section (for example) and starts typing something in the left text-search bar, only layer-type resources will be shown in the list in the autocomplete box. 

In the actual version of Geonode, document-type or map-type resources can be shown while the user is in the Layer section, but when he clicks on the resource name in the box, nothing will appear...

However, with these additions, the principal search box in the header navbar will keep searching in all catalogues and will keep displaying all results from all types anyway. These modifications mainly have effects the left panel search filters. 