### PR TITLE
Add context-specific search for people, groups

### DIFF
--- a/geonode/groups/templates/groups/group_list.html
+++ b/geonode/groups/templates/groups/group_list.html
@@ -14,33 +14,12 @@
     <h2>{% trans "Explore Groups" %}</h2>
   </div>
 
-  <div class="btn-group pull-right" role="group" aria-label="sort">
-    <div class="btn-group pull-right" role="group">
-      <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-        <i class="fa fa-sort-alpha-asc fa-lg"></i>
-        <i class="fa fa-angle-down fa-lg"></i>
-      </button>
-      <ul class="dropdown-menu" id="sort">
-        <li><a data-value="-date" data-filter="order_by" class="selected" ng-click="single_choice_listener($event)">{% trans "Most recent" %}</a></li>
-        <li><a data-value="date" data-filter="order_by" ng-click="single_choice_listener($event)">{% trans "Less recent" %}</a></li>
-        <li><a data-value="title" data-filter="order_by" ng-click="single_choice_listener($event)">{% trans "A - Z" %}</a></li>
-        <li><a data-value="-title" data-filter="order_by" ng-click="single_choice_listener($event)">{% trans "Z - A" %}</a></li>
-        <li><a data-value="-popular_count" data-filter="order_by" ng-click="single_choice_listener($event)">{% trans "Most popular" %}</a></li>
-      </ul>
-    </div>
-  </div>
-
-<div class="row">
-  <div class="col-md-12">
-    <div class="row">
-      <div class="tab-content col-sm-12" id="search-content">
-        {% include "groups/_group_list_item.html" %}
-      </div>
-    </div>
-  </div>
-</div>
-
-{% include 'search/_pagination.html' %}
+  {% with include_type_filter='true' %}
+  {% with facet_type='groups' %}
+  {% include "search/_group_search_content.html" %}
+  {% endwith %}
+  {% endwith %}
+  {% include "_bulk_permissions_form.html" %}
 {% endblock %}
 
 {% block extra_script %}
@@ -51,4 +30,3 @@
   {% include 'search/search_scripts.html' %}
   {% endwith %}
 {% endblock extra_script %}
-

--- a/geonode/groups/templates/groups/group_list.html
+++ b/geonode/groups/templates/groups/group_list.html
@@ -16,7 +16,7 @@
 
   {% with include_type_filter='true' %}
   {% with facet_type='groups' %}
-  {% include "search/_group_search_content.html" %}
+  {% include "search/_search_user_content.html" %}
   {% endwith %}
   {% endwith %}
   {% include "_bulk_permissions_form.html" %}

--- a/geonode/people/templates/people/profile_list.html
+++ b/geonode/people/templates/people/profile_list.html
@@ -1,37 +1,21 @@
 {% extends "people/profile_base.html" %}
 {% load i18n %}
 
+{% block title %} {% trans "Explore People" %} - {{ block.super }} {% endblock %}
+
 {% block body_class %}people people-list explore{% endblock %}
 
 {% block body %}
 <div class="page-header">
   <h2>{% trans "Explore People" %}</h2>
 </div>
-<div class="row">
-  <div class="col-md-12">
-    <div class="btn-group pull-right" role="group" aria-label="tools">
-      <div class="btn-group" role="group">
-        <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          <i class="fa fa-sort-alpha-asc fa-lg"></i>
-          <i class="fa fa-angle-down fa-lg"></i>
-        </button>
-        <ul class="dropdown-menu dropdown-menu-right" id="sort">
-          <li><a data-value="-date" data-filter="order_by" class="selected" ng-click="single_choice_listener($event)">{% trans "Most recent" %}</a></li>
-          <li><a data-value="date" data-filter="order_by" ng-click="single_choice_listener($event)">{% trans "Less recent" %}</a></li>
-          <li><a data-value="title" data-filter="order_by" ng-click="single_choice_listener($event)">{% trans "A - Z" %}</a></li>
-          <li><a data-value="-title" data-filter="order_by" ng-click="single_choice_listener($event)">{% trans "Z - A" %}</a></li>
-          <li><a data-value="-popular_count" data-filter="order_by" ng-click="single_choice_listener($event)">{% trans "Most popular" %}</a></li>
-        </ul>
-      </div>
-    </div>
-    <div class="row">
-      <div class="tab-content col-sm-12" id="search-content">
-        {% include "people/_profile_list_item.html" %}
-      </div>
-    </div>
-  </div>
-</div>
-{% include 'search/_pagination.html' %}
+
+  {% with include_type_filter='true' %}
+  {% with facet_type='people' %}
+  {% include "search/_search_user_content.html" %}
+  {% endwith %}
+  {% endwith %}
+  {% include "_bulk_permissions_form.html" %}
 {% endblock %}
 
 {% block extra_script %}

--- a/geonode/static/geonode/js/search/search.js
+++ b/geonode/static/geonode/js/search/search.js
@@ -392,7 +392,13 @@
         if (HAYSTACK_SEARCH)
             $scope.query['q'] = $('#text_search_input').val();
         else
