### PR TITLE
Invalidate geowebcache after style update

### DIFF
--- a/geonode/geoserver/helpers.py
+++ b/geonode/geoserver/helpers.py
@@ -1503,8 +1503,7 @@ def _invalidate_geowebcache_layer(layer_name, url=None):
         <truncateLayer><layerName>{0}</layerName></truncateLayer>
         """.strip().format(layer_name)
     if not url:
-        path = "geowebcache/rest/masstruncate"
-        url = "/".join([ogc_server_settings.LOCATION.rstrip("/"), path])
+        url = '%sgwc/rest/masstruncate' % ogc_server_settings.LOCATION
     response, _ = http.request(url, method, body=body, headers=headers)
     if response.status != 200:
         line = "Error {0} invalidating GeoWebCache at {1}".format(

--- a/geonode/geoserver/helpers.py
+++ b/geonode/geoserver/helpers.py
@@ -1529,7 +1529,7 @@ def style_update(request, url):
             layer = Layer.objects.get(typename=layer_name)
             style.LayerStyles.add(layer)
             style.save()
-        if request.method == 'PUT':  # update style in GN
+        elif request.method == 'PUT':  # update style in GN
             style = Style.objects.get(name=style_name)
             style.sld_body = sld_body
             style.sld_url = url
@@ -1538,7 +1538,7 @@ def style_update(request, url):
             style.save()
             for layer in style.LayerStyles.all():
                 layer.save()
-    if request.method == 'DELETE':  # delete style from GN
+    elif request.method == 'DELETE':  # delete style from GN
         style_name = os.path.basename(request.path)
         style = Style.objects.get(name=style_name)
         style.delete()

--- a/geonode/geoserver/helpers.py
+++ b/geonode/geoserver/helpers.py
@@ -1504,7 +1504,7 @@ def _invalidate_geowebcache_layer(layer_name, url=None):
         """.strip().format(layer_name)
     if not url:
         path = "geowebcache/rest/masstruncate"
-        url = "/".join(ogc_server_settings.LOCATION.rstrip("/"), path)
+        url = "/".join([ogc_server_settings.LOCATION.rstrip("/"), path])
     response, _ = http.request(url, method, body=body, headers=headers)
     if response.status != "200":
         line = "Error {0} invalidating GeoWebCache at {1}".format(

--- a/geonode/geoserver/helpers.py
+++ b/geonode/geoserver/helpers.py
@@ -1506,7 +1506,7 @@ def _invalidate_geowebcache_layer(layer_name, url=None):
         path = "geowebcache/rest/masstruncate"
         url = "/".join([ogc_server_settings.LOCATION.rstrip("/"), path])
     response, _ = http.request(url, method, body=body, headers=headers)
-    if response.status != "200":
+    if response.status != 200:
         line = "Error {0} invalidating GeoWebCache at {1}".format(
             response.status, url
         )

--- a/geonode/geoserver/helpers.py
+++ b/geonode/geoserver/helpers.py
@@ -1496,14 +1496,16 @@ def _invalidate_geowebcache_layer(layer_name, url=None):
     username, password = ogc_server_settings.credentials
     http.add_credentials(username, password)
     method = "POST"
-    headers = {}
+    headers = {
+        "Content-Type": "text/xml"
+    }
     body = """
         <truncateLayer><layerName>{0}</layerName></truncateLayer>
         """.strip().format(layer_name)
     if not url:
         path = "geowebcache/rest/masstruncate"
         url = "/".join(ogc_server_settings.LOCATION.rstrip("/"), path)
-    response, _ = http.request(url, method, body=body, headers={})
+    response, _ = http.request(url, method, body=body, headers=headers)
     if response.status != "200":
         line = "Error {0} invalidating GeoWebCache at {1}".format(
             response.status, url

--- a/geonode/geoserver/helpers.py
+++ b/geonode/geoserver/helpers.py
@@ -1526,11 +1526,11 @@ def style_update(request, url):
         if request.method == 'POST':
             style = Style(name=style_name, sld_body=sld_body, sld_url=url)
             style.save()
-            layer = Layer.objects.all().filter(typename=layer_name)[0]
+            layer = Layer.objects.get(typename=layer_name)
             style.LayerStyles.add(layer)
             style.save()
         if request.method == 'PUT':  # update style in GN
-            style = Style.objects.all().filter(name=style_name)[0]
+            style = Style.objects.get(name=style_name)
             style.sld_body = sld_body
             style.sld_url = url
             if len(elm_user_style_title.text) > 0:
@@ -1540,7 +1540,7 @@ def style_update(request, url):
                 layer.save()
     if request.method == 'DELETE':  # delete style from GN
         style_name = os.path.basename(request.path)
-        style = Style.objects.all().filter(name=style_name)[0]
+        style = Style.objects.get(name=style_name)
         style.delete()
 
 


### PR DESCRIPTION
It appears that GeoWebCache aggressively caches tiles produced using old SLD data, so that when a style is updated the tiles generated with the old style can be retained. This patch is intended to help GeoNode's GeoWebCache invalidate the tiles for the layer in question. 