### PR TITLE
tab display settings

### DIFF
--- a/geonode/base/templates/base/_resourcebase_snippet.html
+++ b/geonode/base/templates/base/_resourcebase_snippet.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 {% verbatim %}
-<div class="row">
+<div class="row resourcebase-snippet">
   <div ng-if="results.length == 0" ng-cloak>
     <div><h3>No content created yet.</h3></div>
   </div>
@@ -8,7 +8,9 @@
     <div class="col-xs-12 item-container">
       <div class="col-xs-12 profile-avatar">
         <div class="col-xs-4 item-thumb">
-          <a href="{{ item.detail_url }}"><img ng-src="{{ item.thumbnail_url }}" /></a>
+          <a href="{{ item.detail_url }}">
+            <img ng-src="{{ item.thumbnail_url }}" />
+          </a>
         </div>
         <div class="col-xs-8 item-details">
           {% endverbatim %}

--- a/geonode/context_processors.py
+++ b/geonode/context_processors.py
@@ -45,9 +45,17 @@ def resource_urls(request):
             settings,
             'PROXY_URL',
             '/proxy/?url='),
-        SOCIAL_BUTTONS=getattr(
+        DISPLAY_SOCIAL=getattr(
             settings,
-            'SOCIAL_BUTTONS',
+            'DISPLAY_SOCIAL',
+            False),
+        DISPLAY_COMMENTS=getattr(
+            settings,
+            'DISPLAY_COMMENTS',
+            False),
+        DISPLAY_RATINGS=getattr(
+            settings,
+            'DISPLAY_RATINGS',
             False),
         TWITTER_CARD=getattr(
             settings,

--- a/geonode/documents/templates/documents/document_detail.html
+++ b/geonode/documents/templates/documents/document_detail.html
@@ -50,16 +50,23 @@
     </div>
 
     <div class="tab-content">
+      <article id="info" class="tab-pane{% if tab == 'info' or not tab %} active{% endif %}">
       {% include "base/resourcebase_info_panel.html" %}
+      </article>
 
       {% block social_links %}
+        {% if DISPLAY_SOCIAL %}
         {% include "social_links.html" %}
+        {% endif %}
       {% endblock %}
 
+      {% if DISPLAY_COMMENTS %}
       <article id="comments" class="tab-pane">
       {% include "_comments.html" %}
       </article>
+      {% endif %}
 
+      {% if DISPLAY_RATINGS %}
       <article id="rate" class="tab-pane">
         <!-- TODO: Move this to a reusable template snippet -->
         {% if request.user.is_authenticated %}
@@ -73,6 +80,7 @@
         <div class="overall_rating" style="float:left" data-score="{{ document_rating }}"></div> ({{num_votes}})
         <!-- TODO: Add display of who gave what rating based -->
       </article>
+      {% endif %}
 
       {% if EXIF_ENABLED and exif_data %}
         {% with "exif/_exif_document_detail.html" as exif_template %}
@@ -218,7 +226,7 @@
 
 {% block extra_script %}
 {{ block.super }}
-{% if SOCIAL_BUTTONS %}
+{% if DISPLAY_SOCIAL %}
     {% include 'facebook_sdk.html' %}
 {% endif %}
     {% if request.user.is_authenticated %}
@@ -229,7 +237,7 @@
     {% include 'rating.html' %}
     {% include 'request_download.html' %}
     <script type="text/javascript">
-        {% if SOCIAL_BUTTONS %}
+        {% if DISPLAY_SOCIAL %}
         (function() {
             var po = document.createElement('script'); po.type = 'text/javascript'; po.async = true;
             po.src = 'https://apis.google.com/js/plusone.js';

--- a/geonode/layers/templates/layers/layer_detail.html
+++ b/geonode/layers/templates/layers/layer_detail.html
@@ -52,10 +52,11 @@
     </div>
 
     <div class="tab-content">
+      <article id="info" class="tab-pane{% if tab == 'info' or not tab %} active{% endif %}">
+        {% include "base/resourcebase_info_panel.html" %}
+      </article>
 
-    {% include "base/resourcebase_info_panel.html" %}
-
-     {% if resource.is_mosaic %}
+      {% if resource.is_mosaic %}
       <article id="granules" class="description tab-pane {% if tab and tab == 'granules' %}active{% endif %}">
         <div class="paginate-contents">
 
@@ -200,16 +201,18 @@
       </article>
 
       {% block social_links %}
-      {% if SOCIAL_BUTTONS %}
+      {% if DISPLAY_SOCIAL %}
         {% include "social_links.html" %}
       {% endif %}
       {% endblock %}
 
+      {% if DISPLAY_COMMENTS %}
       <article id="comments" class="tab-pane">
         {% with resource as obj %}
           {% include "_comments.html" %}
         {% endwith %}
       </article>
+      {% endif %}
 
       {% if GEOGIG_ENABLED and resource.link_set.geogig %}
         {% with "_geogig_layer_detail.html" as geogig_template %}
@@ -221,6 +224,7 @@
         {% endwith %}
       {% endif %}
 
+      {% if DISPLAY_RATINGS %}
       <article id="rate" class="tab-pane">
         <!-- TODO: Move this to a reusable template snippet -->
         {% if request.user.is_authenticated %}
@@ -233,6 +237,7 @@
         {% num_ratings resource as num_votes %}
         <div class="overall_rating" data-score="{{ layer_rating }}"></div> ({{num_votes}})
       </article>
+      {% endif %}
 
     </div>
 

--- a/geonode/maps/templates/maps/map_detail.html
+++ b/geonode/maps/templates/maps/map_detail.html
@@ -49,9 +49,20 @@
 
       <div class="tab-content">
         {% include "base/resourcebase_info_panel.html" %}
+
+        {% block social_links %}
+            {% if DISPLAY_SOCIAL %}
+              {% include "social_links.html" %}
+            {% endif %}
+        {% endblock %}
+
+        {% if DISPLAY_COMMENTS %}
         <article class="tab-pane" id="comments">
         {% include "_comments.html" %}
         </article>
+        {% endif %}
+
+        {% if DISPLAY_RATINGS %}
         <article class="tab-pane" id="rate">
         <!-- TODO: Move this to a reusable template snippet -->
           {% if request.user.is_authenticated %}
@@ -64,11 +75,7 @@
           {% num_ratings resource as num_votes %}
           <div class="overall_rating" style="float:left" data-score="{{ map_rating }}"></div> ({{num_votes}})
         </article>
-        {% block social_links %}
-            {% if SOCIAL_BUTTONS %}
-                {% include "social_links.html" %}
-            {% endif %}
-        {% endblock %}
+        {% endif %}
       </div>
 
     </div>
@@ -85,7 +92,7 @@
            <a href="{% url "map_metadata_detail" resource.id %}">
                <button class="btn btn-primary btn-md btn-block" >{% trans "Metadata Detail" %}</button>
            </a>
-        </li>  
+        </li>
 
         <div class="modal fade" id="download-map" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
           <div class="modal-dialog">
@@ -181,7 +188,7 @@
           <h4>{% trans "Documents related to this map" %}</h4>
           <p>{% trans "List of documents related to this map:" %}</p>
           <ul class="list-unstyled">
-            {% for document in documents %} 
+            {% for document in documents %}
             <li><a href="{{ document.get_absolute_url }}">{{ document.title }}</a></li>
             {% endfor %}
           </ul>
@@ -219,9 +226,9 @@
         {% endif %}
 
         {% include "base/_resourcebase_contact_snippet.html" %}
-    
+
       </ul>
-      
+
     </div>
 
   </div>
@@ -230,7 +237,7 @@
 
 {% block extra_script %}
 {{ block.super }}
-{% if SOCIAL_BUTTONS %}
+{% if DISPLAY_SOCIAL %}
     {% include 'facebook_sdk.html' %}
 {% endif %}
 {% if request.user.is_authenticated %}
@@ -282,7 +289,7 @@
 
 
  });
-{% if SOCIAL_BUTTONS %}
+{% if DISPLAY_SOCIAL %}
  (function() {
    var po = document.createElement('script'); po.type = 'text/javascript'; po.async = true;
    po.src = 'https://apis.google.com/js/plusone.js';
@@ -297,13 +304,13 @@
       success: function() {
         $('#form_post_comment_div').modal().find('form')[0].reset();
         $('#form_post_comment_div').modal('hide');
-        $('#comments_section').load(window.location.pathname + ' #comments_section', 
+        $('#comments_section').load(window.location.pathname + ' #comments_section',
         		function(){$(this).children().unwrap()})
       }
     });
     return false;
   });
- 
+
 </script>
 {% include "_permissions_form_js.html" %}
 <script type="text/javascript" src="{{ STATIC_URL}}geonode/js/utils/thumbnail.js"></script>
@@ -313,5 +320,5 @@
     $('#edit-map').modal('toggle');
   });
 </script>
