### PR TITLE
Replace exit with a valid command

### DIFF
--- a/scripts/spcgeonode/README.md
+++ b/scripts/spcgeonode/README.md
@@ -173,7 +173,7 @@ docker-compose -f docker-compose.yml up --no-start
 docker-compose -f docker-compose.yml up -d postgres
 
 # Initialize geoserver (to create the geodatadir - this will fail because Django/Postgres arent started yet - but this is expected)
-docker-compose -f docker-compose.yml run --rm geoserver exit 0
+docker-compose -f docker-compose.yml run --rm geoserver true
 
 # Go to the external drive
 cd /path/to/drive/

--- a/scripts/spcgeonode/README.md
+++ b/scripts/spcgeonode/README.md
@@ -172,7 +172,7 @@ docker-compose -f docker-compose.yml up --no-start
 # Start the database
 docker-compose -f docker-compose.yml up -d postgres
 
-# Initialize geoserver
+# Initialize geoserver (to create the geodatadir)
 docker-compose -f docker-compose.yml run --rm geoserver true
 
 # Go to the external drive

--- a/scripts/spcgeonode/README.md
+++ b/scripts/spcgeonode/README.md
@@ -172,7 +172,7 @@ docker-compose -f docker-compose.yml up --no-start
 # Start the database
 docker-compose -f docker-compose.yml up -d postgres
 
-# Initialize geoserver (to create the geodatadir - this will fail because Django/Postgres arent started yet - but this is expected)
+# Initialize geoserver
 docker-compose -f docker-compose.yml run --rm geoserver true
 
 # Go to the external drive


### PR DESCRIPTION
`exit 0` fails becaouse `exit` is not a command available (it is a valid shell builtin command). `true` instead can be found at `/usr/bin/true`.

```
$ man true | head -n4
TRUE(1)                                            User Commands                                           TRUE(1)

NAME
       true - do nothing, successfully
```