### PR TITLE
Removed uploaded/layers from Apache config

### DIFF
--- a/docs/tutorials/install_and_admin/geonode_install/setup_configure_httpd.txt
+++ b/docs/tutorials/install_and_admin/geonode_install/setup_configure_httpd.txt
@@ -66,14 +66,6 @@ Place the following content inside the file:::
             IndexOptions FancyIndexing
         </Directory>
 
-        <Directory "/home/geonode/geonode/geonode/uploaded/layers/">
-            Order allow,deny
-            Options Indexes FollowSymLinks
-            Allow from all
-            Require all granted
-            IndexOptions FancyIndexing
-        </Directory>
-
         <Proxy *>
             Order allow,deny
             Allow from all


### PR DESCRIPTION
"The uploaded/layers directory doesn't have to be served by apache, it only needs write permissions"
- @simod on #2896

https://github.com/GeoNode/geonode/issues/2896#issuecomment-278587461