### PR TITLE
Fixed incorrect DOM name to create geogig store

### DIFF
--- a/geonode/static/geonode/js/upload/LayerInfo.js
+++ b/geonode/static/geonode/js/upload/LayerInfo.js
@@ -151,14 +151,14 @@ define(function (require, exports) {
     LayerInfo.prototype.prepareFormData = function (form_data) {
         var i, ext, file, perm, geogig, geogig_store, time, mosaic;
 
-		var base_ext  = this.name.split('.').pop();
-		var base_name = this.name.slice(0, -(base_ext.length+1));
+        var base_ext  = this.main.name.split('.').pop();
+        var base_name = this.name;
 
-        var base_ext  = this.name.split('.').pop();
-        var base_name = this.name.slice(0, -(base_ext.length+1));
+        var base_ext  = this.main.name.split('.').pop();
+        var base_name = this.name;
 
-        var base_ext  = this.name.split('.').pop();
-        var base_name = this.name.slice(0, -(base_ext.length+1));
+        var base_ext  = this.main.name.split('.').pop();
+        var base_name = this.name;
 
         if (!form_data) {
             form_data = new FormData();


### PR DESCRIPTION
This was modified previously in [PR#2956](https://github.com/GeoNode/geonode/pull/2956) in order to fix XML unsafe names being uploaded (ie spaces and parentheses), but I made an error in removing the JavaScript which would capture the file extension, causing the geogig import to turn up empty. Reverted those lines back to correctly grab the file extension again.