### PR TITLE
Add suffix geoserver to BASEURL

### DIFF
--- a/scripts/spcgeonode/geoserver/docker-entrypoint.sh
+++ b/scripts/spcgeonode/geoserver/docker-entrypoint.sh
@@ -27,6 +27,7 @@ else
         BASEURL="$BASEURL:$HTTP_PORT"
     fi
 fi
+export BASEURL="$BASEURL/geoserver"
 
 echo "BASEURL is $BASEURL"
 


### PR DESCRIPTION
Fix #4206 

It has been suggested that `gs` should be used instead, but regression tests in https://github.com/GeoNode/geonode-selenium show that it would not work at the moment.