### PR TITLE
[WIP] Adds group logos to the groups list in the frontend

### DIFF
--- a/geonode/templates/search/_group_snippet.html
+++ b/geonode/templates/search/_group_snippet.html
@@ -2,6 +2,9 @@
 <div class="row">
   <article ng-repeat="group in results" resource_id="{{ group.id }}" ng-cloak class="ng-cloak">
     <div class="col-xs-12 item-container">
+        <div class="col-xs-4">
+            <img class="img-responsive" ng-show="{{ group.logo }}" ng-src="{{ group.logo }}" alt="{{ group.title }}">
+        </div>
         <div class="col-xs-8 item-details">
           <h4><a href="{{ group.detail_url }}">{{ group.title }}</a></h4>
           <p class="abstract">


### PR DESCRIPTION
This PR adds group logos to the groups page.
It is related to issue #3394 

The current behaviour:
![without_logo](https://user-images.githubusercontent.com/732010/32383840-ff358982-c0b0-11e7-997f-7e1db9811f2c.png)

Proposed modification:
![with_logo](https://user-images.githubusercontent.com/732010/32383839-ff115fb2-c0b0-11e7-933a-1e021c4b4ab5.png)


