### PR TITLE
Wait for GeoServer and PostgreSQL instead of failing

### DIFF
--- a/scripts/spcgeonode/django/initialize.py
+++ b/scripts/spcgeonode/django/initialize.py
@@ -6,7 +6,7 @@ This script initializes Geonode
 # Setting up the  context
 #########################################################
 
-import os, requests, json, uuid, django
+import os, requests, json, uuid, django, time
 django.setup()
 
 #########################################################
@@ -14,6 +14,9 @@ django.setup()
 #########################################################
 
 from django.core.management import call_command
+from django.db import connection
+from django.db.utils import OperationalError
+from requests.exceptions import ConnectionError
 from geonode.people.models import Profile
 from oauth2_provider.models import Application
 from django.conf import settings
@@ -25,20 +28,36 @@ admin_email = os.getenv('ADMIN_EMAIL')
 
 
 #########################################################
-# 1. Running the migrations
+# 1. Waiting for PostgreSQL
 #########################################################
 
 print("-----------------------------------------------------")
-print("1. Running the migrations")
+print("1. Waiting for PostgreSQL")
+for _ in range(60):
+    try:
+        connection.ensure_connection()
+        break
+    except OperationalError:
+        time.sleep(1)
+else:
+    connection.ensure_connection()
+connection.close()
+
+#########################################################
+# 2. Running the migrations
+#########################################################
+
+print("-----------------------------------------------------")
+print("2. Running the migrations")
 call_command('migrate', '--noinput')
 
 
 #########################################################
-# 2. Creating superuser if it doesn't exist
+# 3. Creating superuser if it doesn't exist
 #########################################################
 
 print("-----------------------------------------------------")
-print("2. Creating/updating superuser")
+print("3. Creating/updating superuser")
 try:
     superuser = Profile.objects.get(username=admin_username)
     superuser.set_password(admin_password)
@@ -56,11 +75,11 @@ except Profile.DoesNotExist:
 
 
 #########################################################
-# 3. Create an OAuth2 provider to use authorisations keys
+# 4. Create an OAuth2 provider to use authorisations keys
 #########################################################
 
 print("-----------------------------------------------------")
-print("3. Create/update an OAuth2 provider to use authorisations keys")
+print("4. Create/update an OAuth2 provider to use authorisations keys")
 app, created = Application.objects.get_or_create(
     pk=1,
     name='GeoServer',
@@ -80,39 +99,53 @@ else:
 
 
 #########################################################
-# 4. Loading fixtures
+# 5. Loading fixtures
 #########################################################
 
 print("-----------------------------------------------------")
-print("4. Loading fixtures")
+print("5. Loading fixtures")
 call_command('loaddata', 'initial_data')
 
 
 #########################################################
-# 5. Running updatemaplayerip
+# 6. Running updatemaplayerip
 #########################################################
 
 print("-----------------------------------------------------")
-print("5. Running updatemaplayerip")
+print("6. Running updatemaplayerip")
 # call_command('updatelayers') # TODO CRITICAL : this overrides the layer thumbnail of existing layers even if unchanged !!!
 call_command('updatemaplayerip')
 
 
 #########################################################
-# 6. Collecting static files
+# 7. Collecting static files
 #########################################################
 
 print("-----------------------------------------------------")
-print("6. Collecting static files")
+print("7. Collecting static files")
 call_command('collectstatic', '--noinput', verbosity=0)
 
-
 #########################################################
-# 7. Securing GeoServer
+# 8. Waiting for GeoServer
 #########################################################
 
 print("-----------------------------------------------------")
-print("7. Securing GeoServer")
+print("8. Waiting for GeoServer")
+for _ in range(60*5):
+    try:
+        requests.head("http://geoserver:8080/geoserver")
+        break
+    except ConnectionError:
+        time.sleep(1)
+else:
+    requests.head("http://geoserver:8080/geoserver")
+
+#########################################################
+# 9. Securing GeoServer
+#########################################################
+
+print("-----------------------------------------------------")
+print("9. Securing GeoServer")
 
 # Getting the old password
 try:

--- a/scripts/spcgeonode/geoserver/docker-entrypoint.sh
+++ b/scripts/spcgeonode/geoserver/docker-entrypoint.sh
@@ -60,13 +60,43 @@ sed -i -r "s|<user enabled=\".*\" name=\".*\" password=\".*\"/>|<user enabled=\"
 sed -i -r "s|<userRoles username=\".*\">|<userRoles username=\"$ADMIN_USERNAME\">|" "/spcgeonode-geodatadir/security/role/default/roles.xml"
 ADMIN_ENCRYPTED_PASSWORD=""
 
-
 ############################
-# 3. OAUTH2 CONFIGURATION
+# 3. WAIT FOR POSTGRESQL
 ############################
 
 echo "-----------------------------------------------------"
-echo "3. (Re)setting OAuth2 Configuration"
+echo "3. Wait for PostgreSQL to be ready and initialized"
+
+# Wait for PostgreSQL
+set +e
+for i in $(seq 60); do
+    psql -h postgres -U postgres -c "SLECT client_id FROM oauth2_provider_application" &>/dev/null && break
+    sleep 1
+done
+if [ $? != 0 ]; then
+    echo "PostgreSQL not ready or not initialized"
+    exit 1
+fi
+set -e
+
+############################
+# 4. OAUTH2 CONFIGURATION
+############################
+
+echo "-----------------------------------------------------"
+echo "4. (Re)setting OAuth2 Configuration"
+
+# Wait for PostgreSQL
+set +e
+for i in $(seq 60); do
+    psql -h postgres -U postgres -c "SELECT client_id FROM oauth2_provider_application" &>/dev/null && break
+    sleep 1
+done
+if [ $? != 0 ]; then
+    echo "PostgreSQL not ready or not initialized"
+    exit 1
+fi
+set -e
 
 # Edit /spcgeonode-geodatadir/security/filter/geonode-oauth2/config.xml
 
@@ -96,11 +126,11 @@ CLIENT_SECRET=""
 
 
 ############################
-# 3. RE(SETTING) BASE URL
+# 5. RE(SETTING) BASE URL
 ############################
 
 echo "-----------------------------------------------------"
-echo "4. (Re)setting Baseurl"
+echo "5. (Re)setting Baseurl"
 
 sed -i -r "s|<proxyBaseUrl>.*</proxyBaseUrl>|<proxyBaseUrl>$BASEURL</proxyBaseUrl>|" "/spcgeonode-geodatadir/global.xml" 
 


### PR DESCRIPTION
Instead of having multiple containers failing repeatedly as a normal procedure, this patch allows a clean start for geoserver and geonode, thus reducing resource usage and avoiding raising alarms in monitoring systems.