### PR TITLE
QGIS Server Related PR: GeoNode code improvements.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,8 @@ geonode/static/lib/js/bootstrap-treeview.min.js
 
 # Uploaded files
 geonode/uploaded
+geonode/qgis_layer
+geonode/qgis_tiles
 
 #Testing output
 .coverage

--- a/geonode/base/models.py
+++ b/geonode/base/models.py
@@ -29,6 +29,7 @@ import urllib
 import urllib2
 import cookielib
 
+from geonode.decorators import on_ogc_backend
 from pyproj import transform, Proj
 from urlparse import urljoin, urlsplit
 
@@ -53,6 +54,7 @@ from polymorphic.models import PolymorphicModel
 from polymorphic.managers import PolymorphicManager
 from agon_ratings.models import OverallRating
 
+from geonode import geoserver
 from geonode.base.enumerations import ALL_LANGUAGES, \
     HIERARCHY_LEVELS, UPDATE_FREQUENCIES, \
     DEFAULT_SUPPLEMENTAL_INFORMATION, LINK_TYPES
@@ -207,6 +209,7 @@ class Region(MPTTModel):
 
     @property
     def bbox(self):
+        """BBOX is in the format: [x0,x1,y0,y1]."""
         return [
             self.bbox_x0,
             self.bbox_x1,
@@ -216,11 +219,13 @@ class Region(MPTTModel):
 
     @property
     def bbox_string(self):
+        """BBOX is in the format: [x0,y0,x1,y1]."""
         return ",".join([str(self.bbox_x0), str(self.bbox_y0),
                          str(self.bbox_x1), str(self.bbox_y1)])
 
     @property
     def geographic_bounding_box(self):
+        """BBOX is in the format: [x0,x1,y0,y1]."""
         return bbox_to_wkt(
             self.bbox_x0,
             self.bbox_x1,
@@ -757,6 +762,7 @@ class ResourceBase(PolymorphicModel, PermissionLevelMixin, ItemBase):
 
     @property
     def bbox(self):
+        """BBOX is in the format: [x0,x1,y0,y1]."""
         return [
             self.bbox_x0,
             self.bbox_x1,
@@ -766,11 +772,13 @@ class ResourceBase(PolymorphicModel, PermissionLevelMixin, ItemBase):
 
     @property
     def bbox_string(self):
+        """BBOX is in the format: [x0,y0,x1,y1]."""
         return ",".join([str(self.bbox_x0), str(self.bbox_y0),
                          str(self.bbox_x1), str(self.bbox_y1)])
 
     @property
     def geographic_bounding_box(self):
+        """BBOX is in the format: [x0,x1,y0,y1]."""
         return bbox_to_wkt(
             self.bbox_x0,
             self.bbox_x1,
@@ -913,6 +921,11 @@ class ResourceBase(PolymorphicModel, PermissionLevelMixin, ItemBase):
     def set_bounds_from_bbox(self, bbox):
         """
         Calculate zoom level and center coordinates in mercator.
+
+        :param bbox: BBOX is in the  format: [x0, x1, y0, y1], which is:
+            [min lon, max lon, min lat, max lat] or
+            [xmin, xmax, ymin, ymax]
+        :type bbox: list
         """
         self.set_latlon_bounds(bbox)
 
@@ -1326,6 +1339,7 @@ def rating_post_save(instance, *args, **kwargs):
 signals.post_save.connect(rating_post_save, sender=OverallRating)
 
 
+@on_ogc_backend(geoserver.BACKEND_PACKAGE)
 def do_login(sender, user, request, **kwargs):
     """
     Take action on user login. Generate a new user access_token to be shared
@@ -1373,6 +1387,7 @@ def do_login(sender, user, request, **kwargs):
         request.session['JSESSIONID'] = jsessionid
 
 
+@on_ogc_backend(geoserver.BACKEND_PACKAGE)
 def do_logout(sender, user, request, **kwargs):
     """
     Take action on user logout. Cleanup user access_token and send logout

--- a/geonode/base/populate_test_data.py
+++ b/geonode/base/populate_test_data.py
@@ -39,7 +39,8 @@ import os.path
 import six
 
 
-if 'geonode.geoserver' in settings.INSTALLED_APPS:
+def disconnect_signals():
+    """Disconnect signals for test class purposes."""
     from django.db.models import signals
     from geonode.geoserver.signals import geoserver_pre_save_maplayer
     from geonode.geoserver.signals import geoserver_post_save_map
@@ -49,6 +50,23 @@ if 'geonode.geoserver' in settings.INSTALLED_APPS:
     signals.post_save.disconnect(geoserver_post_save_map, sender=Map)
     signals.pre_save.disconnect(geoserver_pre_save, sender=Layer)
     signals.post_save.disconnect(geoserver_post_save, sender=Layer)
+
+
+def reconnect_signals():
+    """Reconnect signals for test class purposes."""
+    from django.db.models import signals
+    from geonode.geoserver.signals import geoserver_pre_save_maplayer
+    from geonode.geoserver.signals import geoserver_post_save_map
+    from geonode.geoserver.signals import geoserver_pre_save
+    from geonode.geoserver.signals import geoserver_post_save
+    signals.pre_save.connect(geoserver_pre_save_maplayer, sender=MapLayer)
+    signals.post_save.connect(geoserver_post_save_map, sender=Map)
+    signals.pre_save.connect(geoserver_pre_save, sender=Layer)
+    signals.post_save.connect(geoserver_post_save, sender=Layer)
+
+
+if 'geonode.geoserver' in settings.INSTALLED_APPS:
+    disconnect_signals()
 
 # This is used to populate the database with the search fixture data. This is
 # primarily used as a first step to generate the json data for the fixture using

--- a/geonode/context_processors.py
+++ b/geonode/context_processors.py
@@ -146,6 +146,7 @@ def resource_urls(request):
             "SHOW_PROFILE_EMAIL",
             False
         ),
+        OGC_SERVER=getattr(settings, 'OGC_SERVER', None),
     )
     defaults['message_create_url'] = 'message_create' if not settings.USER_MESSAGES_ALLOW_MULTIPLE_RECIPIENTS\
         else 'message_create_multiple'

--- a/geonode/geoserver/helpers.py
+++ b/geonode/geoserver/helpers.py
@@ -49,6 +49,7 @@ from django.db.models.signals import pre_delete
 from django.template.loader import render_to_string
 from django.utils.translation import ugettext as _
 import geoserver
+from geonode.maps.models import Map
 from geoserver.catalog import Catalog
 from geoserver.catalog import ConflictingDataError
 from geoserver.catalog import FailedRequestError, UploadError
@@ -790,6 +791,12 @@ def set_styles(layer, gs_catalog):
         style_set.append(save_style(alt_style))
 
     layer.styles = style_set
+
+    # Update default style to database
+    to_update = {
+        'default_style': layer.default_style
+    }
+    Layer.objects.filter(id=layer.id).update(**to_update)
     return layer
 
 
@@ -1815,7 +1822,7 @@ def create_gs_thumbnail(instance, overwrite=False):
     """
     Create a thumbnail with a GeoServer request.
     """
-    if instance.class_name == 'Map':
+    if isinstance(instance, Map):
         local_layers = []
         for layer in instance.layers:
             if layer.local:

--- a/geonode/geoserver/signals.py
+++ b/geonode/geoserver/signals.py
@@ -29,6 +29,9 @@ from django.conf import settings
 from django.forms.models import model_to_dict
 
 
+# use different name to avoid module clash
+from geonode import geoserver as geoserver_app
+from geonode.decorators import on_ogc_backend
 from geonode.geoserver.ows import wcs_links, wfs_links, wms_links
 from geonode.geoserver.helpers import cascading_delete, set_attributes_from_geoserver
 from geonode.geoserver.helpers import set_styles, gs_catalog
@@ -71,6 +74,7 @@ def geoserver_pre_save(*args, **kwargs):
     pass
 
 
+@on_ogc_backend(geoserver_app.BACKEND_PACKAGE)
 def geoserver_post_save(instance, sender, **kwargs):
     from geonode.messaging import producer
     # this is attached to various models, (ResourceBase, Document)

--- a/geonode/layers/models.py
+++ b/geonode/layers/models.py
@@ -614,7 +614,17 @@ def post_delete_layer(instance, sender, **kwargs):
         pass
 
 
+def post_delete_layer_file(instance, sender, **kwargs):
+    """Delete associated file.
+
+    :param instance: LayerFile instance
+    :type instance: LayerFile
+    """
+    instance.file.delete(save=False)
+
+
 signals.pre_save.connect(pre_save_layer, sender=Layer)
 signals.post_save.connect(resourcebase_post_save, sender=Layer)
 signals.pre_delete.connect(pre_delete_layer, sender=Layer)
 signals.post_delete.connect(post_delete_layer, sender=Layer)
+signals.post_delete.connect(post_delete_layer_file, sender=LayerFile)

--- a/geonode/layers/populate_layers_data.py
+++ b/geonode/layers/populate_layers_data.py
@@ -19,9 +19,13 @@
 #########################################################################
 
 from geonode.layers.models import Style, Attribute, Layer
+from django.conf import settings
+
+ogc_location = settings.OGC_SERVER['default']['LOCATION']
+
 
 styles = [{"name": "test_style_1",
-           "sld_url": "http://localhost:8080/geoserver/rest/styles/test_style.sld",
+           "sld_url": "{ogc_location}rest/styles/test_style.sld".format(ogc_location=ogc_location),
            "sld_body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><sld:StyledLayerDescriptor \
             xmlns=\"http://www.opengis.net/sld\" xmlns:sld=\"http://www.opengis.net/sld\" \
             xmlns:ogc=\"http://www.opengis.net/ogc\" xmlns:gml=\"http://www.opengis.net/gml\" \
@@ -34,7 +38,7 @@ styles = [{"name": "test_style_1",
             </sld:NamedLayer></sld:StyledLayerDescriptor>",
            },
           {"name": "test_style_2",
-           "sld_url": "http://localhost:8080/geoserver/rest/styles/test_style.sld",
+           "sld_url": "{ogc_location}rest/styles/test_style.sld".format(ogc_location=ogc_location),
            "sld_body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><sld:StyledLayerDescriptor \
            xmlns=\"http://www.opengis.net/sld\" xmlns:sld=\"http://www.opengis.net/sld\" \
            xmlns:ogc=\"http://www.opengis.net/ogc\" xmlns:gml=\"http://www.opengis.net/gml\" \
@@ -46,7 +50,7 @@ styles = [{"name": "test_style_1",
            </sld:Rule></sld:FeatureTypeStyle></sld:UserStyle></sld:NamedLayer></sld:StyledLayerDescriptor>",
            },
           {"name": "test_style_3",
-           "sld_url": "http://localhost:8080/geoserver/rest/styles/test_style.sld",
+           "sld_url": "{ogc_location}rest/styles/test_style.sld".format(ogc_location=ogc_location),
            "sld_body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><sld:StyledLayerDescriptor \
            xmlns=\"http://www.opengis.net/sld\" xmlns:sld=\"http://www.opengis.net/sld\" \
            xmlns:ogc=\"http://www.opengis.net/ogc\" xmlns:gml=\"http://www.opengis.net/gml\" \
@@ -58,7 +62,7 @@ styles = [{"name": "test_style_1",
            </sld:FeatureTypeStyle></sld:UserStyle></sld:NamedLayer></sld:StyledLayerDescriptor>",
            },
           {"name": "Evaluación",
-           "sld_url": "http://localhost:8080/geoserver/rest/styles/test_style.sld",
+           "sld_url": "{ogc_location}rest/styles/test_style.sld".format(ogc_location=ogc_location),
            "sld_body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><sld:StyledLayerDescriptor \
            xmlns=\"http://www.opengis.net/sld\" xmlns:sld=\"http://www.opengis.net/sld\" \
            xmlns:ogc=\"http://www.opengis.net/ogc\" xmlns:gml=\"http://www.opengis.net/gml\" version=\"1.0.0\">\

--- a/geonode/maps/models.py
+++ b/geonode/maps/models.py
@@ -215,6 +215,8 @@ class Map(ResourceBase, GXPMapBase):
     def get_bbox_from_layers(self, layers):
         """
         Calculate the bbox from a given list of Layer objects
+
+        bbox format: [xmin, xmax, ymin, ymax]
         """
         bbox = None
         for layer in layers:
@@ -239,6 +241,9 @@ class Map(ResourceBase, GXPMapBase):
         self.center_y = 0
         bbox = None
         index = 0
+
+        if self.uuid is None or self.uuid == '':
+            self.uuid = str(uuid.uuid1())
 
         DEFAULT_MAP_CONFIG, DEFAULT_BASE_LAYERS = default_map_config(None)
 
@@ -273,6 +278,7 @@ class Map(ResourceBase, GXPMapBase):
             index += 1
 
         # Set bounding box based on all layers extents.
+        # bbox format: [xmin, xmax, ymin, ymax]
         bbox = self.get_bbox_from_layers(self.local_layers)
 
         self.set_bounds_from_bbox(bbox)

--- a/geonode/maps/urls.py
+++ b/geonode/maps/urls.py
@@ -19,10 +19,11 @@
 #########################################################################
 
 from django.conf.urls import patterns, url
-from django.conf import settings
 from django.views.generic import TemplateView
 
+from geonode import geoserver, qgis_server
 from geonode.maps.qgis_server_views import MapCreateView, MapDetailView
+from geonode.utils import check_ogc_backend
 
 js_info_dict = {
     'packages': ('geonode.maps',),
@@ -31,11 +32,11 @@ js_info_dict = {
 new_map_view = 'new_map'
 existing_map_view = 'map_view'
 
-if 'geonode.geoserver' in settings.INSTALLED_APPS:
+if check_ogc_backend(geoserver.BACKEND_PACKAGE):
     new_map_view = 'new_map'
     existing_map_view = 'map_view'
 
-elif 'geonode_qgis_server' in settings.INSTALLED_APPS:
+elif check_ogc_backend(qgis_server.BACKEND_PACKAGE):
     new_map_view = MapCreateView.as_view()
     existing_map_view = MapDetailView.as_view()
 

--- a/geonode/maps/views.py
+++ b/geonode/maps/views.py
@@ -48,7 +48,8 @@ from django.views.decorators.http import require_http_methods
 from geonode.layers.models import Layer
 from geonode.maps.models import Map, MapLayer, MapSnapshot
 from geonode.layers.views import _resolve_layer
-from geonode.utils import forward_mercator, llbbox_to_mercator
+from geonode.utils import forward_mercator, llbbox_to_mercator, \
+    check_ogc_backend
 from geonode.utils import DEFAULT_TITLE
 from geonode.utils import DEFAULT_ABSTRACT
 from geonode.utils import default_map_config
@@ -65,10 +66,11 @@ from geonode.documents.models import get_related_documents
 from geonode.people.forms import ProfileForm
 from geonode.utils import num_encode, num_decode
 from geonode.utils import build_social_links
+from geonode import geoserver, qgis_server
 from geonode.base.views import batch_modify
 
 
-if 'geonode.geoserver' in settings.INSTALLED_APPS:
+if check_ogc_backend(geoserver.BACKEND_PACKAGE):
     # FIXME: The post service providing the map_status object
     # should be moved to geonode.geoserver.
     from geonode.geoserver.helpers import ogc_server_settings
@@ -76,7 +78,7 @@ if 'geonode.geoserver' in settings.INSTALLED_APPS:
     # Use the http_client with one that knows the username
     # and password for GeoServer's management user.
     from geonode.geoserver.helpers import http_client, _render_thumbnail
-else:
+elif check_ogc_backend(qgis_server.BACKEND_PACKAGE):
     from geonode.utils import http_client
 
 logger = logging.getLogger("geonode.maps.views")

--- a/geonode/qgis_server/__init__.py
+++ b/geonode/qgis_server/__init__.py
@@ -18,18 +18,5 @@
 #
 #########################################################################
 
-from django.utils.translation import ugettext_noop as _
-from geonode.notifications_helper import NotificationsAppConfigBase
 
-
-class GeoserverAppConfig(NotificationsAppConfigBase):
-    name = 'geonode.geoserver'
-    NOTIFICATIONS = (("layer_uploaded", _("Layer Uploaded"), _("A layer was uploaded"),),
-                     ("layer_comment", _("Comment on Layer"), _("A layer was commented on"),),
-                     ("layer_rated", _("Rating for Layer"), _("A rating was given to a layer"),),
-                     )
-
-
-default_app_config = 'geonode.geoserver.GeoserverAppConfig'
-
-BACKEND_PACKAGE = 'geonode.geoserver'
+BACKEND_PACKAGE = 'geonode.qgis_server'

--- a/geonode/security/models.py
+++ b/geonode/security/models.py
@@ -17,6 +17,9 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 #########################################################################
+from geonode import geoserver
+from geonode.decorators import on_ogc_backend
+
 try:
     import json
 except ImportError:
@@ -269,6 +272,7 @@ def get_geofence_rules_count():
         return -1
 
 
+@on_ogc_backend(geoserver.BACKEND_PACKAGE)
 def set_geofence_invalidate_cache():
     """invalidate GeoFence Cache Rules"""
     if GEOFENCE_SECURITY_ENABLED:
@@ -292,6 +296,7 @@ def set_geofence_invalidate_cache():
             raise e
 
 
+@on_ogc_backend(geoserver.BACKEND_PACKAGE)
 def set_geofence_all(instance):
     """assign access permissions to all users"""
     if GEOFENCE_SECURITY_ENABLED:
@@ -358,6 +363,7 @@ def set_geofence_all(instance):
                 set_geofence_invalidate_cache()
 
 
+@on_ogc_backend(geoserver.BACKEND_PACKAGE)
 def set_geofence_owner(instance, username, view_perms=False, download_perms=False):
     """assign access permissions to owner user"""
     if GEOFENCE_SECURITY_ENABLED:
@@ -471,6 +477,7 @@ def set_geofence_owner(instance, username, view_perms=False, download_perms=Fals
                 set_geofence_invalidate_cache()
 
 
+@on_ogc_backend(geoserver.BACKEND_PACKAGE)
 def set_geofence_group(instance, groupname, view_perms=False, download_perms=False):
     """assign access permissions to owner group"""
     if GEOFENCE_SECURITY_ENABLED:

--- a/geonode/security/tests.py
+++ b/geonode/security/tests.py
@@ -26,6 +26,7 @@ from tastypie.test import ResourceTestCaseMixin
 from django.contrib.auth import get_user_model
 from guardian.shortcuts import get_anonymous_user, assign_perm, remove_perm
 
+from geonode import geoserver
 from geonode.base.populate_test_data import create_models, all_public
 from geonode.maps.tests_populate_maplayers import create_maplayers
 from geonode.people.models import Profile
@@ -33,6 +34,7 @@ from geonode.layers.models import Layer
 from geonode.maps.models import Map
 from geonode.layers.populate_layers_data import create_layer_data
 from geonode.groups.models import Group
+from geonode.utils import check_ogc_backend
 
 
 class BulkPermissionsTests(ResourceTestCaseMixin, TestCase):
@@ -405,17 +407,21 @@ class PermissionsTest(TestCase):
         # 7. change_layer_style
         # 7.1 has not change_layer_style: verify that bobby cannot access
         # the layer style page
-        response = self.client.get(reverse('layer_style_manage', args=(layer.alternate,)))
-        self.assertEquals(response.status_code, 401)
+        if check_ogc_backend(geoserver.BACKEND_PACKAGE):
+            # Only for geoserver backend
+            response = self.client.get(reverse('layer_style_manage', args=(layer.alternate,)))
+            self.assertEquals(response.status_code, 401)
         # 7.2 has change_layer_style: verify that bobby can access the
         # change layer style page
-        assign_perm('change_layer_style', bob, layer)
-        self.assertTrue(
-            bob.has_perm(
-                'change_layer_style',
-                layer))
-        response = self.client.get(reverse('layer_style_manage', args=(layer.alternate,)))
-        self.assertEquals(response.status_code, 200)
+        if check_ogc_backend(geoserver.BACKEND_PACKAGE):
+            # Only for geoserver backend
+            assign_perm('change_layer_style', bob, layer)
+            self.assertTrue(
+                bob.has_perm(
+                    'change_layer_style',
+                    layer))
+            response = self.client.get(reverse('layer_style_manage', args=(layer.alternate,)))
+            self.assertEquals(response.status_code, 200)
 
     def test_anonymus_permissions(self):
 
@@ -462,8 +468,10 @@ class PermissionsTest(TestCase):
         # 7. change_layer_style
         # 7.1 has not change_layer_style: verify that anonymous user cannot access
         # the layer style page but redirected to login
-        response = self.client.get(reverse('layer_style_manage', args=(layer.alternate,)))
-        self.assertEquals(response.status_code, 302)
+        if check_ogc_backend(geoserver.BACKEND_PACKAGE):
+            # Only for geoserver backend
+            response = self.client.get(reverse('layer_style_manage', args=(layer.alternate,)))
+            self.assertEquals(response.status_code, 302)
 
     def test_map_download(self):
         """Test the correct permissions on layers on map download"""

--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -279,7 +279,7 @@ GEONODE_APPS = (
     'geonode.services',
 
     # QGIS Server Apps
-    # 'geonode_qgis_server',
+    # 'geonode.qgis_server',
 
     # GeoServer Apps
     # Geoserver needs to come last because
@@ -752,7 +752,7 @@ PYCSW = {
 
 # default map projection
 # Note: If set to EPSG:4326, then only EPSG:4326 basemaps will work.
-DEFAULT_MAP_CRS = "EPSG:900913"
+DEFAULT_MAP_CRS = "EPSG:3857"
 
 # Where should newly created maps be focused?
 DEFAULT_MAP_CENTER = (0, 0)

--- a/geonode/tests/csw.py
+++ b/geonode/tests/csw.py
@@ -24,6 +24,8 @@ from unittest import TestCase
 from lxml import etree
 import gisdata
 from geonode.catalogue import get_catalogue
+from geonode.utils import check_ogc_backend
+from geonode import geoserver, qgis_server
 
 
 class GeoNodeCSWTest(TestCase):
@@ -120,14 +122,30 @@ class GeoNodeCSWTest(TestCase):
 
         # test for correct service link articulation
         for link in record.references:
-            if link['scheme'] == 'OGC:WMS':
-                self.assertEqual(link['url'],
-                                 'http://localhost:8080/geoserver/geonode/wms',
-                                 'Expected a specific OGC:WMS URL')
-            elif link['scheme'] == 'OGC:WFS':
-                self.assertEqual(link['url'],
-                                 'http://localhost:8080/geoserver/geonode/wfs',
-                                 'Expected a specific OGC:WFS URL')
+            if check_ogc_backend(geoserver.BACKEND_PACKAGE):
+                if link['scheme'] == 'OGC:WMS':
+                    self.assertEqual(
+                        link['url'],
+                        'http://localhost:8080/geoserver/geonode/wms',
+                        'Expected a specific OGC:WMS URL')
+                elif link['scheme'] == 'OGC:WFS':
+                    self.assertEqual(
+                        link['url'],
+                        'http://localhost:8080/geoserver/geonode/wfs',
+                        'Expected a specific OGC:WFS URL')
+            elif check_ogc_backend(qgis_server.BACKEND_PACKAGE):
+                if link['scheme'] == 'OGC:WMS':
+                    self.assertEqual(
+                        link['url'],
+                        'http://localhost:8000/qgis-server/ogc/'
+                        'san_andres_y_providencia_location',
+                        'Expected a specific OGC:WMS URL')
+                elif link['scheme'] == 'OGC:WFS':
+                    self.assertEqual(
+                        link['url'],
+                        'http://localhost:8000/qgis-server/ogc/'
+                        'san_andres_y_providencia_location',
+                        'Expected a specific OGC:WFS URL')
 
     def test_csw_outputschema_iso(self):
         """Verify that GeoNode CSW can handle ISO metadata with ISO outputSchema"""
@@ -176,14 +194,30 @@ class GeoNodeCSWTest(TestCase):
 
         # test for correct link articulation
         for link in record.distribution.online:
-            if link.protocol == 'OGC:WMS':
-                self.assertEqual(link.url,
-                                 'http://localhost:8080/geoserver/geonode/wms',
-                                 'Expected a specific OGC:WMS URL')
-            elif link.protocol == 'OGC:WFS':
-                self.assertEqual(link.url,
-                                 'http://localhost:8080/geoserver/geonode/wfs',
-                                 'Expected a specific OGC:WFS URL')
+            if check_ogc_backend(geoserver.BACKEND_PACKAGE):
+                if link.protocol == 'OGC:WMS':
+                    self.assertEqual(
+                        link.url,
+                        'http://localhost:8080/geoserver/geonode/wms',
+                        'Expected a specific OGC:WMS URL')
+                elif link.protocol == 'OGC:WFS':
+                    self.assertEqual(
+                        link.url,
+                        'http://localhost:8080/geoserver/geonode/wfs',
+                        'Expected a specific OGC:WFS URL')
+            if check_ogc_backend(qgis_server.BACKEND_PACKAGE):
+                if link.protocol == 'OGC:WMS':
+                    self.assertEqual(
+                        link.url,
+                        'http://localhost:8000/qgis-server/ogc/'
+                        'san_andres_y_providencia_location',
+                        'Expected a specific OGC:WMS URL')
+                elif link.protocol == 'OGC:WFS':
+                    self.assertEqual(
+                        link.url,
+                        'http://localhost:8000/qgis-server/ogc/'
+                        'san_andres_y_providencia_location',
+                        'Expected a specific OGC:WFS URL')
 
     def test_csw_outputschema_dc_bbox(self):
         """Verify that GeoNode CSW can handle ISO metadata BBOX model with Dublin Core outputSchema"""

--- a/geonode/tests/integration.py
+++ b/geonode/tests/integration.py
@@ -25,8 +25,12 @@ import urllib2
 # import base64
 import time
 import logging
+
 import traceback
+from urlparse import urljoin
+
 import gisdata
+from decimal import Decimal
 
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
@@ -36,13 +40,15 @@ from django.core.urlresolvers import reverse
 from django.contrib.staticfiles.templatetags import staticfiles
 from django.contrib.auth import get_user_model
 # from guardian.shortcuts import assign_perm
+from geonode.base.populate_test_data import reconnect_signals
 
 from geoserver.catalog import FailedRequestError, UploadError
 
 # from geonode.security.models import *
+from geonode.decorators import on_ogc_backend
 from geonode.layers.models import Layer
 from geonode.maps.models import Map
-from geonode import GeoNodeException
+from geonode import GeoNodeException, geoserver, qgis_server
 from geonode.layers.utils import (
     upload,
     file_upload,
@@ -55,11 +61,14 @@ from geonode.geoserver.helpers import cascading_delete, set_attributes_from_geos
 # from geonode.geoserver.helpers import get_wms
 # from geonode.geoserver.helpers import set_time_info
 from geonode.geoserver.signals import gs_catalog
-
+from geonode.utils import check_ogc_backend
 
 LOGIN_URL = "/accounts/login/"
 
 logging.getLogger("south").setLevel(logging.INFO)
+
+# Reconnect post_save signals that is disconnected by populate_test_data
+reconnect_signals()
 
 """
  HOW TO RUN THE TESTS
@@ -187,6 +196,57 @@ class GeoNodeMapTest(TestCase):
             if link.mime == 'image/tiff':
                 wcs_link = True
         self.assertTrue(wcs_link)
+
+    @on_ogc_backend(qgis_server.BACKEND_PACKAGE)
+    def test_zipped_files(self):
+        """Test that the zipped files is created for raster."""
+        filename = os.path.join(gisdata.GOOD_DATA, 'raster/test_grid.tif')
+        uploaded = file_upload(filename)
+        zip_link = False
+        for link in uploaded.link_set.all():
+            if link.mime == 'ZIP':
+                zip_link = True
+        self.assertTrue(zip_link)
+
+    def test_layer_upload_bbox(self):
+        """Test that the bbox format is correct
+
+        Test that it is correctly saved in` database and represented in the
+        properties correctly.
+        """
+        filename = os.path.join(gisdata.GOOD_DATA, 'raster/test_grid.tif')
+        uploaded = file_upload(filename)
+
+        # Check bbox value
+        bbox_x0 = Decimal('96.9560000000')
+        bbox_x1 = Decimal('97.1097053200')
+        bbox_y0 = Decimal('-5.5187330000')
+        bbox_y1 = Decimal('-5.3035455520')
+        srid = u'EPSG:4326'
+
+        self.assertEqual(bbox_x0, uploaded.bbox_x0)
+        self.assertEqual(bbox_x1, uploaded.bbox_x1)
+        self.assertEqual(bbox_y0, uploaded.bbox_y0)
+        self.assertEqual(bbox_y1, uploaded.bbox_y1)
+        self.assertEqual(srid, uploaded.srid)
+
+        # bbox format: [xmin,xmax,ymin,ymax]
+        expected_bbox = [
+            Decimal('96.9560000000'),
+            Decimal('97.1097053200'),
+            Decimal('-5.5187330000'),
+            Decimal('-5.3035455520'),
+            u'EPSG:4326'
+        ]
+        self.assertEqual(expected_bbox, uploaded.bbox)
+
+        # bbox format: [xmin,ymin,xmax,ymax]
+        expected_bbox_string = (
+            '96.9560000000,-5.5187330000,97.1097053200,-5.3035455520')
+        self.assertEqual(expected_bbox_string, uploaded.bbox_string)
+
+        # Clean up
+        uploaded.delete()
 
     def test_layer_upload(self):
         """Test that layers can be uploaded to running GeoNode/GeoServer
@@ -326,8 +386,15 @@ class GeoNodeMapTest(TestCase):
                          'Expected specific supplemental information '
                          'from uploaded layer XML metadata')
 
-        self.assertEqual(len(uploaded.keyword_list(
-        )), 7, 'Expected specific number of keywords from uploaded layer XML metadata')
+        if check_ogc_backend(geoserver.BACKEND_PACKAGE):
+            self.assertEqual(
+                len(uploaded.keyword_list()), 7,
+                'Expected specific number of keywords from uploaded layer XML metadata')
+        elif check_ogc_backend(qgis_server.BACKEND_PACKAGE):
+            # QGIS Server backend doesn't have GeoServer assigned keywords.
+            self.assertEqual(
+                len(uploaded.keyword_list()), 5,
+                'Expected specific number of keywords from uploaded layer XML metadata')
 
         self.assertTrue(
              u'Airport,Airports,Landing Strips,Runway,Runways' in uploaded.keyword_csv,
@@ -418,6 +485,7 @@ class GeoNodeMapTest(TestCase):
 
     # geonode.maps.views
 
+    @on_ogc_backend(geoserver.BACKEND_PACKAGE)
     def test_layer_delete_from_geoserver(self):
         """Verify that layer is correctly deleted from GeoServer
         """
@@ -465,6 +533,7 @@ class GeoNodeMapTest(TestCase):
                 shp_layer.name,
                 store=tif_store))
 
+    @on_ogc_backend(geoserver.BACKEND_PACKAGE)
     def test_delete_layer(self):
         """Verify that the 'delete_layer' pre_delete hook is functioning
         """
@@ -502,7 +571,7 @@ class GeoNodeMapTest(TestCase):
         self.assertRaises(ObjectDoesNotExist,
                           lambda: Layer.objects.get(pk=shp_layer_id))
 
-    # geonode.geoserver.helpers
+        # geonode.geoserver.helpers
         # If catalogue is installed, then check that it is deleted from there
         # too.
         if 'geonode.catalogue' in settings.INSTALLED_APPS:
@@ -513,7 +582,8 @@ class GeoNodeMapTest(TestCase):
             shp_layer_gn_info = catalogue.get_record(uuid)
             assert shp_layer_gn_info is None
 
-    def test_cascading_delete(self):
+    @on_ogc_backend(geoserver.BACKEND_PACKAGE)
+    def test_geoserver_cascading_delete(self):
         """Verify that the helpers.cascading_delete() method is working properly
         """
         gs_cat = gs_catalog
@@ -617,10 +687,20 @@ class GeoNodeMapTest(TestCase):
             self.assertEquals(response.context['is_featuretype'], True)
 
             # test replace a vector with a raster
+            post_permissions = {
+                'users': {
+                    'AnonymousUser': [
+                        'view_resourcebase', 'download_resourcebase']
+                },
+                'groups': {}
+            }
+            post_data = {
+                'base_file': open(
+                    raster_file, 'rb'),
+                'permissions': json.dumps(post_permissions)
+            }
             response = self.client.post(
-                vector_replace_url, {
-                    'base_file': open(
-                        raster_file, 'rb')})
+                vector_replace_url, post_data)
             # TODO: This should really return a 400 series error with the json dict
             self.assertEquals(response.status_code, 400)
             response_dict = json.loads(response.content)
@@ -642,17 +722,18 @@ class GeoNodeMapTest(TestCase):
                  'dbf_file': layer_dbf,
                  'shx_file': layer_shx,
                  'prj_file': layer_prj,
-                 'charset': 'UTF-8'
+                 'charset': 'UTF-8',
+                 'permissions': json.dumps(post_permissions)
                  })
             response_dict = json.loads(response.content)
 
-            if not response_dict['success'] and 'unknown encoding' in response_dict['errors']:
+            if not response_dict['success'] and 'unknown encoding' in \
+                    response_dict['errors']:
                 print(response_dict['errors'])
                 pass
             else:
                 self.assertEquals(response.status_code, 200)
                 self.assertEquals(response_dict['success'], True)
-
                 # Get a Layer object for the newly created layer.
                 new_vector_layer = Layer.objects.get(pk=vector_layer.pk)
                 # FIXME(Ariel): Check the typename does not change.
@@ -672,7 +753,8 @@ class GeoNodeMapTest(TestCase):
                     {'base_file': layer_base,
                      'dbf_file': layer_dbf,
                      'shx_file': layer_shx,
-                     'prj_file': layer_prj
+                     'prj_file': layer_prj,
+                     'permissions': json.dumps(post_permissions)
                      })
                 self.assertEquals(response.status_code, 401)
         finally:
@@ -705,13 +787,23 @@ class GeoNodeMapTest(TestCase):
                 self.assertIsNotNone(lyr)
                 self.assertEqual(lyr.name, "test_san_andres_y_providencia_administrative")
                 self.assertEqual(lyr.title, "Test San Andres y Providencia Administrative")
-                self.assertEqual(
-                    lyr.keyword_list(), [
+                default_keywords = [
+                    u'import',
+                    u'san andreas',
+                    u'test',
+                ]
+                if check_ogc_backend(geoserver.BACKEND_PACKAGE):
+                    geoserver_keywords = [
                         u'features',
-                        u'import',
-                        u'san andreas',
-                        u'test',
-                        u'test_san_andres_y_providencia_administrative'])
+                        u'test_san_andres_y_providencia_administrative'
+                    ]
+                    self.assertEqual(
+                        set(lyr.keyword_list()),
+                        set(default_keywords + geoserver_keywords))
+                elif check_ogc_backend(qgis_server.BACKEND_PACKAGE):
+                    self.assertEqual(
+                        set(lyr.keyword_list()),
+                        set(default_keywords))
             finally:
                 # Clean up and completely delete the layer
                 lyr.delete()
@@ -840,6 +932,7 @@ xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.
         layer.delete()
     """
 
+    @on_ogc_backend(geoserver.BACKEND_PACKAGE)
     def test_unpublished(self):
         """Test permissions on an unpublished layer
         """
@@ -857,8 +950,10 @@ xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.
             # request getCapabilities: layer must be there as it is published and
             # advertised: we need to check if in response there is
             # <Name>geonode:san_andres_y_providencia_water</Name>
-            url = 'http://localhost:8080/geoserver/ows?' \
+            geoserver_base_url = settings.OGC_SERVER['default']['LOCATION']
+            get_capabilities_url = 'ows?' \
                 'service=wms&version=1.3.0&request=GetCapabilities'
+            url = urljoin(geoserver_base_url, get_capabilities_url)
             str_to_check = '<Name>geonode:san_andres_y_providencia_poi</Name>'
             request = urllib2.Request(url)
             response = urllib2.urlopen(request)
@@ -1072,6 +1167,7 @@ class GeoNodeGeoServerSync(TestCase):
     def tearDown(self):
         pass
 
+    @on_ogc_backend(geoserver.BACKEND_PACKAGE)
     def test_set_attributes_from_geoserver(self):
         """Test attributes syncronization
         """

--- a/geonode/tests/smoke.py
+++ b/geonode/tests/smoke.py
@@ -23,6 +23,9 @@ import math
 from django.test import TestCase
 from django.core.urlresolvers import reverse
 
+from geonode import geoserver
+from geonode.decorators import on_ogc_backend
+
 from geonode.utils import forward_mercator, inverse_mercator
 
 
@@ -66,6 +69,7 @@ class GeoNodeSmokeTests(TestCase):
         response = self.client.get(reverse('layer_browse'))
         self.failUnlessEqual(response.status_code, 200)
 
+    @on_ogc_backend(geoserver.BACKEND_PACKAGE)
     def test_layer_acls(self):
         'Test if the data/acls endpoint renders.'
         response = self.client.get(reverse('layer_acls'))

--- a/geonode/upload/forms.py
+++ b/geonode/upload/forms.py
@@ -24,9 +24,11 @@ import tempfile
 from django import forms
 from django.conf import settings
 from django.core.exceptions import ValidationError
+from geonode import geoserver, qgis_server
 from geonode.layers.forms import JSONField
 from geonode.upload.models import UploadFile
 from geonode.geoserver.helpers import ogc_server_settings
+from geonode.utils import check_ogc_backend
 
 
 class UploadFileForm(forms.ModelForm):
@@ -43,9 +45,9 @@ class LayerUploadForm(forms.Form):
     prj_file = forms.FileField(required=False)
     xml_file = forms.FileField(required=False)
 
-    if 'geonode.geoserver' in settings.INSTALLED_APPS:
+    if check_ogc_backend(geoserver.BACKEND_PACKAGE):
         sld_file = forms.FileField(required=False)
-    if 'geonode_qgis_server' in settings.INSTALLED_APPS:
+    if check_ogc_backend(qgis_server.BACKEND_PACKAGE):
         qml_file = forms.FileField(required=False)
 
     geogig = forms.BooleanField(required=False)
@@ -78,9 +80,9 @@ class LayerUploadForm(forms.Form):
         "xml_file",
     ]
     # Adding style file based on the backend
-    if 'geonode.geoserver' in settings.INSTALLED_APPS:
+    if check_ogc_backend(geoserver.BACKEND_PACKAGE):
         spatial_files.append('sld_file')
-    if 'geonode_qgis_server' in settings.INSTALLED_APPS:
+    if check_ogc_backend(qgis_server.BACKEND_PACKAGE):
         spatial_files.append('qml_file')
 
     spatial_files = tuple(spatial_files)

--- a/geonode/urls.py
+++ b/geonode/urls.py
@@ -143,11 +143,13 @@ if 'geonode.geoserver' in settings.INSTALLED_APPS:
                             (r'^upload/', include('geonode.upload.urls')),
                             (r'^gs/', include('geonode.geoserver.urls')),
                             )
-if 'geonode_qgis_server' in settings.INSTALLED_APPS:
+if 'geonode.qgis_server' in settings.INSTALLED_APPS:
     # QGIS Server's urls
     urlpatterns += patterns('',
-                            (r'', include('geonode_qgis_server.urls')),
-                            )
+                            (r'^qgis-server/',
+                             include(
+                                 'geonode.qgis_server.urls',
+                                 namespace='qgis_server')), )
 
 if settings.NOTIFICATIONS_MODULE in settings.INSTALLED_APPS:
     notifications_urls = '{}.urls'.format(settings.NOTIFICATIONS_MODULE)


### PR DESCRIPTION
This commit contains changes to accomodate QGIS Server as alternative backend.
It also contains various improvements on main geonode codes.

Changes:
- Various code branches to determine which backend is currently being used
- Add decorator annotation to methods specific for GeoServer
- Improve documentation and codes on several methods that will be used by QGIS Server backend later