### PR TITLE
Change Geoexplorer aboutUrl

### DIFF
--- a/geonode/utils.py
+++ b/geonode/utils.py
@@ -303,6 +303,7 @@ class GXPMapBase(object):
                 'title': self.title,
                 'abstract': self.abstract
             },
+            'aboutUrl': '../about',
             'defaultSourceType': "gxp_wmscsource",
             'sources': sources,
             'map': {


### PR DESCRIPTION
When accessing GeoExplorer info popup the about section shows a 404
Needed to change default behavior to adopt geonode's location

Solves https://github.com/GeoNode/geonode/issues/2892