### PR TITLE
Enable .txt and .html formats exports for metadata

### DIFF
--- a/geonode/catalogue/templates/geonode_metadata_full.html
+++ b/geonode/catalogue/templates/geonode_metadata_full.html
@@ -1,0 +1,177 @@
+{% load i18n %}
+<html> 
+	<head>
+    <meta charset="utf-8">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1"> 
+    <title>{{ resource.title }}</title>
+    {% block head %}
+      {% if DEBUG_STATIC %}
+      <link href="{{ STATIC_URL }}lib/css/jquery.dataTables.css" rel="stylesheet" />
+      <link href="{{ STATIC_URL }}lib/css/select2.css" rel="stylesheet"/>
+      <link href="{{ STATIC_URL }}lib/css/bootstrap.min.css" rel="stylesheet"/>
+      <link href="{{ STATIC_URL }}lib/css/jquery-ui.css" rel="stylesheet"/>
+      <link href="{{ STATIC_URL }}lib/css/bootstrap-datetimepicker.css" rel="stylesheet"/>
+      {% else %}
+      <link href="{{ STATIC_URL }}lib/css/assets.min.css" rel="stylesheet"/>
+      {% endif %}
+      <link href="{{ STATIC_URL }}geonode/css/ext-compatibility.css" rel="stylesheet" />
+      <link href="{{ STATIC_URL }}geonode/css/base.css" rel="stylesheet" />
+      <style type="text/css">[ng\:cloak],[ng-cloak],[data-ng-cloak],[x-ng-cloak],.ng-cloak,.x-ng-cloak,.ng-hide:not(.ng-hide-animate){display:none !important;}</style>
+	<style>
+	dl dd{ margin-left:20px; }
+	dl dt {margin-top:10px;}
+	ul.nop {list-style-type: none;}
+	</style>	
+
+    {% endblock %}
+	</head>
+	<body style="background-color:white;">
+		{% block body_outer %}
+		  {% block body %}{% endblock body %}
+		  {% block sidebar %}{% endblock sidebar %}
+		{% endblock body_outer %}
+		<div id="wrap">
+			<div class="container">
+				<div class="page-header">
+					<div class="row">
+						<div >
+						  <h4 >Resource Metadata</h4>
+						  <h2 class="page-title">{{ resource.title }}</h2>
+						</div>
+					</div>
+				</div>
+
+				<div class="row">
+				  <div class="col-md-8">
+					<dl>
+						<dt>Thumbnail</dt>
+							<dd><img class='items-list thumb' style="border: 1px solid #ccc;margin-top:10px;" src='{{resource.thumbnail_url}}' alt="{{ resource.title }}"></dd>
+
+						<dt>Resource ID</dt>
+							<dd>{{resource.uuid}}</dd>
+
+						<dt>{% trans "Title" %}</dt>
+							<dd>{{resource.title}}</dd>
+							
+						<dt>{% trans "Date" %}</dt>
+							<dd>{{resource.date}}, {% trans resource.date_type|title %} </dd>
+
+						<dt>{% trans "Abstract" %}</dt>
+							<dd>{{resource.abstract}}</dd>
+
+						<dt>{% trans "Edition" %}</dt>
+							{% if resource.edition %}
+							<dd>{{resource.edition}}</dd>
+							{% else %}
+								<dd> -- </dd>
+							{% endif %}
+							
+				  
+						<dt>{% trans "Owner" %}</dt>
+							<dd>{{resource.owner}}</dd>
+								
+						<dt>{% trans "Point of Contact" %}</dt>
+							<dd>{{extra_res_md.poc_last_name}}</dd>
+							<dd><a href="mailto:{{extra_res_md.poc_email}}"><i class="fa fa-envelope"></i>{{extra_res_md.poc_email}}</a></dd>							
+							
+
+						<dt>{% trans "Purpose" %}</dt>
+								{% if resource.purpose %}
+									<dd>{{resource.purpose}}</dd>
+								{% else %}
+									<dd> -- </dd>
+								{% endif %}
+							
+
+						<dt>{% trans "Maintenance Frequency" %}</dt>
+							<dd>{{resource.maintenance_frequency}}</dd>
+
+						<dt>{% trans "Type" %} </dt>
+							<dd>{{extra_res_md.sprt_identifier}}</dd>
+
+						<dt>{% trans "Restrictions" %}</dt>
+							<dd>{{resource.restriction_code_type}}</dd>
+							<dd>{{resource.constraints_other}}</dd>
+
+						<dt>{% trans "License" %}</dt>
+							<dd>{{resource.license}}</dd>
+
+						<dt>{% trans "Language" %} </dt>
+							<dd>{{resource.language}}</dd>
+
+						<dt>{% trans "Temporal Extent" %}</dt>
+							<dt>Start </dt>
+								{% if resource.temporal_extent_start %}
+									<dd> {{resource.temporal_extent_start}} </dd>
+								{% else %}
+									<dd> -- </dd>
+								{% endif %}
+							<dt>End </dt>
+								{% if resource.temporal_extent_end %}
+									<dd> {{resource.temporal_extent_end}} </dd>
+								{% else %}
+									<dd> -- </dd>
+								{% endif %}
+
+
+						<dt>{% trans "Supplemental Information" %}</dt>
+							<dd>{{resource.supplemental_information}}</dd>
+
+						<dt>{% trans "Data Quality" %} </dt>
+							{% if resource.data_quality_statement %}
+							<dd>{{resource.data_quality_statement}}</dd>
+							{% else %}
+								<dd> -- </dd>
+							{% endif %}
+
+						<dt>Extent</dt>
+							<dd>
+								<ul class="nop">	
+									<li>long min: {{resource.bbox_x0}}</li>
+									<li>long max: {{resource.bbox_x1}}</li>
+									<li>lat min: {{resource.bbox_y0}}</li>
+									<li>lat max: {{resource.bbox_y1}}</li>
+								</ul>
+							</dd>
+
+						<dt>Spatial Reference System Identifier</dt>
+							<dd>{{resource.srid}}</dd>
+
+						<dt>{% trans "Keywords" %}</dt>
+							<dd>{{extra_res_md.keywords}}</dd>
+
+						<dt>{% trans "Category" %}</dt>
+							<dd>{{resource.category}}</dd>
+							
+						{% if resource.regions.all %}
+						<dt>{% trans "Regions" %}</dt>
+							<dd>
+							  {% for region in resource.regions.all %}
+								  {{ region.name }}
+								{% if not forloop.last %},{% endif %}
+									  {% endfor %}
+							</dd>
+									{% endif %}						
+						
+						{% if "layer" in  request.META.HTTP_REFERER|stringformat:"s" %}
+						<dt>Attributes</dt>
+							<dd>
+								<table id="attr_table" class="table table-striped table-bordered table-condensed" style="margin-top:10px;font-size:14px;">
+								</table>
+							</dd>				
+							<script  type="text/javascript">
+								var content="{{extra_res_md.atrributes}}";
+								content = content.replace(/\&lt;/gi,"<").replace(/\&gt;/gi,">");
+								var headertab="<thead><tr><th style='width:25%'>Attribute name</th><th>Label</th><th>Description</th></tr></thead>";
+								document.getElementById("attr_table").innerHTML=headertab+content;
+							</script>	
+							
+						{% endif %}
+
+				  </div>
+				 </div>
+			 </div>
+		</div>
+	</body>
+</html>

