### PR TITLE
Correctly handle xml sidecar files within a zip

### DIFF
--- a/geonode/upload/tests/integration.py
+++ b/geonode/upload/tests/integration.py
@@ -530,6 +530,21 @@ class TestUpload(UploaderBase):
         self.upload_file(abspath, self.complete_upload,
                          check_name='san_andres_y_providencia_poi')
 
+    def test_zipped_upload_xml_sidecar(self):
+        """Test uploading a zipped shapefile with xml sidecar"""
+        fd, abspath = self.temp_file('.zip')
+        fp = os.fdopen(fd, 'wb')
+        zf = ZipFile(fp, 'w')
+        fpath = os.path.join(
+            GOOD_DATA,
+            'vector',
+            'Air_Runways.*')
+        for f in glob.glob(fpath):
+            zf.write(f, os.path.basename(f))
+        zf.close()
+        self.upload_file(abspath, self.complete_upload,
+                         check_name='Air_Runways')
+
     def test_invalid_layer_upload(self):
         """ Tests the layers that are invalid and should not be uploaded"""
         # this issue with this test is that the importer supports

--- a/geonode/upload/upload.py
+++ b/geonode/upload/upload.py
@@ -57,6 +57,7 @@ import shutil
 import os.path
 import logging
 import uuid
+import zipfile
 
 logger = logging.getLogger(__name__)
 
@@ -736,6 +737,13 @@ def final_step(upload_session, user):
     if xml_file:
         saved_layer.metadata_uploaded = True
         # get model properties from XML
+        # If it's contained within a zip, need to extract it
+        if upload_session.base_file.archive:
+            archive = upload_session.base_file.archive
+            zf = zipfile.ZipFile(archive, 'r')
+            zf.extract(xml_file[0], os.path.dirname(archive))
+            # Assign the absolute path to this file
+            xml_file[0] = os.path.dirname(archive) + '/' + xml_file[0]
         identifier, vals, regions, keywords = set_metadata(open(xml_file[0]).read())
 
         regions_resolved, regions_unresolved = resolve_regions(regions)
@@ -869,7 +877,6 @@ max\ connections={db_conn_max}"""
 
     if not append_to_mosaic_opts:
 
-        import zipfile
         z = zipfile.ZipFile(dirname + '/' + head + '.zip', "w")
 
         z.write(dst_file, arcname=head + "_" + mosaic_time_value + tail)


### PR DESCRIPTION
This is a small change to fix a minor big with the uploader.

The problem exists when we try to upload a zipped shapefile that includes an xml sidecar file. When we ended up in the final_step of the upload process, the xml file would be attempted to be read. However, the code was operating correctly only in the case of the xml being uploaded alongside other individual shapefiles. If they are packaged together in a .zip, it would fail to open the xml file since it hasn't been extracted in this context.

This update will xml files packaged in a zip to be correctly read and handled by the uploader.