### PR TITLE
[WIP] Add kubernetes manifest files

### DIFF
--- a/scripts/kubernetes/local/celery-deployment.yaml
+++ b/scripts/kubernetes/local/celery-deployment.yaml
@@ -1,0 +1,107 @@
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: celery
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: celery
+    spec:
+      containers:
+      - args:
+        - celery
+        - worker
+        - --app=geonode.celery_app:app
+        - -B
+        - -l
+        - INFO
+        env:
+        - name: ALLOWED_HOSTS
+          value: '[''django'']'
+        - name: ASYNC_SIGNALS
+          value: "False"
+        - name: BROKER_URL
+          value: amqp://guest:guest@rabbitmq:5672
+        - name: CELERY_CMD
+          value: celery worker --app=geonode.celery_app:app --broker=amqp://guest:guest@rabbitmq:5672/
+            -B -l INFO
+        - name: C_FORCE_ROOT
+          value: "1"
+        - name: DATABASE_URL
+          value: postgres://postgres:postgres@db:5432/postgres
+        - name: GEODATABASE_URL
+          value: postgis://geonode:geonode@db:5432/geonode_data
+        - name: DEFAULT_BACKEND_DATASTORE
+          value: datastore
+        - name: DJANGO_SETTINGS_MODULE
+          value: geonode.settings
+        - name: DOCKER_ENV
+          value: production
+        - name: GEONODE_DATABASE
+          value: geonode
+        - name: GEONODE_DATABASE_PASSWORD
+          value: geonode
+        - name: GEONODE_GEODATABASE
+          value: geonode_data
+        - name: GEONODE_GEODATABASE_PASSWORD
+          value: geonode_data
+        - name: GEONODE_INSTANCE_NAME
+          value: geonode
+        - name: GEONODE_LB_HOST_IP
+        - name: GEONODE_LB_PORT
+        - name: GEOSERVER_LOCATION
+          value: http://geonode/geoserver/
+        - name: GEOSERVER_PUBLIC_LOCATION
+          value: http://geonode/geoserver/
+        - name: IS_CELERY
+          value: "true"
+        - name: SITEURL
+          value: http://geonode/
+        image: eggshell/geonode:latest
+        imagePullPolicy: Always
+        name: celery4geonode
+        securityContext:
+          privileged: true
+        stdin: true
+        volumeMounts:
+        - name: varlibdocker
+          mountPath: /var/lib/docker
+        - name: rundind
+          mountPath: /var/run/
+      - name: dind
+        image: docker:dind
+        securityContext:
+          privileged: true
+        args:
+          - dockerd
+          - --storage-driver=overlay2
+          - -H unix:///var/run/docker.sock
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: varlibdocker
+          mountPath: /var/lib/docker
+        - name: rundind
+          mountPath: /var/run/
+      restartPolicy: Always
+      volumes:
+      - name: varlibdocker
+        emptyDir: {}
+      - name: rundind
+        hostPath:
+          path: /var/run/dind/
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: celery
+spec:
+  ports:
+  - port: 8000
+    protocol: TCP
+    name: celery
+  selector:
+    app: celery

