### PR TITLE
gitignore celery helper files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,6 @@ geonode/man/
 geonode/pip-selfcheck.json
 geonode/shapely/
 geonode/share/
+
+# celery files
+celerybeat-schedule.*


### PR DESCRIPTION
Running docker-compose generates the celery files at the project root
celerybeat-schedule.bak
celerybeat-schedule.dat
celerybeat-schedule.dir

Add line in .gitignore to ignore from repo
celerybeat-schedule.*