### PR TITLE
fix ident_json view

### DIFF
--- a/geonode/views.py
+++ b/geonode/views.py
@@ -140,7 +140,7 @@ def ident_json(request):
     json_data['counts'] = facets({'request': request, 'facet_type': 'home'})
 
     return HttpResponse(content=json.dumps(json_data),
-                        mimetype='application/json')
+                        content_type='application/json')
 
 
 def h_keywords(request):


### PR DESCRIPTION
mimetype has been deprecated in Django 1.7, mimetype was replaced by content_type.