### PR TITLE
set thumbnail function  for geonode-client

### DIFF
--- a/geonode/base/admin.py
+++ b/geonode/base/admin.py
@@ -33,15 +33,25 @@ from treebeard.forms import movenodeform_factory
 
 from modeltranslation.admin import TranslationAdmin
 
-from geonode.base.models import (TopicCategory, SpatialRepresentationType, Region, RestrictionCodeType,
-                                 ContactRole, Link, Backup, License, HierarchicalKeyword)
+from geonode.base.models import (
+    TopicCategory,
+    SpatialRepresentationType,
+    Region,
+    RestrictionCodeType,
+    ContactRole,
+    Link,
+    Backup,
+    License,
+    HierarchicalKeyword)
 from django.http import HttpResponseRedirect
 
 
 def metadata_batch_edit(modeladmin, request, queryset):
     ids = ','.join([str(element.pk) for element in queryset])
     resource = queryset[0].class_name.lower()
-    return HttpResponseRedirect('/{}s/metadata/batch/{}/'.format(resource, ids))
+    return HttpResponseRedirect(
+        '/{}s/metadata/batch/{}/'.format(resource, ids))
+
 
 metadata_batch_edit.short_description = 'Metadata batch edit'
 
@@ -74,13 +84,18 @@ def run(self, request, queryset):
             for siteObj in queryset:
                 self.message_user(request, "Executed Backup: " + siteObj.name)
                 out = StringIO.StringIO()
-                call_command('backup', force_exec=True, backup_dir=siteObj.base_folder, stdout=out)
+                call_command(
+                    'backup',
+                    force_exec=True,
+                    backup_dir=siteObj.base_folder,
+                    stdout=out)
                 value = out.getvalue()
                 if value:
                     siteObj.location = value
                     siteObj.save()
                 else:
-                    self.message_user(request, siteObj.name + " backup failed!")
+                    self.message_user(
+                        request, siteObj.name + " backup failed!")
         else:
             context = {
                 "objects_name": "Backups",
@@ -89,8 +104,11 @@ def run(self, request, queryset):
                 'cancellable_backups': [siteObj],
                 'action_checkbox_name': helpers.ACTION_CHECKBOX_NAME,
             }
-            return TemplateResponse(request, 'admin/backups/confirm_cancel.html', context,
-                                    current_app=self.admin_site.name)
+            return TemplateResponse(
+                request,
+                'admin/backups/confirm_cancel.html',
+                context,
+                current_app=self.admin_site.name)
 
 
 def restore(self, request, queryset):
@@ -105,9 +123,12 @@ def restore(self, request, queryset):
                 self.message_user(request, "Executed Restore: " + siteObj.name)
                 out = StringIO.StringIO()
                 if siteObj.location:
-                    call_command('restore', force_exec=True, backup_file=str(siteObj.location).strip(), stdout=out)
+                    call_command(
+                        'restore', force_exec=True, backup_file=str(
+                            siteObj.location).strip(), stdout=out)
                 else:
-                    self.message_user(request, siteObj.name + " backup not ready!")
+                    self.message_user(
+                        request, siteObj.name + " backup not ready!")
         else:
             context = {
                 "objects_name": "Restores",
@@ -116,8 +137,11 @@ def restore(self, request, queryset):
                 'cancellable_backups': [siteObj],
                 'action_checkbox_name': helpers.ACTION_CHECKBOX_NAME,
             }
-            return TemplateResponse(request, 'admin/backups/confirm_cancel.html', context,
-                                    current_app=self.admin_site.name)
+            return TemplateResponse(
+                request,
+                'admin/backups/confirm_cancel.html',
+                context,
+                current_app=self.admin_site.name)
 
 
 run.short_description = "Run the Backup"
@@ -142,7 +166,12 @@ class LicenseAdmin(MediaTranslationAdmin):
 class TopicCategoryAdmin(MediaTranslationAdmin):
     model = TopicCategory
     list_display_links = ('identifier',)
