### PR TITLE
use geoip2 for monitoring

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -183,3 +183,4 @@ pytest-bdd==2.20.0
 pytest-splinter==1.8.5
 pytest-django==3.1.2
 setuptools==39.0.1
+geoip2==2.8.0


### PR DESCRIPTION
This adds `geoip2` package so `django.contrib.gis.geoip2` module in django 1.11+ will work