### PR TITLE
Fix duplicate tiling in Leaflet Preview

### DIFF
--- a/geonode/layers/templates/layers/layer_leaflet_map.html
+++ b/geonode/layers/templates/layers/layer_leaflet_map.html
@@ -190,19 +190,12 @@
             zoom_to_box(map, [{{ resource.bbox_string }}]);
         {% endif %}
 
+        var tile_layer;
         {% if resource.get_tiles_url %}
-
             tile_layer = L.tileLayer("{{ resource.get_tiles_url|safe }}",
                     {
                         'opacity': 0.8
                     });
-
-            L.tileLayer.betterWms('{{ resource.ows_url|safe }}', {
-              layers: '{{ resource.typename }}',
-              transparent: true,
-              format: 'image/png'
-            }).addTo(map);
-
         {%  elif resource.ptype == "gxp_wmscsource"  %}
             tile_layer = L.tileLayer.betterWms('{{ resource.ows_url|safe }}', {
                 layers: '{{ resource.typename }}',
@@ -217,7 +210,12 @@
                 transparent: true,
                 'opacity': 0.8
             });
-
+        {% elif resource.ows_url %}
+            tile_layer = L.tileLayer.betterWms('{{ resource.ows_url|safe }}', {
+              layers: '{{ resource.typename }}',
+              transparent: true,
+              format: 'image/png'
+            });
         {% endif %}
 
         if (tile_layer != null) {


### PR DESCRIPTION
# Problem

When we are using leaflet as layer preview library, if the map has both tile_url and ows_url, it will be both rendered in the map. This might be a bug.

# Proposed Solution

Move this particular code:

```
L.tileLayer.betterWms('{{ resource.ows_url|safe }}', {
              layers: '{{ resource.typename }}',
              transparent: true,
              format: 'image/png'
            }).addTo(map);
```

To the bottom of the if else clause (because maybe someone forgot to put another case).
This will make sure `resource.ptype == "gxp_wmscsource"` will be evaluated first.