-            $scope.query['title__icontains'] = $('#text_search_input').val();
+            if (AUTOCOMPLETE_URL_RESOURCEBASE == "/autocomplete/ProfileAutocomplete/")
+                // a user profile has no title; if search was triggered from
+                // the /people page, filter by username instead
+                var query_key = 'username__icontains';
+            else
+                var query_key = 'title__icontains';
+            $scope.query[query_key] = $('#text_search_input').val();
         query_api($scope.query);
     });
 

--- a/geonode/templates/search/_group_search_content.html
+++ b/geonode/templates/search/_group_search_content.html
@@ -1,0 +1,39 @@
+{% load i18n %}
+<div class="row" ng-controller="CartList">
+  <div class="col-md-3">
+    <div class="row">
+      <div class="col-xs-12">
+        {% load base_tags %}
+        <nav class="filter">
+            <h4><a href="" class="toggle toggle-nav">
+                    <i class="fa fa-chevron-down"></i>
+                    {% trans "search" %}
+                </a></h4>
+            <ul class="nav open" id="text">
+                <li>
+                    <div class="input-group">
+                    <input name="text_search_input" id="text_search_input" ng-model="text_query" type="text"
+                           placeholder="Search by name" class="form-control">
+                    <span class="input-group-btn">
+                        <button class="btn btn-primary" type="submit" id="text_search_btn"><i class="fa fa-search"></i></button>
+                    </span>
+                    </div>
+                </li>
+            </ul>
+        </nav>
+      </div>
+    </div>
+  </div>
+  <div class="col-md-9">
+    <div class="col-md-2">
+      <span>Total: </span>
+      <span ng-bind="total_counts"></span>
+    </div>
+    {% include "search/_sort_filters.html" %}
+    <div class="col-md-12 grid-spacer">
+    {% include 'search/_group_snippet.html' %}
+    {% include 'search/_pagination.html' %}
+    </div>
+  </div>
+  {% include "_bulk_permissions_form.html" %}
+</div>

--- a/geonode/templates/search/_group_snippet.html
+++ b/geonode/templates/search/_group_snippet.html
@@ -1,0 +1,34 @@
+{% verbatim %}
+<div class="row">
+  <article ng-repeat="group in results" resource_id="{{ group.id }}" ng-cloak class="ng-cloak">
+    <div class="col-xs-12 item-container">
+        <div class="col-xs-8 item-details">
+          <h4><a href="{{ group.detail_url }}">{{ group.title }}</a></h4>
+          <p class="abstract">
+              {{ group.description | limitTo: 300 }}
+              {{ group.description.length  > 300 ? '...' : ''}}
+          </p>
+          <div class="row">
+            <div class="col-xs-12 item-items">
+              <ul class="list-inline">
+                <li>
+                    <a href="{{ group.detail_url }}">
+                      <strong>{{ group.member_count }}</strong>
+                      <ng-pluralize count="group.member_count" when="{'1': 'Member', 'other': 'Members'}"></ng-pluralize>
+                    </a>
+                </li>
+                <li>
+                    <a href="{{ group.detail_url }}">
+                        <strong>{{ group.manager_count }}</strong>
+                        <ng-pluralize count="group.manager_count" when="{'1': 'Manager', 'other': 'Managers'}"></ng-pluralize>
+                    </a>
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </article>
+</div>
+{% endverbatim %}

--- a/geonode/templates/search/_search_user_content.html
+++ b/geonode/templates/search/_search_user_content.html
@@ -31,9 +31,12 @@
     </div>
     {% include "search/_sort_filters.html" %}
     <div class="col-md-12 grid-spacer">
-    {% include 'search/_group_snippet.html' %}
-    {% include 'search/_pagination.html' %}
+        {% if facet_type == 'groups' %}
+            {% include 'search/_group_snippet.html' %}
+        {% elif facet_type == 'people' %}    
+            {% include "people/_profile_list_item.html" %}
+        {% endif %}
     </div>
+        {% include 'search/_pagination.html' %}
   </div>
-  {% include "_bulk_permissions_form.html" %}
 </div>

--- a/geonode/templates/search/_sort_filters.html
+++ b/geonode/templates/search/_sort_filters.html
@@ -7,13 +7,23 @@
       <i class="fa fa-angle-down fa-lg"></i>
     </button>
     <ul class="dropdown-menu dropdown-menu-right" id="sort">
