### PR TITLE
Mitigate name clashes for WMS service names

### DIFF
--- a/geonode/services/serviceprocessors/wms.py
+++ b/geonode/services/serviceprocessors/wms.py
@@ -115,7 +115,7 @@ class WmsServiceHandler(base.ServiceHandlerBase,
             INDEXED if self._offers_geonode_projection() else CASCADED)
         # self.url = self.parsed_service.url
         # TODO: Check if the name already esists
-        self.name = slugify(urlsplit(self.url).netloc)[:40]
+        self.name = slugify(self.url)[:255]
 
     def create_cascaded_store(self):
         store = self._get_store(create=True)


### PR DESCRIPTION
WMS service names have to be unique, however they are determined from the `netloc` part of the service URL only and are restricted to 40 characters (the field definition in `services.models.Service` allows for 255 characters).

This can lead to name clashes if e.g. multiple services are available on the same network location. Examples:

http://www.lfu.bayern.de/gdi/wms/wasser/abwasser?request=GetCapabilities&service=WMS
http://www.lfu.bayern.de/gdi/wms/wasser/wsg?service=wms&request=GetCapabilities

are different WMS services using the same network location.

Suggestion:

Use the entire service URL for name determination and use all available 255 characters to avoid name clashes.