### PR TITLE
Adding the fix_baselayers command

### DIFF
--- a/docs/tutorials/admin/admin_mgmt_commands/index.txt
+++ b/docs/tutorials/admin/admin_mgmt_commands/index.txt
@@ -166,3 +166,17 @@ Deletes orphaned thumbnails of deleted GeoNode resources (Layers, Maps and Docum
 Usage::
 
    python manage.py delete_orphaned_thumbs
+
+
+fix_baselayers
+==============
+
+Fix base layers for all of the GeoNode maps or for a given map.
+
+Usage::
+
+  # fix base layers for all of the GeoNode map
+  python manage.py fix_baselayers
+
+  # fix base layers for a given map
+  python manage.py fix_baselayers map_id

--- a/geonode/maps/management/commands/fix_baselayers.py
+++ b/geonode/maps/management/commands/fix_baselayers.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+#########################################################################
+#
+# Copyright (C) 2016 OSGeo
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#########################################################################
+
+from django.core.management.base import BaseCommand
+
+from geonode.maps.models import Map
+from geonode.maps.utils import fix_baselayers
+
+
+class Command(BaseCommand):
+    help = ('Fix base layers for all of the GeoNode maps or for a given map.\n\n'
+            'Arguments:\n'
+            'map_id - numeric map ID (optional)\n')
+
+    args = 'map_id'
+
+    def handle(self, *args, **options):
+        if len(args) == 1:
+            map_id = args[0]
+            fix_baselayers(map_id)
+        else:
+            for map in Map.objects.all():
+                fix_baselayers(map.id)

--- a/geonode/maps/tests.py
+++ b/geonode/maps/tests.py
@@ -29,9 +29,11 @@ except ImportError:
 from django.contrib.contenttypes.models import ContentType
 from agon_ratings.models import OverallRating
 from django.contrib.auth import get_user_model
+from django.conf import settings
 
 from geonode.layers.models import Layer
 from geonode.maps.models import Map
+from geonode.maps.utils import fix_baselayers
 from geonode.utils import default_map_config
 from geonode.base.populate_test_data import create_models
 from geonode.maps.tests_populate_maplayers import create_maplayers
@@ -613,3 +615,19 @@ community."
         # Check there are no ratings matching the removed map
         rating = OverallRating.objects.filter(category=1, object_id=map_id)
         self.assertEquals(rating.count(), 0)
+
+    def test_fix_baselayers(self):
+        """Test fix_baselayers function, used by the fix_baselayers command
+        """
+        map_id = 1
+        map_obj = Map.objects.get(id=map_id)
+
+        # number of base layers (we remove the local geoserver entry from the total)
+        n_baselayers = len(settings.MAP_BASELAYERS) - 1
+
+        # number of local layers
+        n_locallayers = map_obj.layer_set.filter(local=True).count()
+
+        fix_baselayers(map_id)
+
+        self.assertEquals(map_obj.layer_set.all().count(), n_baselayers + n_locallayers)

--- a/geonode/maps/utils.py
+++ b/geonode/maps/utils.py
@@ -20,6 +20,10 @@
 
 import json
 
+from django.conf import settings
+
+from .models import Map, MapLayer
+
 
 def _layer_json(layers, sources):
     """
@@ -65,3 +69,64 @@ def _layer_json(layers, sources):
         return cfg
 
     return [layer_config(l, user=None) for l in layers]
+
+
+def fix_baselayers(map_id):
+    """
+    Fix base layers for a given map.
+    """
+
+    try:
+        id = int(map_id)
+    except ValueError:
+        print 'map_id must be an integer'
+        return
+
+    if not Map.objects.filter(pk=id).exists():
+        print 'There is not a map with id %s' % id
+        return
+
+    map = Map.objects.get(pk=id)
+    # first we delete all of the base layers
+    map.layer_set.filter(local=False).delete()
+
+    # now we re-add them
+    source = 0
+    for base_layer in settings.MAP_BASELAYERS:
+        if 'group' in base_layer:
+            # layer_params
+            layer_params = {}
+            layer_params['selected'] = True
+            if 'title' in base_layer:
+                layer_params['title'] = base_layer['title']
+            if 'type' in base_layer:
+                layer_params['type'] = base_layer['type']
+            if 'args' in base_layer:
+                layer_params['args'] = base_layer['args']
+            # source_params
+            source_params = {}
+            source_params['id'] = source
+            for param in base_layer['source']:
+                source_params[param] = base_layer['source'][param]
+            # let's create the map layer
+            name = ''
+            if 'name' in base_layer:
+                name = base_layer['name']
+            else:
+                if 'args' in base_layer:
+                    name = base_layer['args'][0]
+            map_layer = MapLayer(
+                map=map,
+                stack_order=map.layer_set.count() + 1,
+                name=name,
+                opacity=1,
+                transparent=False,
+                fixed=True,
+                group='background',
+                layer_params=json.dumps(layer_params),
+                source_params=json.dumps(source_params)
+            )
+            map_layer.save()
+        source += 1
+
+    print 'Fixed base layers for map with id %s' % id


### PR DESCRIPTION
fix_baselayer is a command to fix the base layers for one or more maps.
Base layers are synced by the command with the ones included in the MAP_BASELAYERS setting.
Tests and documentation provided.

Usage:

  # fix base layers for all of the GeoNode map
  python manage.py fix_baselayers

  # fix base layers for a given map
  python manage.py fix_baselayers map_id