### PR TITLE
Add ability to control thumbnail generation implementation

### DIFF
--- a/geonode/base/models.py
+++ b/geonode/base/models.py
@@ -1036,6 +1036,8 @@ class ResourceBase(PolymorphicModel, PermissionLevelMixin, ItemBase):
         """Determine if the thumbnail object exists and an image exists"""
         return self.link_set.filter(name='Thumbnail').exists()
 
+    # Note - you should probably broadcast layer#post_save() events to ensure
+    # that indexing (or other listeners) are notified
     def save_thumbnail(self, filename, image):
         upload_to = 'thumbs/'
         upload_path = os.path.join('thumbs/', filename)
@@ -1057,14 +1059,18 @@ class ResourceBase(PolymorphicModel, PermissionLevelMixin, ItemBase):
                 '/')
             url = urljoin(settings.SITEURL, url_path)
 
-            Link.objects.get_or_create(resource=self,
-                                       url=url,
-                                       defaults=dict(
-                                           name='Thumbnail',
-                                           extension='png',
-                                           mime='image/png',
-                                           link_type='image',
-                                       ))
+            # should only have one 'Thumbnail' link
+            obj, created = Link.objects.get_or_create(resource=self,
+                                                      name='Thumbnail',
+                                                      defaults=dict(
+                                                          url=url,
+                                                          extension='png',
+                                                          mime='image/png',
+                                                          link_type='image',
+                                                      ))
+            self.thumbnail_url = url
+            obj.url = url
+            obj.save()
 
             ResourceBase.objects.filter(id=self.id).update(
                 thumbnail_url=url

--- a/geonode/geoserver/helpers.py
+++ b/geonode/geoserver/helpers.py
@@ -71,6 +71,7 @@ from geonode.layers.utils import layer_type, get_files, create_thumbnail
 from geonode.security.views import _perms_info_json
 from geonode.utils import set_attributes
 import xml.etree.ElementTree as ET
+from django.utils.module_loading import import_string
 
 
 logger = logging.getLogger(__name__)
@@ -1890,7 +1891,8 @@ def set_time_dimension(cat, layer, time_presentation, time_presentation_res, tim
     cat.save(resource)
 
 
-def create_gs_thumbnail(instance, overwrite=False):
+# this is the original implementation of create_gs_thumbnail()
+def create_gs_thumbnail_geonode(instance, overwrite=False):
     """
     Create a thumbnail with a GeoServer request.
     """
@@ -1936,3 +1938,10 @@ def create_gs_thumbnail(instance, overwrite=False):
 
     create_thumbnail(instance, thumbnail_remote_url, thumbnail_create_url,
                      ogc_client=http_client, overwrite=overwrite, check_bbox=check_bbox)
+
+
+# main entry point to create a thumbnail - will use implementation
+# defined in settings.THUMBNAIL_GENERATOR (see settings.py)
+def create_gs_thumbnail(instance, overwrite=False):
+    implementation = import_string(settings.THUMBNAIL_GENERATOR)
+    return implementation(instance, overwrite)

--- a/geonode/geoserver/signals.py
+++ b/geonode/geoserver/signals.py
@@ -448,8 +448,12 @@ def geoserver_post_save_local(instance, *args, **kwargs):
                                )
                                )
 
-    logger.info("Creating Thumbnail for Layer [%s]" % (instance.alternate))
-    create_gs_thumbnail(instance, overwrite=False)
+    # some thumbnail generators will update thumbnail_url.  If so, don't
+    # immediately re-generate the thumbnail here.  use layer#save(update_fields=['thumbnail_url'])
+    if not ('update_fields' in kwargs and kwargs['update_fields'] is not None and
+            'thumbnail_url' in kwargs['update_fields']):
+        logger.info("Creating Thumbnail for Layer [%s]" % (instance.alternate))
+        create_gs_thumbnail(instance, overwrite=True)
 
     legend_url = ogc_server_settings.PUBLIC_LOCATION + \
         'wms?request=GetLegendGraphic&format=image/png&WIDTH=20&HEIGHT=20&LAYER=' + \

--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -1259,3 +1259,6 @@ SOCIALACCOUNT_ADAPTER = 'geonode.people.adapters.SocialAccountAdapter'
 INVITATIONS_ADAPTER = ACCOUNT_ADAPTER
 
 TEMPLATE_CONTEXT_PROCESSORS += ('django.core.context.processors.request', )
+
+# Choose thumbnail generator -- this is the default generator
+THUMBNAIL_GENERATOR = "geonode.geoserver.helpers.create_gs_thumbnail_geonode"


### PR DESCRIPTION
This allows different implementations of thumbnail generators. This PR configures Geonode to use the old/current implementation - so there should be no changes.

I did, however, make a minor change in ResourceBase#save_thumbnail(). The old implementation (theoretically) allowed multiple thumbnails (just call #save_thumbnail() with different filenames), however, only one is really supported. For example, see ResourceBase#thumbnail_url, ResourceBase#get_thumbnail_url(), and the rest of Geonode just using ResourceBase#thumbnail_url. This makes it more explicit.

There is also a minor change in the layer#post_save() handler. I put a guard on the call to generate a thumbnail. This is because an alternate implementation could be to schedule a celery task to create the thumbnail in the future. This will need to call layer#save() so that search indexers can be made aware that the layer#thumbnail_url has been changed. This could cause a re-generation of the thumbnail (the second call will not cause the thumbnail_url to change so layer#save() will not be called).