### PR TITLE
Fix for GeoNode install of celery (django-celery version installed doesnt support celery 4.0)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,6 @@
 #########################################################################
 
 from distutils.core import setup
-from distutils.command.install import INSTALL_SCHEMES
 from setuptools import find_packages
 import os
 
@@ -66,15 +65,15 @@ setup(name='GeoNode',
         "awesome-slugify>=1.6.2",
 
         # Django Apps
-        "django-pagination >=1.0.5, <=1.0.7", # python-django-pagination
-        "django-extensions>=1.2.5", # python-django-extensions
-        "django-taggit>=0.21.0", # python-django-taggit
-        "django-mptt>=0.8.6", # django-mptt
-        "django-treebeard>=3.0", #django-treebeard
-        "django-guardian>=1.4.1", #django-guardian
+        "django-pagination >=1.0.5, <=1.0.7",  # python-django-pagination
+        "django-extensions>=1.2.5",  # python-django-extensions
+        "django-taggit>=0.21.0",  # python-django-taggit
+        "django-mptt>=0.8.6",  # django-mptt
+        "django-treebeard>=3.0",  # django-treebeard
+        "django-guardian>=1.4.1",  # django-guardian
         # "django-admin-bootstrapped>=1.6.5", #django-admin-bootstrapped
 
-        ## Apps with packages provided in GeoNode's PPA on Launchpad.
+        # Apps with packages provided in GeoNode's PPA on Launchpad.
         "dj-database-url >=0.4.0",
         "django-jsonfield>=0.9.16",  # python-django-jsonfield
         "django-mptt>=0.8.0",  # django-mptt
@@ -118,7 +117,7 @@ setup(name='GeoNode',
         "django-haystack>=2.4.1",
         "elasticsearch>=2.4.0",
         "pyelasticsearch>=0.6.1",
-        "celery>=3.1.17",
+        "celery>=3.1.17,<4.0a0",
         "django-celery>=3.1.16",
 
         # datetimepicker widget
@@ -126,7 +125,7 @@ setup(name='GeoNode',
         "flake8>=2.3.0",
         "pep8>=1.6.2",
 
-        #AWS S3 dependencies
+        # AWS S3 dependencies
         "django-storages>=1.1.8",
         "boto>=2.38.0"
         ],


### PR DESCRIPTION
- removed import on INSTALLED_SCHEMES since its usage was removed on this commit  (aff43c0).

- limiting the version of celery to less then the 4.0 release, due to django-celery not having a release in over a year which would include the updates in master to support the new version of celery.  If you currently install Geonode it will install celery 4.0, but when attempting to use any django commands an ImportError occurs due to no module named timeutils.