### PR TITLE
add missing ast import

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -2,6 +2,7 @@ import json
 import logging
 import os
 import re
+import ast
 
 import docker
 


### PR DESCRIPTION
Running docker-compose would fail.  It looks like it was just missing the import of the ast module.  I made that fix locally and everything worked correctly.  

Relevant output of the error message prior to the change is given below.  

NameError: global name 'ast' is not defined
Traceback (most recent call last):
  File "/usr/local/bin/invoke", line 11, in <module>
    sys.exit(program.run())
  File "/usr/local/lib/python2.7/site-packages/invoke/program.py", line 293, in run
    self.execute()
  File "/usr/local/lib/python2.7/site-packages/invoke/program.py", line 414, in execute
    executor.execute(*self.tasks)
  File "/usr/local/lib/python2.7/site-packages/invoke/executor.py", line 129, in execute
    result = call.task(*args, **call.kwargs)
  File "/usr/local/lib/python2.7/site-packages/invoke/tasks.py", line 115, in __call__
    result = self.body(*args, **kwargs)
  File "/usr/src/app/tasks.py", line 45, in update
    current_allowed = ast.literal_eval(os.getenv('ALLOWED_HOSTS') or \
NameError: global name 'ast' is not defined


