### PR TITLE
Added explanations regarding pygdal install #3784

### DIFF
--- a/docs/tutorials/install_and_admin/quick_install.txt
+++ b/docs/tutorials/install_and_admin/quick_install.txt
@@ -102,13 +102,13 @@ This option installs geonode in a virtual environment. This option is very usefu
 
     sudo add-apt-repository ppa:ubuntugis/ppa && sudo apt-get update
     sudo apt-get install gdal-bin
-    # check GDAL version
-    gdalinfo --version
+  
+    # install the correct PyGDAL version
+    gdal-config --version | cut -c 1-5 | xargs -I % pip install 'pygdal>=%.0,<=%.999'
 
-    # install the correct PyGDAL version (>1.10.1)
-    pip install pygdal==`gdal-config --version`
-
-    # if you cannot find exactly the same version, be sure to install at least the closer major one e.g. 2.1.2 -> 2.1.2.3
+    # if the command cannot install a suitable version, be sure to install at least the closer major one e.g. 2.1.2 -> 2.1.2.3
+    # gdalinfo --version
+    # pip install pygdal==`gdal-config --version`
 
 You can now setup and start GeoNode::
 


### PR DESCRIPTION
This PR reacts on issue: https://github.com/GeoNode/geonode/issues/3784
There is some confusion how to find the correct pygdal version. I would suggest an automated install like
`gdal-config --version | cut -c 1-5 | xargs -I % pip install 'pygdal>=%.0,<=%.999'`.

Another option would be Alessio´s version posted at gitter:
```
GDAL_VERSION=gdal-config --version
PYGDAL_VERSION="$(pip install pygdal==$GDAL_VERSION 2>&1 | grep -oP '(?<=: )(.*)(?=))' | grep -oh $GDAL_VERSION.[0-9])"
pip install pygdal==$PYGDAL_VERSION
```