-    list_display = ('identifier', 'description', 'gn_description', 'fa_class', 'is_choice')
+    list_display = (
+        'identifier',
+        'description',
+        'gn_description',
+        'fa_class',
+        'is_choice')
     if settings.MODIFY_TOPICCATEGORY is False:
         exclude = ('identifier', 'description',)
 
@@ -236,4 +265,5 @@ class ResourceBaseAdminForm(autocomplete_light.ModelForm):
     # which prevents app startup. Therefore, we defer setting the widget until
     # after that's done.
     keywords = TaggitField(required=False)
-    keywords.widget = TaggitWidget(autocomplete='HierarchicalKeywordAutocomplete')
+    keywords.widget = TaggitWidget(
+        autocomplete='HierarchicalKeywordAutocomplete')

--- a/geonode/layers/templates/layers/layer_detail.html
+++ b/geonode/layers/templates/layers/layer_detail.html
@@ -576,10 +576,18 @@
     {% endif %}
         </script>
     <script type="text/javascript">
-      $('#set_thumbnail').click(function(){
-        createMapThumbnail();
-        $('#edit-layer').modal('toggle');
-      });
+    {% if preview == 'react' %}
+    $('#set_thumbnail').click(function(){
+      window.setThumbnail({{resource.id}})
+      $('#edit-layer').modal('toggle');
+    });
+    {% else %}
+    $('#set_thumbnail').click(function(){
+      createMapThumbnail();
+      $('#edit-layer').modal('toggle');
+    });
+    {% endif %}
+
     </script>
     {% if GEONODE_SECURITY_ENABLED %}
     {% include "_permissions_form_js.html" %}

--- a/geonode/layers/views.py
+++ b/geonode/layers/views.py
@@ -22,6 +22,8 @@ import os
 import sys
 import logging
 import shutil
+import json
+import base64
 import traceback
 import uuid
 import decimal
@@ -853,15 +855,14 @@ def layer_granule_remove(request, granule_id, layername, template='layers/layer_
     else:
         return HttpResponse("Not allowed", status=403)
 
-import json
-import base64
+
 def layer_thumbnail(request, layername):
     if request.method == 'POST':
         layer_obj = _resolve_layer(request, layername)
 
         try:
-            preview=json.loads(request.body)['preview']
-            if preview == 'react':
+            preview=json.loads(request.body).get('preview',None)
+            if preview and preview == 'react':
                 format,image=json.loads(request.body)['image'].split(';base64,')
                 image=base64.b64decode(image)
             else:

--- a/geonode/layers/views.py
+++ b/geonode/layers/views.py
@@ -853,13 +853,19 @@ def layer_granule_remove(request, granule_id, layername, template='layers/layer_
     else:
         return HttpResponse("Not allowed", status=403)
 
-
+import json
+import base64
 def layer_thumbnail(request, layername):
     if request.method == 'POST':
         layer_obj = _resolve_layer(request, layername)
 
         try:
-            image = _render_thumbnail(request.body)
+            preview=json.loads(request.body)['preview']
+            if preview == 'react':
+                format,image=json.loads(request.body)['image'].split(';base64,')
+                image=base64.b64decode(image)
+            else:
+                image = _render_thumbnail(request.body)
 
             if not image:
                 return

--- a/geonode/layers/views.py
+++ b/geonode/layers/views.py
@@ -22,7 +22,6 @@ import os
 import sys
 import logging
 import shutil
-import json
 import base64
 import traceback
 import uuid


### PR DESCRIPTION
- Issues
     - set thumbnail button not working with geonode-client 
- solution: 
     - geonode-client use [boundless sdk](https://github.com/boundlessgeo/sdk) which contains a component to create thumbnail or create image for current view as blob so I created a function to post this image data (blob) to our endpoint [here](https://github.com/GeoNode/geonode-client/pull/173). 
     -  but our end point generate thumbnail server-side so we need to skip this step if `preview=='react'`(a flag in the request to identify sender). 


this PR skip generating image (server-side) and save blob data as thumbnail image
