### PR TITLE
fix a srid bug when uploading vector layers

### DIFF
--- a/geonode/tests/integration.py
+++ b/geonode/tests/integration.py
@@ -443,6 +443,12 @@ class GeoNodeMapTest(GeoNodeLiveTestSupport):
                 uploaded.metadata_xml = thelayer_metadata
                 regions_resolved, regions_unresolved = resolve_regions(regions)
                 self.assertIsNotNone(regions_resolved)
+        except GeoNodeException as e:
+            # layer have projection file, but has no valid srid
+            self.assertEqual(
+                str(e),
+                "Invalid Layers. "
+                "Needs an authoritative SRID in its CRS to be accepted")
         # except:
         #     # Sometimes failes with the message:
         #     # UploadError: Could not save the layer air_runways,


### PR DESCRIPTION
the original code failed in identifying srid for non 4326 vector layers.
this PR addresses the problem by calling `identify_epsg` function before `srs.srid` and adds some use cases.

the PR is used for the following use cases:
- layers with epsg:4326
   - no problem at all.
- layers with epsg non 4326
  - this is where the original code fails to identify the correct epsg code from the shapefile. this PR basically is to resolve this issue.
- layers without epsg, but has a valid projection definition
  - none of the original code and this PR will work. 
     we just check if the boundary is within the 4326. 
     if so, then we assume it is a 4326.  
     otherwise, we ask a user to upload a layer with an authoritative SRID