### PR TITLE
improve Thumbnail views

### DIFF
--- a/geonode/layers/views.py
+++ b/geonode/layers/views.py
@@ -1411,7 +1411,11 @@ def layer_thumbnail(request, layername):
                 image = _render_thumbnail(request.body)
 
         if not image:
-            return
+            return HttpResponse(
+                content=_('couldn\'t generate thumbnail'),
+                status=500,
+                content_type='text/plain'
+            )
         filename = "layer-%s-thumb.png" % layer_obj.uuid
         layer_obj.save_thumbnail(filename, image)
 

--- a/geonode/maps/views.py
+++ b/geonode/maps/views.py
@@ -1372,7 +1372,7 @@ def map_thumbnail(request, mapid):
 
         if not image:
             return HttpResponse(
-                content=_('couldn\'t generating thumbnail'),
+                content=_('couldn\'t generate thumbnail'),
                 status=500,
                 content_type='text/plain'
             )

--- a/geonode/maps/views.py
+++ b/geonode/maps/views.py
@@ -1371,7 +1371,11 @@ def map_thumbnail(request, mapid):
             image = _render_thumbnail(request.body)
 
         if not image:
-            return
+            return HttpResponse(
+                content=_('couldn\'t generating thumbnail'),
+                status=500,
+                content_type='text/plain'
+            )
         filename = "map-%s-thumb.png" % map_obj.uuid
         map_obj.save_thumbnail(filename, image)
 


### PR DESCRIPTION
This PR include:
- limit http methods on thumbnail views
- fix for

>  ValueError: The view `geonode.maps.views.map_thumbnail` didn't return an HttpResponse object. It returned None instead.

>  ValueError: The view `geonode.layers.views.layer_thumbnail` didn't return an HttpResponse object. It returned None instead.