### PR TITLE
support for different notations of allowed_hosts env var

### DIFF
--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -70,9 +70,11 @@ else:
 # geonode to be listening for GeoServer auth requests.
 os.environ['DJANGO_LIVE_TEST_SERVER_ADDRESS'] = 'localhost:8000'
 
-if os.getenv('DOCKER_ENV'):
+try:
+    # try to parse python notation, default in dockerized env
     ALLOWED_HOSTS = ast.literal_eval(os.getenv('ALLOWED_HOSTS'))
-else:
+except ValueError:
+    # fallback to regular list of values separated with misc chars
     ALLOWED_HOSTS = ['localhost', ] if os.getenv('ALLOWED_HOSTS') is None \
         else re.split(r' *[,|:|;] *', os.getenv('ALLOWED_HOSTS'))
 


### PR DESCRIPTION
We don't need to distinct between docker env and regular env here. `ALLOWED_HOSTS` can be provided in any of supported form.