### PR TITLE
Development Fixes (pavement, settings, and migrations)

### DIFF
--- a/dev_config.yml
+++ b/dev_config.yml
@@ -7,3 +7,11 @@ WINDOWS:
   nose: "https://s3.amazonaws.com/geonodedeps/nose-1.3.3.win32-py2.7.exe"
   pyproj: "https://pyproj.googlecode.com/files/pyproj-1.9.3.win32-py2.7.exe"
   lxml: "https://pypi.python.org/packages/2.7/l/lxml/lxml-3.6.0.win32-py2.7.exe"
+MIGRATE_APPS:
+  - account
+  - contenttypes
+  - sites
+  - auth
+  - people
+  - base
+  - services

--- a/geonode/base/migrations/0004_auto_20160824_0245.py
+++ b/geonode/base/migrations/0004_auto_20160824_0245.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+# flake8: noqa
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('base', '0003_auto_20160821_1919'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='contactrole',
+            name='role',
+            field=models.CharField(
+                help_text='function performed by the responsible party',
+                max_length=255,
+                choices=[
+                    (b'author', 'party who authored the resource'),
+                    (b'processor', 'party who has processed the data in a manner such that the resource has been modified'),
+                    (b'publisher', 'party who published the resource'),
+                    (b'custodian', 'party that accepts accountability and responsibility for the data and ensures         appropriate care and maintenance of the resource'),
+                    (b'pointOfContact', 'party who can be contacted for acquiring knowledge about or acquisition of the resource'),
+                    (b'distributor', 'party who distributes the resource'),
+                    (b'user', 'party who uses the resource'),
+                    (b'resourceProvider', 'party that supplies the resource'),
+                    (b'originator', 'party who created the resource'),
+                    (b'owner', 'party that owns the resource'),
+                    (b'principalInvestigator', 'key party responsible for gathering information and conducting research')]),
+        ),
+        migrations.AlterField(
+            model_name='resourcebase',
+            name='category',
+            field=models.ForeignKey(
+                blank=True,
+                to='base.TopicCategory',
+                help_text='high-level geographic data thematic classification to assist in the grouping and search of available geographic data sets.',
+                null=True),
+        ),
+    ]

--- a/geonode/people/migrations/0003_auto_20160824_0245.py
+++ b/geonode/people/migrations/0003_auto_20160824_0245.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+# flake8: noqa
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import taggit.managers
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('people', '0002_auto_20160821_1919'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='profile',
+            name='keywords',
+            field= taggit.managers.TaggableManager(
+            to='taggit.Tag',
+            through='taggit.TaggedItem',
+            blank=True,
+            help_text='commonly used word(s) or formalised word(s) or phrase(s) used to describe the subject             (space or comma-separated',
+            verbose_name='keywords'),
+        ),
+    ]

--- a/geonode/services/migrations/0003_auto_20160824_0245.py
+++ b/geonode/services/migrations/0003_auto_20160824_0245.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+# flake8: noqa
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('services', '0002_auto_20160821_1919'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='serviceprofilerole',
+            name='role',
+            field=models.CharField(
+                help_text='function performed by the responsible party',
+                max_length=255,
+                choices=[
+                    (b'author', 'party who authored the resource'),
+                    (b'processor', 'party who has processed the data in a manner such that the resource has been modified'),
+                    (b'publisher', 'party who published the resource'),
+                    (b'custodian', 'party that accepts accountability and responsibility for the data and ensures         appropriate care and maintenance of the resource'),
+                    (b'pointOfContact', 'party who can be contacted for acquiring knowledge about or acquisition of the resource'),
+                    (b'distributor', 'party who distributes the resource'),
+                    (b'user', 'party who uses the resource'),
+                    (b'resourceProvider', 'party that supplies the resource'),
+                    (b'originator', 'party who created the resource'),
+                    (b'owner', 'party that owns the resource'),
+                    (b'principalInvestigator', 'key party responsible for gathering information and conducting research')]),
+        ),
+    ]

--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -42,8 +42,8 @@ PROJECT_ROOT = os.path.abspath(os.path.dirname(__file__))
 
 # Setting debug to true makes Django serve static media and
 # present pretty error pages.
-DEBUG = strtobool(os.getenv('DEBUG', 'False'))
-TEMPLATE_DEBUG = strtobool(os.getenv('TEMPLATE_DEBUG', 'False'))
+DEBUG = strtobool(os.getenv('DEBUG', 'True'))
+TEMPLATE_DEBUG = strtobool(os.getenv('TEMPLATE_DEBUG', 'True'))
 
 # Set to True to load non-minified versions of (static) client dependencies
 # Requires to set-up Node and tools that are required for static development
