### PR TITLE
Make usernames case insensitive for authentication

### DIFF
--- a/geonode/people/models.py
+++ b/geonode/people/models.py
@@ -22,6 +22,7 @@ from django.db import models
 from django.utils.translation import ugettext as _
 from django.core.urlresolvers import reverse
 from django.contrib.auth.models import AbstractUser
+from django.contrib.auth.models import BaseUserManager
 from django.db.models import signals
 from django.conf import settings
 
@@ -36,6 +37,11 @@ from .utils import format_address
 
 if 'notification' in settings.INSTALLED_APPS:
     from notification import models as notification
+
+
+class ProfileUserManager(BaseUserManager):
+    def get_by_natural_key(self, username):
+        return self.get(username__iexact=username)
 
 
 class Profile(AbstractUser):
@@ -102,6 +108,7 @@ class Profile(AbstractUser):
     def class_name(value):
         return value.__class__.__name__
 
+    objects = ProfileUserManager()
     USERNAME_FIELD = 'username'
 
     def group_list_public(self):


### PR DESCRIPTION
This will allow you to login to GeoNode using any case in the log in form.

Ergo, if I want to log in to user TravisB, this change allows me to login with any of the following: travisb, travisB, TRAVISB, etc.