### PR TITLE
Use geoserver instead of gs (partial revert)

### DIFF
--- a/scripts/spcgeonode/django/docker-entrypoint.sh
+++ b/scripts/spcgeonode/django/docker-entrypoint.sh
@@ -23,7 +23,7 @@ else
     fi
 fi
 
-export GEOSERVER_PUBLIC_LOCATION="${SITEURL}/gs/"
+export GEOSERVER_PUBLIC_LOCATION="${SITEURL}/geoserver/"
 
 # Run migrations
 echo 'Running initialize.py...'

--- a/scripts/spcgeonode/docker-compose.yml
+++ b/scripts/spcgeonode/docker-compose.yml
@@ -31,7 +31,7 @@ x-common-django:
     - MEDIA_ROOT=/spcgeonode-media/
     - STATIC_URL=/static/
     - MEDIA_URL=/uploaded/
-    - GEOSERVER_LOCATION=http://nginx/gs/
+    - GEOSERVER_LOCATION=http://nginx/geoserver/
     - ASYNC_SIGNALS=True
     # TODO : we should probably remove this and set Celery to use JSON serialization instead of pickle
     - C_FORCE_ROOT=True


### PR DESCRIPTION
Fix and complete https://github.com/GeoNode/geonode/pull/4208.
I am not sure of the logic behind it, but this is the smallest patch that makes possible again to upload layers in GeoNode.