### PR TITLE
Add new routes/views for simple edit

### DIFF
--- a/geonode/maps/templates/maps/map_detail.html
+++ b/geonode/maps/templates/maps/map_detail.html
@@ -137,7 +137,7 @@
                   <div class="col-sm-3">
                     <i class="fa fa-map-marker fa-3x"></i>
                     <h4>{% trans "Map" %}</h4>
-                    <a class="btn btn-default btn-block btn-xs" href="{% url "map_view" resource.id %}">{% trans "Edit" %}</a>
+                    <a class="btn btn-default btn-block btn-xs" href="{% url "map_edit" resource.id %}">{% trans "Edit" %}</a>
                     <a class="btn btn-danger btn-block btn-xs" href="{% url "map_remove" resource.id %}">{% trans "Remove" %}</a>
                   </div>
                   {% endif %}

--- a/geonode/maps/templates/maps/map_edit.html
+++ b/geonode/maps/templates/maps/map_edit.html
@@ -1,0 +1,19 @@
+{% extends "site_base.html" %}
+
+{% load i18n %}
+{% load base_tags %}
+
+{% block title %} {% trans "Edit Map" %} - {{ block.super }} {% endblock %}
+{% block head %}
+	{% if preview == 'geoext' %}
+		{% include 'maps/map_geoexplorer.js' %}
+	{% elif preview == 'react' %}
+		{% include 'geonode-client/edit_map.html' %}
+	{% else %}
+		{% include 'maps/map_geoexplorer.js' %}
+	{% endif %}
+
+	{{ block.super }}
+{% endblock %}
+
+{% block footer %}{% endblock %}

--- a/geonode/maps/urls.py
+++ b/geonode/maps/urls.py
@@ -50,6 +50,7 @@ urlpatterns = patterns(
     url(r'^snapshot/create/?$', 'snapshot_create'),
     url(r'^(?P<mapid>[^/]+)$', 'map_detail', name='map_detail'),
     url(r'^(?P<mapid>[^/]+)/view$', existing_map_view, name='map_view'),
+    url(r'^(?P<mapid>[^/]+)/edit$', 'map_edit', name='map_edit'),
     url(r'^(?P<mapid>[^/]+)/data$', 'map_json', name='map_json'),
     url(r'^(?P<mapid>[^/]+)/download$', 'map_download', name='map_download'),
     url(r'^(?P<mapid>[^/]+)/wmc$', 'map_wmc', name='map_wmc'),

--- a/geonode/maps/views.py
+++ b/geonode/maps/views.py
@@ -410,6 +410,34 @@ def map_json(request, mapid, snapshot=None):
                 status=400
             )
 
+def map_edit(request, mapid, snapshot=None, template='maps/map_edit.html'):
+    """
+    The view that returns the map composer opened to
+    the map with the given map ID.
+    """
+    map_obj = _resolve_map(request, mapid, 'base.view_resourcebase', _PERMISSION_MSG_VIEW)
+
+    if 'access_token' in request.session:
+        access_token = request.session['access_token']
+    else:
+        access_token = None
+
+    if snapshot is None:
+        config = map_obj.viewer_json(request.user, access_token)
+    else:
+        config = snapshot_config(snapshot, map_obj, request.user, access_token)
+
+    return render_to_response(template, RequestContext(request, {
+        'mapId': mapid,
+        'config': json.dumps(config),
+        'map': map_obj,
+        'preview': getattr(
+            settings,
+            'LAYER_PREVIEW_LIBRARY',
+            '')
+    }))
+
+
 # NEW MAPS #
 
 

--- a/geonode/maps/views.py
+++ b/geonode/maps/views.py
@@ -410,6 +410,7 @@ def map_json(request, mapid, snapshot=None):
                 status=400
             )
 
+
 def map_edit(request, mapid, snapshot=None, template='maps/map_edit.html'):
     """
     The view that returns the map composer opened to

--- a/requirements.txt
+++ b/requirements.txt
@@ -70,4 +70,4 @@ requests==2.11.1
 transifex-client==0.10
 xmltodict==0.9.2
 django-treebeard==3.0
-django-geonode-client==0.0.11
+django-geonode-client===0.0.15


### PR DESCRIPTION
## What does this PR do?
It adds a route to maps for editing maps. 
The new client has two modi, view and compose. Right now the edit path would show the view instead of the compose. 

The current client will not be affected since it is a copy of the current view.