### PR TITLE
Adding a geogig_link URL to /api/layers

### DIFF
--- a/geonode/api/resourcebase_api.py
+++ b/geonode/api/resourcebase_api.py
@@ -34,6 +34,7 @@ from django.conf.urls import url
 from django.core.paginator import Paginator, InvalidPage
 from django.http import Http404
 from django.core.exceptions import ObjectDoesNotExist
+from django.forms.models import model_to_dict
 
 from tastypie.utils.mime import build_content_type
 
@@ -83,6 +84,25 @@ class CommonModelApi(ModelResource):
         null=True,
         full=True)
     owner = fields.ToOneField(ProfileResource, 'owner', full=True)
+    VALUES = [
+        # fields in the db
+        'id',
+        'uuid',
+        'title',
+        'date',
+        'abstract',
+        'csw_wkt_geometry',
+        'csw_type',
+        'owner__username',
+        'share_count',
+        'popular_count',
+        'srid',
+        'category__gn_description',
+        'supplemental_information',
+        'thumbnail_url',
+        'detail_url',
+        'rating',
+    ]
 
     def build_filters(self, filters=None):
         if filters is None:
@@ -460,6 +480,12 @@ class CommonModelApi(ModelResource):
 
         return self.create_response(request, to_be_serialized, response_objects=objects)
 
+    def format_objects(self, objects):
+        """
+        Format the objects for output in a response.
+        """
+        return objects.values(*self.VALUES)
+
     def create_response(
             self,
             request,
@@ -472,25 +498,6 @@ class CommonModelApi(ModelResource):
 
         Mostly a useful shortcut/hook.
         """
-        VALUES = [
-            # fields in the db
-            'id',
-            'uuid',
-            'title',
-            'date',
-            'abstract',
-            'csw_wkt_geometry',
-            'csw_type',
-            'owner__username',
-            'share_count',
-            'popular_count',
-            'srid',
-            'category__gn_description',
-            'supplemental_information',
-            'thumbnail_url',
-            'detail_url',
-            'rating',
-        ]
 
         # If an user does not have at least view permissions, he won't be able to see the resource at all.
         filtered_objects_ids = None
@@ -503,9 +510,9 @@ class CommonModelApi(ModelResource):
                 data['objects'],
                 list):
             if filtered_objects_ids:
-                data['objects'] = [x for x in list(data['objects'].values(*VALUES)) if x['id'] in filtered_objects_ids]
+                data['objects'] = [x for x in list(self.format_objects(data['objects'])) if x['id'] in filtered_objects_ids]
             else:
-                data['objects'] = list(data['objects'].values(*VALUES))
+                data['objects'] = list(self.format_objects(data['objects']))
 
         desired_format = self.determine_format(request)
         serialized = self.serialize(request, data, desired_format)
@@ -554,6 +561,20 @@ class FeaturedResourceBaseResource(CommonModelApi):
 class LayerResource(CommonModelApi):
 
     """Layer API"""
+
+    def format_objects(self, objects):
+        """
+        Formats the object then adds a geogig_link as necessary.
+        """
+        formatted_objects = []
+        for obj in objects:
+            # convert the object to a dict using the standard values.
+            formatted_obj = model_to_dict(obj, fields=self.VALUES)
+            # add the geogig link
+            formatted_obj['geogig_link'] = obj.geogig_link
+            # put the object on the response stack
+            formatted_objects.append(formatted_obj)
+        return formatted_objects
 
     class Meta(CommonMetaApi):
         queryset = Layer.objects.distinct().order_by('-date')

--- a/geonode/api/resourcebase_api.py
+++ b/geonode/api/resourcebase_api.py
@@ -510,7 +510,8 @@ class CommonModelApi(ModelResource):
                 data['objects'],
                 list):
             if filtered_objects_ids:
-                data['objects'] = [x for x in list(self.format_objects(data['objects'])) if x['id'] in filtered_objects_ids]
+                data['objects'] = [x for x in list(self.format_objects(data['objects']))
+                                   if x['id'] in filtered_objects_ids]
             else:
                 data['objects'] = list(self.format_objects(data['objects']))
 

--- a/geonode/layers/models.py
+++ b/geonode/layers/models.py
@@ -260,6 +260,17 @@ class Layer(ResourceBase):
     def class_name(self):
         return self.__class__.__name__
 
+    @property
+    def geogig_enabled(self):
+        return (len(self.link_set.geogig()) > 0)
+
+    @property
+    def geogig_link(self):
+        if(self.geogig_enabled):
+            return getattr(self.link_set.filter(name__icontains='clone in geogig').first(), 'url', None)
+        return None
+
+
 
 class LayerStyles(models.Model):
     layer = models.ForeignKey(Layer)

--- a/geonode/layers/models.py
+++ b/geonode/layers/models.py
@@ -271,7 +271,6 @@ class Layer(ResourceBase):
         return None
 
 
-
 class LayerStyles(models.Model):
     layer = models.ForeignKey(Layer)
     style = models.ForeignKey(Style)


### PR DESCRIPTION
This adds a geogig_link URL to the search results and avoids using the full TastyPie hydration cycle that https://github.com/GeoNode/geonode/pull/2789 caused.

The following changes were made:

1. The model for `Layer` now has `geogig_enabled` and `geogig_link` properties. 
2. Object formatting was moved out of `create_response` and into a new class method, `format_objects`.
3. The `VALUES` object was moved out of `create_response` and is now a class member.
4. The `LayerResource` class has a new `format_objects` method which converts the models to dictionaries, then adds in the `geogig_link` property to the dictionary.

These changes work with https://github.com/boundlessgeo/MapLoom/pull/45

Thanks again.