### PR TITLE
GeoServer stores weren’t being created automatically

### DIFF
--- a/geonode/upload/utils.py
+++ b/geonode/upload/utils.py
@@ -45,6 +45,8 @@ def create_geoserver_db_featurestore(
             ds = cat.get_store(dsname)
         else:
             return None
+        if ds is None:
+            raise FailedRequestError
     except FailedRequestError:
         if store_type == 'geogig':
             if store_name is None and hasattr(


### PR DESCRIPTION
(Backporting issue to 2.6.x from master. See #3345 )
A change in either the GeoServer API or gs_catalog has caused None to be returned when failing to lookup a store. Previously it was throwing a FailedRequestError. This forces an exception to be thrown if None is returned.