### PR TITLE
Exclude remote services layers from map download feature.

### DIFF
--- a/geonode/maps/views.py
+++ b/geonode/maps/views.py
@@ -614,6 +614,9 @@ def map_download(request, mapid, template='maps/map_download.html'):
         j_map = json.loads(mapJson)
         j_layers = j_map["layers"]
         for j_layer in j_layers:
+            if j_layer["service"] is None:
+                j_layers.remove(j_layer)
+                continue
             if(len([l for l in j_layers if l == j_layer])) > 1:
                 j_layers.remove(j_layer)
         mapJson = json.dumps(j_map)


### PR DESCRIPTION
An exception is produced if you add a remote layer (via the Remote Services feature) to a map, then try to download the map by going to:

Download Map -> Download Data Layers -> Start downloading this map

This PR fixes this by removing Remote Services layers from the list of layers to download.