### PR TITLE
fix broken pip install

### DIFF
--- a/geonode/__init__.py
+++ b/geonode/__init__.py
@@ -20,8 +20,6 @@
 
 import os
 
-from .celery_app import app as celery_app
-
 __version__ = (2, 9, 0, 'unstable', 0)
 __all__ = ['celery_app']
 


### PR DESCRIPTION
When running `pip install geonode==2.8.0` I get 
```
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-cmEX1w-build/setup.py", line 33, in <module>
        version=__import__('geonode').get_version(),
      File "geonode/__init__.py", line 23, in <module>
        from .celery_app import app as celery_app
      File "geonode/celery_app.py", line 24, in <module>
        from celery import Celery
    ImportError: No module named celery
```

That's because of `from .celery_app import app as celery_app` in __init__.py which I think was forgotten there by mistake (not sure?)
