### PR TITLE
Fix flake8 warnings 

### DIFF
--- a/geonode/base/admin.py
+++ b/geonode/base/admin.py
@@ -208,6 +208,7 @@ class LinkAdmin(admin.ModelAdmin):
 class HierarchicalKeywordAdmin(TreeAdmin):
     form = movenodeform_factory(HierarchicalKeyword)
 
+
 admin.site.register(TopicCategory, TopicCategoryAdmin)
 admin.site.register(Region, RegionAdmin)
 admin.site.register(SpatialRepresentationType, SpatialRepresentationTypeAdmin)

--- a/geonode/base/autocomplete_light_registry.py
+++ b/geonode/base/autocomplete_light_registry.py
@@ -26,6 +26,7 @@ from models import ResourceBase, Region, HierarchicalKeyword
 class ResourceBaseAutocomplete(autocomplete_light.AutocompleteModelTemplate):
     choice_template = 'autocomplete_response.html'
 
+
 autocomplete_light.register(Region,
                             search_fields=['name'],
                             autocomplete_js_attributes={'placeholder': 'Region/Country ..', },)

--- a/geonode/base/models.py
+++ b/geonode/base/models.py
@@ -865,4 +865,5 @@ def rating_post_save(instance, *args, **kwargs):
     """
     ResourceBase.objects.filter(id=instance.object_id).update(rating=instance.rating)
 
+
 signals.post_save.connect(rating_post_save, sender=OverallRating)

--- a/geonode/base/translation.py
+++ b/geonode/base/translation.py
@@ -46,6 +46,7 @@ class BackupTranslationOptions(TranslationOptions):
 class LicenseTranslationOptions(TranslationOptions):
     fields = ('name', 'description', 'license_text',)
 
+
 translator.register(TopicCategory, TopicCategoryTranslationOptions)
 translator.register(SpatialRepresentationType, SpatialRepresentationTypeTranslationOptions)
 translator.register(Region, RegionTranslationOptions)

--- a/geonode/catalogue/backends/pycsw_local.py
+++ b/geonode/catalogue/backends/pycsw_local.py
@@ -145,7 +145,6 @@ class CatalogueBackend(GenericCatalogueBackend):
                 'typenames': formats,
                 'resulttype': 'results',
                 'constraintlanguage': 'CQL_TEXT',
-                'constraint': 'csw:AnyText like "%%%s%%"' % keywords,
                 'outputschema': 'http://www.isotc211.org/2005/gmd',
                 'constraint': None,
                 'startposition': start,

--- a/geonode/contrib/dynamic/models.py
+++ b/geonode/contrib/dynamic/models.py
@@ -458,6 +458,7 @@ def post_save_layer(instance, sender, **kwargs):
     # Assign this layer model to all ModelDescriptions with the same name.
     ModelDescription.objects.filter(name=instance.name).update(layer=instance)
 
+
 if not has_datastore:
     models.signals.pre_save.connect(configure_models, sender=Layer)
     models.signals.post_save.connect(post_save_layer, sender=Layer)

--- a/geonode/contrib/dynamic/postgis.py
+++ b/geonode/contrib/dynamic/postgis.py
@@ -232,6 +232,7 @@ def execute(sql):
     finally:
         cursor.close()
 
+
 # Obtained from
 # http://www.postgresql.org/docs/9.2/static/sql-keywords-appendix.html
 PG_RESERVED_KEYWORDS = ('ALL',

--- a/geonode/contrib/geosites/api.py
+++ b/geonode/contrib/geosites/api.py
@@ -144,6 +144,7 @@ class SiteProfileResource(ProfileResource):
     class Meta(ProfileResource.Meta):
         queryset = get_user_model().objects.exclude(username='AnonymousUser').filter(id__in=users_for_site())
 
+
 api.register(SiteLayerResource())
 api.register(SiteMapResource())
 api.register(SiteDocumentResource())

--- a/geonode/documents/admin.py
+++ b/geonode/documents/admin.py
@@ -41,4 +41,5 @@ class DocumentAdmin(MediaTranslationAdmin):
     date_hierarchy = 'date'
     form = DocumentAdminForm
 
+
 admin.site.register(Document, DocumentAdmin)

--- a/geonode/documents/autocomplete_light_registry.py
+++ b/geonode/documents/autocomplete_light_registry.py
@@ -25,6 +25,7 @@ from models import Document
 class DocumentAutocomplete(autocomplete_light.AutocompleteModelTemplate):
     choice_template = 'autocomplete_response.html'
 
+
 autocomplete_light.register(
     Document,
     DocumentAutocomplete,

--- a/geonode/documents/translation.py
+++ b/geonode/documents/translation.py
@@ -32,4 +32,5 @@ class DocumentTranslationOptions(TranslationOptions):
         'data_quality_statement',
     )
 
+
 translator.register(Document, DocumentTranslationOptions)

--- a/geonode/geoserver/helpers.py
+++ b/geonode/geoserver/helpers.py
@@ -114,6 +114,7 @@ def _add_sld_boilerplate(symbolizer):
 </StyledLayerDescriptor>
 """
 