--- a/scripts/kubernetes/local/db-deployment.yaml
+++ b/scripts/kubernetes/local/db-deployment.yaml
@@ -1,0 +1,103 @@
+---
+kind: PersistentVolume
+apiVersion: v1
+metadata:
+  name: geonode-dbdata
+  labels:
+    type: local
+spec:
+  capacity:
+    storage: 100Mi
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: "/mnt/dbdata"
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: geonode-dbdata
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+---
+kind: PersistentVolume
+apiVersion: v1
+metadata:
+  name: geonode-dbbackups
+  labels:
+    type: local
+spec:
+  capacity:
+    storage: 100Mi
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: "/mnt/dbbackups"
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: geonode-dbbackups
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: db
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: db
+    spec:
+      containers:
+      - env:
+        - name: GEONODE_DATABASE
+          value: geonode
+        - name: GEONODE_DATABASE_PASSWORD
+          value: geonode
+        - name: GEONODE_GEODATABASE
+          value: geonode_data
+        - name: GEONODE_GEODATABASE_PASSWORD
+          value: geonode_data
+        image: geonode/postgis:9.6
+        name: db4geonode
+        ports:
+        - containerPort: 5432
+          name: postgresql
+        stdin: true
+        volumeMounts:
+        - mountPath: /var/lib/postgresql/data
+          name: geonode-dbdata
+        - mountPath: /pg-backups
+          name: geonode-dbbackups
+      restartPolicy: Always
+      volumes:
+      - name: geonode-dbdata
+        persistentVolumeClaim:
+          claimName: geonode-dbdata
+      - name: geonode-dbbackups
+        persistentVolumeClaim:
+          claimName: geonode-dbbackups
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: db
+spec:
+  ports:
+  - port: 5432
+    protocol: TCP
+    name: db
+  selector:
+    app: db

--- a/scripts/kubernetes/local/django-deployment.yaml
+++ b/scripts/kubernetes/local/django-deployment.yaml
@@ -1,0 +1,118 @@
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: django
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: django
+    spec:
+      containers:
+      - args:
+        - uwsgi
+        - --ini
+        - uwsgi.ini
+        env:
+        - name: ALLOWED_HOSTS
+          value: '[''localhost'', ''django'', ''geonode'', ''geonode-ingress'']'
+        - name: ASYNC_SIGNALS
+          value: "False"
+        - name: BROKER_URL
+          value: amqp://guest:guest@rabbitmq:5672
+        - name: COMPOSE_HTTP_TIMEOUT
+          value: "300"
+        - name: C_FORCE_ROOT
+          value: "1"
+        - name: DATABASE_URL
+          value: postgres://postgres:postgres@db:5432/geonode
+        - name: GEODATABASE_URL
+          value: postgis://geonode:geonode@db:5432/geonode_data
+        - name: DEFAULT_BACKEND_DATASTORE
+          value: datastore
+        - name: DEFAULT_BACKEND_UPLOADER
+          value: geonode.importer
+        - name: DJANGO_SETTINGS_MODULE
+          value: geonode.settings
+        - name: DOCKER_API_VERSION
+          value: '"1.24"'
+        - name: DOCKER_ENV
+          value: production
+        - name: GEOGIG_ENABLED
+          value: "False"
+        - name: GEONODE_DATABASE
+          value: geonode
+        - name: GEONODE_DATABASE_PASSWORD
+          value: geonode
+        - name: GEONODE_GEODATABASE
+          value: geonode_data
+        - name: GEONODE_GEODATABASE_PASSWORD
+          value: geonode_data
+        - name: GEONODE_INSTANCE_NAME
+          value: geonode
+        - name: GEONODE_LB_HOST_IP
+          # value: 10.176.239.166
+        - name: GEONODE_LB_PORT
+          # value: 30080
+        - name: GEOSERVER_LOCATION
+          value: http://geonode/geoserver/
+        - name: GEOSERVER_PUBLIC_LOCATION
+          value: http://geonode/geoserver/
+        - name: IS_CELERY
+          value: "False"
+        - name: MOSAIC_ENABLED
+          value: "False"
+        - name: SITEURL
+          value: http://geonode/
+        - name: TIME_ENABLED
+          value: "True"
+        - name: UWSGI_CMD
+          value: uwsgi --ini /usr/src/app/uwsgi.ini
+        image: eggshell/geonode:latest
+        imagePullPolicy: Always
+        name: django4geonode
+        stdin: true
+        volumeMounts:
+        - name: geonode-geoserver-data-dir
+          mountPath: /geoserver_data/data
+        - name: varlibdocker
+          mountPath: /var/lib/docker
+        - name: rundind
+          mountPath: /var/run/
+      - name: dind
+        image: docker:dind
+        securityContext:
+          privileged: true
+        args:
+          - dockerd
+          - --storage-driver=overlay2
+          - -H unix:///var/run/docker.sock
+        volumeMounts:
+        - name: varlibdocker
+          mountPath: /var/lib/docker
+        - name: rundind
+          mountPath: /var/run/
+      restartPolicy: Always
+      volumes:
+      - name: varlibdocker
+        emptyDir: {}
+      - name: rundind
+        hostPath:
+          path: /var/run/dind/
+      - name: geonode-geoserver-data-dir
+        persistentVolumeClaim:
+          claimName: geonode-geoserver-data-dir
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: django
+spec:
+  ports:
+  - port: 8000
+    protocol: TCP
+    name: django
+  selector:
+    app: django

