### PR TITLE
catch geoserver error in messaging, to avoid looped delivery

### DIFF
--- a/geonode/messaging/consumer.py
+++ b/geonode/messaging/consumer.py
@@ -100,7 +100,10 @@ class Consumer(ConsumerMixin):
         except Layer.DoesNotExist as err:
             logger.debug(err)
             return
-        geoserver_post_save_local(layer)
+        try:
+            geoserver_post_save_local(layer)
+        except Exception, err:
+            logger.error("Cannot handle geoserver message: %s", err, exc_info=err)
         # Not sure if we need to send ack on this fanout version.
         message.ack()
         logger.debug("on_geoserver_messages: finished")


### PR DESCRIPTION
This will catch errors in `geonode.geoserver.signal` handlers, so message can be acknowledged, and won't be repeated indefinitely in consumer.