### PR TITLE
[ISSUE #2914] - User is still authenticated in geoserver after logging out from geonode

### DIFF
--- a/geonode/base/models.py
+++ b/geonode/base/models.py
@@ -1139,8 +1139,9 @@ def do_logout(sender, user, request, **kwargs):
         gs_request = urllib2.Request(url, data, header_params)
 
         try:
-            urllib2.urlopen(gs_request).open()
+            urllib2.urlopen(gs_request)
         except:
+            traceback.print_exc()
             pass
 
         if 'access_token' in request.session:


### PR DESCRIPTION
Along with GeoServer commit https://github.com/geoserver/geoserver/commit/94ea2c0047f6367ce02a2462bde053565f7999fb

**WARNING:** You need to update GeoServer too, at least the OAuth2 Plugin

http://ares.boundlessgeo.com/geoserver/2.9.x/community-latest/geoserver-2.9-SNAPSHOT-sec-oauth2-geonode-plugin.zip