### PR TITLE
populate service.last_check in monitoring in autoconfigure

### DIFF
--- a/geonode/contrib/monitoring/migrations/0022_service_last_check_default.py
+++ b/geonode/contrib/monitoring/migrations/0022_service_last_check_default.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('monitoring', '0021_auto_20180301_0932'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='service',
+            name='last_check',
+            field=models.DateTimeField(auto_now_add=True, null=True),
+        ),
+    ]

--- a/geonode/contrib/monitoring/models.py
+++ b/geonode/contrib/monitoring/models.py
@@ -1595,6 +1595,7 @@ def do_autoconfigure():
                 name=geonode[0],
                 url=geonode[1],
                 host=host,
+                last_check=datetime.now(),
                 service_type=geonode_type)
         service.save()
 
@@ -1606,6 +1607,7 @@ def do_autoconfigure():
                 host=host,
                 service_type=hostgeonode_type,
                 url=geonode[1],
+                last_check=datetime.now(),
                 name=shost_name)
         service.save()
 
@@ -1623,6 +1625,7 @@ def do_autoconfigure():
                 name=geoserver[0],
                 url=geoserver[1],
                 host=host,
+                last_check=datetime.now(),
                 service_type=geoserver_type)
         service.save()
 
@@ -1634,6 +1637,7 @@ def do_autoconfigure():
                 host=host,
                 service_type=hostgeoserver_type,
                 url=geoserver[1],
+                last_check=datetime.now(),
                 name=shost_name)
         service.save()
 

--- a/geonode/contrib/monitoring/models.py
+++ b/geonode/contrib/monitoring/models.py
@@ -120,7 +120,7 @@ class Service(models.Model):
     host = models.ForeignKey(Host, null=False)
     check_interval = models.DurationField(
         null=False, blank=False, default=timedelta(seconds=60))
-    last_check = models.DateTimeField(null=True, blank=True)
+    last_check = models.DateTimeField(null=True, blank=True, auto_now_add=True)
     service_type = models.ForeignKey(ServiceType, null=False)
     active = models.BooleanField(null=False, blank=False, default=True)
     notes = models.TextField(null=True, blank=True)
@@ -1595,7 +1595,6 @@ def do_autoconfigure():
                 name=geonode[0],
                 url=geonode[1],
                 host=host,
-                last_check=datetime.now(),
                 service_type=geonode_type)
         service.save()
 
@@ -1607,7 +1606,6 @@ def do_autoconfigure():
                 host=host,
                 service_type=hostgeonode_type,
                 url=geonode[1],
-                last_check=datetime.now(),
                 name=shost_name)
         service.save()
 
@@ -1625,7 +1623,6 @@ def do_autoconfigure():
                 name=geoserver[0],
                 url=geoserver[1],
                 host=host,
-                last_check=datetime.now(),
                 service_type=geoserver_type)
         service.save()
 
@@ -1637,7 +1634,6 @@ def do_autoconfigure():
                 host=host,
                 service_type=hostgeoserver_type,
                 url=geoserver[1],
-                last_check=datetime.now(),
                 name=shost_name)
         service.save()
 


### PR DESCRIPTION
This will populate `last_check` fields in autoconfiguration. Otherwise, collector will not collect data.