### PR TITLE
removed unused sqlalchemy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -149,7 +149,6 @@ requests-oauthlib==0.8.0
 selenium==3.9.0
 simplejson==3.13.2
 splinter==0.7.7
-SQLAlchemy==1.1.14
 tablib==0.12.1
 transifex-client==0.12.4
 typing==3.6.4


### PR DESCRIPTION
Somewhere on the way, SQLAlchemy got into requirements.txt, from 
https://github.com/GeoNode/geonode/commit/17772e55c0eee6f361c4c373b7305b5a1df6a5a4#diff-b4ef698db8ca845e5845c4618278f29aR151

It looks it's not used anywhere. This PR cleans the situation.