### PR TITLE
Fixed bug breaking Group Activity view

### DIFF
--- a/geonode/groups/views.py
+++ b/geonode/groups/views.py
@@ -276,13 +276,13 @@ class GroupActivityView(ListView):
         context['action_list_layers'] = Action.objects.filter(
             public=True,
             actor_object_id__in=members,
-            action_object_content_type__name='layer')[:15]
+            action_object_content_type__model='layer')[:15]
         context['action_list_maps'] = Action.objects.filter(
             public=True,
             actor_object_id__in=members,
-            action_object_content_type__name='map')[:15]
+            action_object_content_type__model='map')[:15]
         context['action_list_comments'] = Action.objects.filter(
             public=True,
             actor_object_id__in=members,
-            action_object_content_type__name='comment')[:15]
+            action_object_content_type__model='comment')[:15]
         return context


### PR DESCRIPTION
The wrong filter was being applied for this view, causing it to give an error.