### PR TITLE
prevent change of height on cart item hover

### DIFF
--- a/geonode/static/geonode/js/templates/cart.html
+++ b/geonode/static/geonode/js/templates/cart.html
@@ -8,6 +8,6 @@
     <p>Add {{ facetType | default_if_blank : 'objects' }} through the "checkboxes".</p>
   </div>
   <ul class="list-group">
-    <li class="list-group-item" ng-repeat="resource in cart.getCart().items">{{ resource.title | limitTo: 25}}{{ resource.title.length > 25 ? '...' : '' }}<button class="btn btn-default btn-xs pull-right" ng-click="cart.removeItem(resource)"><i class="fa fa-remove fa-lg"></i></button></li>
+    <li class="list-group-item clearfix" ng-repeat="resource in cart.getCart().items">{{ resource.title | limitTo: 25}}{{ resource.title.length > 25 ? '...' : '' }}<button class="btn btn-default btn-xs pull-right" ng-click="cart.removeItem(resource)"><i class="fa fa-remove fa-lg"></i></button></li>
   </ul>
 </div>


### PR DESCRIPTION
The left sided cart items (/layers + /maps) jump on hover. 

Adding a clearfix  causes the outer element to establish a new block formatting context for its floats, so it's able to expand to contain them and it´s items stop jumping on hover.

![ezgif-2-0cbf6f04c7](https://user-images.githubusercontent.com/20478652/43355309-7e91902e-925a-11e8-8e8d-3efd0f2aa6cf.gif)