--- a/scripts/kubernetes/local/geonode-deployment.yaml
+++ b/scripts/kubernetes/local/geonode-deployment.yaml
@@ -1,0 +1,48 @@
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: geonode
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: geonode
+    spec:
+      containers:
+      - image: geonode/nginx:geoserver
+        name: nginx4geonode
+        env:
+        - name: NGINX_LISTEN
+          value: "*:80"
+        ports:
+        - containerPort: 80
+        stdin: true
+      restartPolicy: Always
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: geonode
+spec:
+  selector:
+    app: geonode
+  ports:
+  - name: geonode
+    protocol: TCP
+    port: 80
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: geonode-ingress
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/proxy-body-size: "100m"
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    ingress.bluemix.net/client-max-body-size: "100m"
+spec:
+  backend:
+    serviceName: geonode
+    servicePort: 80

--- a/scripts/kubernetes/local/geoserver-deployment.yaml
+++ b/scripts/kubernetes/local/geoserver-deployment.yaml
@@ -1,0 +1,105 @@
+---
+kind: PersistentVolume
+apiVersion: v1
+metadata:
+  name: geonode-geoserver-data-dir
+  labels:
+    type: local
+spec:
+  capacity:
+    storage: 20Gi
+  accessModes:
+    - ReadWriteMany
+  hostPath:
+    path: "/mnt/geoserver-data"
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: geonode-geoserver-data-dir
+  annotations:
+    volume.beta.kubernetes.io/storage-class: ""
+spec:
+  accessModes:
+  - ReadWriteMany
+  resources:
+    requests:
+      storage: 20Gi
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: geoserver
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: geoserver
+    spec:
+      containers:
+      - env:
+        - name: DOCKERHOST
+        - name: DOCKER_HOST_IP
+        - name: GEONODE_LB_HOST_IP
+        - name: GEONODE_LB_PORT
+        - name: PUBLIC_PORT
+          value: "80"
+        - name: NGINX_BASE_URL
+          value: "http://geonode:80"
+        - name: DATABASE_URL
+          value: postgres://postgres:postgres@db:5432/geonode
+        - name: GEODATABASE_URL
+          value: postgis://geonode:geonode@db:5432/geonode_data
+        image: eggshell/geoserver:latest
+        name: geoserver4geonode
+        stdin: true
+        volumeMounts:
+        - name: geonode-geoserver-data-dir
+          mountPath: /geoserver_data/data
+        - name: varlibdocker
+          mountPath: /var/lib/docker
+        - name: rundind
+          mountPath: /var/run/
+      - name: dind
+        image: docker:dind
+        securityContext:
+          privileged: true
+        args:
+          - dockerd
+          - --storage-driver=overlay2
+          - -H unix:///var/run/docker.sock
+        volumeMounts:
+        - name: varlibdocker
+          mountPath: /var/lib/docker
+        - name: rundind
+          mountPath: /var/run/
+      restartPolicy: Always
+      initContainers:
+        - name: data-dir-conf
+          image: geonode/geoserver_data:latest
+          command: ["cp", "-r", "/tmp/geonode/downloaded/data", "/geoserver_data"]
+          volumeMounts:
+          - mountPath: /geoserver_data/data
+            name: geonode-geoserver-data-dir
+      volumes:
+      - name: varlibdocker
+        emptyDir: {}
+      - name: rundind
+        hostPath:
+          path: /var/run/dind/
+      - name: geonode-geoserver-data-dir
+        persistentVolumeClaim:
+          claimName: geonode-geoserver-data-dir
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: geoserver
+spec:
+  ports:
+  - port: 8080
+    protocol: TCP
+    name: geoserver
+  selector:
+    app: geoserver

