### PR TITLE
Fix issues where docker client may be incompatible with docker server

### DIFF
--- a/scripts/docker/env/development/django.env
+++ b/scripts/docker/env/development/django.env
@@ -9,3 +9,6 @@ PUBLIC_PORT=8000
 DOCKER_HOST_IP
 DEBUG=True
 C_FORCE_ROOT=1
+# See https://github.com/geosolutions-it/geonode-generic/issues/28
+# to see why we force API version to 1.24
+DOCKER_API_VERSION: "1.24"

--- a/scripts/docker/env/production/django.env
+++ b/scripts/docker/env/production/django.env
@@ -19,3 +19,6 @@ GEOSERVER_PUBLIC_LOCATION=http://geonode/geoserver/
 GEOSERVER_LOCATION=http://geonode/geoserver/
 SITEURL=http://geonode/
 COMPOSE_HTTP_TIMEOUT=300
+# See https://github.com/geosolutions-it/geonode-generic/issues/28
+# to see why we force API version to 1.24
+DOCKER_API_VERSION: "1.24"

--- a/tasks.py
+++ b/tasks.py
@@ -76,7 +76,7 @@ def fixtures(ctx):
 
 
 def _docker_host_ip():
-    client = docker.from_env()
+    client = docker.from_env(version='1.24')
     ip_list = client.containers.run(BOOTSTRAP_IMAGE_CHEIP,
                                     network_mode='host'
                                     ).split("\n")
@@ -93,7 +93,7 @@ address {0}".format(ip_list[0]))
 
 
 def _container_exposed_port(component, instname):
-    client = docker.from_env()
+    client = docker.from_env(version='1.24')
     try:
         ports_dict = json.dumps(
             [c.attrs['Config']['ExposedPorts'] for c in client.containers.list(


### PR DESCRIPTION
… API by forcing to APV version 1.24

For more context please see:

https://github.com/geosolutions-it/geonode-generic/issues/28

and

https://github.com/geosolutions-it/geonode-generic/pull/29


