### PR TITLE
introduce new GEOSERVER_WEB_UI_LOCATION options

### DIFF
--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -748,6 +748,10 @@ GEOSERVER_LOCATION = os.getenv(
     'GEOSERVER_LOCATION', 'http://localhost:8080/geoserver/'
 )
 
+GEOSERVER_WEB_UI_LOCATION = os.getenv(
+    'GEOSERVER_WEB_UI_LOCATION', urljoin(SITEURL, '/geoserver/')
+)
+
 GEOSERVER_PUBLIC_LOCATION = os.getenv(
     'GEOSERVER_PUBLIC_LOCATION', urljoin(SITEURL, '/gs/')
 )
@@ -768,6 +772,7 @@ OGC_SERVER = {
     'default': {
         'BACKEND': 'geonode.geoserver',
         'LOCATION': GEOSERVER_LOCATION,
+        'WEB_UI_LOCATION': GEOSERVER_WEB_UI_LOCATION,
         'LOGIN_ENDPOINT': 'j_spring_oauth2_geonode_login',
         'LOGOUT_ENDPOINT': 'j_spring_oauth2_geonode_logout',
         # PUBLIC_LOCATION needs to be kept like this because in dev mode

--- a/geonode/templates/base.html
+++ b/geonode/templates/base.html
@@ -217,7 +217,7 @@
                     <li role="separator" class="divider"></li>
                     <li><a href="{% url "admin:index" %}">{% trans "Admin" %}</a></li>
                     {% if 'geonode.geoserver' in INSTALLED_APPS %}
-                    <li><a href="{{ OGC_SERVER.default.LOCATION }}">GeoServer</a></li>
+                    <li><a href="{{ OGC_SERVER.default.WEB_UI_LOCATION }}">GeoServer</a></li>
                     {% endif %}
                     {% if USE_MONITORING %}
                     <li role="separator" class="divider"></li>


### PR DESCRIPTION
The current two options GEOSERVER_LOCATION and GEOSERVER_PUBLIC_LOCATION are not enough to define the location of the Geoserver Web UI. GEOSERVER_LOCATION is reserved for internal use, GEOSERVER_PUBLIC_LOCATION points to the proxied OWS services. 
A new **GEOSERVER_WEB_UI_LOCATION** option is provided and by default it points to SITEURL/geoserver/.