### PR TITLE
Do not allow upload with empty geogig repo name

### DIFF
--- a/geonode/static/geonode/js/upload/LayerInfo.js
+++ b/geonode/static/geonode/js/upload/LayerInfo.js
@@ -173,9 +173,9 @@ define(function (require, exports) {
         }
 
         if (geogig_enabled) {
-            geogig = $('#' + base_name + '\\:geogig_toggle').is(':checked');
+            geogig_store = $('#' + base_name + '\\:geogig_store').val();
+            geogig = $('#' + base_name + '\\:geogig_toggle').is(':checked') && geogig_store.length != 0;
             if (geogig) {
-                geogig_store = $('#' + base_name + '\\:geogig_store').val();
                 form_data.append('geogig_store', geogig_store);
             } else {
                 form_data.append('geogig_store', "");

--- a/geonode/static/geonode/js/upload/upload.js
+++ b/geonode/static/geonode/js/upload/upload.js
@@ -30,6 +30,7 @@ define(['underscore',
         doSuccessfulUpload,
         attach_events,
         checkFiles,
+        checkGeogig
         fileTypes = fileTypes;
 
     $('body').append(uploadTemplate);
@@ -188,6 +189,22 @@ define(['underscore',
         return matched;
     }
 
+    /** Function to check that a geogig repo has been named, or that
+     *  "Import to Geogig" is not checked.
+     *
+     *  @params  
+     *  @returns {boolean}
+     */
+    checkGeogig = function() {
+        geogig_store = $('#' + base_name + '\\:geogig_store').val();
+        geogig = $('#' + base_name + '\\:geogig_toggle').is(':checked');
+        if (geogig) {
+            return geogig_store.length != 0;
+        } else {
+            return true;
+        }
+    }
+
     doDelete = function(event) {
         var target = event.target || event.srcElement;
         var id = target.id.split("-")[1];
@@ -280,7 +297,7 @@ define(['underscore',
             return false;
         }
 
-        var checked = checkFiles();
+        var checked = checkFiles() && checkGeogig();
         if ($.isEmptyObject(layers) || !checked) {
             alert(gettext('You are trying to upload an incomplete set of files or not all mandatory options have been validated.\n\nPlease check for errors in the form!'));
         } else {


### PR DESCRIPTION
Currently if you upload new data, you can tick "Import to Geogig" and continue your upload without specifying a name for the GeoGig repo. This is not desired and will cause the upload to hang.

For now I have modified the javascript to detect an empty Geogig repo name if the "Import to Geogig" checkbox is ticked, and deliver an error message if the "Upload Files" button is clicked before specifying a name.

Another potential solution is to disable the Upload Files button if: The Geogig repo name is empty AND "Import to Geogig" is ticked. This can be done in conjunction with the current fix. Does this sound appropriate to do? If it is, I'll give it a shot to add that to this commit, or to another commit for the future if we want to get this merged in quickly in the interim.