### PR TITLE
 - Improve GeoExt base GIS viewer; adding 'wrapDateline' option and update OL2 version

### DIFF
--- a/geonode/layers/templates/layers/layer_geoext_map.html
+++ b/geonode/layers/templates/layers/layer_geoext_map.html
@@ -15,7 +15,7 @@
                     ptype: "gxp_wmsgetfeatureinfo",
                     format: "grid",
                     actionTarget: "main.tbar",
-                    outputConfig: {width: 400, height: 200, panIn: false}
+                    outputConfig: {width: 400, height: 200, panIn: false, wrapDateLine: true}
                 }],
                 {% if PROXY_URL %}
                 proxy: '{{ PROXY_URL }}',
@@ -40,17 +40,20 @@
 
                 portalConfig: {
                     renderTo: "preview_map",
-                    height: 600
+                    height: 400
                 },
 
                 listeners: {
                     "ready": function() {
                         app.mapPanel.map.getMaxExtent = function() {
-                            return new OpenLayers.Bounds(-80150033.36,-80150033.36,80150033.36,80150033.36);
+                            return new OpenLayers.Bounds(-80150033.36/2,-80150033.36/2,80150033.36/2,80150033.36/2);
                         }
                         app.mapPanel.map.getMaxResolution = function() {
-                            return 626172.135625;
+                            return 626172.135625/2;
                         }
+                        l = app.selectedLayer.getLayer();
+                        l.addOptions({wrapDateLine:true, displayOutsideMaxExtent: true});
+                        l.addOptions({maxExtent:app.mapPanel.map.getMaxExtent(), restrictedExtent:app.mapPanel.map.getMaxExtent()});
 
                         var map = app.mapPanel.map;
                         var layer = app.map.layers.slice(-1)[0];
@@ -62,7 +65,7 @@
                         if (bbox != undefined)
                         {
                            if (!Array.isArray(bbox) && Object.keys(layer.srs) in bbox) {
-                            bbox = bbox[Object.keys(layer.srs)].bbox;
+                             bbox = bbox[Object.keys(layer.srs)].bbox;
                            }
 
                            var extent = OpenLayers.Bounds.fromArray(bbox);
@@ -75,7 +78,7 @@
                            };
                            map.events.register('changebaselayer',null,zoomToData);
                            if(map.baseLayer){
-                            map.zoomToExtent(extent, false);
+                             map.zoomToExtent(extent, false);
                            }
                         }
                     },
@@ -147,7 +150,8 @@
 
             // change style displayed in map
             Ext.get(Ext.DomQuery.select("input[@name='style']")).on("click", function(evt, elem) {
-                app.selectedLayer.getLayer().mergeNewParams({
+                l = app.selectedLayer.getLayer();
+                l.mergeNewParams({
                     "STYLES": elem.id,
                     "_dc": Math.random()
                 });
@@ -168,6 +172,7 @@
                     };
                 }
             });
