### PR TITLE
Fix QGIS Server settings sample

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,9 @@
 geonode/uploaded
 geonode/qgis_layer
 geonode/qgis_tiles
+geonode/static_root
+geonode/static/.components
+geonode/static/node_modules
 docs
 .coverage
 .celerybeat-*

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,8 @@ env:
     # So QGIS server can access this address
     SITEURL: http://localhost:8000/
     QGIS_SERVER_PORT: 9000
-    ON_TRAVIS: True
-    CELERY_ALWAYS_EAGER: True
+    ON_TRAVIS: 'True'
+    CELERY_ALWAYS_EAGER: 'True'
 
 branches:
   only:

--- a/geonode/local_settings.py.qgis.sample
+++ b/geonode/local_settings.py.qgis.sample
@@ -29,10 +29,15 @@ try:
 except ImportError:
     pass
 
-# GEONODE_APPS += ("geonode.qgis_server", )
+qgis_server_apps_package = "geonode.qgis_server"
+
 GEONODE_APPS = list(GEONODE_APPS)
-# INSTALLED_APPS += ("geonode.qgis_server", )
+if qgis_server_apps_package not in GEONODE_APPS:
+    GEONODE_APPS += ("geonode.qgis_server", )
+
 INSTALLED_APPS = list(INSTALLED_APPS)
+if qgis_server_apps_package not in INSTALLED_APPS:
+    INSTALLED_APPS += ("geonode.qgis_server", )
 
 # QGIS Server Backend settings
 
@@ -44,13 +49,15 @@ if 'geonode.geoserver' in INSTALLED_APPS:
 if 'geonode.geoserver' in GEONODE_APPS:
     GEONODE_APPS.remove("geonode.geoserver")
 
-if 'LOCAL_GEOSERVER' in locals():
-    MAP_BASELAYERS.remove(LOCAL_GEOSERVER)
-    del LOCAL_GEOSERVER
-
-if 'PUBLIC_GEOSERVER' in locals():
+if 'PUBLIC_GEOSERVER' in locals() and \
+        PUBLIC_GEOSERVER in MAP_BASELAYERS:
     MAP_BASELAYERS.remove(PUBLIC_GEOSERVER)
     del PUBLIC_GEOSERVER
+
+if 'LOCAL_GEOSERVER' in locals() and \
+        LOCAL_GEOSERVER in MAP_BASELAYERS:
+    MAP_BASELAYERS.remove(LOCAL_GEOSERVER)
+    del LOCAL_GEOSERVER
 
 # Change context processors
 geoserver_context_processor = 'geonode.geoserver.context_processors.geoserver_urls'
@@ -115,8 +122,10 @@ QGIS_SERVER_CONFIG = {
     'layer_directory': os.path.join(PROJECT_ROOT, "qgis_layer")
 }
 
+import ast
+on_travis = ast.literal_eval(os.environ.get('ON_TRAVIS', 'False'))
 
-on_travis = os.environ.get('ON_TRAVIS', False)
 SKIP_GEOSERVER_TEST = on_travis
 
-CELERY_ALWAYS_EAGER = os.environ.get('CELERY_ALWAYS_EAGER', True)
+CELERY_TASK_ALWAYS_EAGER = ast.literal_eval(
+    os.environ.get('CELERY_TASK_ALWAYS_EAGER', 'True'))

--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -298,7 +298,8 @@ GEONODE_APPS = (
     'geonode.services',
 
     # QGIS Server Apps
-    'geonode.qgis_server',
+    # Only enable this if using QGIS Server
+    # 'geonode.qgis_server',
 
     # GeoServer Apps
     # Geoserver needs to come last because


### PR DESCRIPTION
Previously, there are some errors detected in the sample settings file. This could lead to decreased coverage and unittests on QGIS Server side.

This PR contains the following changes:

- Disable QGIS Server Backend by default. User needs to enable it manually
- Update local_settings.py.qgis.sample
- Include static folder in .dockerignore