### PR TITLE
Bugfix to 2.6 release

### DIFF
--- a/geonode/__init__.py
+++ b/geonode/__init__.py
@@ -20,7 +20,7 @@
 
 import os
 
-__version__ = (2, 6, 0, 'final', 0)
+__version__ = (2, 6, 1, 'final', 0)
 
 
 class GeoNodeException(Exception):

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ django-haystack==2.4.1
 django-jsonfield==0.9.16
 django-leaflet==0.13.7
 django-modeltranslation==0.12
-django-oauth-toolkit==0.10.0
+django-oauth-toolkit<1.0
 django-mptt==0.8.6
 django-nose==1.4.4
 django-pagination==1.0.7

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,8 @@ setup(name='GeoNode',
         "django-downloadview>=1.2",  # python-django-downloadview (1.8)
         "django-polymorphic>=0.9.2",  # python-django-polymorphic (0.8.1) FIXME
         "django-tastypie>=0.12.2, <=0.13.1",  # python-django-tastypie (0.12.0, 0.12.2 in our ppa)
-        "django-oauth-toolkit>=0.10.0",  # python-django-oauth-toolkit (0.10.0)
+        "django-oauth-toolkit>=0.10.0, <1.0",  # python-django-oauth-toolkit (0.10.0)
+        "oauthlib==2.0.1",
 
         # geopython dependencies
         "pyproj>=1.9.3",  # python-pyproj (1.9.5)


### PR DESCRIPTION
See https://github.com/GeoNode/geonode/pull/3111 for more conversation related to this.

What is our preferred way of releasing updates to a current "stable" release? this OAuth2 issue is currently a blocker for e.g., anyone pinning GeoNode 2.6 out of PyPI as a project dependency, etc.

Pulling in @afabiani's fix & releasing a 2.6.1 package is one way to handle this, but if there is another preferred solution let's talk about it & get this resolved. :)