### PR TITLE
register models for actstream 0.5+ / Django 1.8+

### DIFF
--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -435,13 +435,6 @@ AGON_RATINGS_CATEGORY_CHOICES = {
 
 # Activity Stream
 ACTSTREAM_SETTINGS = {
-    'MODELS': (
-        'people.Profile',
-        'layers.layer',
-        'maps.map',
-        'dialogos.comment',
-        'documents.document',
-        'services.service'),
     'FETCH_RELATIONS': True,
     'USE_PREFETCH': False,
     'USE_JSONFIELD': True,

--- a/geonode/social/__init__.py
+++ b/geonode/social/__init__.py
@@ -17,3 +17,6 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 #########################################################################
+
+
+default_app_config = "geonode.social.apps.SocialConfig"

--- a/geonode/social/apps.py
+++ b/geonode/social/apps.py
@@ -1,0 +1,14 @@
+from django.apps import apps, AppConfig
+from actstream import registry
+
+
+class SocialConfig(AppConfig):
+    name = 'geonode.social'
+
+    def ready(self):
+        registry.register(apps.get_app_config('layers').get_model('Layer'))
+        registry.register(apps.get_app_config('maps').get_model('Map'))
+        registry.register(apps.get_app_config('documents').get_model('Document'))
+        registry.register(apps.get_app_config('people').get_model('Profile'))
+        registry.register(apps.get_app_config('services').get_model('Service'))
+        registry.register(apps.get_app_config('dialogos').get_model('Comment'))


### PR DESCRIPTION
The current pinned version of actstream no longer works "old-style", with models set in `ACTSTREAM_SETTINGS['MODELS']`... models now need registered in actstream prior to their use as action objects. In Django 1.8+, this requires use of AppConfig.

See also: http://django-activity-stream.readthedocs.io/en/latest/configuration.html