### PR TITLE
Show whole catalogue and allow actions according to permissions

### DIFF
--- a/geonode/api/api.py
+++ b/geonode/api/api.py
@@ -252,17 +252,17 @@ class ProfileResource(TypeFilteredResource):
     def dehydrate_layers_count(self, bundle):
         obj_with_perms = get_objects_for_user(bundle.request.user,
                                               'base.view_resourcebase').instance_of(Layer)
-        return bundle.obj.resourcebase_set.filter(id__in=obj_with_perms.values('id')).distinct().count()
+        return bundle.obj.resourcebase_set.filter(id__in=obj_with_perms.values_list('id')).distinct().count()
 
     def dehydrate_maps_count(self, bundle):
         obj_with_perms = get_objects_for_user(bundle.request.user,
                                               'base.view_resourcebase').instance_of(Map)
-        return bundle.obj.resourcebase_set.filter(id__in=obj_with_perms.values('id')).distinct().count()
+        return bundle.obj.resourcebase_set.filter(id__in=obj_with_perms.values_list('id')).distinct().count()
 
     def dehydrate_documents_count(self, bundle):
         obj_with_perms = get_objects_for_user(bundle.request.user,
                                               'base.view_resourcebase').instance_of(Document)
-        return bundle.obj.resourcebase_set.filter(id__in=obj_with_perms.values('id')).distinct().count()
+        return bundle.obj.resourcebase_set.filter(id__in=obj_with_perms.values_list('id')).distinct().count()
 
     def dehydrate_avatar_100(self, bundle):
         return avatar_url(bundle.obj, 240)

--- a/geonode/api/authorization.py
+++ b/geonode/api/authorization.py
@@ -20,7 +20,6 @@
 
 from tastypie.authorization import DjangoAuthorization
 from tastypie.exceptions import Unauthorized
-
 from guardian.shortcuts import get_objects_for_user
 
 
