### PR TITLE
pin some incompatible python dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(name='GeoNode',
 
             # native dependencies
             "Pillow<=3.3.1",  # python-imaging (3.1.2) - python-pillow (3.3.1 in our ppa)
-            "lxml<=3.8.0",  # python-lxml (3.6.2 in our ppa) FIXME
+            "lxml==3.6.2",  # python-lxml (3.6.2 in our ppa) FIXME # <=3.8.0 throws pkg_resources.ContextualVersionConflict: (lxml 3.8.0 (/usr/local/lib/python2.7/site-packages), Requirement.parse('lxml==3.6.2'), set(['pycsw']))
             "psycopg2<=2.7.3.1",  # python-psycopg2 (2.7.3.1 in our ppa)
             "Django==1.8.19",  # python-django (1.8.19 in our ppa) FIXME
 

--- a/setup.py
+++ b/setup.py
@@ -133,7 +133,7 @@ setup(name='GeoNode',
             "django-activity-stream<=0.6.5",  # python-django-activity-stream (0.6.5 in our ppa)
             "django-appconf<=1.0.2",  # (1.0.2 in ppa)
             "django-apptemplates==1.4",  # # python-django-apptemplates (1.4 in our ppa)
-            "django-autocomplete-light>=2.3.3,<3.0a0",  # (2.3.3.1 in ppa)
+            "django-autocomplete-light==2.3.3",  # (2.3.3.1 in ppa) # pinned because >=2.3.4 throw an exception on startup
             "django-autofixture<=0.12.1",  # python-django-autofixture (0.12.1 in our ppa)
             "django-autoslug<=1.9.3",  # python-django-autoslug (1.9.3 in our ppa)
             "django-braces<=1.12.0",  # pytnon-django-braces (1.12.0 in our ppa)


### PR DESCRIPTION
django-autocomplete-light 2.3.4 and lxml 3.8 throw exceptions (see below).

django-autocomplete-light 2.3.4
```
Traceback (most recent call last):
  File "initialize.py", line 11, in <module>
    django.setup()
  File "/usr/local/lib/python2.7/site-packages/django/__init__.py", line 18, in setup
    apps.populate(settings.INSTALLED_APPS)
  File "/usr/local/lib/python2.7/site-packages/django/apps/registry.py", line 85, in populate
    app_config = AppConfig.create(entry)
  File "/usr/local/lib/python2.7/site-packages/django/apps/config.py", line 86, in create
    module = import_module(entry)
  File "/usr/local/lib/python2.7/importlib/__init__.py", line 37, in import_module
    __import__(name)
  File "/usr/local/lib/python2.7/site-packages/autocomplete_light/__init__.py", line 7, in <module>
    from .shortcuts import *  # noqa
  File "/usr/local/lib/python2.7/site-packages/autocomplete_light/shortcuts.py", line 1, in <module>
    from .autocomplete.shortcuts import *
  File "/usr/local/lib/python2.7/site-packages/autocomplete_light/autocomplete/shortcuts.py", line 1, in <module>
    from .base import AutocompleteBase
  File "/usr/local/lib/python2.7/site-packages/autocomplete_light/autocomplete/base.py", line 4, in <module>
    from django.urls import reverse, NoReverseMatch
ImportError: No module named urls
```

lxml 3.8
```
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/django/core/handlers/wsgi.py", line 170, in __call__
    self.load_middleware()
  File "/usr/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 52, in load_middleware
    mw_instance = mw_class()
  File "/usr/local/lib/python2.7/site-packages/django/middleware/locale.py", line 24, in __init__
    for url_pattern in get_resolver(None).url_patterns:
  File "/usr/local/lib/python2.7/site-packages/django/core/urlresolvers.py", line 401, in url_patterns
    patterns = getattr(self.urlconf_module, "urlpatterns", self.urlconf_module)
  File "/usr/local/lib/python2.7/site-packages/django/core/urlresolvers.py", line 395, in urlconf_module
    self._urlconf_module = import_module(self.urlconf_name)
  File "/usr/local/lib/python2.7/importlib/__init__.py", line 37, in import_module
    __import__(name)
  File "./spcgeonode/urls.py", line 2, in <module>
    from geonode.urls import *
  File "/usr/local/lib/python2.7/site-packages/geonode/urls.py", line 82, in <module>
    url(r'^catalogue/', include('geonode.catalogue.urls')),
  File "/usr/local/lib/python2.7/site-packages/django/conf/urls/__init__.py", line 33, in include
    urlconf_module = import_module(urlconf_module)
  File "/usr/local/lib/python2.7/importlib/__init__.py", line 37, in import_module
    __import__(name)
  File "/usr/local/lib/python2.7/site-packages/geonode/catalogue/urls.py", line 22, in <module>
    from . import views
  File "/usr/local/lib/python2.7/site-packages/geonode/catalogue/views.py", line 29, in <module>
    from pycsw import server
  File "/usr/local/lib/python2.7/site-packages/pycsw/__init__.py", line 35, in <module>
    __version__ = pkg_resources.require("pycsw")[0].version
  File "/usr/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 892, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/usr/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 783, in resolve
    raise VersionConflict(dist, req).with_context(dependent_req)
pkg_resources.ContextualVersionConflict: (lxml 3.8.0 (/usr/local/lib/python2.7/site-packages), Requirement.parse('lxml==3.6.2'), set(['pycsw']))
```

