### PR TITLE
 - Intercept and handle correctly resource not found exception

### DIFF
--- a/geonode/geoserver/tests.py
+++ b/geonode/geoserver/tests.py
@@ -77,7 +77,9 @@ class LayerTests(TestCase):
                 args=(
                     invalid_layer_typename,
                 )))
-        self.assertEquals(response.status_code, 404)
+        self.assertEquals(response.status_code, 200)
+        response_json = json.loads(response.content)
+        self.assertEquals(response_json['authorized'], False)
 
         # First test un-authenticated
         response = self.client.post(
@@ -112,7 +114,6 @@ class LayerTests(TestCase):
                     valid_layer_typename,
                 )))
 
-        # Test that the method returns 401 because it's not a datastore
         response_json = json.loads(response.content)
         self.assertEquals(response_json['authorized'], True)
 

--- a/geonode/geoserver/views.py
+++ b/geonode/geoserver/views.py
@@ -299,7 +299,12 @@ def feature_edit_check(request, layername):
     If the layer is not a raster and the user has edit permission, return a status of 200 (OK).
     Otherwise, return a status of 401 (unauthorized).
     """
-    layer = _resolve_layer(request, layername)
+    try:
+        layer = _resolve_layer(request, layername)
+    except:
+        # Intercept and handle correctly resource not found exception
+        return HttpResponse(
+            json.dumps({'authorized': False}), content_type="application/json")
     datastore = ogc_server_settings.DATASTORE
     feature_edit = getattr(settings, "GEOGIG_DATASTORE", None) or datastore
     is_admin = False


### PR DESCRIPTION
Without this small check, the method returns "404: not found" to anonymous users or unauthorized ones.