### PR TITLE
Fix docker builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,3 +42,5 @@ test: smoketest unittest
 reset: down up wait sync
 
 hardreset: pull build reset
+
+develop: pull build up sync

--- a/README
+++ b/README
@@ -59,6 +59,9 @@ Or if you want to use the provided Makefile::
 
     # pull latest images
     make pull
+
+    # complete development setup
+    make develop
     
 .. note:: For development you need to add ``geonode`` alias into ``/etc/hosts/`` file as following::
 

--- a/scripts/docker/env/development/django.env
+++ b/scripts/docker/env/development/django.env
@@ -1,7 +1,7 @@
 BROKER_URL=amqp://guest:guest@rabbitmq:5672/
 DJANGO_SETTINGS_MODULE=geonode.settings
 GEOSERVER_INTERNAL_URL=http://geoservices:8080/geoserver/
-ALLOWED_HOSTS=['django',]
+ALLOWED_HOSTS=django,geonode
 DOCKER_HOST
 PUBLIC_PORT=8000
 DOCKER_HOST_IP

--- a/scripts/docker/env/production/django.env
+++ b/scripts/docker/env/production/django.env
@@ -1,7 +1,7 @@
 DATABASE_URL=postgres://postgres:postgres@postgres:5432/postgres
 BROKER_URL=amqp://guest:guest@rabbitmq:5672/
 DJANGO_SETTINGS_MODULE=geonode.settings
-ALLOWED_HOSTS=['django',]
+ALLOWED_HOSTS=django,geonode
 C_FORCE_ROOT=1
 GEOSERVER_PUBLIC_LOCATION=http://geonode/geoserver/
 GEOSERVER_LOCATION=http://geonode/geoserver/


### PR DESCRIPTION
In the current setup using docker, the allowed hosts aren't read properly since they're in a list in the ENV file.  This removes the list syntax, since django already puts the data we send to it from the ENV file into a list for ALLOWED_HOSTS and adds geonode to the ALLOWED_HOSTS list since we're supposed to access the build at geonode/ in our browsers based on the README by modifying our local hosts file.