### PR TITLE
Send access token only to OGC_SERVER

### DIFF
--- a/geonode/maps/views.py
+++ b/geonode/maps/views.py
@@ -60,6 +60,7 @@ from geonode.documents.models import get_related_documents
 from geonode.people.forms import ProfileForm
 from geonode.utils import num_encode, num_decode
 from geonode.utils import build_social_links
+import urlparse
 
 if 'geonode.geoserver' in settings.INSTALLED_APPS:
     # FIXME: The post service providing the map_status object
@@ -572,8 +573,12 @@ def new_map_config(request):
 
                 if layer.storeType == "remoteStore":
                     service = layer.service
-                    # Probably not a good idea to send the access token to every remote service
-                    if access_token and 'access_token' not in service.base_url:
+                    # Probably not a good idea to send the access token to every remote service.
+                    # This should never match, so no access token should be sent to remote services.
+                    ogc_server_url = urlparse.urlsplit(ogc_server_settings.PUBLIC_LOCATION).netloc
+                    service_url = urlparse.urlsplit(service.base_url).netloc
+
+                    if access_token and ogc_server_url == service_url and 'access_token' not in service.base_url:
                         url = service.base_url+'?access_token='+access_token
                     else:
                         url = service.base_url
@@ -588,7 +593,10 @@ def new_map_config(request):
                                             "url": url,
                                             "name": service.name}))
                 else:
-                    if access_token and 'access_token' not in layer.ows_url:
+                    ogc_server_url = urlparse.urlsplit(ogc_server_settings.PUBLIC_LOCATION).netloc
+                    layer_url = urlparse.urlsplit(layer.ows_url).netloc
+
+                    if access_token and ogc_server_url == layer_url and 'access_token' not in layer.ows_url:
                         url = layer.ows_url+'?access_token='+access_token
                     else:
                         url = layer.ows_url

--- a/geonode/utils.py
+++ b/geonode/utils.py
@@ -39,6 +39,8 @@ from django.http import HttpResponse
 from django.shortcuts import get_object_or_404
 from django.utils.translation import ugettext_lazy as _
 import httplib2
+import urlparse
+import urllib
 
 
 try:
@@ -371,10 +373,27 @@ class GXPLayerBase(object):
             cfg = dict(ptype="gxp_wmscsource", restUrl="/gs/rest")
 
         if self.ows_url:
-            # Do we need to deal with expired access tokens here?
-            # if we do, then need to remove the existing token and add the new one
-            if access_token and 'access_token' not in self.ows_url:
-                cfg["url"] = self.ows_url+'?access_token='+access_token
+            '''
+            This limits the access token we add to only the OGC servers decalred in OGC_SERVER.
+            Will also override any access_token in the request and replace it with an existing one.
+            '''
+            urls = []
+            for name, server in settings.OGC_SERVER.iteritems():
+                url = urlparse.urlsplit(server['PUBLIC_LOCATION'])
+                urls.append(url.netloc)
+
+            my_url = urlparse.urlsplit(self.ows_url)
+
+            if access_token and my_url.netloc in urls:
+                request_params = urlparse.parse_qs(my_url.query)
+                if 'access_token' in request_params:
+                    del request_params['access_token']
+                request_params['access_token'] = [access_token]
+                encoded_params = urllib.urlencode(request_params, doseq=True)
+
+                parsed_url = urlparse.SplitResult(my_url.scheme, my_url.netloc, my_url.path,
+                                                  encoded_params, my_url.fragment)
+                cfg["url"] = parsed_url.geturl()
             else:
                 cfg["url"] = self.ows_url
 


### PR DESCRIPTION
Solves an issue where the access token was sent to most services/endpoints, which in some cases causes the request to fail.

Also solves a case where expired access tokens where being used.