### PR TITLE
Split geoserver.helpers.set_attributes()

### DIFF
--- a/geonode/contrib/geosites/models.py
+++ b/geonode/contrib/geosites/models.py
@@ -21,6 +21,7 @@
 from django.db import models
 from django.db.models import signals
 from django.contrib.sites.models import Site
+from django.conf import settings
 
 from geonode.base.models import ResourceBase
 from geonode.layers.models import Layer
@@ -98,13 +99,14 @@ def post_delete_profile(instance, sender, **kwargs):
 
 
 # Django doesn't propagate the signals to the parents so we need to add the listeners on the children
-signals.post_save.connect(post_save_resource, sender=Layer)
-signals.post_save.connect(post_save_resource, sender=Map)
-signals.post_save.connect(post_save_resource, sender=Document)
-signals.post_save.connect(post_save_site, sender=Site)
-signals.post_delete.connect(post_delete_resource, sender=Layer)
-signals.post_delete.connect(post_delete_resource, sender=Map)
-signals.post_delete.connect(post_delete_resource, sender=Document)
-signals.post_delete.connect(post_delete_site, sender=Site)
-signals.post_save.connect(post_save_profile, sender=Profile)
-signals.post_delete.connect(post_delete_profile, sender=Profile)
+if 'geonode.contrib.geosites' in settings.INSTALLED_APPS:
+    signals.post_save.connect(post_save_resource, sender=Layer)
+    signals.post_save.connect(post_save_resource, sender=Map)
+    signals.post_save.connect(post_save_resource, sender=Document)
+    signals.post_save.connect(post_save_site, sender=Site)
+    signals.post_delete.connect(post_delete_resource, sender=Layer)
+    signals.post_delete.connect(post_delete_resource, sender=Map)
+    signals.post_delete.connect(post_delete_resource, sender=Document)
+    signals.post_delete.connect(post_delete_site, sender=Site)
+    signals.post_save.connect(post_save_profile, sender=Profile)
+    signals.post_delete.connect(post_delete_profile, sender=Profile)

--- a/geonode/geoserver/helpers.py
+++ b/geonode/geoserver/helpers.py
@@ -462,7 +462,7 @@ def gs_slurp(
             })
 
             # recalculate the layer statistics
-            set_attributes(layer, overwrite=True)
+            set_attributes_from_geoserver(layer, overwrite=True)
 
             # Fix metadata links if the ip has changed
             if layer.link_set.metadata().count() > 0:
@@ -626,7 +626,7 @@ def get_stores(store_type=None):
     return store_list
 
 
