### PR TITLE
#3754: corrected geonode Version. Fixed tomcat reference

### DIFF
--- a/docs/tutorials/install_and_admin/geonode_install/install_geonode_application.txt
+++ b/docs/tutorials/install_and_admin/geonode_install/install_geonode_application.txt
@@ -38,7 +38,7 @@ packages
 
     $ sudo apt-get update
         
-    $ sudo apt-get install python-virtualenv python-dev libxml2 libxml2-dev libxslt1-dev zlib1g-dev libjpeg-dev libpq-dev libgdal-dev git default-jdk
+    $ sudo apt-get install python-virtualenv python-dev libxml2 libxml2-dev libxslt1-dev zlib1g-dev libjpeg-dev libpq-dev git default-jdk
     $ sudo apt-get install build-essential openssh-server gettext nano vim unzip zip patch git-core postfix
 
     $ sudo apt-add-repository ppa:webupd8team/java
@@ -124,20 +124,26 @@ We are going to install GeoNode as a dependency of a **Customized DJango Project
 .. code-block:: bash
 
     $ pip install Django==1.8.18
-    $ django-admin.py startproject --template=https://github.com/GeoNode/geonode-project/archive/2.9.x-rev.zip -e py,rst,json,yml my_geonode
+    $ django-admin.py startproject --template=https://github.com/GeoNode/geonode-project/archive/2.8.0.zip -e py,rst,json,yml my_geonode
 
 Let's install the GeoNode dependencies and packages into the Python Virtual Environment:
 
 .. code-block:: bash
 
-    $ cd my_geonode
+	$ cd my_geonode
+
+	# Find the closest pygdal version. 
+    # Example: 2.2.1 ...  2.2.1.3, ...
+    $ gdal-config --version && pip install pygdal==
+
     $ vim requirements.txt
-    # Make sure requirements contains reference to geonode master branch
-    -e git://github.com/GeoNode/geonode.git@master#egg=geonode
+    # Make sure requirements contains reference to geonode 2.8 branch
+    # and correct gdal version (see above)
+    -e git://github.com/GeoNode/geonode.git@2.8.0#egg=geonode
+    pygdal==2.2.1.3
 
     $ pip install -r requirements.txt
     $ pip install -e .
-    $ pip install pygdal==2.2.1.3
-    # The closest to your `gdal-config --version`
+
 
 In the next section we are going to setup PostgreSQL Databases for GeoNode and finalize the setup

--- a/docs/tutorials/install_and_admin/geonode_install/install_geoserver_application.txt
+++ b/docs/tutorials/install_and_admin/geonode_install/install_geoserver_application.txt
@@ -90,7 +90,7 @@ Test GeoServer
 
 Now start Tomcat to deploy GeoServer::
 
-    sudo service tomcat7 start
+    sudo service tomcat8 start
 
 Tomcat will extract GeoServer web archive and start GeoServer. This may take some time
 


### PR DESCRIPTION
This PR is based  #3754 
- apt install: libgdal-dev has been set twice 
- the documentation title says install **geonode 2.8** but as master is used one will currently end with 2.9 which can be missleading. I would suggest to  consistently stay with 2.8 (stable)
- I´ve extended the pip part comments for  installation of pygdal as this might be a hard step for not advanced users. as the user already opens requirements.txt I think it´s easiest to set the correct pygdal version in this step as well. As alternative I´m using [this](https://gist.github.com/t-book/ccc2f8d6e2c3b735e76c9b779152ee39) with vagrant but think it´s better to keep things simple and understandable for users in docs.
- the documentation is saying tomcat7 restart. which should be tomcat8 restart

that´s it.

cheers,

toni