### PR TITLE
[worldmap client] use gxp_gnsource in geoserver base map

### DIFF
--- a/geonode/contrib/worldmap/wm_extra/views.py
+++ b/geonode/contrib/worldmap/wm_extra/views.py
@@ -839,24 +839,6 @@ def gxp2wm(config, map_obj=None):
     if not [d for d in config['map']['groups'] if d['group'] == group]:
         config['map']['groups'].append({"expanded": "true", "group": group})
 
-    # we need to run this code. It looks like empty map has not the gxp_gnsource
-    add_gnsource = True
-    for source in config['sources']:
-        if 'ptype' in config['sources'][source]:
-            if config['sources'][source]['ptype'] == 'gxp_gnsource':
-                add_gnsource = False
-    if add_gnsource:
-        config['sources']['wm_gnsource'] = {
-                                    'url': settings.OGC_SERVER['default']['PUBLIC_LOCATION'] + "wms",
-                                    'restUrl': '/gs/rest', 'ptype': 'gxp_gnsource'
-                                  }
-
-    # make sure we have the wm source in config
-    config['sources']['wm'] = {
-                                'url': settings.OGC_SERVER['default']['PUBLIC_LOCATION'] + "wms",
-                                'restUrl': '/gs/rest', 'ptype': 'gxp_wmscsource'
-                              }
-
     if config_is_string:
         config = json.dumps(config)
 

--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -1485,14 +1485,19 @@ if os.name == 'nt':
             # maybe it will be found regardless if not it will throw 500 error
             from django.contrib.gis.geos import GEOSGeometry  # flake8: noqa
 
+USE_WORLDMAP = strtobool(os.getenv('USE_WORLDMAP', 'False'))
 
 # define the urls after the settings are overridden
 if USE_GEOSERVER:
+    if USE_WORLDMAP:
+        LOCAL_GXP_PTYPE = 'gxp_gnsource'
+    else:
+        LOCAL_GXP_PTYPE = 'gxp_wmscsource'
     PUBLIC_GEOSERVER = {
         "source": {
             "title": "GeoServer - Public Layers",
             "attribution": "&copy; %s" % SITEURL,
-            "ptype": "gxp_wmscsource",
+            "ptype": LOCAL_GXP_PTYPE,
             "url": OGC_SERVER['default']['PUBLIC_LOCATION'] + "ows",
             "restUrl": "/gs/rest"
         }
@@ -1501,7 +1506,7 @@ if USE_GEOSERVER:
         "source": {
             "title": "GeoServer - Private Layers",
             "attribution": "&copy; %s" % SITEURL,
-            "ptype": "gxp_wmscsource",
+            "ptype": LOCAL_GXP_PTYPE,
             "url": "/gs/ows",
             "restUrl": "/gs/rest"
         }
@@ -1647,8 +1652,6 @@ GEOTIFF_IO_BASE_URL = os.getenv(
 )
 
 # WorldMap settings
-USE_WORLDMAP = strtobool(os.getenv('USE_WORLDMAP', 'False'))
-
 if USE_WORLDMAP:
     GEONODE_CLIENT_LOCATION = '/static/worldmap_client/'
     INSTALLED_APPS += (


### PR DESCRIPTION
When using worldmap client we need geoserver layers to use gxp_gnsource vs gxp_wmscsource