### PR TITLE
Format people cards to be universal height so sorting works properly

### DIFF
--- a/geonode/people/templates/people/_profile_list_item.html
+++ b/geonode/people/templates/people/_profile_list_item.html
@@ -7,12 +7,19 @@
         <div class="col-xs-4 profile-image">
           <a href="{{ profile.profile_detail_url }}" ><img ng-src="{{ profile.avatar_100 }}"/></a>
         </div>
-        <div class="col-xs-8 profile-details">
+        <div class="col-xs-8 profile-details" style="height: 110px;">
           <h5>
             <a href="{{ profile.profile_detail_url }}">{{ profile.first_name != '' ? profile.first_name : profile.username }} {{ profile.last_name != '' ? profile.last_name : '' }}
             </a>
           </h5>
-          <p><small>{{ profile.organization != '' ?  profile.organization : "No Organization info" }}</small></p>
+          <p>
+            <small ng-hide="profile.organization">
+              No Organization Info
+            </small>
+            <small ng-show="profile.organization">
+              {{ profile.organization | limitTo:30 }} <small ng-if="profile.organization.length > 30">...</small>
+            </small>
+          </p>
           <!-- <p>{{ profile.username }}</p> -->
           <!-- <a href="mailto:{{ profile.email }}" ng-if="profile.email != ''"><i class="fa fa-envelope"></i></a> -->
         </div>


### PR DESCRIPTION
This change solves an issue where sorting looks incorrect in the UI due to formatting errors.

Steps to reproduce visual bug:
1. Create more than 4 users.
2. Give each user an Organization Name, varying their length to emphasize the problem.
3. Navigate to the People search page.
4. Select the filter dropdown, and pick any of them which will cause the tiles to become reorganized.

You should see the profile cards look out of order due to being of varying sizes.

Additionally, another small bug existed where the tiles were supposed to display "No Organization Info" if the organization field had no data. This was also corrected.