### PR TITLE
Add typename to search API output, fix layer creation bug.

### DIFF
--- a/geonode/api/resourcebase_api.py
+++ b/geonode/api/resourcebase_api.py
@@ -479,6 +479,7 @@ class CommonModelApi(ModelResource):
             'title',
             'date',
             'abstract',
+            'typename',
             'csw_wkt_geometry',
             'csw_type',
             'owner__username',

--- a/geonode/catalogue/backends/pycsw_local.py
+++ b/geonode/catalogue/backends/pycsw_local.py
@@ -46,7 +46,7 @@ CONFIGURATION = {
     },
     'repository': {
         'source': 'geonode',
-        'filter': 'is_published = 1',
+        'filter': 'is_published = true',
         'mappings': os.path.join(os.path.dirname(__file__), 'pycsw_local_mappings.py')
     }
 }


### PR DESCRIPTION
The Typename is required to reference the layer to the appropriate layer in GeoServer when the title has been edited.  This change puts the typename of the layer in the output.

Also found a bug in pycsw_local.py which caused PostgreSQL to try to compare a boolean to an integer. Postgres will not automatically cast 1 to "true" and this causing layer uploads to fail.