### PR TITLE
Fix to correctly show icons on people and group filters

### DIFF
--- a/geonode/templates/search/_sort_filters.html
+++ b/geonode/templates/search/_sort_filters.html
@@ -3,20 +3,20 @@
 <div class="btn-group pull-right" role="group" aria-label="tools">
   <div class="btn-group" role="group">
     <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-      <div ng-if="dataValue == 'title'" ng-cloak>
+      <div ng-if="dataValue == 'title' || dataValue == 'username'" ng-cloak>
         <i class="fa fa-sort-alpha-asc fa-lg"></i>
         <i class="fa fa-angle-down fa-lg"></i>
       </div>
-      <div ng-if="dataValue == '-title'" ng-cloak>
+      <div ng-if="dataValue == '-title' || dataValue == '-username'" ng-cloak>
         <i class="fa fa-sort-alpha-desc fa-lg"></i>
         <i class="fa fa-angle-down fa-lg"></i>
       </div>
-      <div ng-if="dataValue == 'date'" ng-cloak>
+      <div ng-if="dataValue == 'date' || dataValue == 'last_modified' || dataValue == 'date_joined'" ng-cloak>
         <i class="fa fa-clock-o"></i>
         <i class="fa fa-clock-o fa-level-up"></i>
         <i class="fa fa-angle-down fa-lg"></i>
       </div>
-      <div ng-if="dataValue == '-date'" ng-cloak>
+      <div ng-if="dataValue == '-date' || dataValue == '-last_modified' || dataValue == '-date_joined'" ng-cloak>
         <i class="fa fa-clock-o"></i>
         <i class="fa fa-clock-o fa-level-down"></i>
         <i class="fa fa-angle-down fa-lg"></i>


### PR DESCRIPTION
Adjusts the icons display for search filters so they work and display correctly for people and groups. Currently only works correctly for maps/layers, and disappears when selecting a different filter on the people or group search.