### PR TITLE
fix for AttributeError: 'module' object has no attribute 'BASEMAP'

### DIFF
--- a/geonode/contrib/api_basemaps/bing.py
+++ b/geonode/contrib/api_basemaps/bing.py
@@ -30,4 +30,4 @@ BASEMAP = {
     'visibility': False,
     'group': 'background'
 }
-settings.MAP_BASELAYERS.append(settings.BASEMAP)
+settings.MAP_BASELAYERS.append(BASEMAP)


### PR DESCRIPTION
error message : 
```
    
settings.MAP_BASELAYERS.append(settings.BASEMAP)
AttributeError: 'module' object has no attribute 'BASEMAP'
```