### PR TITLE
[Minor Improvement] - Print Owners Full Name instead of username when available

### DIFF
--- a/geonode/api/api.py
+++ b/geonode/api/api.py
@@ -569,6 +569,10 @@ class ProfileResource(TypeFilteredResource):
 
 class OwnersResource(TypeFilteredResource):
     """Owners api, lighter and faster version of the profiles api"""
+    full_name = fields.CharField(null=True)
+
+    def dehydrate_full_name(self, bundle):
+        return bundle.obj.get_full_name() or bundle.obj.username
 
     def serialize(self, request, data, format, options=None):
         if options is None:

--- a/geonode/base/templates/base/_resourcebase_snippet.html
+++ b/geonode/base/templates/base/_resourcebase_snippet.html
@@ -34,7 +34,7 @@
           <div class="row">
             <div class="col-lg-12 item-items">
               <ul class="list-inline">
-                <li><a href="/people/profile/{{ item.owner__username }}"><i class="fa fa-user"></i>{{ item.owner__username }}</a></li>
+                <li><a href="/people/profile/{{ item.owner__username }}"><i class="fa fa-user"></i>{{ item.owner_name }}</a></li>
                 <li><a href="{{ item.detail_url }}#info"><i class="fa fa-calendar-o"></i>{{ item.date|date:'d MMM y' }}</a></li>
                 <li><a href="{{ item.detail_url }}"><i class="fa fa-eye"></i>{{ item.popular_count }}</a></li>
                 <li><a href="{{ item.detail_url }}#share"><i class="fa fa-share"></i>{{ item.share_count }}</a></li>

--- a/geonode/templates/search/_general_filters.html
+++ b/geonode/templates/search/_general_filters.html
@@ -31,7 +31,7 @@
   <ul class="nav closed" id="owners">
     {% verbatim %}
     <li ng-repeat="owner in owners" ng-if="owner.count > 0">
-      <a data-value="{{ owner.username }}" data-filter="owner__username__in" ng-click="multiple_choice_listener($event)" class="{{owner.active}}">{{ owner.username }}
+      <a data-value="{{ owner.username }}" data-filter="owner__username__in" ng-click="multiple_choice_listener($event)" class="{{owner.active}}">{{ owner.full_name }}
         <span class="badge pull-right">{{ owner.count }}</span>
       </a>
     </li>


### PR DESCRIPTION
As detailed in the title, allow search and index pages to show the Owners Full Names if available, like shown here below

![image](https://user-images.githubusercontent.com/1278021/34269393-6555d908-e684-11e7-99ab-ade89afeabf9.png)
