### PR TITLE
Implement enhanced WMS capabilities

### DIFF
--- a/geonode/context_processors.py
+++ b/geonode/context_processors.py
@@ -124,6 +124,7 @@ def resource_urls(request):
             dict()).get(
             'METADATA',
             'never'),
+        USE_GEOSERVER=settings.USE_GEOSERVER,
         USE_NOTIFICATIONS=has_notifications,
         USE_MONITORING='geonode.contrib.monitoring' in settings.INSTALLED_APPS and settings.MONITORING_ENABLED,
         DEFAULT_ANONYMOUS_VIEW_PERMISSION=getattr(settings, 'DEFAULT_ANONYMOUS_VIEW_PERMISSION', False),

--- a/geonode/context_processors.py
+++ b/geonode/context_processors.py
@@ -60,6 +60,10 @@ def resource_urls(request):
             settings,
             'DISPLAY_RATINGS',
             False),
+        DISPLAY_WMS_LINKS=getattr(
+            settings,
+            'DISPLAY_WMS_LINKS',
+            False),
         TWITTER_CARD=getattr(
             settings,
             'TWITTER_CARD',

--- a/geonode/geoserver/templates/geoserver/layer.xml
+++ b/geonode/geoserver/templates/geoserver/layer.xml
@@ -1,0 +1,30 @@
+<Layer queryable="{% if layer.storeType == 'dataStore' %}1{% else %}0{% endif %}">
+<Name>{{ layer.name }}</Name>
+<Title>{{ layer.title }}</Title>
+<Abstract>{{ layer.abstract }}</Abstract>
+<KeywordList>
+    {% for kw in layer.keyword_list %}
+    <Keyword>{{ kw }}</Keyword>
+    {% endfor %}
+</KeywordList>
+<SRS>{{ layer.srid }}</SRS>
+<LatLonBoundingBox minx="{{ layer.bbox_x0 }}" miny="{{layer.bbox_y0 }}" maxx="{{ layer.bbox_x1 }}" maxy="{{ layer.bbox_y1 }}"/>
+<BoundingBox SRS="{{ layer.srid }}" minx="{{ layer.bbox_x0 }}" miny="{{ layer.bbox_y0 }}" maxx="{{ layer.bbox_x1 }}" maxy="{{ layer.bbox_y1 }}"/>
+<Attribution>
+<Title>{{ layer.owner.username }}</Title>
+</Attribution>
+<MetadataURL type="FGDC">
+<Format>text/xml</Format>
+<OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="{{ catalogue_url }}?outputschema=http%3A%2F%2Fwww.opengis.net%2Fcat%2Fcsw%2Fcsdgm&amp;service=CSW&amp;request=GetRecordById&amp;version=2.0.2&amp;elementsetname=full&amp;id={{ layer.uuid }}"/>
+</MetadataURL>
+{% for style in layer.styles.all %}
+  <Style>
+  <Name>{{ style.name }}</Name>
+  <Title>{{ style.title }}</Title>
+  <LegendURL width="20" height="20">
+  <Format>image/png</Format>
+  <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="{{ geoserver_public_url }}wms?request=GetLegendGraphic&amp;format=image%2Fpng&amp;width=20&amp;height=20&amp;layer={{ layer.alternate }}&amp;style={{ style.name }}"/>
+  </LegendURL>
+  </Style>
+{% endfor %}
+</Layer>

--- a/geonode/geoserver/views.py
+++ b/geonode/geoserver/views.py
@@ -23,6 +23,7 @@ import logging
 import base64
 import httplib2
 import os
+from lxml import etree
 
 from django.contrib.auth import authenticate
 from django.http import HttpResponse, HttpResponseRedirect
@@ -33,6 +34,8 @@ from django.contrib.auth.decorators import user_passes_test
 from django.contrib.auth import get_user_model
 from django.contrib.auth.decorators import login_required
 from django.core.urlresolvers import reverse
+from django.template.loader import get_template
+from django.template import Context
 from django.template import RequestContext
 from django.utils.datastructures import MultiValueDictKeyError
 from django.utils.translation import ugettext as _
@@ -43,6 +46,7 @@ from geonode.base.models import ResourceBase
 from geonode.layers.forms import LayerStyleUploadForm
 from geonode.layers.models import Layer, Style
 from geonode.layers.views import _resolve_layer, _PERMISSION_MSG_MODIFY
+from geonode.maps.models import Map
 from geonode.geoserver.signals import gs_catalog
 from geonode.tasks.update import geoserver_update_layers
 from geonode.utils import json_response, _get_basic_auth_info
@@ -573,3 +577,91 @@ def layer_acls(request):
         result['email'] = acl_user.email
 
     return HttpResponse(json.dumps(result), content_type="application/json")
+
+
+# capabilities
+def get_layer_capabilities(workspace, layer):
+    """
+    Retrieve a layer-specific GetCapabilities document
+    """
+    # TODO implement this for 1.3.0 too
+    wms_url = '%s%s/%s/wms?request=GetCapabilities&version=1.1.0' % (ogc_server_settings.public_url, workspace, layer)
+    http = httplib2.Http()
+    response, getcap = http.request(wms_url)
+    return getcap
+
+
+def format_online_resource(workspace, layer, element):
+    """
+    Replace workspace/layer-specific OnlineResource links with the more
+    generic links returned by a site-wide GetCapabilities document
+    """
+    layerName = element.find('.//Name')
+    layerName.text = workspace + ":" + layer
+    layerresources = element.findall('.//OnlineResource')
+    for resource in layerresources:
+        wtf = resource.attrib['{http://www.w3.org/1999/xlink}href']
+        resource.attrib['{http://www.w3.org/1999/xlink}href'] = wtf.replace("/" + workspace + "/" + layer, "")
+
+
+def get_capabilities(request, layerid=None, user=None, mapid=None, category=None):
+    """
+    Compile a GetCapabilities document containing public layers
+    filtered by layer, user, map, or category
+    """
+
+    rootdoc = None
+    rootlayerelem = None
+    layers = None
+
+    cap_name = ' Capabilities - '
+    if layerid is not None:
+        layer_obj = Layer.objects.get(id=layerid)
+        cap_name += layer_obj.title
+        layers = Layer.objects.filter(id=layerid)
+    elif user is not None:
+        layers = Layer.objects.filter(owner__username=user)
+        cap_name += user
+    elif category is not None:
+        layers = Layer.objects.filter(category__identifier=category)
+        cap_name += category
+    elif mapid is not None:
+        map_obj = Map.objects.get(id=mapid)
+        cap_name += map_obj.title
+        alternates = []
+        for layer in map_obj.layers:
+            if layer.local:
+                alternates.append(layer.name)
+        layers = Layer.objects.filter(alternate__in=alternates)
+
+    for layer in layers:
+        try:
+            workspace, layername = layer.typename.split(":")
+            if rootdoc is None:  # 1st one, seed with real GetCapabilities doc
+                try:
+                    layercap = etree.fromstring(get_layer_capabilities(workspace, layername))
+                    rootdoc = etree.ElementTree(layercap)
+                    rootlayerelem = rootdoc.find('.//Capability/Layer')
+                    format_online_resource(workspace, layername, rootdoc)
+                    rootdoc.find('.//Service/Name').text = cap_name
+                except Exception, e:
+                    logger.error("Error occurred creating GetCapabilities for %s:%s" % (layer.typename, str(e)))
+            else:
+                    # Get the required info from layer model
+                    tpl = get_template("geoserver/layer.xml")
+                    ctx = Context({
+                                   'layer': layer,
+                                   'geoserver_public_url': ogc_server_settings.public_url,
+                                   'catalogue_url': settings.CATALOGUE['default']['URL'],
+                    })
+                    gc_str = tpl.render(ctx)
+                    gc_str = gc_str.encode("utf-8")
+                    layerelem = etree.XML(gc_str)
+                    rootlayerelem.append(layerelem)
+        except Exception, e:
+                logger.error("Error occurred creating GetCapabilities for %s:%s" % (layer.typename, str(e)))
+                pass
+    if rootdoc is not None:
+        capabilities = etree.tostring(rootdoc, xml_declaration=True, encoding='UTF-8', pretty_print=True)
+        return HttpResponse(capabilities, content_type="text/xml")
+    return HttpResponse(status=200)

--- a/geonode/layers/templates/layers/layer_detail.html
+++ b/geonode/layers/templates/layers/layer_detail.html
@@ -61,6 +61,10 @@
     <div class="tab-content">
       <article id="info" class="tab-pane{% if tab == 'info' or not tab %} active{% endif %}">
         {% include "base/resourcebase_info_panel.html" %}
+
+        {% if DISPLAY_WMS_LINKS %}
+        <p><a href="{% url 'capabilities_layer' resource.id %}"><i class="fa fa-map"></i> {% trans 'Layer WMS GetCapabilities document' %}</a></p>
+        {% endif %}
       </article>
 
       {% if resource.is_mosaic %}

--- a/geonode/layers/templates/layers/layer_detail.html
+++ b/geonode/layers/templates/layers/layer_detail.html
@@ -62,7 +62,7 @@
       <article id="info" class="tab-pane{% if tab == 'info' or not tab %} active{% endif %}">
         {% include "base/resourcebase_info_panel.html" %}
 
-        {% if DISPLAY_WMS_LINKS %}
+        {% if USE_GEOSERVER and DISPLAY_WMS_LINKS %}
         <p><a href="{% url 'capabilities_layer' resource.id %}"><i class="fa fa-map"></i> {% trans 'Layer WMS GetCapabilities document' %}</a></p>
         {% endif %}
       </article>

--- a/geonode/maps/templates/maps/map_detail.html
+++ b/geonode/maps/templates/maps/map_detail.html
@@ -56,6 +56,10 @@
       <div class="tab-content">
         {% include "base/resourcebase_info_panel.html" %}
 
+        {% if DISPLAY_WMS_LINKS %}
+        <p><a href="{% url 'capabilities_map' resource.id %}"><i class="fa fa-map"></i> {% trans 'Map layers WMS GetCapabilities document' %}</a></p>
+        {% endif %}
+
         {% block social_links %}
             {% if DISPLAY_SOCIAL %}
               {% include "social_links.html" %}

--- a/geonode/maps/templates/maps/map_detail.html
+++ b/geonode/maps/templates/maps/map_detail.html
@@ -56,7 +56,7 @@
       <div class="tab-content">
         {% include "base/resourcebase_info_panel.html" %}
 
-        {% if DISPLAY_WMS_LINKS %}
+        {% if USE_GEOSERVER and DISPLAY_WMS_LINKS %}
         <p><a href="{% url 'capabilities_map' resource.id %}"><i class="fa fa-map"></i> {% trans 'Map layers WMS GetCapabilities document' %}</a></p>
         {% endif %}
 

--- a/geonode/people/templates/people/profile_detail.html
+++ b/geonode/people/templates/people/profile_detail.html
@@ -115,7 +115,7 @@
       </tr>
     </tbody>
   </table>
-  {% if DISPLAY_WMS_LINKS %}
+  {% if USE_GEOSERVER and DISPLAY_WMS_LINKS %}
   <p><a href="{% url 'capabilities_user' user.username %}"><i class="fa fa-map"></i> {% trans 'User layers WMS GetCapabilities document' %}</a></p>
   {% endif %}
 </div>

--- a/geonode/people/templates/people/profile_detail.html
+++ b/geonode/people/templates/people/profile_detail.html
@@ -115,6 +115,9 @@
       </tr>
     </tbody>
   </table>
+  {% if DISPLAY_WMS_LINKS %}
+  <p><a href="{% url 'capabilities_user' user.username %}"><i class="fa fa-map"></i> {% trans 'User layers WMS GetCapabilities document' %}</a></p>
+  {% endif %}
 </div>
 
 <div class="col-xs-12 col-md-3">

--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -1185,7 +1185,8 @@ if os.name == 'nt':
 
 
 # define the urls after the settings are overridden
-if 'geonode.geoserver' in INSTALLED_APPS:
+USE_GEOSERVER = 'geonode.geoserver' in INSTALLED_APPS
+if USE_GEOSERVER:
     LOCAL_GEOSERVER = {
         "source": {
             "ptype": "gxp_wmscsource",

--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -806,6 +806,7 @@ MAP_BASELAYERS = [{
 DISPLAY_SOCIAL = strtobool(os.getenv('DISPLAY_SOCIAL', 'True'))
 DISPLAY_COMMENTS = strtobool(os.getenv('DISPLAY_COMMENTS', 'True'))
 DISPLAY_RATINGS = strtobool(os.getenv('DISPLAY_RATINGS', 'True'))
+DISPLAY_WMS_LINKS = strtobool(os.getenv('DISPLAY_WMS_LINKS', 'True'))
 
 SOCIAL_ORIGINS = [{
     "label": "Email",

--- a/geonode/tests/integration.py
+++ b/geonode/tests/integration.py
@@ -25,12 +25,11 @@ import urllib2
 # import base64
 import time
 import logging
-
 import traceback
-from urlparse import urljoin
-
 import gisdata
 from decimal import Decimal
+from lxml import etree
+from urlparse import urljoin
 
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
@@ -46,6 +45,7 @@ from geoserver.catalog import FailedRequestError, UploadError
 
 # from geonode.security.models import *
 from geonode.decorators import on_ogc_backend
+from geonode.base.models import TopicCategory
 from geonode.layers.models import Layer
 from geonode.maps.models import Map
 from geonode import GeoNodeException, geoserver, qgis_server
@@ -1197,3 +1197,108 @@ class GeoNodeGeoServerSync(TestCase):
                 attribute.description,
                 '%s_description' % attribute.attribute
             )
+
+
+class GeoNodeGeoServerCapabilities(TestCase):
+
+    """Tests GeoNode/GeoServer GetCapabilities per layer, user, category and map
+    """
+
+    def setUp(self):
+        call_command('loaddata', 'initial_data', verbosity=0)
+        call_command('loaddata', 'people_data', verbosity=0)
+
+    def tearDown(self):
+        pass
+
+    @on_ogc_backend(geoserver.BACKEND_PACKAGE)
+    def test_capabilities(self):
+        """Test capabilities
+        """
+
+        # a category
+        category = TopicCategory.objects.all()[0]
+
+        # some users
+        norman = get_user_model().objects.get(username="norman")
+        admin = get_user_model().objects.get(username="admin")
+
+        # create 3 layers, 2 with norman as an owner an 2 with category as a category
+        layer1 = file_upload(
+            os.path.join(
+                gisdata.VECTOR_DATA,
+                "san_andres_y_providencia_poi.shp"),
+            name='layer1',
+            user=norman,
+            category=category,
+            overwrite=True,
+        )
+        layer2 = file_upload(
+            os.path.join(
+                gisdata.VECTOR_DATA,
+                "single_point.shp"),
+            name='layer2',
+            user=norman,
+            overwrite=True,
+        )
+        layer3 = file_upload(
+            os.path.join(
+                gisdata.VECTOR_DATA,
+                "san_andres_y_providencia_administrative.shp"),
+            name='layer3',
+            user=admin,
+            category=category,
+            overwrite=True,
+        )
+
+        # 0. test capabilities_layer
+        url = reverse('capabilities_layer', args=[layer1.id])
+        resp = self.client.get(url)
+        layercap = etree.fromstring(resp.content)
+        rootdoc = etree.ElementTree(layercap)
+        layernodes = rootdoc.findall('.//Capability/Layer/Layer')
+        layernode = layernodes[0]
+
+        self.assertEquals(1, len(layernodes))
+        self.assertEquals(layernode.find('Name').text, layer1.name)
+
+        # 1. test capabilities_user
+        url = reverse('capabilities_user', args=[norman.username])
+        resp = self.client.get(url)
+        layercap = etree.fromstring(resp.content)
+        rootdoc = etree.ElementTree(layercap)
+        layernodes = rootdoc.findall('.//Capability/Layer/Layer')
+
+        # norman has 2 layers
+        self.assertEquals(2, len(layernodes))
+
+        # the norman two layers are named layer1 and layer2
+        count = 0
+        for layernode in layernodes:
+            if layernode.find('Name').text == layer1.name:
+                count += 1
+            elif layernode.find('Name').text == layer2.name:
+                count += 1
+        self.assertEquals(2, count)
+
+        # 2. test capabilities_category
+        url = reverse('capabilities_category', args=[category.identifier])
+        resp = self.client.get(url)
+        layercap = etree.fromstring(resp.content)
+        rootdoc = etree.ElementTree(layercap)
+        layernodes = rootdoc.findall('.//Capability/Layer/Layer')
+
+        # category is in two layers
+        self.assertEquals(2, len(layernodes))
+
+        # the layers for category are named layer1 and layer3
+        count = 0
+        for layernode in layernodes:
+            if layernode.find('Name').text == layer1.name:
+                count += 1
+            elif layernode.find('Name').text == layer3.name:
+                count += 1
+        self.assertEquals(2, count)
+
+        # 3. test for a map
+        # TODO

--- a/geonode/tests/smoke.py
+++ b/geonode/tests/smoke.py
@@ -20,7 +20,7 @@
 
 import os
 import math
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.core.urlresolvers import reverse
 
 from geonode import geoserver
@@ -97,6 +97,7 @@ class GeoNodeSmokeTests(TestCase):
         response = self.client.get(reverse('profile_browse'))
         self.failUnlessEqual(response.status_code, 200)
 
+    @override_settings(USE_GEOSERVER=False)
     def test_profiles(self):
         '''Test that user profile pages render.'''
         response = self.client.get(reverse('profile_detail', args=['admin']))

--- a/geonode/urls.py
+++ b/geonode/urls.py
@@ -137,10 +137,20 @@ if "geonode.contrib.createlayer" in settings.INSTALLED_APPS:
                             )
 
 if 'geonode.geoserver' in settings.INSTALLED_APPS:
+    from geonode.geoserver.views import get_capabilities
     # GeoServer Helper Views
     urlpatterns += patterns('',
                             # Upload views
                             (r'^upload/', include('geonode.upload.urls')),
+                            # capabilities
+                            url(r'^capabilities/layer/(?P<layerid>\d+)/$',
+                                get_capabilities, name='capabilities_layer'),
+                            url(r'^capabilities/map/(?P<mapid>\d+)/$',
+                                get_capabilities, name='capabilities_map'),
+                            url(r'^capabilities/user/(?P<user>\w+)/$',
+                                get_capabilities, name='capabilities_user'),
+                            url(r'^capabilities/category/(?P<category>\w+)/$',
+                                get_capabilities, name='capabilities_category'),
                             (r'^gs/', include('geonode.geoserver.urls')),
                             )
 if 'geonode.qgis_server' in settings.INSTALLED_APPS:


### PR DESCRIPTION
This PR implements enhanced WMS GetCapabilities endpoints.

It will be possible to retrieve a GetCapabilities document for a single layer, for all of the layers of a given map, user and category.

Example:

GetCapabilities for all layers in a map:
http://localhost:8000/capabilities/map/3/

GetCapabilities for all layers of a given user:
http://localhost:8000/capabilities/user/admin/

GetCapabilities for all layers in a category:
http://localhost:8000/capabilities/map/biota/

GetCapabilities for a given layer:
http://localhost:8000/layers/geonode:mylayer

In the UI this link are displayed in the layer, map and profile details page when DISPLAY_WMS_LINKS is True (which is by default).

<img width="1297" alt="screenshot 2017-11-09 16 49 44" src="https://user-images.githubusercontent.com/148380/32631361-05dcc5c2-c56e-11e7-8e83-729dff6d7161.png">

Code is migrated from old WorldMap version and it is courtesy of @mbertrand 