### PR TITLE
Duplicate Access tokens on OGC request

### DIFF
--- a/geonode/maps/views.py
+++ b/geonode/maps/views.py
@@ -572,7 +572,8 @@ def new_map_config(request):
 
                 if layer.storeType == "remoteStore":
                     service = layer.service
-                    if access_token:
+                    # Probably not a good idea to send the access token to every remote service
+                    if access_token and 'access_token' not in service.base_url:
                         url = service.base_url+'?access_token='+access_token
                     else:
                         url = service.base_url
@@ -587,7 +588,7 @@ def new_map_config(request):
                                             "url": url,
                                             "name": service.name}))
                 else:
-                    if access_token:
+                    if access_token and 'access_token' not in layer.ows_url:
                         url = layer.ows_url+'?access_token='+access_token
                     else:
                         url = layer.ows_url

--- a/geonode/people/views.py
+++ b/geonode/people/views.py
@@ -101,7 +101,7 @@ def forgot_username(request):
             if users:
                 username = users[0].username
                 email_message = email_subject + " : " + username
-                send_email.delay(email_subject, email_message, settings.DEFAULT_FROM_EMAIL,
+                send_email(email_subject, email_message, settings.DEFAULT_FROM_EMAIL,
                                  [username_form.cleaned_data['email']], fail_silently=False)
                 message = _("Your username has been emailed to you.")
             else:

--- a/geonode/people/views.py
+++ b/geonode/people/views.py
@@ -102,7 +102,7 @@ def forgot_username(request):
                 username = users[0].username
                 email_message = email_subject + " : " + username
                 send_email(email_subject, email_message, settings.DEFAULT_FROM_EMAIL,
-                                 [username_form.cleaned_data['email']], fail_silently=False)
+                           [username_form.cleaned_data['email']], fail_silently=False)
                 message = _("Your username has been emailed to you.")
             else:
                 message = _("No user could be found with that email address.")

--- a/geonode/utils.py
+++ b/geonode/utils.py
@@ -371,7 +371,8 @@ class GXPLayerBase(object):
             cfg = dict(ptype="gxp_wmscsource", restUrl="/gs/rest")
 
         if self.ows_url:
-            # Do we need to deal with expired access tokens here? if we do, then need to remove the existing token and add the new one
+            # Do we need to deal with expired access tokens here?
+            # if we do, then need to remove the existing token and add the new one
             if access_token and 'access_token' not in self.ows_url:
                 cfg["url"] = self.ows_url+'?access_token='+access_token
             else:

--- a/geonode/utils.py
+++ b/geonode/utils.py
@@ -371,7 +371,8 @@ class GXPLayerBase(object):
             cfg = dict(ptype="gxp_wmscsource", restUrl="/gs/rest")
 
         if self.ows_url:
-            if access_token:
+            # Do we need to deal with expired access tokens here? if we do, then need to remove the existing token and add the new one
+            if access_token and 'access_token' not in self.ows_url:
                 cfg["url"] = self.ows_url+'?access_token='+access_token
             else:
                 cfg["url"] = self.ows_url


### PR DESCRIPTION
Solves an issue where two access tokens are added to OGC requests, which causes the request(s) to fail and for the Geoserver OAuth endpoint to be unusable in the browser's existing session.
