### PR TITLE
Provide default value if request doesn't include offset to avoid TypeError

### DIFF
--- a/geonode/api/resourcebase_api.py
+++ b/geonode/api/resourcebase_api.py
@@ -410,7 +410,7 @@ class CommonModelApi(ModelResource):
 
             try:
                 page = paginator.page(
-                    int(request.GET.get('offset')) /
+                    int(request.GET.get('offset') or 0) /
                     int(request.GET.get('limit'), 0) + 1)
             except InvalidPage:
                 raise Http404("Sorry, no results on that page.")


### PR DESCRIPTION
If a request fails to provide an `offset` value, e.g., `int(None)` throws an exception