### PR TITLE
Adding django-braces and oauthlib in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ django-activity-stream==0.6.1
 django-appconf==0.5
 django-autocomplete-light==2.3.3
 django-bootstrap3-datetimepicker==2.2.3
+django-braces==1.10.0
 django-celery==3.1.16
 django-downloadview==1.2
 django-extensions==1.6.1
@@ -52,6 +53,7 @@ httplib2==0.9.2
 kombu==3.0.35
 lxml==3.6.4
 mccabe==0.5.2
+oauthlib==2.0.1
 pep8==1.6.2
 pillow==3.3.1
 pinax-theme-bootstrap==3.0a11
@@ -69,4 +71,3 @@ requests==2.11.1
 transifex-client==0.10
 xmltodict==0.9.2
 django-treebeard==3.0
-


### PR DESCRIPTION
## Whart does this PR do?
Installing today GeoNode from master on a Ubuntu virtualenv, I have detected two dependencies missing, which caused the following errors

### oauthlib missing

oauthlib missing was causing an error when using paver:

$ paver sync

Traceback (most recent call last):
  File "manage.py", line 29, in <module>
    execute_from_command_line(sys.argv)
  File "/home/vagrant/env/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 354, in execute_from_command_line
    utility.execute()
  File "/home/vagrant/env/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 328, in execute
    django.setup()
  File "/home/vagrant/env/local/lib/python2.7/site-packages/django/__init__.py", line 18, in setup
    apps.populate(settings.INSTALLED_APPS)
  File "/home/vagrant/env/local/lib/python2.7/site-packages/django/apps/registry.py", line 108, in populate
    app_config.import_models(all_models)
  File "/home/vagrant/env/local/lib/python2.7/site-packages/django/apps/config.py", line 198, in import_models
    self.models_module = import_module(models_module_name)
  File "/usr/lib/python2.7/importlib/__init__.py", line 37, in import_module
    __import__(name)
  File "/home/vagrant/env/local/lib/python2.7/site-packages/oauth2_provider/models.py", line 17, in <module>
    from .generators import generate_client_secret, generate_client_id
  File "/home/vagrant/env/local/lib/python2.7/site-packages/oauth2_provider/generators.py", line 4, in <module>
    from oauthlib.common import generate_client_id as oauthlib_generate_client_id
ImportError: No module named oauthlib.common
python manage.py loaddata sample_admin.json

### django-braces missing

django-braces missing was causing an error when running django server:

Traceback (most recent call last):
  File "/usr/lib/python2.7/wsgiref/handlers.py", line 85, in run
    self.result = application(self.environ, self.start_response)
  File "/home/vagrant/env/local/lib/python2.7/site-packages/django/contrib/staticfiles/handlers.py", line 63, in __call__
    return self.application(environ, start_response)
  File "/home/vagrant/env/local/lib/python2.7/site-packages/django/core/handlers/wsgi.py", line 170, in __call__
    self.load_middleware()
  File "/home/vagrant/env/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 52, in load_middleware
    mw_instance = mw_class()
  File "/home/vagrant/env/local/lib/python2.7/site-packages/django/middleware/locale.py", line 24, in __init__
    for url_pattern in get_resolver(None).url_patterns:
  File "/home/vagrant/env/local/lib/python2.7/site-packages/django/core/urlresolvers.py", line 401, in url_patterns
    patterns = getattr(self.urlconf_module, "urlpatterns", self.urlconf_module)
  File "/home/vagrant/env/local/lib/python2.7/site-packages/django/core/urlresolvers.py", line 395, in urlconf_module
    self._urlconf_module = import_module(self.urlconf_name)
  File "/usr/lib/python2.7/importlib/__init__.py", line 37, in import_module
    __import__(name)
  File "/home/vagrant/geonode/geonode/geonode/urls.py", line 112, in <module>
    url(r'^o/', include('oauth2_provider.urls', namespace='oauth2_provider')),
  File "/home/vagrant/env/local/lib/python2.7/site-packages/django/conf/urls/__init__.py", line 33, in include
    urlconf_module = import_module(urlconf_module)
  File "/usr/lib/python2.7/importlib/__init__.py", line 37, in import_module
    __import__(name)
  File "/home/vagrant/env/local/lib/python2.7/site-packages/oauth2_provider/urls.py", line 4, in <module>
    from . import views
  File "/home/vagrant/env/local/lib/python2.7/site-packages/oauth2_provider/views/__init__.py", line 2, in <module>
    from .base import AuthorizationView, TokenView, RevokeTokenView
  File "/home/vagrant/env/local/lib/python2.7/site-packages/oauth2_provider/views/base.py", line 9, in <module>
    from braces.views import LoginRequiredMixin, CsrfExemptMixin
ImportError: No module named braces.views

## Screenshot

Not applicatble.

## Related Issue

Apparently not issues are open about this.