### PR TITLE
Respond correctly when user removes the last related file for a layer…

### DIFF
--- a/geonode/static/geonode/js/upload/LayerInfo.js
+++ b/geonode/static/geonode/js/upload/LayerInfo.js
@@ -699,6 +699,7 @@ define(function (require, exports) {
             }
             a.data('layer', self.name);
             a.data('file',  file.name);
+            a.attr('class', 'remove-file');
             a.appendTo(p);
             a.on('click', function (event) {
                 var target = $(event.target),
@@ -706,10 +707,14 @@ define(function (require, exports) {
                     layer_name = target.data('layer'),
                     file_name  = target.data('file');
                 self.removeFile(file_name);
+                if (self.files.length == 0) {
+                    delete layers[self.name];
+                }
                 if (file_ext === 'xml') {
                     $('#metadata_uploaded_preserve_check').hide();
                 }
-                self.displayRefresh();
+                self.errors = self.collectErrors();
+                self.displayErrors();
             });
         });
     };

--- a/geonode/static/geonode/js/upload/upload.js
+++ b/geonode/static/geonode/js/upload/upload.js
@@ -352,6 +352,10 @@ define(['underscore',
             buildFileInfo(_.groupBy(file_input.files, path.getName));
             displayFiles(file_queue);
         });
+        // Detect click on "Remove" link and update the file_queue
+        $(options.file_queue).on('click', '.remove-file', function () {
+            displayFiles(file_queue);
+        });
         $(options.clear_button).on('click', doClearState);
         $(options.upload_button).on('click', doUploads);
         $("[id^=delete]").on('click', doDelete);


### PR DESCRIPTION
… upload

The motivation for this change is because the user can currently get "stuck" with an empty layer upload.

Steps to reproduce:
1) Go to the "layer upload" page.
2) Select some files to upload.
3) Click "remove" for all files related to a layer.

You are now in the "broken layer" state. Even if you have correct layers, having one layer missing files it needs will cause an error on upload. Currently it can only be fixed by clicking the "Clear" button to clear all staged files. This is not intuitive and may not be what the user wants.

With this change, clicking "remove" on the final file associated with the layer will automatically remove this layer from the staged layers for upload.