### PR TITLE
Fixing missing and broken links to actions on the user's activity page

### DIFF
--- a/geonode/social/urls.py
+++ b/geonode/social/urls.py
@@ -19,6 +19,10 @@
 #########################################################################
 
 from django.conf.urls import patterns, url
-from geonode.social.views import RecentActivity
+from geonode.social.views import RecentActivity, UserActivity
 
-urlpatterns = patterns('', url(r'^recent-activity$', RecentActivity.as_view(), name='recent-activity'),)
+urlpatterns = patterns('',
+                       url(r'^recent-activity$',
+                           RecentActivity.as_view(), name='recent-activity'),
+                       url(r'^user-activity/(?P<actor>[^/]*)$',
+                           UserActivity.as_view(), name='user-activity'),)

--- a/geonode/social/views.py
+++ b/geonode/social/views.py
@@ -42,3 +42,22 @@ class RecentActivity(ListView):
             public=True,
             action_object_content_type__model='comment')[:15]
         return context
+
+
+class UserActivity(ListView):
+    """
+    Returns recent user activity.
+    """
+    context_object_name = 'action_list'
+    template_name = 'actstream/actor.html'
+
+    def get_queryset(self):
+        # There's no generic foreign key for 'actor', so can't filter directly
+        # Hence the code below is essentially applying the filter afterwards
+        return [x for x in Action.objects.filter(public=True)[:15]
+                if x.actor.username == self.kwargs['actor']]
+
+    def get_context_data(self, *args, **kwargs):
+        context = super(ListView, self).get_context_data(*args, **kwargs)
+        context['actor'] = self.kwargs['actor']
+        return context


### PR DESCRIPTION
Prior to these applied changes, the "My Activity" link would sometimes incorrectly display the user's actions. They would lack the link to the object sometimes, and sometimes not display at all.

The User activity feed prior to this change:
![alt tag](http://i.imgur.com/CH7hOoI.jpg)