--- a/scripts/kubernetes/local/rabbitmq-deployment.yaml
+++ b/scripts/kubernetes/local/rabbitmq-deployment.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: rabbitmq
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: rabbitmq
+    spec:
+      containers:
+      - image: rabbitmq
+        name: rabbitmq4geonode
+        ports:
+          - containerPort: 5672
+        stdin: true
+        tty: true
+      restartPolicy: Always
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: rabbitmq
+spec:
+  ports:
+#  - port: 4369
+#    protocol: TCP
+#    name: "4369"
+#  - port: 5671
+#    protocol: TCP
+#    name: "5671"
+  - port: 5672
+    protocol: TCP
+    name: "5672"
+#  - port: 25672
+#    protocol: TCP
+#    name: "25672"
+  selector:
+    app: rabbitmq

--- a/scripts/kubernetes/remote/celery-deployment.yaml
+++ b/scripts/kubernetes/remote/celery-deployment.yaml
@@ -1,0 +1,107 @@
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: celery
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: celery
+    spec:
+      containers:
+      - args:
+        - celery
+        - worker
+        - --app=geonode.celery_app:app
+        - -B
+        - -l
+        - INFO
+        env:
+        - name: ALLOWED_HOSTS
+          value: '[''django'']'
+        - name: ASYNC_SIGNALS
+          value: "False"
+        - name: BROKER_URL
+          value: amqp://guest:guest@rabbitmq:5672
+        - name: CELERY_CMD
+          value: celery worker --app=geonode.celery_app:app --broker=amqp://guest:guest@rabbitmq:5672/
+            -B -l INFO
+        - name: C_FORCE_ROOT
+          value: "1"
+        - name: DATABASE_URL
+          value: postgres://postgres:postgres@db:5432/postgres
+        - name: GEODATABASE_URL
+          value: postgis://geonode:geonode@db:5432/geonode_data
+        - name: DEFAULT_BACKEND_DATASTORE
+          value: datastore
+        - name: DJANGO_SETTINGS_MODULE
+          value: geonode.settings
+        - name: DOCKER_ENV
+          value: production
+        - name: GEONODE_DATABASE
+          value: geonode
+        - name: GEONODE_DATABASE_PASSWORD
+          value: geonode
+        - name: GEONODE_GEODATABASE
+          value: geonode_data
+        - name: GEONODE_GEODATABASE_PASSWORD
+          value: geonode_data
+        - name: GEONODE_INSTANCE_NAME
+          value: geonode
+        - name: GEONODE_LB_HOST_IP
+        - name: GEONODE_LB_PORT
+        - name: GEOSERVER_LOCATION
+          value: http://geonode/geoserver/
+        - name: GEOSERVER_PUBLIC_LOCATION
+          value: http://geonode/geoserver/
+        - name: IS_CELERY
+          value: "true"
+        - name: SITEURL
+          value: http://geonode/
+        image: eggshell/geonode:latest
+        imagePullPolicy: Always
+        name: celery4geonode
+        securityContext:
+          privileged: true
+        stdin: true
+        volumeMounts:
+        - name: varlibdocker
+          mountPath: /var/lib/docker
+        - name: rundind
+          mountPath: /var/run/
+      - name: dind
+        image: docker:dind
+        securityContext:
+          privileged: true
+        args:
+          - dockerd
+          - --storage-driver=overlay2
+          - -H unix:///var/run/docker.sock
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: varlibdocker
+          mountPath: /var/lib/docker
+        - name: rundind
+          mountPath: /var/run/
+      restartPolicy: Always
+      volumes:
+      - name: varlibdocker
+        emptyDir: {}
+      - name: rundind
+        hostPath:
+          path: /var/run/dind/
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: celery
+spec:
+  ports:
+  - port: 8000
+    protocol: TCP
+    name: celery
+  selector:
+    app: celery

