### PR TITLE
Fix "replace layer" errors

### DIFF
--- a/geonode/geoserver/helpers.py
+++ b/geonode/geoserver/helpers.py
@@ -327,6 +327,7 @@ def delete_from_postgis(resource_name):
     import psycopg2
     db = ogc_server_settings.datastore_db
     conn = None
+    port = str(db['PORT'])
     try:
         conn = psycopg2.connect(
             "dbname='" +
@@ -336,7 +337,7 @@ def delete_from_postgis(resource_name):
             "'  password='" +
             db['PASSWORD'] +
             "' port=" +
-            db['PORT'] +
+            port +
             " host='" +
             db['HOST'] +
             "'")

--- a/geonode/layers/utils.py
+++ b/geonode/layers/utils.py
@@ -486,7 +486,8 @@ def file_upload(filename, name=None, user=None, title=None, abstract=None,
     # process the layer again after that by
     # doing a layer.save()
     if not created and overwrite:
-        layer.upload_session.layerfile_set.all().delete()
+        if layer.upload_session:
+            layer.upload_session.layerfile_set.all().delete()
         layer.upload_session = upload_session
         # Pass the parameter overwrite to tell whether the
         # geoserver_post_save_signal should upload the new file or not


### PR DESCRIPTION
Currently, replacing a layer throws `'NoneType' object has no attribute 'layerfile_set'` half-way through, and fails to complete the replacement: it successfully deletes the original layer, but doesn't finish importing the new layer, so the result is error + no layer at all.

The str/int port fix is incidental to the main issue above but resolves a TypeError occurring during the same replace-layer process.