--- a/geonode/catalogue/urls.py
+++ b/geonode/catalogue/urls.py
@@ -23,5 +23,9 @@ from . import views
 
 urlpatterns = [
     url(r'^csw$', views.csw_global_dispatch, name='csw_global_dispatch'),
-    url(r'^opensearch$', views.opensearch_dispatch, name='opensearch_dispatch')
+    url(r'^opensearch$', views.opensearch_dispatch, name='opensearch_dispatch'),
+    url(r'^csw_to_extra_format/(?P<layeruuid>[^/]*)/(?P<resname>[^/]*).txt$',
+        views.csw_render_extra_format_txt, name="csw_render_extra_format_txt"),
+    url(r'^csw_to_extra_format/(?P<layeruuid>[^/]*)/(?P<resname>[^/]*).html$',
+        views.csw_render_extra_format_html, name="csw_render_extra_format_html")
 ]

--- a/geonode/catalogue/views.py
+++ b/geonode/catalogue/views.py
@@ -20,6 +20,7 @@
 
 import json
 import os
+import logging
 from django.conf import settings
 from django.http import HttpResponse, HttpResponseRedirect
 from django.shortcuts import render_to_response
@@ -27,6 +28,12 @@ from django.views.decorators.csrf import csrf_exempt
 from pycsw import server
 from geonode.catalogue.backends.pycsw_local import CONFIGURATION
 from geonode.base.models import ResourceBase
