### PR TITLE
Fix typos in "Install GeoNode for Development"

### DIFF
--- a/docs/tutorials/devel/devel_env/index.txt
+++ b/docs/tutorials/devel/devel_env/index.txt
@@ -29,7 +29,7 @@ Summary of the installation steps
 
     .. code-block:: console
 
-        service apahe2 stop
+        service apache2 stop
         service tomcat7 stop
 
 #. If possible log as **root** user, open a terminal and ``cd /home/geonode/dev``
@@ -334,7 +334,7 @@ Summary of the installation steps
 
         .. code-block:: console
 
-            service apahe2 stop
+            service apache2 stop
             service tomcat7 stop
 
    .. code-block:: console
@@ -402,7 +402,7 @@ Start working on Geonode the next day after install
 
             .. code-block:: console
 
-                service apahe2 stop
+                service apache2 stop
                 service tomcat7 stop
 
       .. code-block:: console

--- a/docs/tutorials/devel/devel_env/index_bk.txt
+++ b/docs/tutorials/devel/devel_env/index_bk.txt
@@ -28,7 +28,7 @@ Summary of the installation steps
 
     .. code-block:: console
 
-        service apahe2 stop
+        service apache2 stop
         service tomcat7 stop
 
 #. If possible log as **root** user, open a terminal and ``cd /home/geonode/dev``
@@ -331,7 +331,7 @@ Summary of the installation steps
 
         .. code-block:: console
 
-            service apahe2 stop
+            service apache2 stop
             service tomcat7 stop
 
    .. code-block:: console
@@ -397,7 +397,7 @@ Start working on Geonode the next day after install
 
             .. code-block:: console
 
-                service apahe2 stop
+                service apache2 stop
                 service tomcat7 stop
 
       .. code-block:: console


### PR DESCRIPTION
This fixes some typos in the "Install GeoNode for Development" section of the "Developers Workshop".