### PR TITLE
fix exception during renders of admin forms using autocomplete_light

### DIFF
--- a/geonode/base/admin.py
+++ b/geonode/base/admin.py
@@ -130,5 +130,10 @@ admin.site.register(License, LicenseAdmin)
 
 
 class ResourceBaseAdminForm(autocomplete_light.ModelForm):
-    # keywords = TaggitField(widget=TaggitWidget('TagAutocomplete'), required=False)
-    keywords = TaggitField(widget=TaggitWidget(), required=False)
+    # We need to specify autocomplete='TagAutocomplete' or admin views like
+    # /admin/maps/map/2/ raise exceptions during form rendering.
+    # But if we specify it up front, TaggitField.__init__ throws an exception
+    # which prevents app startup. Therefore, we defer setting the widget until
+    # after that's done.
+    keywords = TaggitField(required=False)
+    keywords.widget = TaggitWidget(autocomplete='TagAutocomplete')


### PR DESCRIPTION
This is a proposed fix for #2566. 

To recap, when accessing admin URLs pertaining to certain models (e.g. /admin/maps/map/2/), template rendering raises "TypeError: 'NoneType' object is not callable" (I'll spare readers the full traceback because I'm certain you can easily replicate it against any version of Geonode going back to the great Django 1.8 upgrade commit). So these admin views for these models do not load.

To diagnose, this relates to `class ResourceBaseAdminForm` in `base/admin.py`, where `TaggitField` is instantiated with an instance of `TaggitWidget`. Before this patch, no value is specified for the first arg `autocomplete`; therefore, during the template render, that `None` value gets called. 

The first step of the fix is suggested by a commented-out line where `autocomplete` is specified as `'TagAutocomplete'`. However, when using this line, the boot-time instantiation of `TaggitField` fails, preventing the app from running at all. This probably explains why that line was commented out, because it is a step toward solving the admin problem but it leaves the app as a whole broken.

The basis of this PR (and admittedly it is a kludge) is to let TaggitField do its thing as currently, by not giving it a widget with autocomplete set, and then afterward setting such a widget so that the template render can work. I chose this solution to try to make a minimal patch and because django-autocomplete-light should probably be upgraded to its rewrite v3 someday anyway. If someone else has a better solution in the near term I'd be happy to see that solution merged instead of this PR.