### PR TITLE
Remove the 3D viewer tool from maps

### DIFF
--- a/geonode/templates/geonode/geo_header.html
+++ b/geonode/templates/geonode/geo_header.html
@@ -17,7 +17,10 @@ OpenLayers.Request.DEFAULT_CONFIG.headers = {
  *  Add GetFeedFeatureInfo tool to GeoExplorer.Viewer
  */
 GeoExplorer.Viewer.prototype.loadConfig = function(config) {
-	config.viewerTools.push( {
+    // remove the 3D Viewer which is broken 
+    config.viewerTools.splice(10,1);
+
+    config.viewerTools.push( {
 		ptype: "gxp_getfeedfeatureinfo",
 		checked: true
 	});

--- a/geonode/templates/geonode/geo_header_debug.html
+++ b/geonode/templates/geonode/geo_header_debug.html
@@ -328,6 +328,9 @@ OpenLayers.Request.DEFAULT_CONFIG.headers = {
  *  Add GetFeedFeatureInfo tool to GeoExplorer.Viewer
  */
 GeoExplorer.Viewer.prototype.loadConfig = function(config) {
+    // remove the 3D Viewer which is broken 
+    config.viewerTools.splice(10,1);
+
 	config.viewerTools.push( {
 		ptype: "gxp_getfeedfeatureinfo",
 		checked: true


### PR DESCRIPTION
Google deprecated the Google Earth service by the end of 2015.
As the functionallity is broken, the button must be removed.

Solves https://github.com/GeoNode/geonode/issues/2921