@@ -61,12 +61,14 @@ ALLOWED_HOSTS = os.getenv('ALLOWED_HOSTS', ['localhost', 'django'])
 _DEFAULT_SECRET_KEY = 'myv-y4#7j-d*p-__@j#*3z@!y24fz8%^z2v6atuy4bo9vqr1_a'
 SECRET_KEY = os.getenv('SECRET_KEY', _DEFAULT_SECRET_KEY)
 
-DATABASE_URL = os.getenv('DATABASE_URL', 'sqlite:///         development.db')
+DATABASE_URL = os.getenv(
+    'DATABASE_URL',
+    'sqlite:///{path}'.format(path=os.path.join(PROJECT_ROOT, 'development.db')))
 
 # Defines settings for development
-DATABASES = {'default':
-              dj_database_url.parse(DATABASE_URL,            conn_max_age=600),
-            } 
+DATABASES = {
+    'default': dj_database_url.parse(DATABASE_URL, conn_max_age=600)
+}
 
 MANAGERS = ADMINS = os.getenv('ADMINS', [])
 
@@ -926,7 +928,7 @@ except ImportError:
     pass
 
 
-# Load additonal basemaps, see geonode/contrib/api_basemap/README.md 
+# Load additonal basemaps, see geonode/contrib/api_basemap/README.md
 try:
     from geonode.contrib.api_basemaps import *
 except ImportError:

--- a/pavement.py
+++ b/pavement.py
@@ -214,8 +214,7 @@ def sync(options):
     """
     Run the syncdb and migrate management commands to create and migrate a DB
     """
-    migrate_apps = ['account', 'contenttypes', 'sites', 'auth', 'people', 'base', 'services']  # Order is very important
-    for app in migrate_apps:
+    for app in dev_config['MIGRATE_APPS']:
         try:
             sh("python manage.py migrate {app} --noinput".format(app=app))
         except:

--- a/pavement.py
+++ b/pavement.py
@@ -55,6 +55,7 @@ dev_config = None
 with open("dev_config.yml", 'r') as f:
     dev_config = yaml.load(f)
 
+
 def grab(src, dest, name):
     download = True
     if not dest.exists():
@@ -73,6 +74,7 @@ def grab(src, dest, name):
                 shutil.copyfile(str(src2), str(dest))
         else:
             urllib.urlretrieve(str(src), str(dest))
+
 
 @task
 @cmdopts([
@@ -210,18 +212,12 @@ def sync(options):
     """
     Run the syncdb and migrate management commands to create and migrate a DB
     """
-    try:
-        sh("python manage.py migrate auth --noinput")
-    except:
-        pass
-    try:
-        sh("python manage.py migrate sites --noinput")
-    except:
-        pass
-    try:
-        sh("python manage.py migrate people --noinput")
-    except:
-        pass
+    migrate_apps = ['account', 'contenttypes', 'sites', 'auth', 'people', 'base', 'services']  # Order is very important
+    for app in migrate_apps:
+        try:
+            sh("python manage.py migrate {app} --noinput".format(app=app))
+        except:
+            pass
     try:
         sh("python manage.py migrate --noinput")
     except:


### PR DESCRIPTION
This PR fixes a set of bugs preventing launch of a simple development machine using paver.  With this fix, we can launch Ubuntu 16.04 LTS development machines for vanilla/community GeoNode!  I use https://github.com/pjdufour/geonode-devops for provisioning the development machine.

**Settings**
- Fixed sqlite database path issue (reverted back to previous use of `PROJECT_ROOT`)
- Reverted `DEBUG` and `TEMPLATE_DEBUG` back to `True` by default.

**Migrations**
- Added additional migrate commands to paver (in correct order).
- Added migrations for `services`, `base`, and `people` apps.

I identified the missing migrations using `python manage.py makemigrations --dry-run  --noinput`, which should probably be added to docs somewhere.  Output was:

```
Migrations for 'services':
  0003_auto_20160824_0245.py:
    - Alter field role on serviceprofilerole
Migrations for 'base':
  0004_auto_20160824_0245.py:
    - Alter field role on contactrole
    - Alter field category on resourcebase
Migrations for 'people':
  0003_auto_20160824_0245.py:
    - Alter field keywords on profile
```

If anyone is an expert at migrations, please take a look.  I'm new to migrations.