### PR TITLE
Fix Shapely Version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 if on_rtd:
     shapely_dep = "Shapely<1.5.13"
 else:
-    shapely_dep = "Shapely>=1.5.13"
+    shapely_dep = "Shapely==1.5.17"
 
 setup(name='GeoNode',
       version=__import__('geonode').get_version(),


### PR DESCRIPTION
Shapely 1.6.0 is not compatible with geonode
we need to restrict Shapely version to 1.5.17 or less
please review this [issue](https://github.com/cartologic/cartoview/issues/57)