### PR TITLE
Add the find_geoserver_broken_layers command

### DIFF
--- a/docs/tutorials/admin/admin_mgmt_commands/index.txt
+++ b/docs/tutorials/admin/admin_mgmt_commands/index.txt
@@ -245,3 +245,17 @@ Usage::
 
   # synchronize all layers which contain a given search string in their name
   python manage.py sync_geofence --layername cambridge
+
+
+find_geoserver_broken_layers
+============================
+
+Find GeoNode layers with a missing GeoServer resource.
+
+Usage::
+
+  # search the whole catalog
+  python manage.py find_geoserver_broken_layers
+
+  # search all layers which contain a given search string in their name and owned by a given user
+  python manage.py sync_geofence --layername cambridge  --owner bob

--- a/geonode/geoserver/management/commands/find_geoserver_broken_layers.py
+++ b/geonode/geoserver/management/commands/find_geoserver_broken_layers.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+#########################################################################
+#
+# Copyright (C) 2017 OSGeo
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#########################################################################
+
+import sys
+
+from django.core.management.base import BaseCommand
+
+from geonode.geoserver.helpers import gs_catalog
+from geonode.layers.models import Layer
+from geonode.people.models import Profile
+
+
+def is_gs_resource_valid(layer):
+    gs_resource = gs_catalog.get_resource(
+            layer.name,
+            store=layer.store,
+            workspace=layer.workspace)
+    if gs_resource:
+        return True
+    else:
+        return False
+
+
+class Command(BaseCommand):
+    help = 'Find GeoNode layers with a missing GeoServer resource'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--layername',
+            dest='layername',
+            default=None,
+            help='Filter by a layername.',
+        )
+        parser.add_argument(
+            '--owner',
+            dest='owner',
+            default=None,
+            help='Filter by a owner.',
+        )
+
+    def handle(self, **options):
+        if options['layername']:
+            layers = Layer.objects.filter(name__icontains=options['layername'])
+        else:
+            layers = Layer.objects.all()
+        if options['owner']:
+            layers = layers.filter(owner=Profile.objects.filter(username=options['owner']))
+
+        layers_count = layers.count()
+        count = 0
+
+        layer_errors = []
+        for layer in layers:
+            count += 1
+            try:
+                print 'Checking layer %s/%s: %s owned by %s' % (count,
+                                                                layers_count,
+                                                                layer.alternate,
+                                                                layer.owner.username)
+                if not is_gs_resource_valid(layer):
+                    print 'Layer %s is broken!' % layer.alternate
+                    layer_errors.append(layer)
+            except:
+                print("Unexpected error:", sys.exc_info()[0])
+
+        print '\n***** Layers with errors: %s in a total of %s *****' % (len(layer_errors), layers_count)
+        for layer_error in layer_errors:
+            print '%s by %s' % (layer.alternate, layer.owner.username)


### PR DESCRIPTION
A command which will list layers which have a missing resource in GeoServer

sample usage:

```
$ ./manage.py find_geoserver_broken_layers --owner admin
Checking layer 1/4: geonode:flares_noaa owned by admin
Checking layer 2/4: geonode:tm_world_borders_0_3 owned by admin
Layer geonode:tm_world_borders_0_3 is broken!
Checking layer 3/4: geonode:camer_hyd_basins_vm0_2007 owned by admin
Checking layer 4/4: geonode:ukr_nhr_hotspots owned by admin

***** Layers with errors: 1 in a total of 4 *****
geonode:ukr_nhr_hotspots by admin
```