### PR TITLE
Rename django image tag from latest to geonode

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
      image: rabbitmq
 
   django:
-    image: geonode/django
+    image: geonode/django:geonode
     links:
       - postgres
       - elasticsearch
@@ -21,7 +21,7 @@ services:
       - ./scripts/docker/env/production/django.env
 
   celery:
-    image: geonode/django
+    image: geonode/django:geonode
     links:
       - rabbitmq
       - postgres
@@ -31,7 +31,7 @@ services:
       - ./scripts/docker/env/production/django.env
 
   consumers:
-    image: geonode/django
+    image: geonode/django:geonode
     links:
       - rabbitmq
       - postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
      image: rabbitmq
 
   django:
-    image: geonode/django:geonode
+    image: geonode/geonode:geonode
     links:
       - postgres
       - elasticsearch
@@ -21,7 +21,7 @@ services:
       - ./scripts/docker/env/production/django.env
 
   celery:
-    image: geonode/django:geonode
+    image: geonode/geonode:geonode
     links:
       - rabbitmq
       - postgres
@@ -31,7 +31,7 @@ services:
       - ./scripts/docker/env/production/django.env
 
   consumers:
-    image: geonode/django:geonode
+    image: geonode/geonode:geonode
     links:
       - rabbitmq
       - postgres


### PR DESCRIPTION
The rationale is to allow developers to build django image with the tag `latest` from master for new features