### PR TITLE
test-specific requirements: twisted

### DIFF
--- a/requirements_tests.txt
+++ b/requirements_tests.txt
@@ -1,0 +1,1 @@
+Twisted


### PR DESCRIPTION
We have Twisted test facilities introduced in test runner https://github.com/GeoNode/geonode/blob/master/geonode/tests/suite/runner.py#L9-L10

Dependency was introduced in https://github.com/GeoNode/geonode/commit/c0b298f69883d94875a4cc20dc34a447a9f879b5#diff-b4ef698db8ca845e5845c4618278f29aR160
but removed later in https://github.com/GeoNode/geonode/commit/3817491d9850fd6f8a0b207ac088afc93298663d#diff-b4ef698db8ca845e5845c4618278f29aL159

This reintroduces Twisted in requirements, but to avoid messing with main requirements, it's in tests-specific file.