### PR TITLE
Execute signals when running updatelayers

### DIFF
--- a/geonode/geoserver/helpers.py
+++ b/geonode/geoserver/helpers.py
@@ -368,7 +368,8 @@ def gs_slurp(
         skip_unadvertised=False,
         skip_geonode_registered=False,
         remove_deleted=False,
-        permissions=None):
+        permissions=None,
+        execute_signals=False):
     """Configure the layers available in GeoServer in GeoNode.
 
        It returns a list of dictionaries with the name of the layer,
@@ -468,6 +469,11 @@ def gs_slurp(
 
             # recalculate the layer statistics
             set_attributes_from_geoserver(layer, overwrite=True)
+
+            # in some cases we need to explicitily save the resource to execute the signals
+            # (for sure when running updatelayers)
+            if execute_signals:
+                layer.save()
 
             # Fix metadata links if the ip has changed
             if layer.link_set.metadata().count() > 0:

--- a/geonode/geoserver/management/commands/updatelayers.py
+++ b/geonode/geoserver/management/commands/updatelayers.py
@@ -115,7 +115,8 @@ class Command(BaseCommand):
             skip_unadvertised=skip_unadvertised,
             skip_geonode_registered=skip_geonode_registered,
             remove_deleted=remove_deleted,
-            permissions=permissions)
+            permissions=permissions,
+            execute_signals=True)
 
         if verbosity > 1:
             print "\nDetailed report of failures:"


### PR DESCRIPTION
Added an option in gs_slurp to execute signals (false by default).
Fixes #2838