### PR TITLE
fix broken og:image link in meta tag in head

### DIFF
--- a/geonode/people/templates/people/_profile_opengraph.html
+++ b/geonode/people/templates/people/_profile_opengraph.html
@@ -3,6 +3,6 @@
 <meta property="og:site_name" content="{{ SITE_NAME }}" />
 <meta property="og:url" content="http{% if request.is_secure %}s{% endif %}://{{ SITE_DOMAIN }}{{ profile.get_absolute_url }}" />
 <meta property="og:description" content="{{ profile.get_full_name | default:profile.username }} on {{ SITE_NAME }}" />
-<meta name="og:image" content="http{% if request.is_secure %}s{% endif %}://{{ SITE_DOMAIN }}{% avatar_url profile 200 %}" />
+<meta name="og:image" content="{% avatar_url profile 200 %}" />
 <meta name="og:image:width" content="200" />
 <meta name="og:image:height" content="200" />


### PR DESCRIPTION
Certain URLs, e.g.
`http://192.168.99.110:8000/people/profile/admin/?limit=100&offset=0`

Contain malformed meta links, e.g.
`<meta name="og:image" content="http://example.comhttp://www.gravatar.com/avatar/9a46584a89af11e4130ca7d6808e81a7/?s=200">`

The cause is straightforward in the template itself - see the diff. I'm guessing we probably don't want https://{{SITE_DOMAIN}} prepended to a gravatar URL. 