### PR TITLE
Fixes #3641 - tabbed content on map detail page broken

### DIFF
--- a/geonode/maps/templates/maps/map_detail.html
+++ b/geonode/maps/templates/maps/map_detail.html
@@ -54,18 +54,19 @@
       </div>
 
       <div class="tab-content">
-        {% include "base/resourcebase_info_panel.html" %}
+        <article id="info" class="tab-pane{% if tab == 'info' or not tab %} active{% endif %}">
+          {% include "base/resourcebase_info_panel.html" %}
 
-        {% if USE_GEOSERVER and DISPLAY_WMS_LINKS %}
-        <p>
-          {% if request.user.is_authenticated and 'access_token' in request.session %}
-            <a href="{% url 'capabilities_map' resource.id %}?access_token={{ request.session.access_token }}">
-          {% else %}
-            <a href="{% url 'capabilities_map' resource.id %}">
+          {% if USE_GEOSERVER and DISPLAY_WMS_LINKS %}
+          <p>
+            {% if request.user.is_authenticated and 'access_token' in request.session %}
+              <a href="{% url 'capabilities_map' resource.id %}?access_token={{ request.session.access_token }}">
+            {% else %}
+              <a href="{% url 'capabilities_map' resource.id %}">
+            {% endif %}
+            <i class="fa fa-map"></i> {% trans 'Map layers WMS GetCapabilities document' %}</a></p>
           {% endif %}
-          <i class="fa fa-map"></i> {% trans 'Map layers WMS GetCapabilities document' %}</a></p>
-        {% endif %}
-
+        </article>
         {% block social_links %}
             {% if DISPLAY_SOCIAL %}
               {% include "social_links.html" %}


### PR DESCRIPTION
Fixes #3641 by adding an `<article>` wrapper around the info content.

Equivalent to same section in layer_detail.html: https://github.com/GeoNode/geonode/blob/a80e8e40c851f2df954e1db1bbccb08b60a3686a/geonode/layers/templates/layers/layer_detail.html#L62