--- a/scripts/kubernetes/remote/db-deployment.yaml
+++ b/scripts/kubernetes/remote/db-deployment.yaml
@@ -1,0 +1,107 @@
+---
+kind: PersistentVolume
+apiVersion: v1
+metadata:
+  name: geonode-dbdata
+  labels:
+    type: local
+spec:
+  capacity:
+    storage: 100Mi
+  accessModes:
+    - ReadWriteMany
+  hostPath:
+    path: "/mnt/dbdata"
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: geonode-dbdata
+  annotations:
+    volume.beta.kubernetes.io/storage-class: ""
+spec:
+  accessModes:
+  - ReadWriteMany
+  resources:
+    requests:
+      storage: 100Mi
+---
+kind: PersistentVolume
+apiVersion: v1
+metadata:
+  name: geonode-dbbackups
+  labels:
+    type: local
+spec:
+  capacity:
+    storage: 100Mi
+  accessModes:
+    - ReadWriteMany
+  hostPath:
+    path: "/mnt/dbbackups"
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: geonode-dbbackups
+  annotations:
+    volume.beta.kubernetes.io/storage-class: ""
+spec:
+  accessModes:
+  - ReadWriteMany
+  resources:
+    requests:
+      storage: 100Mi
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: db
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: db
+    spec:
+      containers:
+      - env:
+        - name: GEONODE_DATABASE
+          value: geonode
+        - name: GEONODE_DATABASE_PASSWORD
+          value: geonode
+        - name: GEONODE_GEODATABASE
+          value: geonode_data
+        - name: GEONODE_GEODATABASE_PASSWORD
+          value: geonode_data
+        image: geonode/postgis:9.6
+        name: db4geonode
+        ports:
+        - containerPort: 5432
+          name: postgresql
+        stdin: true
+        volumeMounts:
+        - mountPath: /var/lib/postgresql/data
+          name: geonode-dbdata
+        - mountPath: /pg-backups
+          name: geonode-dbbackups
+      restartPolicy: Always
+      volumes:
+      - name: geonode-dbdata
+        persistentVolumeClaim:
+          claimName: geonode-dbdata
+      - name: geonode-dbbackups
+        persistentVolumeClaim:
+          claimName: geonode-dbbackups
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: db
+spec:
+  ports:
+  - port: 5432
+    protocol: TCP
+    name: db
+  selector:
+    app: db

