### PR TITLE
Removing a duplicate in requirements which is causing an error on pip install

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -118,7 +118,6 @@ vine==1.1.4
 xlrd==1.1.0
 xlwt==1.3.0
 xmltodict==0.9.2
-redis==2.10.5
 user-agents
 xmljson
 psutil


### PR DESCRIPTION
Removing a duplicate in requirements which is causing an error on pip install