### PR TITLE
Hide Geoserver menu when not needed

### DIFF
--- a/geonode/context_processors.py
+++ b/geonode/context_processors.py
@@ -35,6 +35,7 @@ def resource_urls(request):
         SITE_NAME=site.name,
         SITE_DOMAIN=site.domain,
         SITEURL=settings.SITEURL,
+        INSTALLED_APPS=settings.INSTALLED_APPS,
         RESOURCE_PUBLISHING=settings.RESOURCE_PUBLISHING,
         THEME_ACCOUNT_CONTACT_EMAIL=settings.THEME_ACCOUNT_CONTACT_EMAIL,
         DEBUG_STATIC=getattr(

--- a/geonode/templates/base.html
+++ b/geonode/templates/base.html
@@ -126,7 +126,9 @@
                 <li><a href="{% url "messages_inbox" %}">{% trans "Inbox" %}</a></li>
                 <li role="separator" class="divider"></li>
                 <li><a href="{% url "admin:index" %}">Admin</a></li>
+                {% if 'geonode.geoserver' in INSTALLED_APPS %}
                 <li><a href="{{ GEOSERVER_BASE_URL }}">GeoServer</a></li>
+                {% endif %}
                 <li role="separator" class="divider"></li>
                 <li><a href="{% url "help" %}">{% trans "Help" %}</li>
                 <li role="separator" class="divider"></li>


### PR DESCRIPTION
Hide Geoserver menu when not needed

Add settings.INSTALLED_APPS accessible as global variable in HTML.
Disable geoserver link in admin menu if geoserver is not present.