### PR TITLE
fix: get rabbitmq broker url from docker env file

### DIFF
--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -952,7 +952,7 @@ SEARCH_FILTERS = {
 # Queue non-blocking notifications.
 NOTIFICATION_QUEUE_ALL = False
 
-BROKER_URL = "django://"
+BROKER_URL = os.getenv('BROKER_URL', "django://")
 CELERY_ALWAYS_EAGER = True
 CELERY_EAGER_PROPAGATES_EXCEPTIONS = True
 CELERY_IGNORE_RESULT = True


### PR DESCRIPTION
Since BROKER_URL is set in https://github.com/GeoNode/geonode/blob/master/scripts/docker/env/production/django.env#L2 we can get the value from the env file.

This should fix the celery container from constantly restarting because of invalid BROKER_URL.