### PR TITLE
Update the object_list limit 

### DIFF
--- a/geonode/api/resourcebase_api.py
+++ b/geonode/api/resourcebase_api.py
@@ -411,7 +411,7 @@ class CommonModelApi(ModelResource):
 
         object_list = {
            "meta": {
-                "limit": settings.CLIENT_RESULTS_LIMIT,
+                "limit": settings.API_LIMIT_PER_PAGE,
                 "next": next_page,
                 "offset": int(getattr(request.GET, 'offset', 0)),
                 "previous": previous_page,

--- a/geonode/api/resourcebase_api.py
+++ b/geonode/api/resourcebase_api.py
@@ -410,14 +410,15 @@ class CommonModelApi(ModelResource):
             objects = []
 
         object_list = {
-           "meta": {"limit": settings.CLIENT_RESULTS_LIMIT,
-                    "next": next_page,
-                    "offset": int(getattr(request.GET, 'offset', 0)),
-                    "previous": previous_page,
-                    "total_count": total_count,
-                    "facets": facets,
-                    },
-            'objects': map(lambda x: self.get_haystack_api_fields(x), objects),
+           "meta": {
+                "limit": settings.CLIENT_RESULTS_LIMIT,
+                "next": next_page,
+                "offset": int(getattr(request.GET, 'offset', 0)),
+                "previous": previous_page,
+                "total_count": total_count,
+                "facets": facets,
+            },
+           "objects": map(lambda x: self.get_haystack_api_fields(x), objects),
         }
         self.log_throttled_access(request)
         return self.create_response(request, object_list)

--- a/geonode/api/resourcebase_api.py
+++ b/geonode/api/resourcebase_api.py
@@ -410,7 +410,7 @@ class CommonModelApi(ModelResource):
             objects = []
 
         object_list = {
-           "meta": {"limit": 100,  # noqa
+           "meta": {"limit": settings.CLIENT_RESULTS_LIMIT,
                     "next": next_page,
                     "offset": int(getattr(request.GET, 'offset', 0)),
                     "previous": previous_page,


### PR DESCRIPTION
Update the object_list limit to use the value assigned to CLIENT_RESULTS_LIMIT in settings rather than a hard coded value.