### PR TITLE
[backport 2.6.x] backport thumbnail fix

### DIFF
--- a/geonode/static/geonode/js/utils/thumbnail.js
+++ b/geonode/static/geonode/js/utils/thumbnail.js
@@ -5,10 +5,32 @@ var createMapThumbnail = function(obj_id) {
     var map = xmap.clone(); 
     map.find('*').each(function(i) {
         e = $(this);
-        if(e.css('display') === 'none' || (e.attr("class") !== undefined && (e.attr("class").indexOf('olControl') >= 0 || e.attr("class").indexOf('x-') >= 0))) {
-            e.remove(); 
-        } else if (e.attr('src') === '/static/geoexplorer/externals/ext/resources/images/default/s.gif') {
+        if(e.css('display') === 'none' ||
+            // leaflet
+            ($('.leaflet-tile-pane')[0] != undefined && e.attr("class") !== undefined &&
+                ((e.attr("class").indexOf('leaflet-layer') < 0 && e.attr("class").indexOf('leaflet-tile') < 0) ||
+                 e.attr("class").indexOf('x-') >= 0)) ||
+            // OpenLayers
+            ($('.olMapViewport')[0] != undefined && e.attr("class") !== undefined &&
+                (e.attr("class").indexOf('olControl') >= 0 ||
+                 e.attr("class").indexOf('olImageLoadError') >= 0 ||
+                 e.attr("class").indexOf('ol-overlaycontainer') >= 0 ||
+                 e.attr("class").indexOf('x-') >= 0))
+        ) {
             e.remove();
+        } else if (e.attr('src') !== undefined) {
+            if (e.attr('src').indexOf('images/default') > 0 || e.attr('src').indexOf('default/img') > 0) {
+                e.remove();
+            }
+            if (!e.attr('src').startsWith("http")) {
+                var href = e.attr('src');
+                e.attr('src', 'http:' + href);
+            }
+
+            e.css({
+                "visibility":"inherit",
+                "position":"absolute"
+            });
         } else {
             e.removeAttr("id");
         }


### PR DESCRIPTION
partial backport (only thumbnail.js) from
https://github.com/GeoNode/geonode/commit/c5d7ea5bcd803186fec165fdc8e67989698736cf
698736cf#diff-7bfea77702d6821693ca6297dcec75b5

Fixes https://github.com/GeoNode/geonode/issues/3692