### PR TITLE
Revert " - remove layer_is FK constraints from layer_styles migrations"

### DIFF
--- a/geonode/layers/migrations/0002_initial_step2.py
+++ b/geonode/layers/migrations/0002_initial_step2.py
@@ -49,6 +49,6 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='attribute',
             name='layer',
-            field=models.ForeignKey(blank=True, related_name='attribute_set', to='layers.Layer', null=True),
+            field=models.ForeignKey(related_name='attribute_set', to='layers.Layer'),
         ),
     ]


### PR DESCRIPTION
Reference: https://github.com/GeoNode/geonode/issues/2579

Just a revert commit, but I'm raising it as a good practice / papertrail patch to pull in if desired.