+
 _raster_template = """
 <RasterSymbolizer>
     <Opacity>1.0</Opacity>

--- a/geonode/groups/admin.py
+++ b/geonode/groups/admin.py
@@ -33,6 +33,7 @@ class GroupAdmin(admin.ModelAdmin):
     ]
     exclude = ['group', ]
 
+
 admin.site.register(GroupProfile, GroupAdmin)
 
 admin.site.register(GroupInvitation)

--- a/geonode/groups/autocomplete_light_registry.py
+++ b/geonode/groups/autocomplete_light_registry.py
@@ -25,6 +25,7 @@ from .models import GroupProfile
 class GroupProfileAutocomplete(autocomplete_light.AutocompleteModelTemplate):
     choice_template = 'autocomplete_response.html'
 
+
 autocomplete_light.register(
     GroupProfile,
     GroupProfileAutocomplete,

--- a/geonode/groups/models.py
+++ b/geonode/groups/models.py
@@ -286,4 +286,5 @@ def group_pre_delete(instance, sender, **kwargs):
         raise Exception('Deletion of the anonymous group is\
          not permitted as will break the geonode permissions system')
 
+
 signals.pre_delete.connect(group_pre_delete, sender=Group)

--- a/geonode/layers/admin.py
+++ b/geonode/layers/admin.py
@@ -88,6 +88,7 @@ class UploadSessionAdmin(admin.ModelAdmin):
     list_display = ('date', 'user', 'processed')
     inlines = [LayerFileInline]
 
+
 admin.site.register(Layer, LayerAdmin)
 admin.site.register(Attribute, AttributeAdmin)
 admin.site.register(Style, StyleAdmin)

--- a/geonode/layers/autocomplete_light_registry.py
+++ b/geonode/layers/autocomplete_light_registry.py
@@ -25,6 +25,7 @@ from models import Layer
 class LayerAutocomplete(autocomplete_light.AutocompleteModelTemplate):
     choice_template = 'autocomplete_response.html'
 
+
 autocomplete_light.register(
     Layer,
     LayerAutocomplete,

--- a/geonode/layers/translation.py
+++ b/geonode/layers/translation.py
@@ -32,4 +32,5 @@ class LayerTranslationOptions(TranslationOptions):
         'data_quality_statement',
     )
 
+
 translator.register(Layer, LayerTranslationOptions)

--- a/geonode/maps/admin.py
+++ b/geonode/maps/admin.py
@@ -51,6 +51,7 @@ class MapLayerAdmin(admin.ModelAdmin):
     search_fields = ('map__title', 'name',)
     form = autocomplete_light.modelform_factory(MapLayer, fields='__all__')
 
+
 admin.site.register(Map, MapAdmin)
 admin.site.register(MapLayer, MapLayerAdmin)
 admin.site.register(MapSnapshot)

--- a/geonode/maps/autocomplete_light_registry.py
+++ b/geonode/maps/autocomplete_light_registry.py
@@ -25,6 +25,7 @@ from models import Map
 class MapAutocomplete(autocomplete_light.AutocompleteModelTemplate):
     choice_template = 'autocomplete_response.html'
 
+
 autocomplete_light.register(
     Map,
     MapAutocomplete,

--- a/geonode/maps/models.py
+++ b/geonode/maps/models.py
@@ -553,5 +553,6 @@ class MapSnapshot(models.Model):
             "url": num_encode(self.id)
         }
 
+
 signals.pre_delete.connect(pre_delete_map, sender=Map)
 signals.post_save.connect(resourcebase_post_save, sender=Map)

--- a/geonode/maps/translation.py
+++ b/geonode/maps/translation.py
@@ -32,4 +32,5 @@ class MapTranslationOptions(TranslationOptions):
         'data_quality_statement',
     )
 
+
 translator.register(Map, MapTranslationOptions)

--- a/geonode/people/admin.py
+++ b/geonode/people/admin.py
@@ -198,4 +198,5 @@ class ProfileAdmin(admin.ModelAdmin):
         return super(ProfileAdmin, self).response_add(request, obj,
                                                       post_url_continue)
 
+
 admin.site.register(Profile, ProfileAdmin)

--- a/geonode/people/autocomplete_light_registry.py
+++ b/geonode/people/autocomplete_light_registry.py
@@ -29,6 +29,7 @@ class ProfileAutocomplete(autocomplete_light.AutocompleteModelTemplate):
         self.choices = self.choices.exclude(username='AnonymousUser')
         return super(ProfileAutocomplete, self).choices_for_request()
 
+
 autocomplete_light.register(
     Profile,
     ProfileAutocomplete,

--- a/geonode/people/models.py
+++ b/geonode/people/models.py
@@ -166,6 +166,7 @@ def profile_pre_save(instance, sender, **kw):
             'notification' in settings.INSTALLED_APPS:
         notification.send([instance, ], "account_active")
 
+
 signals.pre_save.connect(profile_pre_save, sender=Profile)
 signals.post_save.connect(profile_post_save, sender=Profile)
 signals.post_save.connect(email_post_save, sender=EmailAddress)

--- a/geonode/services/admin.py
+++ b/geonode/services/admin.py
@@ -37,4 +37,5 @@ class ServiceAdmin(admin.ModelAdmin):
     list_filter = ('type', 'method')
     form = ServiceAdminForm
 
+
 admin.site.register(Service, ServiceAdmin)

--- a/geonode/upload/admin.py
+++ b/geonode/upload/admin.py
@@ -26,6 +26,7 @@ from django.contrib import admin
 def import_link(obj):
     return "<a href='%s'>Geoserver Importer Link</a>" % obj.get_import_url()
 
+
 import_link.short_description = 'Link'
 import_link.allow_tags = True
 
@@ -34,6 +35,7 @@ class UploadAdmin(admin.ModelAdmin):
     list_display = ('user', 'date', 'state', import_link)
     date_hierarchy = 'date'
     list_filter = ('user', 'state')
+
 
 admin.site.register(Upload, UploadAdmin)
 admin.site.register(UploadFile)

--- a/geonode/upload/views.py
+++ b/geonode/upload/views.py
@@ -558,6 +558,7 @@ def final_step_view(req, upload_session):
          }
     )
 
+
 _steps = {
     'save': save_step_view,
     'time': time_step_view,


### PR DESCRIPTION
This boring patch fixes all the flake8 errors obtained by running `python -m flake8 geonode` with the following versions:
`3.2.1 (pyflakes: 1.3.0, mccabe: 0.5.2, pycodestyle: 2.2.0) CPython 2.7.12 on Linux`

I'm aware the existing flake8 config is ignoring some classes of errors, this fixes them anyway