-        {% if facet_type != 'groups' %}
-      <li><a data-value="-date" data-filter="order_by" class="selected" ng-click="single_choice_listener($event)">{% trans "Most recent" %}</a></li>
-      <li><a data-value="date" data-filter="order_by" ng-click="single_choice_listener($event)">{% trans "Less recent" %}</a></li>
-      <li><a data-value="-popular_count" data-filter="order_by" ng-click="single_choice_listener($event)">{% trans "Most popular" %}</a></li>
+      {% if facet_type != 'groups' and facet_type != 'people' %}
+          <li><a data-value="-date" data-filter="order_by" class="selected" ng-click="single_choice_listener($event)">{% trans "Most recent" %}</a></li>
+          <li><a data-value="date" data-filter="order_by" ng-click="single_choice_listener($event)">{% trans "Less recent" %}</a></li>
+          <li><a data-value="title" data-filter="order_by" ng-click="single_choice_listener($event)">{% trans "A - Z" %}</a></li>
+          <li><a data-value="-title" data-filter="order_by" ng-click="single_choice_listener($event)">{% trans "Z - A" %}</a></li>
+          <li><a data-value="-popular_count" data-filter="order_by" ng-click="single_choice_listener($event)">{% trans "Most popular" %}</a></li>
+      {% elif facet_type == 'groups' %}
+          <li><a data-value="-last_modified" data-filter="order_by" class="selected" ng-click="single_choice_listener($event)">{% trans "Most recent" %}</a></li>
+          <li><a data-value="last_modified" data-filter="order_by" ng-click="single_choice_listener($event)">{% trans "Less recent" %}</a></li>
+          <li><a data-value="title" data-filter="order_by" ng-click="single_choice_listener($event)">{% trans "A - Z" %}</a></li>
+          <li><a data-value="-title" data-filter="order_by" ng-click="single_choice_listener($event)">{% trans "Z - A" %}</a></li>
+      {% elif facet_type == 'people' %}
+          <li><a data-value="-date_joined" data-filter="order_by" class="selected" ng-click="single_choice_listener($event)">{% trans "Most recent" %}</a></li>
+          <li><a data-value="date_joined" data-filter="order_by" ng-click="single_choice_listener($event)">{% trans "Less recent" %}</a></li>
+          <li><a data-value="username" data-filter="order_by" ng-click="single_choice_listener($event)">{% trans "A - Z" %}</a></li>
+          <li><a data-value="-username" data-filter="order_by" ng-click="single_choice_listener($event)">{% trans "Z - A" %}</a></li>
       {% endif %}
-      <li><a data-value="title" data-filter="order_by" ng-click="single_choice_listener($event)">{% trans "A - Z" %}</a></li>
-      <li><a data-value="-title" data-filter="order_by" ng-click="single_choice_listener($event)">{% trans "Z - A" %}</a></li>
     </ul>
   </div>
 </div>

--- a/geonode/templates/search/_sort_filters.html
+++ b/geonode/templates/search/_sort_filters.html
@@ -7,11 +7,13 @@
       <i class="fa fa-angle-down fa-lg"></i>
     </button>
     <ul class="dropdown-menu dropdown-menu-right" id="sort">
+        {% if facet_type != 'groups' %}
       <li><a data-value="-date" data-filter="order_by" class="selected" ng-click="single_choice_listener($event)">{% trans "Most recent" %}</a></li>
       <li><a data-value="date" data-filter="order_by" ng-click="single_choice_listener($event)">{% trans "Less recent" %}</a></li>
+      <li><a data-value="-popular_count" data-filter="order_by" ng-click="single_choice_listener($event)">{% trans "Most popular" %}</a></li>
+      {% endif %}
       <li><a data-value="title" data-filter="order_by" ng-click="single_choice_listener($event)">{% trans "A - Z" %}</a></li>
       <li><a data-value="-title" data-filter="order_by" ng-click="single_choice_listener($event)">{% trans "Z - A" %}</a></li>
-      <li><a data-value="-popular_count" data-filter="order_by" ng-click="single_choice_listener($event)">{% trans "Most popular" %}</a></li>
     </ul>
   </div>
 </div>


### PR DESCRIPTION
_Feel free to squash prior to merging; left as-is for info only_

Ref: https://github.com/GeoNode/geonode/issues/2555

Adds a context-dependent search (filter box) to the `/people` and `/groups` pages. This search works similarly to those on the other resource pages (map, layer, documents). In the case of `/people` search, searches as executed on the `username` property (as people profiles do not have a `title`).

![group_search](https://cloud.githubusercontent.com/assets/1209376/17850602/925d336e-6823-11e6-8662-db56f2bd5cbb.png)
_Re-styled group page showing all groups_


![group_search_result](https://cloud.githubusercontent.com/assets/1209376/17850603/925d69b0-6823-11e6-993d-33a0a7173ed1.png)
_search results using context-specific group search: autocomplete results are shown in drop-down from search box_


![people_search](https://cloud.githubusercontent.com/assets/1209376/17850605/9261618c-6823-11e6-929f-0de052059568.png)
_Same; for /people_


![people_search_result](https://cloud.githubusercontent.com/assets/1209376/17850604/925d7bb2-6823-11e6-95be-71cf15191fab.png)
_Same; for /people -- text may be entered to search first name, last name, or username values: autocomplete shows the username of matching profile(s)_