-def set_attributes(layer, overwrite=False):
+def set_attributes_from_geoserver(layer, overwrite=False):
     """
     Retrieve layer attribute names & types from Geoserver,
     then store in GeoNode database using Attribute model

--- a/geonode/geoserver/signals.py
+++ b/geonode/geoserver/signals.py
@@ -29,7 +29,7 @@ from django.utils.translation import ugettext
 from django.conf import settings
 
 from geonode.geoserver.ows import wcs_links, wfs_links, wms_links
-from geonode.geoserver.helpers import cascading_delete, set_attributes
+from geonode.geoserver.helpers import cascading_delete, set_attributes_from_geoserver
 from geonode.geoserver.helpers import set_styles, gs_catalog
 from geonode.geoserver.helpers import ogc_server_settings
 from geonode.geoserver.helpers import geoserver_upload, http_client
@@ -182,7 +182,7 @@ def geoserver_post_save(instance, sender, **kwargs):
 
     if instance.storeType == "remoteStore":
         # Save layer attributes
-        set_attributes(instance)
+        set_attributes_from_geoserver(instance)
         return
 
     if not getattr(instance, 'gs_resource', None):
@@ -471,7 +471,7 @@ def geoserver_post_save(instance, sender, **kwargs):
         Link.objects.filter(pk=link.pk).update(url=tile_url)
 
     # Save layer attributes
-    set_attributes(instance)
+    set_attributes_from_geoserver(instance)
 
     # Save layer styles
     set_styles(instance, gs_catalog)

--- a/geonode/services/views.py
+++ b/geonode/services/views.py
@@ -57,7 +57,7 @@ from geonode.utils import bbox_to_wkt
 from geonode.services.forms import CreateServiceForm, ServiceForm
 from geonode.utils import mercator_to_llbbox
 from geonode.layers.utils import create_thumbnail
-from geonode.geoserver.helpers import set_attributes
+from geonode.geoserver.helpers import set_attributes_from_geoserver
 from geonode.base.models import Link
 
 logger = logging.getLogger("geonode.core.layers.views")
@@ -655,7 +655,7 @@ def _register_indexed_layers(service, wms=None, verbosity=False):
                 saved_layer.save()
                 saved_layer.set_default_permissions()
                 saved_layer.keywords.add(*keywords)
-                set_attributes(saved_layer)
+                set_attributes_from_geoserver(saved_layer)
 
                 service_layer, created = ServiceLayer.objects.get_or_create(
                     typename=wms_layer.name,

--- a/geonode/tests/integration.py
+++ b/geonode/tests/integration.py
@@ -48,7 +48,7 @@ from geonode.layers.utils import (
 )
 from geonode.tests.utils import check_layer, get_web_page
 
-from geonode.geoserver.helpers import cascading_delete, set_attributes
+from geonode.geoserver.helpers import cascading_delete, set_attributes_from_geoserver
 # FIXME(Ariel): Uncomment these when #1767 is fixed
 # from geonode.geoserver.helpers import get_time_info
 # from geonode.geoserver.helpers import get_wms
@@ -1001,7 +1001,7 @@ class GeoNodeGeoServerSync(TestCase):
     def tearDown(self):
         pass
 
-    def test_set_attributes(self):
+    def test_set_attributes_from_geoserver(self):
         """Test attributes syncronization
         """
 
@@ -1018,7 +1018,7 @@ class GeoNodeGeoServerSync(TestCase):
             attribute.save()
 
         # sync the attributes with GeoServer
-        set_attributes(layer)
+        set_attributes_from_geoserver(layer)
 
         # tests if everything is synced properly
         for attribute in layer.attribute_set.all():

--- a/geonode/utils.py
+++ b/geonode/utils.py
@@ -753,7 +753,13 @@ def set_attributes(layer, attribute_map, overwrite=False, attribute_stats=None):
                     description=description, attribute_label=label,
                     display_order=display_order)
                 if created:
-                    result = attribute_stats[layer.name][field] if attribute_stats else None
+                    if (not attribute_stats
+                        or layer.name not in attribute_stats
+                        or field not in attribute_stats[layer.name]):
+                        result = None
+                    else:
+                        result = attribute_stats[layer.name][field]
+
                     if result is not None:
                         logger.debug("Generating layer attribute statistics")
                         la.count = result['Count']

--- a/geonode/utils.py
+++ b/geonode/utils.py
@@ -18,28 +18,31 @@
 #
 #########################################################################
 
-import logging
-import os
-import httplib2
 import base64
-import math
 import copy
-import string
+import datetime
+import logging
+import math
+import os
 import re
+import string
+
+from django.conf import settings
+from django.core.cache import cache
+from django.core.exceptions import PermissionDenied
+from django.http import Http404
+from django.http import HttpResponse
+from django.shortcuts import get_object_or_404
+from django.utils.translation import ugettext_lazy as _
+import httplib2
 from osgeo import ogr
 from slugify import Slugify
 
-from django.conf import settings
-from django.core.exceptions import PermissionDenied
-from django.utils.translation import ugettext_lazy as _
-from django.shortcuts import get_object_or_404
+
 try:
     import json
 except ImportError:
     from django.utils import simplejson as json
-from django.http import HttpResponse
-from django.core.cache import cache
-from django.http import Http404
 
 DEFAULT_TITLE = ""
 DEFAULT_ABSTRACT = ""
@@ -604,7 +607,7 @@ def build_caveats(resourcebase):
     if resourcebase.data_quality_statement:
         caveats.append(resourcebase.data_quality_statement)
     if len(caveats) > 0:
-        return u"- "+u"%0A- ".join(caveats)
+        return u"- " + u"%0A- ".join(caveats)
     else:
         return u""
 
@@ -675,14 +678,14 @@ def check_shp_columnnames(layer):
                 new_field_name = custom_slugify(field_name)
 
                 if not b.match(new_field_name):
-                    new_field_name = '_'+new_field_name
+                    new_field_name = '_' + new_field_name
                 j = 0
                 while new_field_name in list_col_original or new_field_name in list_col.values():
                     if j == 0:
                         new_field_name += '_0'
-                    if new_field_name.endswith('_'+str(j)):
+                    if new_field_name.endswith('_' + str(j)):
                         j += 1
-                        new_field_name = new_field_name[:-2]+'_'+str(j)
+                        new_field_name = new_field_name[:-2] + '_' + str(j)
                 list_col.update({field_name: new_field_name})
     except UnicodeDecodeError as e:
         print str(e)
@@ -695,3 +698,86 @@ def check_shp_columnnames(layer):
             qry = u"ALTER TABLE {0} RENAME COLUMN \"{1}\" TO \"{2}\"".format(inLayer.GetName(), key, list_col[key])
             inDataSource.ExecuteSQL(qry.encode(layer.charset))
     return True, None, list_col
+
+
+Attribute = None
+def set_attributes(layer, attribute_map, overwrite=False, attribute_stats=None):
+    """ *layer*: a geonode.layers.models.Layer instance
+        *attribute_map*: a list of 2-lists specifying attribute names and types,
+            example: [ ['id', 'Integer'], ... ]
+        *overwrite*: replace existing attributes with new values if name/type matches.
+        *attribute_stats*: dictionary of return values from get_attribute_statistics(),
+            of the form to get values by referencing attribute_stats[<layer_name>][<field_name>].
+    """
+    # Some import dependency tweaking; functions in this module are used before
+    # models are fully set up so Attribute has to be imported here.
+    # The global Attribute caches the import so it's not done every time
+    # this function is called.
+    global Attribute
+    if Attribute == None:
+        from geonode.layers.models import Attribute as LayerAttribute
+        Attribute = LayerAttribute
+
+    # we need 3 more items; description, attribute_label, and display_order
+    attribute_map_dict = {
+        'field': 0,
+        'ftype': 1,
+        'description': 2,
+        'label': 3,
+        'display_order': 4,
+    }
+    for attribute in attribute_map:
+        attribute.extend((None, None, 0))
+
+    attributes = layer.attribute_set.all()
+    # Delete existing attributes if they no longer exist in an updated layer
+    for la in attributes:
+        lafound = False
+        for attribute in attribute_map:
+            field, ftype, description, label, display_order = attribute
+            if field == la.attribute:
+                lafound = True
+                # store description and attribute_label in attribute_map
+                attribute[attribute_map_dict['description']] = la.description
+                attribute[attribute_map_dict['label']] = la.attribute_label
+                attribute[attribute_map_dict['display_order']] = la.display_order
+        if overwrite or not lafound:
+            logger.debug(
+                "Going to delete [%s] for [%s]",
+                la.attribute,
+                layer.name.encode('utf-8'))
+            la.delete()
+
+    # Add new layer attributes if they don't already exist
+    if attribute_map is not None:
+        iter = len(Attribute.objects.filter(layer=layer)) + 1
+        for attribute in attribute_map:
+            field, ftype, description, label, display_order = attribute
+            if field is not None:
+                la, created = Attribute.objects.get_or_create(
+                    layer=layer, attribute=field, attribute_type=ftype,
+                    description=description, attribute_label=label,
+                    display_order=display_order)
+                if created:
+                    result = attribute_stats[layer.name][field] if attribute_stats else None
+                    if result is not None:
+                        logger.debug("Generating layer attribute statistics")
+                        la.count = result['Count']
+                        la.min = result['Min']
+                        la.max = result['Max']
+                        la.average = result['Average']
+                        la.median = result['Median']
+                        la.stddev = result['StandardDeviation']
+                        la.sum = result['Sum']
+                        la.unique_values = result['unique_values']
+                        la.last_stats_updated = datetime.datetime.now()
+                    la.visible = ftype.find("gml:") != 0
+                    la.display_order = iter
+                    la.save()
+                    iter += 1
+                    logger.debug(
+                        "Created [%s] attribute for [%s]",
+                        field,
+                        layer.name.encode('utf-8'))
+    else:
+        logger.debug("No attributes found")

--- a/geonode/utils.py
+++ b/geonode/utils.py
@@ -753,9 +753,8 @@ def set_attributes(layer, attribute_map, overwrite=False, attribute_stats=None):
                     description=description, attribute_label=label,
                     display_order=display_order)
                 if created:
-                    if (not attribute_stats
-                        or layer.name not in attribute_stats
-                        or field not in attribute_stats[layer.name]):
+                    if (not attribute_stats or layer.name not in attribute_stats or
+                            field not in attribute_stats[layer.name]):
                         result = None
                     else:
                         result = attribute_stats[layer.name][field]

--- a/geonode/utils.py
+++ b/geonode/utils.py
@@ -700,7 +700,6 @@ def check_shp_columnnames(layer):
     return True, None, list_col
 
 
-Attribute = None
 def set_attributes(layer, attribute_map, overwrite=False, attribute_stats=None):
     """ *layer*: a geonode.layers.models.Layer instance
         *attribute_map*: a list of 2-lists specifying attribute names and types,
@@ -711,12 +710,7 @@ def set_attributes(layer, attribute_map, overwrite=False, attribute_stats=None):
     """
     # Some import dependency tweaking; functions in this module are used before
     # models are fully set up so Attribute has to be imported here.
-    # The global Attribute caches the import so it's not done every time
-    # this function is called.
-    global Attribute
-    if Attribute == None:
-        from geonode.layers.models import Attribute as LayerAttribute
-        Attribute = LayerAttribute
+    from geonode.layers.models import Attribute
 
     # we need 3 more items; description, attribute_label, and display_order
     attribute_map_dict = {


### PR DESCRIPTION
Split this function into two with one containing geoserver-agnostic logic, and the other home to the geoserver-specific logic.  This is support for django-osgeo-importer changes which will allow imports that don't require a geoserver instance.
