### PR TITLE
'name' no longer a ContentType field in Django 1.8+

### DIFF
--- a/geonode/social/views.py
+++ b/geonode/social/views.py
@@ -34,11 +34,11 @@ class RecentActivity(ListView):
         context = super(ListView, self).get_context_data(*args, **kwargs)
         context['action_list_layers'] = Action.objects.filter(
             public=True,
-            action_object_content_type__name='layer')[:15]
+            action_object_content_type__model='layer')[:15]
         context['action_list_maps'] = Action.objects.filter(
             public=True,
-            action_object_content_type__name='map')[:15]
+            action_object_content_type__model='map')[:15]
         context['action_list_comments'] = Action.objects.filter(
             public=True,
-            action_object_content_type__name='comment')[:15]
+            action_object_content_type__model='comment')[:15]
         return context


### PR DESCRIPTION
As of Django 1.8, 'name' has been removed as a real field on the ContentType model. Using 'model' instead gives the same/desired results.

*error prior to fix:*
```
Internal Server Error: /social/recent-activity
Traceback (most recent call last):
  File "/vagrant/.venv/lib/python2.7/site-packages/django/core/handlers/base.py", line 132, in get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/vagrant/.venv/lib/python2.7/site-packages/django/views/generic/base.py", line 71, in view
    return self.dispatch(request, *args, **kwargs)
  File "/vagrant/.venv/lib/python2.7/site-packages/django/views/generic/base.py", line 89, in dispatch
    return handler(request, *args, **kwargs)
  File "/vagrant/.venv/lib/python2.7/site-packages/django/views/generic/list.py", line 174, in get
    context = self.get_context_data()
  File "/vagrant/.venv/lib/python2.7/site-packages/geonode/social/views.py", line 37, in get_context_data
    action_object_content_type__name='layer')[:15]
  File "/vagrant/.venv/lib/python2.7/site-packages/django/db/models/manager.py", line 127, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/vagrant/.venv/lib/python2.7/site-packages/django/db/models/query.py", line 679, in filter
    return self._filter_or_exclude(False, *args, **kwargs)
  File "/vagrant/.venv/lib/python2.7/site-packages/django/db/models/query.py", line 697, in _filter_or_exclude
    clone.query.add_q(Q(*args, **kwargs))
  File "/vagrant/.venv/lib/python2.7/site-packages/django/db/models/sql/query.py", line 1310, in add_q
    clause, require_inner = self._add_q(where_part, self.used_aliases)
  File "/vagrant/.venv/lib/python2.7/site-packages/django/db/models/sql/query.py", line 1338, in _add_q
    allow_joins=allow_joins, split_subq=split_subq,
  File "/vagrant/.venv/lib/python2.7/site-packages/django/db/models/sql/query.py", line 1200, in build_filter
    lookups, value)
  File "/vagrant/.venv/lib/python2.7/site-packages/django/db/models/fields/related.py", line 1777, in get_lookup_constraint
    raise TypeError('Related Field got invalid lookup: %s' % lookup_type)
TypeError: Related Field got invalid lookup: name
```

See also: https://docs.djangoproject.com/en/1.8/ref/contrib/contenttypes/