### PR TITLE
Allow sending messages to multiple users and groups

### DIFF
--- a/geonode/context_processors.py
+++ b/geonode/context_processors.py
@@ -153,7 +153,4 @@ def resource_urls(request):
         ),
         OGC_SERVER=getattr(settings, 'OGC_SERVER', None),
     )
-    defaults['message_create_url'] = 'message_create' if not settings.USER_MESSAGES_ALLOW_MULTIPLE_RECIPIENTS\
-        else 'message_create_multiple'
-
     return defaults

--- a/geonode/groups/templatetags/groups_tags.py
+++ b/geonode/groups/templatetags/groups_tags.py
@@ -1,0 +1,40 @@
+from django import template
+from django.contrib.staticfiles.storage import staticfiles_storage
+
+register = template.Library()
+
+
+@register.simple_tag
+def group_profile_image(group_profile, css_classes="", size=None):
+    """Returns an HTML img tag with the input group_profiles's logo.
+
+    If the group profile does not have an associated logo, a stock image is
+    used.
+
+    """
+
+    if isinstance(css_classes, basestring):
+        class_attr = 'class="{}" '.format(css_classes)
+    else:
+        try:
+            class_attr = 'class="{}" '.format(
+                " ".join(str(i) for i in css_classes))
+        except Exception:
+            class_attr = ""
+    if size is not None:
+        style_attr = 'style="width: {size}px; height: {size}px" '.format(
+            size=size)
+    else:
+        style_attr = ""
+
+    if group_profile.logo.name:
+        url = group_profile.logo.url
+    else:
+        url = staticfiles_storage.url("geonode/img/default-avatar.jpg")
+    img_tag = '<img {css}{style}src="{url}" alt="{alt}">'.format(
+        css=class_attr,
+        style=style_attr,
+        url=url,
+        alt=group_profile.title,
+    )
+    return img_tag

--- a/geonode/templates/user_messages/_message_snippet.html
+++ b/geonode/templates/user_messages/_message_snippet.html
@@ -1,6 +1,7 @@
 {% load i18n %}
 
 {% load avatar_tags %}
+{% load groups_tags %}
 
 <table class="table table-striped table-bordered table-condensed">
     <thead>
@@ -15,26 +16,46 @@
         <tbody>
         {% for thread in threads %}
         <tr>
-            <td>
-                {% for user in thread.users.all %}
-                    {% ifnotequal request.user user %}
-                        <p>{% avatar user 30 %}</p>
-                        <a href="{{ user.get_absolute_url }}">{{ user }}</a>
-                    {% endifnotequal %}
+            <td class="col-md-3">
+                {% for user in thread.single_users.all %}
+                    <div class="media">
+                        {% ifnotequal request.user user %}
+                            <div class="media-left">
+                                {% avatar user 30 %}
+                            </div>
+                            <div class="media-body">
+                                <a href="{{  user.get_absolute_url }}">{{ user }}</a>
+                            </div>
+                        {% endifnotequal %}
+                    </div>
+                {% endfor %}
+                {% for group in thread.registered_groups.all %}
+                    <div class="media">
+                        {% with profile=group.groupprofile %}
+                            <div class="media-left">
+                                <a href="{{ profile.get_absolute_url }}">
+                                    {% group_profile_image profile css_classes="media-object" size=30 %}
+                                </a>
+                            </div>
+                            <div class="media-body">
+                                <a href="{{ profile.get_absolute_url }}">{{ profile.title }}</a>
+                            </div>
+                        {% endwith %}
+                    </div>
                 {% endfor %}
             </td>
-            <td><a href="{{ thread.get_absolute_url }}">{{ thread.subject }}</a></td>
-            <td>
+            <td class="col-md-3"><a href="{{ thread.get_absolute_url }}">{{ thread.subject }}</a></td>
+            <td class="col-md-1">
                 {% ifequal request.user thread.latest_message.sender %}
                   {% trans "me" %}
                 {% else %}
                   <a href="{{ thread.latest_message.sender.get_absolute_url }}">{{ thread.latest_message.sender }}</a>
                 {% endifequal %}
             </td>
-            <td>
+            <td class="col-md-4">
                 {{ thread.latest_message.content|slice:"50" }}<a href="{{ thread.get_absolute_url }}">...</a>
             </td>
-            <td>
+            <td class="col-md-1">
                 <form id="thread_delete_{{ thread.pk }}" method="post" action="{% url "messages_thread_delete" thread.pk %}">
                     {% csrf_token %}
                     <button class="btn btn-danger message_delete_btn">{% trans "Delete" %}</button>

--- a/geonode/templates/user_messages/inbox.html
+++ b/geonode/templates/user_messages/inbox.html
@@ -35,7 +35,7 @@
 {% endblock %}
 
 {% block sidebar %}
-<a href="{% url message_create_url %}" class="btn btn-primary" type="button">{% trans "Create Message" %}</a>
+<a href="{% url 'message_create' %}" class="btn btn-primary" type="button">{% trans "Create Message" %}</a>
 {% endblock %}
 
 {% block extra_script %}