+from geonode.layers.models import Layer
+from geonode.base.models import ContactRole, SpatialRepresentationType
+from geonode.people.models import Profile
+from django.db import connection
+from django.core.exceptions import ObjectDoesNotExist
+from django.template import RequestContext
 
 
 @csrf_exempt
@@ -105,3 +112,172 @@ def data_json(request):
         json_data.append(record)
 
     return HttpResponse(json.dumps(json_data), 'application/json')
+
+
+# transforms a row sql query into a two dimension array
+def dictfetchall(cursor):
+    """Returns all rows from a cursor as a dict"""
+    desc = cursor.description
+    return [
+        dict(zip([col[0] for col in desc], row))
+        for row in cursor.fetchall()
+    ]
+
+
+# choose separators
+def get_CSV_spec_char():
+    return {"separator": ';', "carriage_return": '\r\n'}
+
+
+# format value to unicode str without ';' char
+def fst(value):
+    chrs = get_CSV_spec_char()
+    return unicode(value).replace(chrs["separator"],
+                                  ',').replace('\\n', ' ').replace('\r\n', ' ')
+
+
+# from a resource object, build the corresponding metadata dict
+# the aim is to handle the output format (csv, html or pdf) the same structure
+def build_md_dict(resource):
+    md_dict = {
+        'r_uuid': {'label': 'uuid', 'value': resource.uuid},
+        'r_title': {'label': 'titre', 'value': resource.title}
+    }
+    return md_dict
+
+
+def get_keywords(resource):
+    content = ' '
+    cursor = connection.cursor()
+    cursor.execute(
+        "SELECT a.*,b.* FROM taggit_taggeditem as a,taggit_tag"
+        " as b WHERE a.object_id = %s AND a.tag_id=b.id", [resource.id])
+    struct_kw = dictfetchall(cursor)
+    for x in struct_kw:
+        content += fst(x['name']) + ', '
+    return content[:-2]
+
+
+# from a resource uuid, return a httpResponse
+# containing the whole geonode metadata
+@csrf_exempt
+def csw_render_extra_format_txt(request, layeruuid, resname):
+    """pycsw wrapper"""
+    resource = ResourceBase.objects.get(uuid=layeruuid)
+    chrs = get_CSV_spec_char()
+    s = chrs['separator']
+    c = chrs['carriage_return']
+    sc = s + c
+    content = 'Resource metadata' + sc
+    content += 'uuid' + s + fst(resource.uuid) + sc
+    content += 'title' + s + fst(resource.title) + sc
+    content += 'resource owner' + s + fst(resource.owner) + sc
+    content += 'date' + s + fst(resource.date) + sc
+    content += 'date type' + s + fst(resource.date_type) + sc
+    content += 'abstract' + s + fst(resource.abstract) + sc
+    content += 'edition' + s + fst(resource.edition) + sc
+    content += 'purpose' + s + fst(resource.purpose) + sc
+    content += 'maintenance frequency' + s + fst(
+                resource.maintenance_frequency) + sc
+
+    try:
+        sprt = SpatialRepresentationType.objects.get(
+               id=resource.spatial_representation_type_id)
+        content += 'identifier'+s+fst(sprt.identifier) + sc
+    except ObjectDoesNotExist:
+        content += 'ObjectDoesNotExist' + sc
+
+    content += 'restriction code type' + s + fst(
+                resource.restriction_code_type) + sc
+    content += 'constraints other ' + s + fst(
+                resource.constraints_other) + sc
+    content += 'license' + s + fst(resource.license) + sc
+    content += 'language' + s + fst(resource.language) + sc
+    content += 'temporal extent' + sc
+    content += 'temporal extent start' + s + fst(
+                resource.temporal_extent_start) + sc
+    content += 'temporal extent end' + s + fst(
+                resource.temporal_extent_end) + sc
+    content += 'supplemental information' + s + fst(
+                resource.supplemental_information) + sc
+    """content += 'URL de distribution ' + s + fst(
+                resource.distribution_url) + sc"""
+    """content += 'description de la distribution' + s + fst(
+                resource.distribution_description) + sc"""
+    content += 'data quality statement' + s + fst(
+                resource.data_quality_statement) + sc
+    content += 'extent ' + s + fst(resource.bbox_x0) + ',' + fst(
+                resource.bbox_x1) + ',' + fst(
+                resource.bbox_y0) + ',' + fst(resource.bbox_y1) + sc
+    content += 'SRID  ' + s + fst(resource.srid) + sc
+    content += 'Thumbnail url' + s + fst(resource.thumbnail_url) + sc
+
+    content += 'keywords;' + get_keywords(resource) + s
+    content += 'category' + s + fst(resource.category) + sc
+
+    content += 'regions' + s
+    for reg in resource.regions.all():
+        content += fst(reg.name_en)+','
+    content = content[:-1]
+    content += sc
+
+    if resource.detail_url.find('/layers/') > -1:
+        layer = Layer.objects.get(resourcebase_ptr_id=resource.id)
+        content += 'attribute data' + sc
+        content += 'attribute name;label;description\n'
+        for attr in layer.attribute_set.all():
+            content += fst(attr.attribute) + s
+            content += fst(attr.attribute_label) + s
+            content += fst(attr.description) + sc
+
+    pocr = ContactRole.objects.get(
+           resource_id=resource.id, role='pointOfContact')
+    pocp = Profile.objects.get(id=pocr.contact_id)
+    content += "Point of Contact" + sc
+    content += "name" + s + fst(pocp.last_name) + sc
+    content += "e-mail" + s + fst(pocp.email) + sc
+
+    logger = logging.getLogger(__name__)
+    logger.error(content)
+
+    # return render_to_response("/var/www/temp_download_md/test_3.txt")
+    return HttpResponse(content.encode('utf-8').decode('utf-8'),
+                        content_type="text/csv")
+
+
+def csw_render_extra_format_html(request, layeruuid, resname):
+    resource = ResourceBase.objects.get(uuid=layeruuid)
+    extra_res_md = {}
+    try:
+        sprt = SpatialRepresentationType.objects.get(
+               id=resource.spatial_representation_type_id)
+        extra_res_md['sprt_identifier'] = sprt.identifier
+    except ObjectDoesNotExist:
+        extra_res_md['sprt_identifier'] = 'not filled'
+    kw = get_keywords(resource)
+    if len(kw) == 0:
+        extra_res_md['keywords'] = "no keywords"
+    else:
+        extra_res_md['keywords'] = get_keywords(resource)
+
+    if resource.detail_url.find('/layers/') > -1:
+        layer = Layer.objects.get(resourcebase_ptr_id=resource.id)
+        extra_res_md['atrributes'] = ''
+        for attr in layer.attribute_set.all():
+            extra_res_md['atrributes'] += '<tr>'
+            extra_res_md['atrributes'] += '<td>' + unicode(
+                                           attr.attribute) + '</td>'
+            extra_res_md['atrributes'] += '<td>' + unicode(
+                                           attr.attribute_label) + '</td>'
+            extra_res_md['atrributes'] += '<td>' + unicode(
+                                           attr.description) + '</td>'
+            extra_res_md['atrributes'] += '</tr>'
+
+    pocr = ContactRole.objects.get(
+           resource_id=resource.id, role='pointOfContact')
+    pocp = Profile.objects.get(id=pocr.contact_id)
+    extra_res_md['poc_last_name'] = pocp.last_name
+    extra_res_md['poc_email'] = pocp.email
+    return render_to_response("geonode_metadata_full.html", RequestContext(
+           request, {"resource": resource,
+                     "extra_res_md": extra_res_md}))

