### PR TITLE
Adding charset as option in importlayers command

### DIFF
--- a/geonode/layers/management/commands/importlayers.py
+++ b/geonode/layers/management/commands/importlayers.py
@@ -140,6 +140,13 @@ class Command(BaseCommand):
             default=False,
             action="store_true",
             help="Force metadata XML to be preserved"
+        ),
+        make_option(
+            '-C',
+            '--charset',
+            dest='charset',
+            default='UTF-8',
+            help=("Specify the charset of data")
         )
     )
 
@@ -158,6 +165,7 @@ class Command(BaseCommand):
         private = options.get('private', False)
         metadata_uploaded_preserve = options.get('metadata_uploaded_preserve',
                                                  False)
+        charset = options.get('charset', 'UTF-8')
 
         if verbosity > 0:
             console = self.stdout
@@ -198,7 +206,8 @@ class Command(BaseCommand):
                 category=category,
                 regions=regions,
                 private=private,
-                metadata_uploaded_preserve=metadata_uploaded_preserve)
+                metadata_uploaded_preserve=metadata_uploaded_preserve,
+                charset=charset)
 
             output.extend(out)
 

--- a/geonode/layers/utils.py
+++ b/geonode/layers/utils.py
@@ -573,6 +573,10 @@ def file_upload(filename, name=None, user=None, title=None, abstract=None,
     if category is not None:
         layer.category = category
         saveAgain = True
+    
+    if charset != 'UTF-8':
+        layer.charset = charset
+        saveAgain = True
 
     if saveAgain:
         layer.save()
@@ -586,7 +590,8 @@ def upload(incoming, user=None, overwrite=False,
            category=None, keywords=None, regions=None,
            skip=True, ignore_errors=True,
            verbosity=1, console=None,
-           private=False, metadata_uploaded_preserve=False):
+           private=False, metadata_uploaded_preserve=False,
+           charset='UTF-8'):
     """Upload a directory of spatial data files to GeoNode
 
        This function also verifies that each layer is in GeoServer.
@@ -680,8 +685,8 @@ def upload(incoming, user=None, overwrite=False,
                                     category=category,
                                     keywords=keywords,
                                     regions=regions,
-                                    metadata_uploaded_preserve=metadata_uploaded_preserve
-                                    )
+                                    metadata_uploaded_preserve=metadata_uploaded_preserve,
+                                    charset=charset)
                 if not existed:
                     status = 'created'
                 else:


### PR DESCRIPTION
I needed to import a bunch of datasets in a specific charset (not in UTF-8 which is the default) with the command importlayers. I realized that there is not an option of specifying a charset. So I extended the importlayers command in order to include that option. 
What do you think about it ?
