### PR TITLE
truncate upload names over length to allow upload

### DIFF
--- a/geonode/upload/upload.py
+++ b/geonode/upload/upload.py
@@ -290,6 +290,10 @@ def save_step(user, layer, spatial_files, overwrite=True,
         next_id = max(int(last_importer_session), int(upload_next_id)) + 1
         next_id = max(int(last_importer_session), int(upload_next_id)) + 1
 
+        # Truncate name to maximum length defined by the field.
+        max_length = Upload._meta.get_field('name').max_length
+        name = name[:max_length]
+
         # save record of this whether valid or not - will help w/ debugging
         upload = Upload.objects.create(
             user=user,


### PR DESCRIPTION
One approach to the problem described in
https://github.com/GeoNode/geonode/issues/2646

This patch uses the Django field definition to get the length, so this can be controlled from that one place and won't get out of sync.