### PR TITLE
 Fix for oauth integration and GeoNode set to Lockdown

### DIFF
--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -462,6 +462,8 @@ OAUTH2_PROVIDER = {
     'CLIENT_ID_GENERATOR_CLASS': 'oauth2_provider.generators.ClientIdGenerator',
 }
 
+# authorized exempt urls needed for oauth when GeoNode is set to lockdown
+AUTH_EXEMPT_URLS = ('/api/o/*', '/api/roles', '/api/adminRole', '/api/users',)
 
 ANONYMOUS_USER_ID = os.getenv('ANONYMOUS_USER_ID','-1')
 GUARDIAN_GET_INIT_ANONYMOUS_USER = os.getenv(


### PR DESCRIPTION
When `GEONODE_LOCKDOWN = True` the /api/* endpoints need to be added to `AUTH_EXEMPT_URLS`. Otherwise GeoServer will be unable to pull the ROLES.