### PR TITLE
Remove Double Migrations [Master]

### DIFF
--- a/geonode/base/migrations/24_to_26.py
+++ b/geonode/base/migrations/24_to_26.py
@@ -124,29 +124,4 @@ class Migration(migrations.Migration):
             name='thesauruskeyword',
             unique_together=set([('thesaurus', 'alt_label')]),
         ),
-        migrations.AddField(
-            model_name='region',
-            name='bbox_x0',
-            field=models.DecimalField(null=True, max_digits=19, decimal_places=10, blank=True),
-        ),
-        migrations.AddField(
-            model_name='region',
-            name='bbox_x1',
-            field=models.DecimalField(null=True, max_digits=19, decimal_places=10, blank=True),
-        ),
-        migrations.AddField(
-            model_name='region',
-            name='bbox_y0',
-            field=models.DecimalField(null=True, max_digits=19, decimal_places=10, blank=True),
-        ),
-        migrations.AddField(
-            model_name='region',
-            name='bbox_y1',
-            field=models.DecimalField(null=True, max_digits=19, decimal_places=10, blank=True),
-        ),
-        migrations.AddField(
-            model_name='region',
-            name='srid',
-            field=models.CharField(default=b'EPSG:4326', max_length=255),
-        ),
     ]


### PR DESCRIPTION
Remove fields that were added in two separate migrations causing errors when you stand up geonode.  This PR needs to go into master as well as 2.7.x so I will be creating two PRs for it.  You can see the other instance of these same migrations that I kept at https://github.com/GeoNode/geonode/blob/master/geonode/base/migrations/26_to_27.py.  