### PR TITLE
 - Avoid Multiple Tags Exception

### DIFF
--- a/geonode/base/models.py
+++ b/geonode/base/models.py
@@ -382,8 +382,11 @@ class _HierarchicalTagManager(_TaggableManager):
             tag_objs.add(HierarchicalKeyword.add_root(name=new_tag))
 
         for tag in tag_objs:
-            self.through.objects.get_or_create(
-                tag=tag, **self._lookup_kwargs())
+            try:
+                self.through.objects.get_or_create(
+                    tag=tag, **self._lookup_kwargs())
+            except Exception as e:
+                logger.exception(e)
 
 
 class Thesaurus(models.Model):


### PR DESCRIPTION
This error happened when in the Keywords selectbox a tag appear more than once. This should not happen, usually, but it may happen if there some error on the metadata xml.

A fix on GeoNode has been pushed in order to overcome such kind of exceptional cases.