### PR TITLE
ASCII support

### DIFF
--- a/geonode/layers/forms.py
+++ b/geonode/layers/forms.py
@@ -137,8 +137,8 @@ class LayerUploadForm(forms.Form):
         if not cleaned["metadata_upload_form"] and base_ext.lower() not in (
                 ".shp", ".tif", ".tiff", ".geotif", ".geotiff", ".asc"):
             raise forms.ValidationError(
-                "Only Shapefiles and GeoTiffs are supported. You uploaded a %s file" %
-                base_ext)
+                "Only Shapefiles, GeoTiffs, and ASCIIs are supported. You "
+                "uploaded a %s file" % base_ext)
         elif cleaned["metadata_upload_form"] and base_ext.lower() not in (".xml"):
             raise forms.ValidationError(
                 "Only XML files are supported. You uploaded a %s file" %

--- a/geonode/layers/forms.py
+++ b/geonode/layers/forms.py
@@ -134,7 +134,8 @@ class LayerUploadForm(forms.Form):
             if cleaned["xml_file"] is not None:
                 xml_file = cleaned["xml_file"].name
 
-        if not cleaned["metadata_upload_form"] and base_ext.lower() not in (".shp", ".tif", ".tiff", ".geotif", ".geotiff"):
+        if not cleaned["metadata_upload_form"] and base_ext.lower() not in (
+                ".shp", ".tif", ".tiff", ".geotif", ".geotiff", ".asc"):
             raise forms.ValidationError(
                 "Only Shapefiles and GeoTiffs are supported. You uploaded a %s file" %
                 base_ext)

--- a/geonode/layers/models.py
+++ b/geonode/layers/models.py
@@ -44,7 +44,7 @@ csv_exts = ['.csv']
 kml_exts = ['.kml']
 vec_exts = shp_exts + csv_exts + kml_exts
 
-cov_exts = ['.tif', '.tiff', '.geotiff', '.geotif']
+cov_exts = ['.tif', '.tiff', '.geotiff', '.geotif', '.asc']
 
 TIME_REGEX = (
     ('[0-9]{8}', _('YYYYMMDD')),
@@ -216,7 +216,7 @@ class Layer(ResourceBase):
         if base_files_count == 0:
             return None, None
 
-        msg = 'There should only be one main file (.shp or .geotiff), found %s' % base_files_count
+        msg = 'There should only be one main file (.shp or .geotiff or .asc), found %s' % base_files_count
         assert base_files_count == 1, msg
 
         # we need to check, for shapefile, if column names are valid

--- a/geonode/layers/tests.py
+++ b/geonode/layers/tests.py
@@ -295,6 +295,13 @@ class LayersTest(TestCase):
         files = dict(base_file=SimpleUploadedFile('foo.GEOTIF', ' '))
         self.assertTrue(LayerUploadForm(dict(), files).is_valid())
 
+    def testASCIIValidation(self):
+        files = dict(base_file=SimpleUploadedFile('foo.asc', ' '))
+        self.assertTrue(LayerUploadForm(dict(), files).is_valid())
+
+        files = dict(base_file=SimpleUploadedFile('foo.ASC', ' '))
+        self.assertTrue(LayerUploadForm(dict(), files).is_valid())
+
     def testZipValidation(self):
         the_zip = zipfile.ZipFile('test_upload.zip', 'w')
         in_memory_file = StringIO.StringIO()
@@ -353,6 +360,9 @@ class LayersTest(TestCase):
         self.assertEquals(layer_type('foo.geotiff'), 'raster')
         self.assertEquals(layer_type('foo.GEOTIFF'), 'raster')
         self.assertEquals(layer_type('foo.gEoTiFf'), 'raster')
+        self.assertEquals(layer_type('foo.asc'), 'raster')
+        self.assertEquals(layer_type('foo.ASC'), 'raster')
+        self.assertEquals(layer_type('foo.AsC'), 'raster')
 
         # basically anything else should produce a GeoNodeException
         self.assertRaises(GeoNodeException, lambda: layer_type('foo.gml'))

--- a/geonode/static/geonode/js/upload/FileTypes.js
+++ b/geonode/static/geonode/js/upload/FileTypes.js
@@ -9,6 +9,11 @@ define(['./FileType'], function (FileType) {
             main: 'shp',
             requires: ['shp', 'prj', 'dbf', 'shx']
         });
+    file_types['ASCII'] = new FileType({
+            name: gettext('ASCII Text File'),
+            format: 'raster',
+            main: 'asc'
+        });
     file_types['TIF'] = new FileType({
             name: gettext('GeoTIFF'),
             format: 'raster',

--- a/geonode/upload/files.py
+++ b/geonode/upload/files.py
@@ -126,6 +126,8 @@ types = [
              auxillary_file_exts=('dbf', 'shx', 'prj')),
     FileType("GeoTIFF", "tif", raster,
              aliases=('tiff', 'geotif', 'geotiff')),
+    FileType("ASCII Text File", "asc", raster,
+             auxillary_file_exts=('prj')),
     # requires geoserver importer extension
     FileType("PNG", "png", raster,
              auxillary_file_exts=('prj')),

--- a/geonode/upload/views.py
+++ b/geonode/upload/views.py
@@ -572,6 +572,7 @@ _steps = {
 _pages = {
     'shp': ('srs', 'time', 'run', 'final'),
     'tif': ('run', 'final'),
+    'asc': ('run', 'final'),
     'kml': ('run', 'final'),
     'csv': ('csv', 'time', 'run', 'final'),
     'geojson': ('run', 'final'),


### PR DESCRIPTION
Make GeoNode supports asc file uploader.

At first I just want to make the support available with QGIS Server backend, but it seems it will work also on geoserver. This PR is only addressing the GeoServer backend one. The QGIS Server backend will be added in the another PR (since we move qgis_server to geonode).

cc @gubuntu @lucernae