### PR TITLE
Switch to https

### DIFF
--- a/geonode/static/geonode/js/search/search.js
+++ b/geonode/static/geonode/js/search/search.js
@@ -620,7 +620,7 @@
               url: '//{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
               layerOptions: {
                 subdomains: ['a', 'b', 'c'],
-                attribution: '&copy; <a href="//www.openstreetmap.org/copyright">OpenStreetMap</a>',
+                attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
                 continuousWorld: true
               }
             }

--- a/geonode/static/geonode/js/search/search.js
+++ b/geonode/static/geonode/js/search/search.js
@@ -615,12 +615,12 @@
         layers: {
           baselayers: {
             stamen: {
-              name: 'Toner Lite',
+              name: 'OpenStreetMap Mapnik',
               type: 'xyz',
-              url: 'http://{s}.tile.stamen.com/toner-lite/{z}/{x}/{y}.png',
+              url: '//{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
               layerOptions: {
                 subdomains: ['a', 'b', 'c'],
-                attribution: 'Map tiles by <a href="http://stamen.com">Stamen Design</a>',
+                attribution: '&copy; <a href="//www.openstreetmap.org/copyright">OpenStreetMap</a>',
                 continuousWorld: true
               }
             }
@@ -649,7 +649,7 @@
 
       var showMap = false;
       $('#_extent_filter').click(function(evt) {
-     	  showMap = !showMap
+          showMap = !showMap
         if (showMap){
           leafletData.getMap().then(function(map) {
             map.invalidateSize();


### PR DESCRIPTION
This PR use 'OpenStreetMap Mapnik' as default source for baselayer which allow http and https connection. This will remove browser warning about mixed content when using HTTPS to connect to geonode.

Same PR as https://github.com/GeoNode/geonode/pull/3409 but target master branch