### PR TITLE
Peg django-tastypie to 0.13.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ setup(name='GeoNode',
         "django-guardian>=1.4.1",  # django-guardian (1.4.1)
         "django-downloadview>=1.2",  # python-django-downloadview (1.8)
         "django-polymorphic>=0.9.2",  # python-django-polymorphic (0.8.1) FIXME
-        "django-tastypie>=0.12.2",  # python-django-tastypie (0.12.0, 0.12.2 in our ppa)
+        "django-tastypie>=0.12.2, <=0.13.1",  # python-django-tastypie (0.12.0, 0.12.2 in our ppa)
         "django-oauth-toolkit>=0.10.0",  # python-django-oauth-toolkit (0.10.0)
 
         # geopython dependencies


### PR DESCRIPTION
Recent versions of Tastypie have a `ignore_bad_filters` that is not supported on the underlying queryset object.