- 
+
 {% endblock %}

--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -51,7 +51,7 @@ DEBUG = strtobool(os.getenv('DEBUG', 'True'))
 DEBUG_STATIC = strtobool(os.getenv('DEBUG_STATIC', 'False'))
 
 #Define email service on GeoNode
-EMAIL_ENABLE = strtobool(os.getenv('EMAIL_ENABLE', 'True')) 
+EMAIL_ENABLE = strtobool(os.getenv('EMAIL_ENABLE', 'True'))
 
 # This is needed for integration tests, they require
 # geonode to be listening for GeoServer auth requests.
@@ -731,7 +731,9 @@ MAP_BASELAYERS = [{
     "group": "background"
 }]
 
-SOCIAL_BUTTONS = True
+DISPLAY_SOCIAL = strtobool(os.getenv('DISPLAY_SOCIAL', 'True'))
+DISPLAY_COMMENTS = strtobool(os.getenv('DISPLAY_COMMENTS', 'True'))
+DISPLAY_RATINGS = strtobool(os.getenv('DISPLAY_RATINGS', 'True'))
 
 SOCIAL_ORIGINS = [{
     "label": "Email",
@@ -1071,5 +1073,5 @@ if 'geonode.geoserver' in INSTALLED_APPS:
 THESAURI = []
 
 if EMAIL_ENABLE:
-    #Setting up email backend 
+    #Setting up email backend
     EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'

--- a/geonode/templates/_actions.html
+++ b/geonode/templates/_actions.html
@@ -7,11 +7,15 @@
   {% if resource.is_mosaic %}
   <li><a href="#granules" data-toggle="tab"><i class="fa fa-bars"></i>{% trans "Granules" %}</a></li>
   {% endif %}
-  {% if SOCIAL_BUTTONS %}
+  {% if DISPLAY_SOCIAL %}
   <li><a href="#share" data-toggle="tab"><i class="fa fa-share"></i>{% trans "Share" %}</a></li>
   {% endif %}
+  {% if DISPLAY_RATINGS %}
   <li><a href="#rate" data-toggle="tab"><i class="fa fa-star"></i>{% trans "Ratings" %}</a></li>
+  {% endif %}
+  {% if DISPLAY_COMMENTS %}
   <li><a href="#comments" data-toggle="tab"><i class="fa fa-comment-o"></i> {% trans "Comments" %}</a></li>
+  {% endif %}
   {% if GEOGIG_ENABLED and resource.link_set.geogig %}
   <li><a href="#geogig" data-toggle="tab"><i class="fa fa-code-fork"></i> {% trans "GeoGig" %}</a></li>
   {% endif %}


### PR DESCRIPTION
Created 3 settings to easily toggle detail page tabs on/off.  Particularly useful for downstream projects that are not currently using the commenting or ratings.  All default to `True`.

- DISPLAY_SOCIAL (FKA SOCIAL_BUTTONS)
- DISPLAY_COMMENTS
- DISPLAY_RATINGS

Other minor fixes to detail pages, too.