### PR TITLE
[Docs Updates] - GeoServer Advanced Security: update GeoServer/GeoFence Default Role Service section

### DIFF
--- a/docs/tutorials/admin/geoserver_geonode_security/index.txt
+++ b/docs/tutorials/admin/geoserver_geonode_security/index.txt
@@ -529,6 +529,14 @@ Setup of the GeoNode REST Role Service
 
     Once everything has been setup and it is working, choose the ``Administrator role`` and ``Group administrator role`` as ``ROLE_ADMIN``
 
+Allow GeoFence to validate rules with ``ROLES``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. warning:: The following instruction are different accordingly to the GeoServer version you are currently using.
+
+GeoServer 2.9.x and 2.10.x
+--------------------------
+
 #. Access the ``Security`` > ``Settings`` section
 
     .. figure:: img/oauth011.png
@@ -536,6 +544,19 @@ Setup of the GeoNode REST Role Service
 #. Choose the ``geonode REST role service`` as ``Active role service``
 
     .. figure:: img/oauth012.png
+
+GeoServer 2.12.x and above
+--------------------------
+
+With the latest updates to GeoFence Plugin, the latter no more recognizes the Role Service from the default settings but from the ``geofence-server.properties`` file.
+
+That said, it is important that the ``Security`` > ``Settings`` role service will be set to **default**, in order to allow GeoServer following the standard authorization chain.
+
+On the other side, you will need to be sure that the ``geofence-server.properties`` file under the ``$GEOSERVER_DATA_DIR/geofence`` folder, contains the two following additional properties: ::
+
+    gwc.context.suffix=gwc
+    org.geoserver.rest.DefaultUserGroupServiceName=geonode REST role service
+
 
 Setup of the GeoServer OAuth2 Authentication Filter
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/tutorials/install_and_admin/geonode_install/index.txt
+++ b/docs/tutorials/install_and_admin/geonode_install/index.txt
@@ -10,8 +10,8 @@ on an Ubuntu 16.04 machine.
 .. toctree::
     :maxdepth: 2
 
-    install_geonode_application.rst
-    create_geonode_db.rst
-    setup_configure_httpd.rst
-    install_geoserver_application.rst
-    all_together.rst
+    install_geonode_application.txt
+    create_geonode_db.txt
+    setup_configure_httpd.txt
+    install_geoserver_application.txt
+    all_together.txt


### PR DESCRIPTION
Updated docs on GeoServer Advanced Security section;

GeoFence plugin from 2.12.x version and above, gets the default role service from the properties file and no more from the GeoServer default settings.