### PR TITLE
Enable update layers management command to accept the permissions dict

### DIFF
--- a/geonode/geoserver/management/commands/updatelayers.py
+++ b/geonode/geoserver/management/commands/updatelayers.py
@@ -24,6 +24,7 @@ from geonode.people.utils import get_valid_user
 from geonode.geoserver.helpers import gs_slurp
 import traceback
 import sys
+import ast
 
 
 class Command(BaseCommand):
@@ -77,7 +78,13 @@ class Command(BaseCommand):
             '--workspace',
             dest="workspace",
             default=None,
-            help="Only update data on specified workspace"))
+            help="Only update data on specified workspace"),
+        make_option(
+            '-p',
+            '--permissions',
+            dest="permissions",
+            default="None",
+            help="Permissions to apply to each layer"))
 
     def handle(self, **options):
         ignore_errors = options.get('ignore_errors')
@@ -90,6 +97,7 @@ class Command(BaseCommand):
         workspace = options.get('workspace')
         filter = options.get('filter')
         store = options.get('store')
+        permissions = ast.literal_eval(options.get('permissions'))
 
         if verbosity > 0:
             console = sys.stdout
@@ -106,7 +114,8 @@ class Command(BaseCommand):
             filter=filter,
             skip_unadvertised=skip_unadvertised,
             skip_geonode_registered=skip_geonode_registered,
-            remove_deleted=remove_deleted)
+            remove_deleted=remove_deleted,
+            permissions=permissions)
 
         if verbosity > 1:
             print "\nDetailed report of failures:"


### PR DESCRIPTION
This PR exposes the permissions arg so that custom permissions can be applied to layers during the creation/registration process.

Example Usage:

```
python manage.py updatelayers --skip-geonode-registered -i -p "{'users': {'AnonymousUser': ['change_layer_data', 'download_resourcebase', 'view_resourcebase']},'groups': {'registered': ['change_layer_data', 'download_resourcebase', 'view_resourcebase']}}"
```
