### PR TITLE
Version constrain six, see https://github.com/benjaminp/six/issues/210

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,7 @@ setup(name='GeoNode',
         "pyflakes<=1.6.0",
         "pep8<=1.7.0",  # python-pep8 (1.7.0)
         "boto==2.38.0",  # python-boto (2.38.0)
+        "six==1.10.0", # https://github.com/benjaminp/six/issues/210
 
         # Django Apps
         "django-pagination>=1.0.5,<=1.0.7",  # python-django-pagination (1.0.7)


### PR DESCRIPTION
Running any Django command with the latest version of Six, and with Geonode's dependencies (the version of ```django-autocomplete-light``` that gets pulled in, to be precise) will fail with something similar to this:
```

Traceback (most recent call last):
  File "manage.py", line 11, in <module>
    execute_from_command_line(sys.argv)
  File "/usr/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 354, in execute_from_command_line
    utility.execute()
  File "/usr/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 328, in execute
    django.setup()
  File "/usr/local/lib/python2.7/site-packages/django/__init__.py", line 18, in setup
    apps.populate(settings.INSTALLED_APPS)
  File "/usr/local/lib/python2.7/site-packages/django/apps/registry.py", line 85, in populate
    app_config = AppConfig.create(entry)
  File "/usr/local/lib/python2.7/site-packages/django/apps/config.py", line 86, in create
    module = import_module(entry)
  File "/usr/local/lib/python2.7/importlib/__init__.py", line 37, in import_module
    __import__(name)
  File "/usr/local/lib/python2.7/site-packages/autocomplete_light/__init__.py", line 7, in <module>
    from .shortcuts import *  # noqa
  File "/usr/local/lib/python2.7/site-packages/autocomplete_light/shortcuts.py", line 8, in <module>
    from .forms import *
  File "/usr/local/lib/python2.7/site-packages/autocomplete_light/forms.py", line 438, in <module>
    class ModelForm(six.with_metaclass(*bases)):
  File "/usr/local/lib/python2.7/site-packages/autocomplete_light/forms.py", line 283, in __new__
    attrs)
  File "/usr/local/lib/python2.7/site-packages/django/forms/models.py", line 247, in __new__
    new_class = super(ModelFormMetaclass, mcs).__new__(mcs, name, bases, attrs)
  File "/usr/local/lib/python2.7/site-packages/django/forms/forms.py", line 91, in __new__
    .__new__(mcs, name, bases, attrs))
  File "/usr/local/lib/python2.7/site-packages/django/forms/widgets.py", line 145, in __new__
    .__new__(mcs, name, bases, attrs))
TypeError: Error when calling the metaclass bases
    metaclass conflict: the metaclass of a derived class must be a (non-strict) subclass of the metaclasses of all its bases
```