### PR TITLE
added search input for styles to manage page

### DIFF
--- a/docs/organizational/contribute/README
+++ b/docs/organizational/contribute/README
@@ -82,7 +82,7 @@ For GeoServer: http://geonode/geoserver/web/
 Ubuntu
 ------
 
-Ubuntu development build instructions using an isolated virtual environment (tested on Ubuntu 14.04 LTS)::
+Ubuntu development build instructions using an isolated virtual environment (tested on Ubuntu 16.04 LTS)::
 
     # Install Ubuntu dependencies
     sudo apt-get update

--- a/docs/tutorials/install_and_admin/quick_install.txt
+++ b/docs/tutorials/install_and_admin/quick_install.txt
@@ -77,7 +77,7 @@ For further information, read the Admin Docs at http://docs.geonode.org/en/maste
 Ubuntu (for development)
 ---------------------------------
 
-This option installs geonode in a virtual environment. This option is very useful in case you want to develop using Ubuntu (tested on Ubuntu 14.04 LTS)::
+This option installs geonode in a virtual environment. This option is very useful in case you want to develop using Ubuntu (tested on Ubuntu 16.04 LTS)::
 
     # Install Ubuntu dependencies
     sudo apt-get update

--- a/geonode/layers/templates/layers/layer_style_manage.html
+++ b/geonode/layers/templates/layers/layer_style_manage.html
@@ -41,7 +41,13 @@
         <h4>{% trans "Available styles" %}</h4>
         <p>{% trans "Click on an available style in the upper box to assign it to this layer. Selected styles appear in the lower box." %}</p>
       </div>
+              
       <div class="col-md-9">
+        <div class="row form-group">
+          <div class="col-xs-6 col-md-3">
+            <input type="text" class="js-searchlist form-control"  placeholder="&#xF002; Search" style="font-family:Arial, FontAwesome, sans-serif">
+          </div>
+        </div>
         <select multiple="multiple" id="style-select" name="style-select">
           {% for style in gs_styles %}
             {% if style in layer_styles %}
@@ -87,6 +93,16 @@
         });
       }
     });
+
+    $('.js-searchlist').on('keyup', function() {  
+      var searchString = $(this).val();
+      $(".ms-elem-selectable:not(.ms-selected)").each(function() {
+        var listElement = $(this);
+        var styleName = $("span", listElement).html();
+        if(styleName !=null)
+          styleName.toUpperCase().indexOf(searchString.toUpperCase()) > -1 ? listElement.show() : listElement.hide();            
+      }); 
+    });   
   });
 </script>
 {% endblock %}


### PR DESCRIPTION
The list of style name grows fast and it´s hard to find what one is looking for when managing styles. This PR suggests a search input to filter available style names by input.  Here is what you can expect: https://vimeo.com/279245798 

**Some thoughts.**
- The used library for the multiselect (http://loudev.com/) suggests to use a third party library to add search capabilites "Note: This feature is not built-in but depends on an other plugin. I personally use the excellent quicksearch library, but you can use whatever library you like." 
I´ve decided to not add another dependency but add functionalities with some lines of jquery. As it´s specific to the page the code has been added to the template file (and not to assets.js)
- Icon: Unfortunately the selector of the top search is nested (.navbar-nav .search input...), to add the magnifying glass icon to the new input as well would need a new rule in css (BEM naming for future templates?). Instead I´ve integrated the icon as placeholder text. Therefore the style attribute with font-family is needed. In my opinion the use of a placeholder is elegant as the icon is hidden when a user enters text (more space for writing).

Cheers,

Toni