### PR TITLE
require celery version to be at least 3.1.18

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ awesome-slugify==1.6.2
 beautifulsoup4==4.2.1
 billiard==3.3.0.23
 boto==2.38.0
-celery==3.1.17
+celery==3.1.18
 dj-database-url==0.4.0
 django-activity-stream==0.6.1
 django-appconf==0.5

--- a/setup.py
+++ b/setup.py
@@ -117,7 +117,7 @@ setup(name='GeoNode',
         "django-haystack>=2.4.1",
         "elasticsearch>=2.4.0",
         "pyelasticsearch>=0.6.1",
-        "celery>=3.1.17,<4.0a0",
+        "celery>=3.1.18,<4.0a0",
         "django-celery>=3.1.16",
 
         # datetimepicker widget


### PR DESCRIPTION
When using `pip install -r requirements.txt` I was finding that my Celery worker was not booting properly.

```
...
File "/env/lib/python2.7/site-packages/django/core/management/base.py", line 534, in check
    self.stderr.write(msg, lambda x: x)
TypeError: function takes exactly 1 argument (2 given)
```

This is an incompatibility between Celery 3.1.17 and Django 1.8. https://github.com/celery/celery/issues/2536

Fix: upgrade to Celery 3.1.18, which supports Django 1.8. http://docs.celeryproject.org/en/latest/history/changelog-3.1.html#version-3-1-18

I verified that 3.1.18, 3.1.19, 3.1.25 and some other versions boot fine without this exception.

If I had to guess about why we only just noticed this, I would guess that most users installing GeoNode since the upgrade to Django 1.8 did not use the `celery==3.1.17` pin in `requirements.txt`.

As an addendum, if we aren't going to test regularly with the `requirements.txt` version pins then this is an example of how those will tend to bitrot, and similarly for the minimum versions in `setup.py`.