### PR TITLE
Fixing syntax error: celery_app

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       - rabbitmq
       - postgres
       - elasticsearch
-    command: celery worker --app=geonode.celeryapp:app -B -l INFO
+    command: celery worker --app=geonode.celery_app:app -B -l INFO
     environment:
       - DATABASE_URL=postgres://postgres:postgres@postgres:5432/postgres
       - BROKER_URL=amqp://guest:guest@rabbitmq:5672/


### PR DESCRIPTION
Please! Fix it Celery service on docker-compose:

Correct way:

```
celery:
    image: geonode/django
    links:
      - rabbitmq
      - postgres
      - elasticsearch
    command: celery worker --app=geonode.celery_app:app -B -l INFO
```
Instead of:

```
celery:
    image: geonode/django
    links:
      - rabbitmq
      - postgres
      - elasticsearch
    command: celery worker --app=geonode.celeryapp:app -B -l INFO
```