### PR TITLE
Add .shp file to file_paths for validate_shapefile_components

### DIFF
--- a/geonode/upload/upload_validators.py
+++ b/geonode/upload/upload_validators.py
@@ -71,7 +71,8 @@ def validate_uploaded_files(cleaned, uploaded_files, field_spatial_types):
         valid_extensions = validate_kmz(
             cleaned["base_file"])
     elif base_ext.lower() == "shp":
-        file_paths = [f.name for f in uploaded_files]
+        file_paths = [cleaned["base_file"].name]
+        file_paths += [f.name for f in uploaded_files]
         valid_extensions = validate_shapefile_components(
             file_paths)
     elif base_ext.lower() == "kml":


### PR DESCRIPTION
Uploading a shapefile results in _IndexError: list index out of range_ for `shape_component = shp_files[0]` in the `def validate_shapefile_components(possible_filenames):`

Fixed this by adding the .shp file to the file_paths passed along (also tested for a zipped shapefile, this was already working correctly).