### PR TITLE
Fixes #3639 - fix layer import to get title and abstract from metadata xml

### DIFF
--- a/geonode/layers/utils.py
+++ b/geonode/layers/utils.py
@@ -514,6 +514,9 @@ def file_upload(filename, name=None, user=None, title=None, abstract=None,
             else:
                 defaults[key] = value
 
+        title = defaults.get('title',title)
+        abstract = defaults.get('abstract',abstract)
+
     regions_resolved, regions_unresolved = resolve_regions(regions)
     keywords.extend(regions_unresolved)
 


### PR DESCRIPTION
Fixes #3639 by setting the title and abstract from xml metadata on layer import if they exist. Defaults back to previously set variables if title and abstract are not found in the metadata. Thanks to @erinkenna.