### PR TITLE
Process inbox messages using AJAX

### DIFF
--- a/geonode/templates/user_messages/_message_snippet.html
+++ b/geonode/templates/user_messages/_message_snippet.html
@@ -37,7 +37,7 @@
             <td>
                 <form id="thread_delete_{{ thread.pk }}" method="post" action="{% url "messages_thread_delete" thread.pk %}">
                     {% csrf_token %}
-                    <input type="submit" value="{% trans "Delete" %}" class="btn btn-danger" type="button"/>
+                    <button class="btn btn-danger message_delete_btn">{% trans "Delete" %}</button>
                 </form>
             </td>
         </tr>

--- a/geonode/templates/user_messages/inbox.html
+++ b/geonode/templates/user_messages/inbox.html
@@ -37,3 +37,21 @@
 {% block sidebar %}
 <a href="{% url "message_create" %}" class="btn btn-primary" type="button">{% trans "Create Message" %}</a>
 {% endblock %}
+
+{% block extra_script %}
+<script type="text/javascript">
+$('.message_delete_btn').click(function(event) {
+  form = $(this).parent()[0];
+  $.ajax({
+    type: "POST",
+    url: $(form).attr('action'),
+    data: $(form).serialize(),
+    success: function() {
+      $('#inbox').load(window.location.pathname + ' #inbox');
+      $('#all').load(window.location.pathname + ' #all');
+    }
+  });
+  return false;
+});
+</script>
+{% endblock extra_script %}


### PR DESCRIPTION
This is an update to the inbox messages to use AJAX. Now when a user deletes a message, it sends an AJAX request. Therefore, they will remain in their active tab (`Inbox` or `All`), where before you would always be returned to the default active tab, `Inbox`.