### PR TITLE
Add rabbitmq volume

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,8 @@ services:
     labels:
         org.geonode.component: rabbitmq
         org.geonode.instance.name: geonode
+    volumes:
+      - rabbitmq:/var/lib/rabbitmq
 
   celery:
     restart: unless-stopped
@@ -138,4 +140,5 @@ volumes:
     name: ${COMPOSE_PROJECT_NAME}-dbdata
   dbbackups:
     name: ${COMPOSE_PROJECT_NAME}-dbbackups
-
+  rabbitmq:
+    name: ${COMPOSE_PROJECT_NAME}-rabbitmq

--- a/scripts/spcgeonode/docker-compose.yml
+++ b/scripts/spcgeonode/docker-compose.yml
@@ -156,7 +156,9 @@ services:
 
   # Vanilla RabbitMQ service. This is needed by celery
   rabbitmq:
-    image: rabbitmq:3.7-alpine 
+    image: rabbitmq:3.7-alpine
+    volumes:
+      - rabbitmq:/var/lib/rabbitmq
     restart: on-failure
 
 volumes:
@@ -166,4 +168,4 @@ volumes:
   geodatadir:
   certificates:
   pgdumps:
-
+  rabbitmq:


### PR DESCRIPTION
[RabbitMQ Dockerfile](https://github.com/docker-library/rabbitmq/blob/master/Dockerfile-alpine.template) contains a `VOLUME` command, thus creating a volume even if `docker-compose.yml` do not use it apparently. It is better to be aware of the existence of that volume to avoid further problems and permission issues with third party software (volumes created by containers have different permissions from the ones defined by the compose file in Portainer).