### PR TITLE
Handle OS X zipped files in upload

### DIFF
--- a/geonode/upload/files.py
+++ b/geonode/upload/files.py
@@ -207,6 +207,13 @@ def _find_file_type(file_names, extension):
     return filter(lambda f: f.lower().endswith(extension), file_names)
 
 
+def clean_macosx_dir(file_names):
+    """
+    Returns the files sans anything in a __MACOSX directory
+    """
+    return [f for f in file_names if '__MACOSX' not in f]
+
+
 def scan_file(file_name):
     '''get a list of SpatialFiles for the provided file'''
 
@@ -223,6 +230,7 @@ def scan_file(file_name):
         try:
             zf = zipfile.ZipFile(file_name, 'r')
             files = zf.namelist()
+            files = clean_macosx_dir(files)
             if _contains_bad_names(files):
                 zf.extractall(dirname)
                 files = None


### PR DESCRIPTION
OS X adds a "__MACOSX" directory when creating a zipped file. We allow for uploading of zip files in importer, but it will trip up in the `_contains_bad_names` function, because it recognizes this directory as an xml unsafe name. If we skip this, it'll give an index out of bounds error later, presumably because there's extra copies of the files (I'm not actually 100% sure why).

The goal of this commit is to just clean the directory, so I added a function which just strips anything in a "__MACOSX" directory.