### PR TITLE
Package up all necessary files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include README README.rst LICENSE
-recursive-exclude ./geonode/static/.components
-recursive-include geonode *.js *.css *.png *.eot *.woff *.tff *.svg *.html *.xml *.json *.ini
+recursive-exclude geonode/static/.components
+recursive-include geonode *.css *.eot *.gif *.html *.ico *.ini *.jpg *.js *.json *.less *.md *.mo *.po *.otf *.png *.rst *.sample *.svg *.swf *.ttf *.txt *.woff *.woff2 *.xml *.xsl README
+recursive-include geonode/contrib/geosites gunicorn nginx


### PR DESCRIPTION
previous adjustments to the setup.py and MANIFEST.ini were not allowing certain filetypes to be packaged, loading.gif was the most noticeable.