### PR TITLE
Use the correct datastore name in _create_db_featurestore

### DIFF
--- a/geonode/geoserver/helpers.py
+++ b/geonode/geoserver/helpers.py
@@ -1099,7 +1099,7 @@ def _create_db_featurestore(name, data, overwrite=False, charset="UTF-8", worksp
     """
     cat = gs_catalog
     db = ogc_server_settings.datastore_db
-    dsname = db['NAME']
+    dsname = ogc_server_settings.DATASTORE
 
     ds_exists = False
     try:


### PR DESCRIPTION
When uploading new layers to GeoServer, the  ```_create_db_featurestore``` function in geoserver/helpers.py looks for a datastore with a name that matches the database name of the configured datastore-connection.

Other similar functions, such as ```create_geoserver_db_featurestore``` in upload/utils.py (https://github.com/GeoNode/geonode/blob/2.8.0/geonode/upload/utils.py#L636) and ```get_or_create_datastore``` in contrib/createlayer/utils.py (https://github.com/GeoNode/geonode/blob/2.8.0/geonode/contrib/createlayer/utils.py#L144) use ```ogc_server_settings.DATASTORE``` as the datastore name. 

If your datastore name and your datastore-database-name are not identical, this means you end up with two datastores in geoserver that point to the same PostGIS database, which is confusing.

This pull request alters the ```_create_db_featurestore``` to use ```ogc_server_settings.DATASTORE``` as the datastore name, in line with other related functions.