### PR TITLE
Adding Greek code 'gre' into Language field in admin layer's form

### DIFF
--- a/geonode/base/enumerations.py
+++ b/geonode/base/enumerations.py
@@ -349,6 +349,7 @@ ALL_LANGUAGES = (
     ('fry', 'Frisian'),
     ('glg', 'Gallegan'),
     ('ger', 'German'),
+    ('gre', 'Greek'),
     ('kal', 'Greenlandic'),
     ('grn', 'Guarani'),
     ('guj', 'Gujarati'),


### PR DESCRIPTION
I tried to upload shapefiles with xml metadata catalogues but after uploading, the layer detail page raised 500 internal error. I realized that the problem came from the language code because the LanguageCode tag in the xml file, had the codeListValue="gre" (Greek language code) while the Language field in admin Layer metadata form didn't contain that code. As a result, the system assigned as language code the first choice from the list (Abkhazian). So, I added the 'gre' code in geonode/base/enumerations.py and the problem solved.