--- a/geonode/documents/templates/documents/document_detail.html
+++ b/geonode/documents/templates/documents/document_detail.html
@@ -159,7 +159,19 @@
               <h4 class="modal-title" id="myModalLabel">{% trans "Download Metadata" %}</h4>
             </div>
             <div class="modal-body">
-              <ul>
+			    <div style="margin-bottom:20px">
+					<h5 class="modal-title" id="myModalLabel">
+					Full metadata
+					</h5>
+					<ul style="list-style: outside none none;padding: 0;">
+						<li><a href="https://{{request.META.HTTP_HOST}}/catalogue/csw_to_extra_format/{{resource.uuid}}/{{resource.title}}.txt"> Text format </a></li>
+						<li><a target="_blank" href="https://{{request.META.HTTP_HOST}}/catalogue/csw_to_extra_format/{{resource.uuid}}/{{resource.title}}.html"> HTML format </a></li>
+					</ul>
+				</div>		  
+			  <h5 class="modal-title" id="myModalLabel">
+			  Standard Metadata - XML format
+			  </h5>	
+              <ul style="list-style: outside none none;padding: 0;">
                 {% for link in metadata %}
                 <li><a href="{{ link.url }}">{{ link.name }}</a></li>
                 {% endfor %}

--- a/geonode/layers/templates/layers/layer_detail.html
+++ b/geonode/layers/templates/layers/layer_detail.html
@@ -357,6 +357,18 @@
             <h4 class="modal-title" id="myModalLabel">{% trans "Download Metadata" %}</h4>
           </div>
           <div class="modal-body">
+		    <div style="margin-bottom:20px">
+				 <h5 class="modal-title" id="myModalLabel">
+				Full metadata 
+				 </h5>
+				<ul>
+					<li><a href="http://{{request.META.HTTP_HOST}}/catalogue/csw_to_extra_format/{{resource.uuid}}/{{resource.title}}.txt"> Text format </a></li>
+					<li><a target="_blank" href="http://{{request.META.HTTP_HOST}}/catalogue/csw_to_extra_format/{{resource.uuid}}/{{resource.title}}.html"> HTML format </a></li>
+				</ul>
+			</div>
+			<h5 class="modal-title" id="myModalLabel">
+			Standard Metadata - XML format
+			</h5>
             <ul>
               {% for link in metadata %}
                 <li><a href="{{ link.url }}">{{ link.name }}</a></li>


### PR DESCRIPTION
Hi, these additions allow the user to download full metadata in .txt and .html formats. 
I'm sorry to post this PR a second time (#2530), but there was a problem on the other one, so I thought it was better to do a new one. 

I noticed there will be a new "Metadata Detail" section in the future version of GeoNode, so I don't know if my PR will be that useful ! But anyway, here it is. 

Thanks