--- a/scripts/kubernetes/remote/django-deployment.yaml
+++ b/scripts/kubernetes/remote/django-deployment.yaml
@@ -1,0 +1,118 @@
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: django
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: django
+    spec:
+      containers:
+      - args:
+        - uwsgi
+        - --ini
+        - uwsgi.ini
+        env:
+        - name: ALLOWED_HOSTS
+          value: '[''localhost'', ''django'', ''geonode'', ''geonode-external'', ''eggshell.us-south.containers.appdomain.cloud'']'
+        - name: ASYNC_SIGNALS
+          value: "False"
+        - name: BROKER_URL
+          value: amqp://guest:guest@rabbitmq:5672
+        - name: COMPOSE_HTTP_TIMEOUT
+          value: "300"
+        - name: C_FORCE_ROOT
+          value: "1"
+        - name: DATABASE_URL
+          value: postgres://postgres:postgres@db:5432/geonode
+        - name: GEODATABASE_URL
+          value: postgis://geonode:geonode@db:5432/geonode_data
+        - name: DEFAULT_BACKEND_DATASTORE
+          value: datastore
+        - name: DEFAULT_BACKEND_UPLOADER
+          value: geonode.importer
+        - name: DJANGO_SETTINGS_MODULE
+          value: geonode.settings
+        - name: DOCKER_API_VERSION
+          value: '"1.24"'
+        - name: DOCKER_ENV
+          value: production
+        - name: GEOGIG_ENABLED
+          value: "False"
+        - name: GEONODE_DATABASE
+          value: geonode
+        - name: GEONODE_DATABASE_PASSWORD
+          value: geonode
+        - name: GEONODE_GEODATABASE
+          value: geonode_data
+        - name: GEONODE_GEODATABASE_PASSWORD
+          value: geonode_data
+        - name: GEONODE_INSTANCE_NAME
+          value: geonode
+        - name: GEONODE_LB_HOST_IP
+          # value: 10.176.239.166
+        - name: GEONODE_LB_PORT
+          # value: 30080
+        - name: GEOSERVER_LOCATION
+          value: http://geonode/geoserver/
+        - name: GEOSERVER_PUBLIC_LOCATION
+          value: http://geonode/geoserver/
+        - name: IS_CELERY
+          value: "False"
+        - name: MOSAIC_ENABLED
+          value: "False"
+        - name: SITEURL
+          value: http://geonode/
+        - name: TIME_ENABLED
+          value: "True"
+        - name: UWSGI_CMD
+          value: uwsgi --ini /usr/src/app/uwsgi.ini
+        image: eggshell/geonode:latest
+        imagePullPolicy: Always
+        name: django4geonode
+        stdin: true
+        volumeMounts:
+        - name: geonode-geoserver-data-dir
+          mountPath: /geoserver_data/data
+        - name: varlibdocker
+          mountPath: /var/lib/docker
+        - name: rundind
+          mountPath: /var/run/
+      - name: dind
+        image: docker:dind
+        securityContext:
+          privileged: true
+        args:
+          - dockerd
+          - --storage-driver=overlay2
+          - -H unix:///var/run/docker.sock
+        volumeMounts:
+        - name: varlibdocker
+          mountPath: /var/lib/docker
+        - name: rundind
+          mountPath: /var/run/
+      restartPolicy: Always
+      volumes:
+      - name: varlibdocker
+        emptyDir: {}
+      - name: rundind
+        hostPath:
+          path: /var/run/dind/
+      - name: geonode-geoserver-data-dir
+        persistentVolumeClaim:
+          claimName: geonode-geoserver-data-dir
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: django
+spec:
+  ports:
+  - port: 8000
+    protocol: TCP
+    name: django
+  selector:
+    app: django

--- a/scripts/kubernetes/remote/geonode-deployment.yaml
+++ b/scripts/kubernetes/remote/geonode-deployment.yaml
@@ -1,0 +1,56 @@
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: geonode
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: geonode
+    spec:
+      containers:
+      - image: geonode/nginx:geoserver
+        name: nginx4geonode
+        env:
+        - name: NGINX_LISTEN
+          value: "*:80"
+        ports:
+        - containerPort: 80
+        stdin: true
+      restartPolicy: Always
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: geonode
+spec:
+  selector:
+    app: geonode
+  ports:
+  - name: geonode
+    protocol: TCP
+    port: 80
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: geonode-ingress
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/proxy-body-size: "100m"
+    ingress.bluemix.net/client-max-body-size: "100m"
+spec:
+  tls:
+  - hosts:
+    - eggshell.us-south.containers.appdomain.cloud
+    secretName: eggshell
+  rules:
+  - host: eggshell.us-south.containers.appdomain.cloud
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: geonode
+          servicePort: 80