--- a/geonode/templates/user_messages/message_create.html
+++ b/geonode/templates/user_messages/message_create.html
@@ -7,7 +7,7 @@
 
 {% block body %}
 <h3>{% trans "Create Message" %}</h3>
-<form method="post" action="{% url message_create_url %}">
+<form method="post" action="{% url 'message_create' %}">
   {% csrf_token %}
   <table width=100%>
     {{ form|as_bootstrap }}

--- a/geonode/tests/test_user_messages.py
+++ b/geonode/tests/test_user_messages.py
@@ -1,0 +1,69 @@
+from django.contrib.auth import get_user_model
+from django.core.urlresolvers import reverse
+from django.test import TestCase
+
+from user_messages.models import Message
+
+
+class UserMessagesTestCase(TestCase):
+
+    def setUp(self):
+        self.user_password = "somepass"
+        self.first_user = get_user_model().objects.create_user(
+            "someuser", "someuser@fakemail.com", self.user_password)
+        self.second_user = get_user_model().objects.create_user(
+            "otheruser", "otheruser@fakemail.com", self.user_password)
+        first_message = Message.objects.new_message(
+            from_user=self.first_user,
+            subject="testing message",
+            content="some content",
+            to_users=[self.second_user]
+        )
+        self.thread = first_message.thread
+
+    def test_inbox_renders(self):
+        self.client.login(
+            username=self.first_user.username, password=self.user_password)
+        response = self.client.get(reverse("messages_inbox"))
+        self.assertTemplateUsed(response, "user_messages/inbox.html")
+        self.assertEqual(response.status_code, 200)
+
+    def test_inbox_redirects_when_not_logged_in(self):
+        target_url = reverse("messages_inbox")
+        response = self.client.get(target_url)
+        self.assertRedirects(
+            response,
+            "{}?next={}".format(reverse("account_login"), target_url)
+        )
+
+    def test_new_message_renders(self):
+        self.client.login(
+            username=self.first_user.username, password=self.user_password)
+        response = self.client.get(
+            reverse("message_create", args=(self.first_user.id,)))
+        self.assertTemplateUsed(response, "user_messages/message_create.html")
+        self.assertEqual(response.status_code, 200)
+
+    def test_new_message_redirects_when_not_logged_in(self):
+        target_url = reverse("message_create", args=(self.first_user.id,))
+        response = self.client.get(target_url)
+        self.assertRedirects(
+            response,
+            "{}?next={}".format(reverse("account_login"), target_url)
+        )
+
+    def test_thread_detail_renders(self):
+        self.client.login(
+            username=self.first_user.username, password=self.user_password)
+        response = self.client.get(
+            reverse("messages_thread_detail", args=(self.thread.id,)))
+        self.assertTemplateUsed(response, "user_messages/thread_detail.html")
+        self.assertEqual(response.status_code, 200)
+
+    def test_thread_detail_redirects_when_not_logged_in(self):
+        target_url = reverse("messages_thread_detail", args=(self.thread.id,))
+        response = self.client.get(target_url)
+        self.assertRedirects(
+            response,
+            "{}?next={}".format(reverse("account_login"), target_url)
+        )

--- a/requirements.txt
+++ b/requirements.txt
@@ -73,7 +73,7 @@ geonode-announcements==1.0.8
 geonode-arcrest==10.2
 geonode-avatar==2.1.6
 geonode-dialogos==0.7
-geonode-user-messages==0.1.6
+geonode-user-messages==0.1.7
 gisdata==0.5.4
 gsconfig==1.0.8
 gsimporter==1.0.0

--- a/setup.py
+++ b/setup.py
@@ -134,7 +134,7 @@ setup(name='GeoNode',
 
         # GeoNode org maintained apps.
         "django-geoexplorer>=4.0.0,<5.0",
-        "geonode-user-messages<=0.1.6",  # (0.1.3 in ppa) FIXME
+        "geonode-user-messages<=0.1.7",  # (0.1.3 in ppa) FIXME
         "geonode-avatar<=2.1.6",  # (2.1.5 in ppa) FIXME
         "geonode-announcements<=1.0.8",
         "geonode-agon-ratings<=0.3.5",  # (0.3.1 in ppa) FIXME


### PR DESCRIPTION
This PR updates geonode in order to take advantage of the recente changes in [geonode-user-messages](https://github.com/GeoNode/geonode-user-messages/commit/309fd76fea526a1d054feef650a3a6b62b1fc437) that enable sending messages to multiple users and multiple groups.

It closes #3429

Main modifications:
- Added a new templatetag to display a group's logo, or a stock image
  if no logo exists;
- `geonode-user-messages` version bumped to 0.1.7
- `templates/user_messages` adapted to display groups as well as users;
- Removed the `USER_MESSAGES_ALLOW_MULTIPLE_RECIPIENTS` setting. This settings was undocumented and IMHO it is not needed anymore. The `geonode-user-messages` app has been updated to allow sending to multiple users by default. Therefore it is up to the user to decide who to message by selecting things in the UI;
- Added some tests to ensure templates get rendered.