### PR TITLE
 Geonode 2.6 : Adding django-jsonfield-compat package to setup.py and requirements.txt 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,7 @@ django-geoexplorer==4.0.5
 django-guardian==1.4.6
 django-haystack==2.4.1
 django-jsonfield==0.9.16
+django-jsonfield-compat==0.4.4
 django-leaflet==0.13.7
 django-modeltranslation==0.12
 django-oauth-toolkit<1.0

--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,7 @@ setup(name='GeoNode',
         "django-pagination >=1.0.5, <=1.0.7",  # python-django-pagination (1.0.7)
         "django-extensions>=1.2.5",  # python-django-extensions (1.5.9)
         "django-jsonfield>=0.9.16",  # python-django-jsonfield (0.9.15, 1.0.1 in our ppa)
+        "django-jsonfield-compat>=0.4.4",
         "django-taggit>=0.21.0",  # python-django-taggit (0.18.0)
         "django-mptt>=0.8.6",  # django-mptt (0.8.0, 0.8.6 in our ppa)
         "django-treebeard>=3.0",  # django-treebeard (4.0)


### PR DESCRIPTION
During my upgrade from GeoNode 2.4 to GeoNode 2.6, I noticed that the system after the command: 
sudo -u geonode python manage.py collectstatic
raises the following error:
Traceback (most recent call last):
  File "manage.py", line 29, in <module>
    execute_from_command_line(sys.argv)
  File "/usr/local/lib/python2.7/dist-packages/django/core/management/__init__.py", line 354, in execute_from_command_line
    utility.execute()
  File "/usr/local/lib/python2.7/dist-packages/django/core/management/__init__.py", line 328, in execute
    django.setup()
  File "/usr/local/lib/python2.7/dist-packages/django/__init__.py", line 18, in setup
    apps.populate(settings.INSTALLED_APPS)
  File "/usr/local/lib/python2.7/dist-packages/django/apps/registry.py", line 115, in populate
    app_config.ready()
  File "/usr/local/lib/python2.7/dist-packages/actstream/apps.py", line 21, in ready
    'You must have django-jsonfield and django-jsonfield-compat '
django.core.exceptions.ImproperlyConfigured: You must have django-jsonfield and django-jsonfield-compat installed if you wish to use a JSONField on your actions

Also I found a related topic in GeoNode  Users mailing list:
http://osgeo-org.1560.x6.nabble.com/problems-setting-up-customize-look-and-feel-td5331033.html#a5331360

So, I modified the setup.py and requirements.txt files in order to include the package 
django-jsonfield-compat, Version  = 0.4.4.

After that, I tested it executing : 
sudo pip install -e .
sudo -u geonode python manage.py collectstatic 
and the problem solved.
The django-jsonfield is already installed in version : 1.0.1.
I tested it following the GeoNode (v2.6) installation on Ubuntu guide in Ubuntu 16.04 LTS machine
