### PR TITLE
Clear comment modal after adding comment

### DIFF
--- a/geonode/layers/templates/layers/layer_detail.html
+++ b/geonode/layers/templates/layers/layer_detail.html
@@ -500,6 +500,7 @@
               url: $("#form_post_comment").attr('action'),
               data: $("#form_post_comment").serialize(),
               success: function() {
+                $('#form_post_comment_div').modal().find('form')[0].reset();
                 $('#form_post_comment_div').modal('hide');
                 $('#comments_section').load(window.location.pathname + ' #comments_section',
                 		function(){$(this).children().unwrap()})

--- a/geonode/maps/templates/maps/map_detail.html
+++ b/geonode/maps/templates/maps/map_detail.html
@@ -298,6 +298,7 @@
       url: $("#form_post_comment").attr('action'),
       data: $("#form_post_comment").serialize(),
       success: function() {
+        $('#form_post_comment_div').modal().find('form')[0].reset();
         $('#form_post_comment_div').modal('hide');
         $('#comments_section').load(window.location.pathname + ' #comments_section', 
         		function(){$(this).children().unwrap()})


### PR DESCRIPTION
Prevents the modal from spawning with the previous comment if you click "Add comment" again before refreshing the page.