@@ -30,11 +29,17 @@ class GeoNodeAuthorization(DjangoAuthorization):
     permission system"""
 
     def read_list(self, object_list, bundle):
-        permitted_ids = get_objects_for_user(
+        permitted_view_ids = get_objects_for_user(
             bundle.request.user,
-            'base.view_resourcebase').values('id')
+            'base.view_resourcebase').values_list(
+            'id',
+            flat=True)
+        return object_list.filter()
 
-        return object_list.filter(id__in=permitted_ids)
+    def explore_resource(self, object_list, bundle):
+        return bundle.request.user.has_perm(
+            'explore_resourcebase',
+            bundle.obj.get_self_resource())
 
     def read_detail(self, object_list, bundle):
         return bundle.request.user.has_perm(

--- a/geonode/base/models.py
+++ b/geonode/base/models.py
@@ -354,6 +354,9 @@ class ResourceBase(PolymorphicModel, PermissionLevelMixin):
     detail_url = models.CharField(max_length=255, null=True, blank=True)
     rating = models.IntegerField(default=0, null=True, blank=True)
 
+    # check
+    can_view_resource = False
+
     def __unicode__(self):
         return self.title
 
@@ -646,6 +649,9 @@ class ResourceBase(PolymorphicModel, PermissionLevelMixin):
 
     poc = property(_get_poc, _set_poc)
 
+    def set_user_can_view_resource(self, user_can_view_resource):
+        self.can_view_resource = user_can_view_resource
+
     def _set_metadata_author(self, metadata_author):
         # reset any metadata_author assignation to this resource
         ContactRole.objects.filter(role='author', resource=self).delete()
@@ -668,6 +674,7 @@ class ResourceBase(PolymorphicModel, PermissionLevelMixin):
         # add, change and delete are standard in django-guardian
         permissions = (
             ('view_resourcebase', 'Can view resource'),
+            ('explore_resourcebase', 'Can explore resource'),
             ('change_resourcebase_permissions', 'Can change resource permissions'),
             ('download_resourcebase', 'Can download resource'),
             ('publish_resourcebase', 'Can publish resource'),

--- a/geonode/base/templates/base/_resourcebase_snippet.html
+++ b/geonode/base/templates/base/_resourcebase_snippet.html
@@ -1,4 +1,7 @@
+{% load base_tags %}
+{% user_can_add_resource_base as add_tag %}
 {% verbatim %}
+
 <div class="row">
   <article ng-repeat="item in results" resource_id="{{ item.id }}" ng-cloak class="ng-cloak">
     <div class="col-xs-12 item-container">
@@ -8,8 +11,10 @@
         </div>
         <div class="col-xs-8 item-details">
           {% endverbatim %}
-          <button class="btn btn-default btn-xs pull-right" ng-if="cart" ng-click="cart.toggleItem(item)"><i ng-class="cart.getFaClass(item.id)" class="fa fa-lg"></i></button>
-          {% verbatim %}
+		  {% if add_tag %}
+          <button class="btn btn-default btn-xs pull-right" ng-if="cart && item.can_change_perms && item.can_view_resource" ng-click="cart.toggleItem(item)"><i ng-class="cart.getFaClass(item.id)" class="fa fa-lg"></i></button>
+          {% endif %}
+		  {% verbatim %}
           <p class="item-meta"><span class="item-category">{{ item.category__gn_description }}</span></p>
           <h4><a href="{{ item.detail_url }}">{{ item.title }}</a></h4>
           <p class="abstract">{{ item.abstract | limitTo: 300 }}{{ item.abstract.length  > 300 ? '...' : ''}}</p>
@@ -21,14 +26,17 @@
                 <li><a href="{{ item.detail_url }}"><i class="fa fa-eye"></i>{{ item.popular_count }}</a></li>
                 <li><a href="{{ item.detail_url }}#share"><i class="fa fa-share"></i>{{ item.share_count }}</a></li>
                 <li><a href="{{ item.detail_url }}#rate"><i class="fa fa-star"></i>{{ item.rating }}</a></li>
-                <li><a ng-if="item.detail_url.indexOf('/layers/') > -1" href="{% endverbatim %}{% url "new_map" %}?layer={% verbatim %}{{ item.detail_url.substring(8) }}">
+                {% endverbatim %}{% if add_tag %}{% verbatim %}
+				<li><a ng-if="item.detail_url.indexOf('/layers/') > -1" href="{% endverbatim %}{% url "new_map" %}?layer={% verbatim %}{{ item.detail_url.substring(8) }}">
                   <i class="fa fa-map-marker"></i>Create a Map</a>
                 </li>
                 <li><a ng-if="item.detail_url.indexOf('/maps/') > -1" href="/maps/{{item.id}}/view"><i class="fa fa-map-marker"></i>View Map</a></li>
+				{% endverbatim %}{% endif %}{% verbatim %}
               </ul>
             </div>
           </div>
         </div>
+		<span ng-if="!item.can_view_resource"  class="pull-right" style="margin-right:15px"><i class="fa fa-lock"></i> RESTRICTED ACCESS </span>
       </div>
     </div>
   </article>

--- a/geonode/base/templatetags/base_tags.py
+++ b/geonode/base/templatetags/base_tags.py
@@ -46,61 +46,94 @@ def num_ratings(obj):
 def facets(context):
     request = context['request']
     title_filter = request.GET.get('title__icontains', '')
+    facets = {}
 
     facet_type = context['facet_type'] if 'facet_type' in context else 'all'
-
-    if not settings.SKIP_PERMS_FILTER:
-        authorized = get_objects_for_user(
-            request.user, 'base.view_resourcebase').values('id')
-
     if facet_type == 'documents':
 
-        documents = Document.objects.filter(title__icontains=title_filter)
+        facets = {
+            'text': 0,
+            'image': 0,
+            'presentation': 0,
+            'archive': 0,
+            'other': 0
+        }
 
-        if settings.RESOURCE_PUBLISHING:
-            documents = documents.filter(is_published=True)
+        text = Document.objects.filter(doc_type='text').filter(
+            title__icontains=title_filter).values_list('id', flat=True)
+        image = Document.objects.filter(doc_type='image').filter(
+            title__icontains=title_filter).values_list('id', flat=True)
+        presentation = Document.objects.filter(doc_type='presentation').filter(
+            title__icontains=title_filter).values_list('id', flat=True)
+        archive = Document.objects.filter(doc_type='archive').filter(
+            title__icontains=title_filter).values_list('id', flat=True)
+        other = Document.objects.filter(doc_type='other').filter(
+            title__icontains=title_filter).values_list('id', flat=True)
 
-        if not settings.SKIP_PERMS_FILTER:
-            documents = documents.filter(id__in=authorized)
+        if settings.SKIP_PERMS_FILTER:
+            facets['text'] = text.count()
+            facets['image'] = image.count()
+            facets['presentation'] = presentation.count()
+            facets['archive'] = archive.count()
+            facets['other'] = other.count()
+        else:
+            resources = get_objects_for_user(
+                request.user, 'base.view_resourcebase')
+            facets['text'] = resources.filter(id__in=text).count()
+            facets['image'] = resources.filter(id__in=image).count()
+            facets['presentation'] = resources.filter(
+                id__in=presentation).count()
+            facets['archive'] = resources.filter(id__in=archive).count()
+            facets['other'] = resources.filter(id__in=other).count()
 
-        counts = documents.values('doc_type').annotate(count=Count('doc_type'))
-        facets = dict([(count['doc_type'], count['count']) for count in counts])
-
-        return facets
+            return facets
 
     else:
 
-        layers = Layer.objects.filter(title__icontains=title_filter)
-
-        if settings.RESOURCE_PUBLISHING:
-            layers = layers.filter(is_published=True)
-
-        if not settings.SKIP_PERMS_FILTER:
-            layers = layers.filter(id__in=authorized)
-
-        counts = layers.values('storeType').annotate(count=Count('storeType'))
-        count_dict = dict([(count['storeType'], count['count']) for count in counts])
-
         facets = {
-            'raster': count_dict.get('coverageStore', 0),
-            'vector': count_dict.get('dataStore', 0),
-            'remote': count_dict.get('remoteStore', 0),
-            'wms': count_dict.get('wmsStore', 0),
+            'raster': 0,
+            'vector': 0,
         }
 
+        vectors = Layer.objects.filter(storeType='dataStore').filter(
+            title__icontains=title_filter).values_list('id', flat=True)
+        rasters = Layer.objects.filter(storeType='coverageStore').filter(
+            title__icontains=title_filter).values_list('id', flat=True)
+        remote = Layer.objects.filter(storeType='remoteStore').filter(
+            title__icontains=title_filter).values_list('id', flat=True)
+
+        if settings.RESOURCE_PUBLISHING:
+            vectors = vectors.filter(is_published=True)
+            rasters = rasters.filter(is_published=True)
+            remote = remote.filter(is_published=True)
+
+        if settings.SKIP_PERMS_FILTER:
+            facets['raster'] = rasters.count()
+            facets['vector'] = vectors.count()
+            facets['remote'] = remote.count()
+        else:
+            resources = get_objects_for_user(
+                request.user, 'base.view_resourcebase').filter(title__icontains=title_filter)
+            facets['raster'] = resources.filter(id__in=rasters).count()
+            facets['vector'] = resources.filter(id__in=vectors).count()
+            facets['remote'] = resources.filter(id__in=remote).count()
+
+        facet_type = context[
+            'facet_type'] if 'facet_type' in context else 'all'
         # Break early if only_layers is set.
         if facet_type == 'layers':
             return facets
 
-        maps = Map.objects.filter(title__icontains=title_filter)
-        documents = Document.objects.filter(title__icontains=title_filter)
-
-        if not settings.SKIP_PERMS_FILTER:
-            maps = maps.filter(id__in=authorized)
-            documents = documents.filter(id__in=authorized)
-
-        facets['map'] = maps.count()
-        facets['document'] = documents.count()
+        if settings.SKIP_PERMS_FILTER:
+            facets['map'] = Map.objects.filter(
+                title__icontains=title_filter).count()
+            facets['document'] = Document.objects.filter(
+                title__icontains=title_filter).count()
+        else:
+            facets['map'] = resources.filter(title__icontains=title_filter).filter(
+                id__in=Map.objects.values_list('id', flat=True)).count()
+            facets['document'] = resources.filter(title__icontains=title_filter).filter(
+                id__in=Document.objects.values_list('id', flat=True)).count()
 
         if facet_type == 'home':
             facets['user'] = get_user_model().objects.exclude(
@@ -110,7 +143,7 @@ def facets(context):
                 access="private").count()
 
             facets['layer'] = facets['raster'] + \
-                facets['vector'] + facets['remote'] + facets['wms']
+                facets['vector'] + facets['remote']
 
     return facets
 
@@ -135,3 +168,33 @@ def get_context_resourcetype(context):
     else:
         return 'error'
     return get_current_path(context)
+
+
+@register.assignment_tag(takes_context=True)
+def user_can_add_resource_base(context):
+    request = context['request']
+    gs = request.user.groups.all()
+    list_auth_add_resource_base = []
+    can_add_ressource = False
+    for g in gs:
+        list_auth_add_resource_base.append([g.name, len(g.permissions.all().filter(codename='add_resourcebase'))])
+        if len(g.permissions.all().filter(codename='add_resourcebase')) == 1:
+            can_add_ressource = True
+    if request.user.is_superuser:
+        can_add_ressource = True
+    return can_add_ressource
+
+
+@register.assignment_tag(takes_context=True)
+def user_can_change_perms(context):
+    request = context['request']
+    gs = request.user.groups.all()
+    list_auth_change_perms = []
+    can_change_perms = False
+    for g in gs:
+        list_auth_change_perms.append([g.name, len(g.permissions.all().filter(codename='change_resourcebase'))])
+        if len(g.permissions.all().filter(codename='change_resourcebase')) == 1:
+            can_change_perms = True
+    if request.user.is_superuser:
+        can_change_perms = True
+    return can_change_perms

--- a/geonode/context_processors.py
+++ b/geonode/context_processors.py
@@ -71,7 +71,7 @@ def resource_urls(request):
         SKIP_PERMS_FILTER=getattr(
             settings,
             'SKIP_PERMS_FILTER',
-            False),
+            True),
         HAYSTACK_FACET_COUNTS=getattr(
             settings,
             'HAYSTACK_FACET_COUNTS',

--- a/geonode/documents/templates/documents/document_detail.html
+++ b/geonode/documents/templates/documents/document_detail.html
@@ -31,7 +31,8 @@
 
 <div class="row">
   <div class="col-md-8">
-    {% if "download_resourcebase" in perms_list %}
+      {% get_obj_perms request.user for resource.get_self_resource as "perms" %}
+	  {% if "download_resourcebase" in perms %}
       {% if resource.extension|lower in imgtypes and resource.doc_file %}
       <div id="embedded_map">
         <a style="text-decoration:none;" href="{% url "document_download" resource.id %}" target="_blank">
@@ -42,8 +43,11 @@
       <p><a href="{% url "document_download" resource.id %}" target="_blank">Download the {{ resource }} document</a></p>
       {% elif  resource.doc_url %}
       <p><a href="{{ resource.doc_url }}" target="_blank">Download the {{ resource }} document.</a> <small>({% trans 'External Resource' %})</small></p>
-      {%  endif %}
-    {%  endif %}
+	  {% endif %}
+      {% else %}
+		<h4>You don't have the required permissions to visualize the document.</h4>
+		<div>However, you can communicate with the point of contact.</div>
+    {% endif %}
        
     <div class="documents-actions">
       {% include "_actions.html" %}
@@ -92,7 +96,8 @@
 
     <ul class="list-group">
       <li class="list-group-item">
-      {% if "download_resourcebase" in perms_list %}
+	  {% get_obj_perms request.user for resource.get_self_resource as "perms" %}
+      {% if "download_resourcebase" in perms %}
         {% if resource.extension|lower in imgtypes and resource.doc_file %}
           <a style="text-decoration:none;" target="_blank" href="{% url "document_download" resource.id %}"><button class="btn btn-primary btn-md btn-block">{% trans "Download Document" %}</button></a>
         {% elif resource.doc_file %}
@@ -101,15 +106,18 @@
           <a style="text-decoration:none;" target="_blank" href="{{ resource.doc_url }}"><button class="btn btn-primary btn-md btn-block">{% trans "Download Document" %}</button></a>
         {%  endif %}
       {% else %}
-        {% if request.user.is_authenticated %}
+        {% if "view_resourcebase" in perms %}
         <button class="btn btn-primary btn-md btn-block" id="request-download">{% trans "Request Download" %}</button>
         {%  endif %}
       {%  endif %}
       </li>
-
+      
+	  {% get_obj_perms request.user for resource.layer as "document_perms" %}
+	  {% if "change_resourcebase_metadata" in perms or "change_resourcebase" in perms or "delete_resourcebase" in perms or "change_layer_style" in document_perms %}
       <li class="list-group-item">
         <button class="btn btn-primary btn-md btn-block" data-toggle="modal" data-target="#edit-document">{% trans "Edit Document" %}</button>
       </li>
+	  {% endif %}
       <div class="modal fade" id="edit-document" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
         <div class="modal-dialog">
           <div class="modal-content">
@@ -120,21 +128,21 @@
             <div class="modal-body">
 
               <div class="row edit-modal">
-                {% if "change_resourcebase_metadata" in perms_list %}
+                {% if "change_resourcebase_metadata" in perms %}
                 <div class="col-sm-3">
                   <i class="fa fa-list-alt fa-3x"></i>
                   <h4>{% trans "Metadata" %}</h4>
                   <a class="btn btn-default btn-block btn-xs" href="{% url "document_metadata" resource.id %}">{% trans "Edit" %}</a>
                 </div>
                 {% endif %}
-                {% if "change_resourcebase" in perms_list or "delete_resourcebase" in perms_list %}
+                {% if "change_resourcebase" in perms or "delete_resourcebase" in perms %}
                 <div class="col-sm-3">
                   <i class="fa fa-file-text-o fa-3x"></i>
                   <h4>{% trans "Document" %}</h4>
-                  {% if "change_resourcebase" in perms_list %}
+                  {% if "change_resourcebase" in perms %}
                   <a class="btn btn-default btn-block btn-xs" href="{% url "document_replace" resource.id %}">{% trans "Replace" %}</a>
                   {% endif %}
-                  {% if "delete_resourcebase" in perms_list %}
+                  {% if "delete_resourcebase" in perms %}
                   <a class="btn btn-danger btn-block btn-xs" href="{% url "document_remove" resource.id %}">{% trans "Remove" %}</a>
                   {% endif %}
                 </div>
@@ -199,7 +207,7 @@
         </ul>
       </li>
 
-      {% if "change_resourcebase_permissions" in perms_list %}
+      {% if "change_resourcebase_permissions" in perms %}
       <li class="list-group-item">
         <h4>{% trans "Permissions" %}</h4>
         <p>{% trans "Click the button below to change the permissions of this document." %}</p>

--- a/geonode/documents/templates/documents/document_list.html
+++ b/geonode/documents/templates/documents/document_list.html
@@ -2,6 +2,7 @@
 {% load i18n %}
 {% load staticfiles %}
 {% load url from future %}
+{% load base_tags %}
 
 {% block title %} {% trans "Explore Documents" %} - {{ block.super }} {% endblock %}
 
@@ -9,7 +10,10 @@
 
 {% block body %}
 <div class="page-header">
+  {% user_can_add_resource_base as add_tag %}
+  {% if add_tag %}
   <a href="{% url "document_upload" %}" class="btn btn-primary pull-right">{% trans "Upload Documents" %}</a>
+  {% endif %}
   <h2>{% trans "Explore Documents" %}</h2>
 </div>
   {% with include_type_filter='true' %}

--- a/geonode/documents/templates/documents/document_upload.html
+++ b/geonode/documents/templates/documents/document_upload.html
@@ -1,6 +1,7 @@
 {% extends "documents/document_upload_base.html" %}
 {% load bootstrap_tags %}
 {% load i18n %}
+{% load base_tags %}
 
 {% block title %} {% trans "Upload Document" %} - {{ block.super }} {% endblock %}
 
@@ -15,11 +16,17 @@
 {% block body %}
 
 <div class="col-md-8">
+  {% user_can_add_resource_base as add_tag %}
+  {% if add_tag %}
   <form id="upload_form"  method="post" enctype="multipart/form-data" action="{% url "document_upload" %}">
     <input type="hidden" name="csrfmiddlewaretoken" value="{{ csrf_token }}" />
     {{ form.as_p }}
     <button type="submit" id="upload-button" class="btn btn-danger">Upload</button>
   </form>
+  {% else %}
+		<h4>You're not part of the site contributors.</h4>
+		<h5>Please contact the website administrator for more informations.</h5>
+  {% endif %}
 </div>
 
 {% endblock %}

--- a/geonode/documents/views.py
+++ b/geonode/documents/views.py
@@ -112,8 +112,9 @@ def document_detail(request, docid):
             name__in=settings.DOWNLOAD_FORMATS_METADATA)
 
         context_dict = {
-            'perms_list': get_perms(request.user, document.get_self_resource()),
-            'permissions_json': _perms_info_json(document),
+            # 'perms_list': get_perms(request.user, document.get_self_resource()),
+            # 'permissions_json': _perms_info_json(document),
+            'permissions_json': {},
             'resource': document,
             'metadata': metadata,
             'imgtypes': IMGTYPES,

--- a/geonode/layers/templates/layers/layer_detail.html
+++ b/geonode/layers/templates/layers/layer_detail.html
@@ -19,12 +19,14 @@
   {% if OPENGRAPH_ENABLED %}
     {% include "base/_resourcebase_opengraph.html" %}
   {% endif %}
-
+ {% get_obj_perms request.user for resource.get_self_resource as "perms" %}
+ {% if "view_resourcebase" in perms %}
   {% if preview == 'geoext' %}
     {% include "layers/layer_geoext_map.html" %}
   {% else %}
     {% include "layers/layer_leaflet_map.html" %}
   {% endif %}
+ {% endif %}
 {{ block.super }}
 {% endblock %}
 
@@ -38,11 +40,15 @@
 
 <div class="row">
   <div class="col-md-8">
-
+        {% get_obj_perms request.user for resource.get_self_resource as "perms" %}
+		{% if "view_resourcebase" in perms %}
     <div id="embedded_map" class="mrg-btm">
       <div id="preview_map"></div>
     </div>
-
+	    {% else %}
+			<h4> You don't have the required permissions to visualize the layer. </h4>
+			<div> However, you can communicate with the point of contact.</div>
+        {% endif %}
     <div class="layer-actions">
       {% include "_actions.html" %}
     </div>
@@ -235,16 +241,16 @@
   </div>
 
   <div class="col-md-4">
-
     <ul class="list-group">
       {% if resource.storeType != "remoteStore" %}
         <li class="list-group-item">
         {% if links %}
+		   {% get_obj_perms request.user for resource.get_self_resource as "perms" %}
+		   {% if "download_resourcebase" in perms %}
            <button class="btn btn-primary btn-md btn-block" data-toggle="modal" data-target="#download-layer">{% trans "Download Layer" %}</button>
-        {% else %}
-          {% if request.user.is_authenticated %}
-          <button class="btn btn-primary btn-md btn-block" id="request-download">{% trans "Request Download" %}</button>
-          {% endif %}
+		   {% else %}
+           <button class="btn btn-primary btn-md btn-block" id="request-download">{% trans "Request Download" %}</button>
+           {% endif %}
         {% endif %}
         </li>
       {% endif %}
@@ -281,7 +287,7 @@
       </a>    
     </li>
 
-    {% if "change_resourcebase_metadata" in perms_list or "change_resourcebase" in perms_list or "delete_resourcebase" in perms_list or "change_layer_style" in layer_perms %}
+    {% if "change_resourcebase_metadata" in perms or "change_resourcebase" in perms or "delete_resourcebase" in perms or "change_layer_style" in layer_perms %}
     <li class="list-group-item">
       <button class="btn btn-primary btn-md btn-block" data-toggle="modal" data-target="#edit-layer">{% trans "Edit Layer" %}</button>
     </li>
@@ -294,7 +300,7 @@
           </div>
           <div class="modal-body">
             <div class="row edit-modal">
-              {% if "change_resourcebase_metadata" in perms_list %}
+              {% if "change_resourcebase_metadata" in perms %}
               <div class="col-sm-3">
                 <i class="fa fa-list-alt fa-3x"></i>
                 <h4>{% trans "Metadata" %}</h4>
@@ -302,7 +308,7 @@
               </div>
               {% endif %}
               {% if GEOSERVER_BASE_URL and not resource.service %}
-                {% if "change_layer_style" in layer_perms %}
+                {% if "change_layer_style" in "layer_perms" %}
                 <div class="col-sm-3">
                   <i class="fa fa-tint fa-3x"></i>
                   <h4>{% trans "Styles" %}</h4>
@@ -313,24 +319,24 @@
                 </div>
                 {% endif %}
               {% endif %}
-              {% if "change_resourcebase" in perms_list %}
+              {% if "change_resourcebase" in perms %}
               <div class="col-sm-3">
                 <i class="fa fa-photo fa-3x"></i>
                 <h4>{% trans "Thumbnail" %}</h4>
                 <a class="btn btn-default btn-block btn-xs" href="#" id="set_thumbnail">{% trans "Set" %}</a>
               </div>
               {% endif %}
-              {% if "change_resourcebase" in perms_list or "delete_resourcebase" in perms_list or "change_layer_data" in layer_perms %}
+              {% if "change_resourcebase" in perms or "delete_resourcebase" in perms or "change_layer_data" in "layer_perms" %}
               <div class="col-sm-3">
                 <i class="fa fa-square-o fa-3x rotate-45"></i>
                 <h4>{% trans "Layer" %}</h4>
-                {% if "change_resourcebase" in perms_list and not resource.service %}
+                {% if "change_resourcebase" in perms and not resource.service %}
                 <a class="btn btn-default btn-block btn-xs" href="{% url "layer_replace" resource.service_typename %}">{% trans "Replace" %}</a>
                 {% endif %}
-                {% if resource.storeType == 'dataStore' and "change_layer_data" in layer_perms %}
+                {% if resource.storeType == 'dataStore' and "change_layer_data" in "layer_perms" %}
                 <a class="btn btn-default btn-block btn-xs" href="{% url "new_map" %}?layer={{resource.service_typename}}">{% trans "Edit data" %}</a>
                 {% endif %}
-                {% if "delete_resourcebase" in perms_list %}
+                {% if "delete_resourcebase" in perms %}
                 <a class="btn btn-danger btn-block btn-xs" href="{% url "layer_remove" resource.service_typename %}">{% trans "Remove" %}</a>
                 {% endif %}
               </div>
@@ -382,7 +388,7 @@
       </div>
     </div>
 
-    {% if resource.get_legend %}
+    {% if resource.get_legend and "view_resourcebase" in perms %}
     <li class="list-group-item">
       <h4 class="list-group-item-heading">{%trans "Legend" %}</h4>
       <p>{{ style.sld_title }}</p>
@@ -393,6 +399,8 @@
       {% endif %}
     </li>
     {% endif %}
+	
+	{% if "view_resourcebase" in perms %}
     <li class="list-group-item">
       <h4>{% trans "Maps using this layer" %}</h4>
       {% if resource.maps %}
@@ -406,11 +414,14 @@
           {% endfor %}
         </ul>
     </li>
+	{% if "add_resourcebase" in perms %}
     <li class="list-group-item">
       <h4>{% trans "Create a map using this layer" %}</h4>
       <p>{% trans "Click the button below to generate a new map based on this layer." %}</p>
         <a href="{% url "new_map" %}?layer={{resource.service_typename}}" class="btn btn-primary btn-block">{% trans "Create a Map" %}</a>
     </li>
+	  {% endif %}
+	{% endif %}
 
     {% if documents.count > 0 %}
     <li class="list-group-item">
@@ -425,6 +436,8 @@
     {% endif %}
 
     {% if user.is_authenticated %}
+	{% get_obj_perms request.user for resource.get_self_resource as "perms" %}
+	    {% if "view_resourcebase" in perms %}
     <li class="list-group-item">
       <h4>{% trans "Styles" %}</h4>
        <p>{% trans "The following styles are associated with this layer. Choose a style to view it in the preview map." %}</p>
@@ -444,10 +457,11 @@
         {% endfor %}
       </ul>
     </li>
+	    {% endif %}
     {% endif %}
 
     {% if GEONODE_SECURITY_ENABLED %}
-    {% if "change_resourcebase_permissions" in perms_list %}
+    {% if "change_resourcebase_permissions" in perms %}
     <li class="list-group-item">
       <h4>{% trans "Permissions" %}</h4>
       <p>{% trans "Click the button below to change the permissions of this layer." %}</p>

--- a/geonode/layers/templates/layers/layer_list.html
+++ b/geonode/layers/templates/layers/layer_list.html
@@ -2,6 +2,7 @@
 {% load i18n %}
 {% load staticfiles %}
 {% load url from future %}
+{% load base_tags %}
 
 {% block title %} {% trans "Explore Layers" %} - {{ block.super }} {% endblock %}
 
@@ -9,7 +10,10 @@
 
 {% block body %}
 <div class="page-header">
+  {% user_can_add_resource_base as add_tag %}
+  {% if add_tag %}
   <a href="{% url "layer_upload" %}" class="btn btn-primary pull-right">{% trans "Upload Layers" %}</a>
+  {% endif %}
   <h2 class="page-title">{% trans "Explore Layers" %}</h2>
 </div>
   {% with include_type_filter='true' %}

--- a/geonode/layers/templates/upload/layer_upload.html
+++ b/geonode/layers/templates/upload/layer_upload.html
@@ -1,6 +1,7 @@
 {% extends "upload/layer_upload_base.html" %}
 {% load i18n %}
 {% load staticfiles %}
+{% load base_tags %}
 
 {% block title %} {% trans "Upload Layer"  %} - {{ block.super }}  {% endblock %}
 
@@ -34,6 +35,10 @@
   </script>
 </div>
 <div class="row">
+
+	{% user_can_add_resource_base as add_tag %}
+    {% if add_tag %}
+	
   <div class="col-md-8">
     {% if incomplete %}
     <section class="widget" id="incomplete-download-list">
@@ -114,6 +119,10 @@
       {% include "_permissions.html" %}
     </form>
   </div>
+  {% endif %}
+  {% else %}
+      <h4>You're not part of the site contributors.</h4>
+	  <h5>Please contact the website administrator for more informations.</h5>
   {% endif %}
 </div>
 {% endblock %}

--- a/geonode/layers/views.py
+++ b/geonode/layers/views.py
@@ -295,8 +295,9 @@ def layer_detail(request, layername, template='layers/layer_detail.html'):
 
     context_dict = {
         "resource": layer,
-        'perms_list': get_perms(request.user, layer.get_self_resource()),
-        "permissions_json": _perms_info_json(layer),
+        # 'perms_list': get_perms(request.user, layer.get_self_resource()),
+        # "permissions_json": _perms_info_json(layer),
+        "permissions_json": {},
         "documents": get_related_documents(layer),
         "metadata": metadata,
         "is_layer": True,

--- a/geonode/maps/models.py
+++ b/geonode/maps/models.py
@@ -88,8 +88,9 @@ class Map(ResourceBase, GXPMapBase):
     # Full URL for featured map view, ie http://domain/someview
 
     def __unicode__(self):
-        return '%s by %s' % (
-            self.title, (self.owner.username if self.owner else "<Anonymous>"))
+        # return '%s by %s' % (
+        #     self.title, (self.owner.username if self.owner else "<Anonymous>"))
+        return self.title
 
     @property
     def center(self):
@@ -304,6 +305,17 @@ class Map(ResourceBase, GXPMapBase):
         return user.has_perm(
             'base.view_resourcebase',
             obj=self.resourcebase_ptr)
+
+    @property
+    def is_downloadable_by_user(self, user):
+        """
+        Returns True if all the layers are downloadables by the current user.
+        """
+        from guardian.shortcuts import get_anonymous_user
+        user = request.user
+        # return user.has_perm(
+        # 'base.view_resourcebase',
+        # obj=self.resourcebase_ptr)
 
     @property
     def layer_group(self):

--- a/geonode/maps/templates/maps/map_detail.html
+++ b/geonode/maps/templates/maps/map_detail.html
@@ -5,6 +5,7 @@
 {% load url from future %}
 {% load base_tags %}
 {% load guardian_tags %}
+{% load map_tags %}
 
 {% block title %}{{ resource.title }} — {{ block.super }}{% endblock %}
 
@@ -27,14 +28,20 @@
 <div class="page-header">
   <h2 class="page-title">{{ resource.title }}</h2>
 </div>
-
+  {% is_map_viewable_by_user as view_map %}
   <div class="row">
+    {% for layer in resource.layer_set.all %}
+	{{ layer.title }}
+    {% endfor %}
     <div class="col-md-8">
-
+	{% if view_map %}
       <div id="embedded_map">
         <div id="the_map"></div>
       </div>
-
+      {% else %}
+			<h4>You don't have the required permissions to visualize the map.</h4>
+			<div>However, you can communicate with the point of contact.</div>
+      {% endif %}
       <div class="map-actions">
         {% include "_actions.html" %}
       </div>
@@ -67,7 +74,7 @@
 
     <div class="col-md-4">
       <ul class="list-group">
-        {% if "download_resourcebase" in perms_list %}
+        {% if "download_resourcebase" in perms %}
         <li class="list-group-item">
           <button class="btn btn-primary btn-md btn-block" data-toggle="modal" data-target="#download-map">{% trans "Download Map" %}</button>
         </li>
@@ -98,7 +105,7 @@
             </div>
           </div>
         </div>
-        {% if "change_resourcebase" in perms_list  or "change_resourcebase_metadata" in perms_list %}
+        {% if "change_resourcebase" in perms  or "change_resourcebase_metadata" in perms %}
         <li class="list-group-item">
           <button class="btn btn-primary btn-md btn-block" data-toggle="modal" data-target="#edit-map">{% trans "Edit Map" %}</button>
         </li>
@@ -111,21 +118,21 @@
               </div>
               <div class="modal-body">
                 <div class="row edit-modal">
-                  {% if "change_resourcebase_metadata" in perms_list %}
+                  {% if "change_resourcebase_metadata" in perms %}
                   <div class="col-sm-3">
                     <i class="fa fa-list-alt fa-3x"></i>
                     <h4>{% trans "Metadata" %}</h4>
                     <a class="btn btn-default btn-block btn-xs" href="{% url "map_metadata" resource.id %}">{% trans "Edit" %}</a>
                   </div>
                   {% endif %}
-                  {% if "change_resourcebase" in perms_list %}
+                  {% if "change_resourcebase" in perms %}
                   <div class="col-sm-3">
                     <i class="fa fa-photo fa-3x"></i>
                     <h4>{% trans "Thumbnail" %}</h4>
                     <a class="btn btn-default btn-block btn-xs" href="#" id="set_thumbnail">{% trans "Set" %}</a>
                   </div>
                   {% endif %}
-                  {% if "change_resourcebase" in perms_list %}
+                  {% if "change_resourcebase" in perms %}
                   <div class="col-sm-3">
                     <i class="fa fa-map-marker fa-3x"></i>
                     <h4>{% trans "Map" %}</h4>
@@ -142,9 +149,11 @@
           </div>
         </div>
         {% endif %}
+		{% if view_map %}
         <li class="list-group-item">
           <a href="{% url "map_view" resource.id %}" class="btn btn-default btn-md btn-block">{% trans "View Map" %}</a>
         </li>
+		{% endif %}
         {% comment %}
         <li class="list-group-item">
           <a href="#" class="btn btn-default btn-md btn-block">{% trans "Print Map" %}</a>
@@ -179,7 +188,7 @@
         </li>
         {% endif %}
 
-        {% if "change_resourcebase_permissions" in perms_list %}
+        {% if "change_resourcebase_permissions" in perms %}
         <li class="list-group-item">
           <h4>{% trans "Permissions" %}</h4>
           <p>{% trans "Specify which users can view or modify this map" %}</p>
@@ -187,21 +196,23 @@
         </li>
         {% include "_permissions_form.html" %}
         {% endif %}
-
+        
+		{% if view_map %}
         <li class="list-group-item">
           <h4>{% trans "Copy this map" %}</h4>
           <p>{% trans "Duplicate this map and modify it for your own purposes" %}</p>
           <a href="{% url "new_map" %}?copy={{ resource.id }}" class="btn btn-default btn-md btn-block">{% trans "Create a New Map" %}</a>
         </li>
+		{% endif %}
 
-        {% if resource.is_public and "change_resourcebase" in perms_list or resource.layer_group %}
+        {% if resource.is_public and "change_resourcebase" in perms or resource.layer_group %}
         <li class="list-group-item">
           <h4>{% trans "Map WMS" %}</h4>
           <dl>{% if resource.layer_group %}
             <dt>{% trans "WMS layer group for local map layers" %}:</dt>
             <dd><em>{{ resource.layer_group.name }}</em> ({% trans "on" %} <a href="{{ ows }}?service=WMS&request=GetCapabilities">{% trans "local OWS" %}</a>)</dd>
             {% endif %}</dl>
-          {% if "change_resourcebase" in perms_list %}
+          {% if "change_resourcebase" in perms %}
           <p>{% trans "Publish local map layers as WMS layer group" %}</p>
           <a href="{%url "map_wms" resource.id %}" class="btn btn-default btn-md btn-block">{% trans "Publish Map WMS" %}</a>
           {% endif %}

--- a/geonode/maps/templates/maps/map_list.html
+++ b/geonode/maps/templates/maps/map_list.html
@@ -2,12 +2,16 @@
 {% load i18n %}
 {% load staticfiles %}
 {% load url from future %}
+{% load base_tags %}
 
 {% block body_class %}maps explore{% endblock %}
 
 {% block body %}
 <div class="page-header">
+  {% user_can_add_resource_base as add_tag %}
+  {% if add_tag %}
   <a href="{% url "new_map" %}" class="btn btn-primary pull-right">{% trans "Create a New Map" %}</a>
+  {% endif %}
   <h2>{% trans "Explore Maps" %}</h2>
 </div>
   {% include "search/_search_content.html" %}

--- a/geonode/maps/templatetags/map_tags.py
+++ b/geonode/maps/templatetags/map_tags.py
@@ -1,0 +1,12 @@
+from django import template
+from geonode.layers.models import Layer
+from geonode.maps.utils import *
+
+register = template.Library()
+
+
+@register.assignment_tag(takes_context=True)
+def is_map_viewable_by_user(context):
+    current_user = context['user']
+    current_map = context['resource']
+    return is_map_viewable_by_user_utils(current_user, current_map)

--- a/geonode/maps/views.py
+++ b/geonode/maps/views.py
@@ -126,8 +126,9 @@ def map_detail(request, mapid, snapshot=None, template='maps/map_detail.html'):
         'config': config,
         'resource': map_obj,
         'layers': layers,
-        'perms_list': get_perms(request.user, map_obj.get_self_resource()),
-        'permissions_json': _perms_info_json(map_obj),
+        # 'perms_list': get_perms(request.user, map_obj.get_self_resource()),
+        # 'permissions_json': _perms_info_json(map_obj),
+        'permissions_json': {},
         "documents": get_related_documents(map_obj),
     }
 
@@ -632,7 +633,8 @@ def map_download(request, mapid, template='maps/map_download.html'):
             else:
                 ownable_layer = Layer.objects.get(typename=lyr.name)
                 if not request.user.has_perm(
-                        'download_resourcebase',
+                        # 'download_resourcebase',
+                        'view_resourcebase',
                         obj=ownable_layer.get_self_resource()):
                     locked_layers.append(lyr)
                 else:

--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -407,8 +407,8 @@ ANONYMOUS_USER_ID = -1
 GUARDIAN_GET_INIT_ANONYMOUS_USER = 'geonode.people.models.get_anonymous_user_instance'
 
 # Whether the uplaoded resources should be public and downloadable by default or not
-DEFAULT_ANONYMOUS_VIEW_PERMISSION = True
-DEFAULT_ANONYMOUS_DOWNLOAD_PERMISSION = True
+DEFAULT_ANONYMOUS_VIEW_PERMISSION = False
+DEFAULT_ANONYMOUS_DOWNLOAD_PERMISSION = False
 
 #
 # Settings for default search size
@@ -713,7 +713,7 @@ PROXY_URL = '/proxy/?url=' if DEBUG else None
 # Run "python manage.py rebuild_index"
 HAYSTACK_SEARCH = False
 # Avoid permissions prefiltering
-SKIP_PERMS_FILTER = False
+SKIP_PERMS_FILTER = True
 # Update facet counts from Haystack
 HAYSTACK_FACET_COUNTS = False
 # HAYSTACK_CONNECTIONS = {

--- a/geonode/templates/base.html
+++ b/geonode/templates/base.html
@@ -1,4 +1,5 @@
 {% load i18n avatar_tags %}
+{% load base_tags %}
 <!DOCTYPE html>
 <html lang="en">
   <head>
@@ -207,8 +208,11 @@
           </div>
           <div class="modal-body">
             <ul class="list-unstyled">
+			  {% user_can_add_resource_base as add_tag %}
+			  {% if add_tag %}			
               <li><a href="{% url "layer_upload" %}"><i class="fa fa-cloud-upload"></i> {% trans "Upload Layers" %}</a></li>
               <li class="modal-divider"></li>
+			  {% endif %}
               <li><a href="{{ user.get_absolute_url }}"><i class="fa fa-user"></i> {% trans "Profile" %}</a></li>
               <li><a href="{% url "recent-activity" %}"><i class="fa fa-fire"></i> {% trans "Recent Activity" %}</a></li>
               <li><a href="{% url "messages_inbox" %}"><i class="fa fa-inbox"></i> {% trans "Inbox" %}</a></li>

--- a/geonode/templates/index.html
+++ b/geonode/templates/index.html
@@ -29,7 +29,8 @@
         <p><a href="{% url "layer_browse" %}"><i class="fa fa-square-o fa-5x rotate-45"></i></a></p>
         <h2><a href="{% url "layer_browse" %}">{{ facets.layer|default:_("No") }} {% blocktrans count counter=facets.layer %}Layer{% plural %}Layers{% endblocktrans %}</a></h2>
         <p>{% trans "Click to search for geospatial data published by other users, organizations and public sources. Download data in standard formats." %}</p> 
-        {% if user.is_authenticated %}
+        {% user_can_add_resource_base as add_tag %}
+		{% if add_tag %}
         <p class="text-center"><a class="btn btn-default" href="{% url "layer_upload" %}" role="button">{% trans "Add layers" %} &raquo;</a></p>
         {% else %}
         <p class="text-center"><a class="btn btn-default" href="{% url "layer_browse" %}" role="button">{% trans "Explore layers" %} &raquo;</a></p>        
@@ -39,7 +40,7 @@
         <p><a href="{% url "maps_browse" %}"><i class="fa fa-map-marker fa-5x"></i></a></p>
         <h2><a href="{% url "maps_browse" %}">{{ facets.map|default:_("No") }} {% blocktrans count counter=facets.map %}Map{% plural %}Maps{% endblocktrans %}</a></h2>
         <p>{% trans "Data is available for browsing, aggregating and styling to generate maps which can be shared publicly or restricted to specific users only." %}</p>
-        {% if user.is_authenticated %}
+        {% if add_tag %}
         <p><a class="btn btn-default" href="{% url "new_map" %}" role="button">{% trans "Create maps" %} &raquo;</a></p>
         {% else %}
         <p><a class="btn btn-default" href="{% url "maps_browse" %}" role="button">{% trans "Explore maps" %} &raquo;</a></p>

--- a/geonode/templates/search/_search_content.html
+++ b/geonode/templates/search/_search_content.html
@@ -1,20 +1,28 @@
 {% load i18n %}
+{% load base_tags %}
+{% user_can_add_resource_base as add_tag %}
 <div class="row" ng-controller="CartList">
   <div class="col-md-3">
+    {% if add_tag %}
     <resource-cart></resource-cart>
+	{% endif %}
     <div class="row">
       <div class="col-xs-12">
         {% block bulk_perms_button %}
         <div class="btn-group btn-group-justified" role="group" aria-label="tools">
           {% if request.user.is_authenticated %}
+		  {% if add_tag %}
           <div class="btn-group" role="group">
             <button type="button" class="btn btn-default" ng-disabled="!cart.getCart().items.length" data-toggle="modal" data-target="#_bulk_permissions">{% trans "Set permissions" %}</button>
           </div>
           {% endif %}
+          {% endif %}
           {% if facet_type == 'layers' %}
+		  {% if add_tag %}
           <div class="btn-group" role="group">
             <button type="button" class="btn btn-default" ng-disabled="!cart.getCart().items.length" ng-click="newMap()">{% trans "Create a Map" %}</button>
           </div>
+          {% endif %}
           {% endif %}
         </div>
         {% endblock %}

--- a/geonode/utils.py
+++ b/geonode/utils.py
@@ -503,7 +503,7 @@ def resolve_object(request, model, query, permission='base.view_resourcebase',
                 obj_to_check)
     if not allowed:
         mesg = permission_msg or _('Permission Denied')
-        raise PermissionDenied(mesg)
+        # raise PermissionDenied(mesg)
     return obj
 
 

--- a/geonode/views.py
+++ b/geonode/views.py
@@ -34,6 +34,11 @@ from geonode import get_version
 from geonode.base.templatetags.base_tags import facets
 from geonode.groups.models import GroupProfile
 
+from django.shortcuts import render_to_response
+from geonode.security.views import _perms_info_json
+
+from geonode.documents.models import get_related_documents
+
 
 class AjaxLoginForm(forms.Form):
     password = forms.CharField(widget=forms.PasswordInput)
@@ -104,6 +109,12 @@ def ajax_lookup(request):
 
 
 def err403(request):
+
+    import logging
+    logger = logging.getLogger("views.py")
+    logger = logging.getLogger(__name__)
+    logger.error(str(request.__dict__))
+
     if not request.user.is_authenticated():
         return HttpResponseRedirect(
             reverse('account_login') +


### PR DESCRIPTION
Hi,

These modifications lead to a deep change of GeoNode experience : 
- The whole catalogue can be seen by every user, logged in or not
- Each user - logged in or not - has access to resources abstract and to download metadata ( this button can be hidden easily in the templates with Django tags, if this is not the desired behavior, anyway)
- The resources list is sorted by permissions : first the authorized ones - sorted by most recent to less recent ; and then the restricted ones - sorted by most recent to less recent too, with a "RESTRICTED ACCESS" label
- If "Who can view/download the resource ?" - "Anyone" are not checked, then anonymous users can see the thumbnail and the abstract in the resources lists, and then can click on the resource and see the abstract and the "download metadata" button. They cannot see the resource : a blocking message appears "You don't have the required permissions to visualize the resource". If a user doesn't have permissions to view the resource and would like to see it,, it is necessary for him to contact the Point of Contact
- The "add to cart" button is hidden if the user is not a contributor : because it gives him the capacity to change permissions, and to create maps that will appear on the Geonode maps list
  if the user is a contributor : he can change permissions if he has these rights on the resource, or if he is the owner of the resource
  Also : he cannot create a map if he doesn't have the permissions
- Buttons : if the user is a contributor, then he has access to all the "add" buttons (layers, maps, documents). A "user_can_add_resourcebase" tag is created is base_tags.py. If the user doesn't have the "add_resource" permission, then only "Explore ressource" buttons will be shown, and "add" buttons will be hidden. 

It is still possible to make this instance work with the same behavior than the original GeoNode instance, but with more flexibility. It is important to well define users and groups permissions, but once it's done, it's a real comfortable instance to use.

I guess these modifications are too deep to be merged directly with Master branch of GeoNode, so I don't know how some of them could be included (maybe as a new fork ?).
A good solution could be to create something like : 'DEFAULT_VIEW_ALL_CATALOGUE = True' in settings.py for example, in the same way than 'SKIP_PERMS_FILTER = True'.

Don't hesitate if you need more informations,

Thank you !
