### PR TITLE
catch and fix import error

### DIFF
--- a/pavement.py
+++ b/pavement.py
@@ -360,7 +360,12 @@ def start_geoserver(options):
     Start GeoServer with GeoNode extensions
     """
 
-    from geonode.settings import OGC_SERVER
+    try:
+        from geonode.settings import OGC_SERVER
+    except ImportError:
+        sys.path.extend([os.path.dirname(__file__)])
+        from geonode.settings import OGC_SERVER
+
     GEOSERVER_BASE_URL = OGC_SERVER['default']['LOCATION']
     url = GEOSERVER_BASE_URL
 


### PR DESCRIPTION
Still having a problem with this and if I am, hopefully this quick
check and fix will prevent it for other users.

Begin commit message

revisiting a previous issue.  The problem has been isolated and
in contrast with a previous PR, the problem statement and
fix in a try catch block has been isolated to where the problem
occurs as opposed to a top level, beginning of file  sys.path.append

The ALLOWED_HOSTS setting needs to be a list but
there is no way to make it so just by using os.getenv

Added logic to check if the environment variable exits
and if so, split on comma. colon, or semicolon excluding
leading or trailing spaces