### PR TITLE
Fix race condition during Raster upload/import

### DIFF
--- a/geonode/upload/upload.py
+++ b/geonode/upload/upload.py
@@ -383,16 +383,14 @@ def run_import(upload_session, async):
     import_session = upload_session.import_session
     import_session = gs_uploader.get_session(import_session.id)
     task = import_session.tasks[0]
+    import_execution_requested = False
     if import_session.state == 'INCOMPLETE':
         if task.state != 'ERROR':
             raise Exception('unknown item state: %s' % task.state)
     elif import_session.state == 'PENDING' and task.target.store_type == 'coverageStore':
         if task.state == 'READY':
             import_session.commit(async)
-
-    elif import_session.state == 'PENDING' and task.target.store_type == 'coverageStore':
-        if task.state == 'READY':
-            import_session.commit(async)
+            import_execution_requested = True
 
     # if a target datastore is configured, ensure the datastore exists
     # in geoserver and set the uploader target appropriately
@@ -426,7 +424,8 @@ def run_import(upload_session, async):
 
     _log('running import session')
     # run async if using a database
-    import_session.commit(async)
+    if not import_execution_requested:
+        import_session.commit(async)
 
     # @todo check status of import session - it may fail, but due to protocol,
     # this will not be reported during the commit


### PR DESCRIPTION
When uploading a Raster layer, the GeoServer Importer would sometimes fail with a NullPointerExcption trying to deference the target DataStore on the Task. In debugging the issue, I found that in these cases, the Import Task execution request would *reattach* to the GeoServer Catalog and effectively overwrite the DataStore on the Task to null.
The code for this case was always sending the Import Task execution twice [ `import_session.commit(async)` ], once on line 391 and then again just before returning the target datastore, while other cases would only send the request at the very end. Preventing the second request for Raster uploads seems to eliminate the race condition in GeoServer Importer.

Also, I removed the repeated block of code at 393, it will never get hit since it's the same block at 389