+
             Ext.Ajax.on('requestcomplete', function(req, cippa, opts){
                 if(opts.method == 'PUT'){
                     $('#legend_icon').attr('src', $('#legend_icon').attr('src')+'&'+Math.random());

--- a/geonode/maps/templates/maps/map_geoexplorer.js
+++ b/geonode/maps/templates/maps/map_geoexplorer.js
@@ -32,6 +32,49 @@ Ext.onReady(function() {
         csrfToken: "{{ csrf_token }}",
         tools: [{ptype: "gxp_getfeedfeatureinfo"}],
         listeners: {
+            "ready": function() {
+                app.mapPanel.map.getMaxExtent = function() {
+                    return new OpenLayers.Bounds(-80150033.36/2,-80150033.36/2,80150033.36/2,80150033.36/2);
+                }
+                app.mapPanel.map.getMaxResolution = function() {
+                    return 626172.135625/2;
+                }
+                l = app.selectedLayer.getLayer();
+                l.addOptions({wrapDateLine:true, displayOutsideMaxExtent: true});
+                l.addOptions({maxExtent:app.mapPanel.map.getMaxExtent(), restrictedExtent:app.mapPanel.map.getMaxExtent()});
+                for (var l in app.mapPanel.map.layers) {
+                    l = app.selectedLayer.getLayer();
+                    l.addOptions({wrapDateLine:true, displayOutsideMaxExtent: true});
+                    l.addOptions({maxExtent:app.mapPanel.map.getMaxExtent(), restrictedExtent:app.mapPanel.map.getMaxExtent()});
+                }
+
+                var map = app.mapPanel.map;
+                var layer = app.map.layers.slice(-1)[0];
+
+                // FIXME(Ariel): Zoom to extent until #1795 is fixed.
+                //map.zoomToExtent(layer.maxExtent, false)
+
+                var bbox = layer.bbox;
+                if (bbox != undefined)
+                {
+                   if (!Array.isArray(bbox) && Object.keys(layer.srs) in bbox) {
+                    bbox = bbox[Object.keys(layer.srs)].bbox;
+                   }
+
+                   var extent = OpenLayers.Bounds.fromArray(bbox);
+                   var zoomToData = function()
+                   {
+                       map.zoomToExtent(extent, false);
+                       app.mapPanel.center = map.center;
+                       app.mapPanel.zoom = map.zoom;
+                       map.events.unregister('changebaselayer', null, zoomToData);
+                   };
+                   map.events.register('changebaselayer',null,zoomToData);
+                   if(map.baseLayer){
+                    map.zoomToExtent(extent, false);
+                   }
+                }
+            },
            'save': function(obj_id) {
                createMapThumbnail(obj_id);
            }

--- a/geonode/maps/templates/maps/map_include.html
+++ b/geonode/maps/templates/maps/map_include.html
@@ -14,7 +14,7 @@ Ext.onReady(function() {
             ptype: "gxp_wmsgetfeatureinfo",
             format: "grid",
             actionTarget: "main.tbar",
-            outputConfig: {width: 400, height: 200, panIn: false}
+            outputConfig: {width: 400, height: 200, panIn: false, wrapDateLine: true}
         }],
         useToolbar: true,
         {% if PROXY_URL %}
@@ -29,17 +29,25 @@ Ext.onReady(function() {
 
         // tell the map viewer where and how to be rendered
         portalConfig: {
-            height: 600,
+            height: 400,
             renderTo: "the_map"
         },
 
         listeners: {
             "ready": function() {
                 app.mapPanel.map.getMaxExtent = function() {
-                    return new OpenLayers.Bounds(-80150033.36,-80150033.36,80150033.36,80150033.36);
+                    return new OpenLayers.Bounds(-80150033.36/2,-80150033.36/2,80150033.36/2,80150033.36/2);
                 }
                 app.mapPanel.map.getMaxResolution = function() {
-                    return 626172.135625;
+                    return 626172.135625/2;
+                }
+                l = app.selectedLayer.getLayer();
+                l.addOptions({wrapDateLine:true, displayOutsideMaxExtent: true});
+                l.addOptions({maxExtent:app.mapPanel.map.getMaxExtent(), restrictedExtent:app.mapPanel.map.getMaxExtent()});
+                for (var l in app.mapPanel.map.layers) {
+                    l = app.selectedLayer.getLayer();
+                    l.addOptions({wrapDateLine:true, displayOutsideMaxExtent: true});
+                    l.addOptions({maxExtent:app.mapPanel.map.getMaxExtent(), restrictedExtent:app.mapPanel.map.getMaxExtent()});
                 }
 
                 var map = app.mapPanel.map;

--- a/geonode/maps/utils.py
+++ b/geonode/maps/utils.py
@@ -103,6 +103,10 @@ def fix_baselayers(map_id):
                 layer_params['type'] = base_layer['type']
             if 'args' in base_layer:
                 layer_params['args'] = base_layer['args']
+            if 'wrapDateLine' in base_layer:
+                layer_params['wrapDateLine'] = base_layer['wrapDateLine']
+            else:
+                layer_params['wrapDateLine'] = True
             # source_params
             source_params = {}
             source_params['id'] = source

--- a/geonode/maps/views.py
+++ b/geonode/maps/views.py
@@ -726,6 +726,7 @@ def add_layers_to_map_config(request, map_obj, layer_names, add_base_layers=True
         # Add required parameters for GXP lazy-loading
         config["title"] = layer.title
         config["queryable"] = True
+        config["wrapDateLine"] = True
 
         config["srs"] = getattr(
             settings, 'DEFAULT_MAP_CRS', 'EPSG:900913')

--- a/geonode/utils.py
+++ b/geonode/utils.py
@@ -202,6 +202,8 @@ def layer_from_viewer_config(model, layer, source, ordering):
               "fixed", "group", "visibility", "source", "getFeatureInfo"]:
         if k in layer_cfg:
             del layer_cfg[k]
+    layer_cfg["wrapDateLine"] = True
+    layer_cfg["displayOutsideMaxExtent"] = True
 
     source_cfg = dict(source)
     for k in ["url", "projection"]:
@@ -475,6 +477,8 @@ class GXPLayer(GXPLayerBase):
         self.fixed = False
         self.group = None
         self.visibility = True
+        self.wrapDateLine = True
+        self.displayOutsideMaxExtent = True
         self.ows_url = ows_url
         self.layer_params = ""
         self.source_params = ""

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,7 @@ django-extensions==1.6.1
 django-floppyforms==1.7.0
 django-forms-bootstrap==3.1.0
 django-friendly-tag-loader==1.2.1
-django-geoexplorer==4.0.20
+django-geoexplorer==4.0.21
 django-geonode-client==0.0.15
 django-guardian==1.4.9
 django-haystack==2.6.0


### PR DESCRIPTION
This is actually the outcome on GeoExt GIS client

![image](https://user-images.githubusercontent.com/1278021/31652792-a851e7e8-b320-11e7-8def-f7033236bd91.png)

and the maps

![image](https://user-images.githubusercontent.com/1278021/31652819-c01188ac-b320-11e7-9eca-81123b452276.png)