--- a/scripts/kubernetes/remote/geoserver-deployment.yaml
+++ b/scripts/kubernetes/remote/geoserver-deployment.yaml
@@ -1,0 +1,105 @@
+---
+kind: PersistentVolume
+apiVersion: v1
+metadata:
+  name: geonode-geoserver-data-dir
+  labels:
+    type: local
+spec:
+  capacity:
+    storage: 20Gi
+  accessModes:
+    - ReadWriteMany
+  hostPath:
+    path: "/mnt/geoserver-data"
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: geonode-geoserver-data-dir
+  annotations:
+    volume.beta.kubernetes.io/storage-class: ""
+spec:
+  accessModes:
+  - ReadWriteMany
+  resources:
+    requests:
+      storage: 20Gi
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: geoserver
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: geoserver
+    spec:
+      containers:
+      - env:
+        - name: DOCKERHOST
+        - name: DOCKER_HOST_IP
+        - name: GEONODE_LB_HOST_IP
+        - name: GEONODE_LB_PORT
+        - name: PUBLIC_PORT
+          value: "80"
+        - name: NGINX_BASE_URL
+          value: "http://geonode:80"
+        - name: DATABASE_URL
+          value: postgres://postgres:postgres@db:5432/geonode
+        - name: GEODATABASE_URL
+          value: postgis://geonode:geonode@db:5432/geonode_data
+        image: eggshell/geoserver:latest
+        name: geoserver4geonode
+        stdin: true
+        volumeMounts:
+        - name: geonode-geoserver-data-dir
+          mountPath: /geoserver_data/data
+        - name: varlibdocker
+          mountPath: /var/lib/docker
+        - name: rundind
+          mountPath: /var/run/
+      - name: dind
+        image: docker:dind
+        securityContext:
+          privileged: true
+        args:
+          - dockerd
+          - --storage-driver=overlay2
+          - -H unix:///var/run/docker.sock
+        volumeMounts:
+        - name: varlibdocker
+          mountPath: /var/lib/docker
+        - name: rundind
+          mountPath: /var/run/
+      restartPolicy: Always
+      initContainers:
+        - name: data-dir-conf
+          image: geonode/geoserver_data:latest
+          command: ["cp", "-r", "/tmp/geonode/downloaded/data", "/geoserver_data"]
+          volumeMounts:
+          - mountPath: /geoserver_data/data
+            name: geonode-geoserver-data-dir
+      volumes:
+      - name: varlibdocker
+        emptyDir: {}
+      - name: rundind
+        hostPath:
+          path: /var/run/dind/
+      - name: geonode-geoserver-data-dir
+        persistentVolumeClaim:
+          claimName: geonode-geoserver-data-dir
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: geoserver
+spec:
+  ports:
+  - port: 8080
+    protocol: TCP
+    name: geoserver
+  selector:
+    app: geoserver

--- a/scripts/kubernetes/remote/rabbitmq-deployment.yaml
+++ b/scripts/kubernetes/remote/rabbitmq-deployment.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: rabbitmq
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: rabbitmq
+    spec:
+      containers:
+      - image: rabbitmq
+        name: rabbitmq4geonode
+        ports:
+          - containerPort: 5672
+        stdin: true
+        tty: true
+      restartPolicy: Always
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: rabbitmq
+spec:
+  ports:
+#  - port: 4369
+#    protocol: TCP
+#    name: "4369"
+#  - port: 5671
+#    protocol: TCP
+#    name: "5671"
+  - port: 5672
+    protocol: TCP
+    name: "5672"
+#  - port: 25672
+#    protocol: TCP
+#    name: "25672"
+  selector:
+    app: rabbitmq


### PR DESCRIPTION
This will add a directory named deployment which contains all of the
necessary kubernetes manifest files to deploy onto a user's
managed kubernetes platform of choice. These have been written to
be platform-agnostic, but have not yet been tested for use with
Minikube.

Documentation will need to be added, but I want to get opinions
and have discussions with the geonode community before moving
further. I have a running deployment using these configs here:

https://eggshell.us-south.containers.appdomain.cloud/

Signed-off-by: Cullen Taylor <mctaylor@us.ibm.com>