### PR TITLE
Restored older GeoServer Version #4120

### DIFF
--- a/dev_config.yml
+++ b/dev_config.yml
@@ -1,5 +1,5 @@
 ---
-GEOSERVER_URL: "https://build.geo-solutions.it/geonode/geoserver/latest/geoserver-2.13.x.war"
+GEOSERVER_URL: "https://s3.eu-central-1.amazonaws.com/csgis-public/2load/geoserver-2.13.x.war"
 DATA_DIR_URL: "https://build.geo-solutions.it/geonode/geoserver/latest/data-2.13.x.zip"
 JETTY_RUNNER_URL: "http://repo2.maven.org/maven2/org/eclipse/jetty/jetty-runner/9.4.7.v20170914/jetty-runner-9.4.7.v20170914.jar"
 WINDOWS:


### PR DESCRIPTION
The latest GeoServer 2.13 build has problems with uploading of shape files. In agreement with Alessio we restored an older working build. This can remain for 2.8 branch until the problem is fixed. See #4210 for more.