### PR TITLE
Setup Postgres password for SPC Geonode

### DIFF
--- a/scripts/spcgeonode/.env
+++ b/scripts/spcgeonode/.env
@@ -26,7 +26,7 @@ ADMIN_USERNAME=super
 ADMIN_PASSWORD=duper
 ADMIN_EMAIL=admin@example.com
 
-# PostgreSQL superuser password
+# PostgreSQL superuser password (to be set if PostgreSQL is exposed)
 POSTGRES_PASSWORD=
 
 # Django secret key (replace this by any complex and random string)

--- a/scripts/spcgeonode/.env
+++ b/scripts/spcgeonode/.env
@@ -26,6 +26,9 @@ ADMIN_USERNAME=super
 ADMIN_PASSWORD=duper
 ADMIN_EMAIL=admin@example.com
 
+# PostgreSQL superuser password
+POSTGRES_PASSWORD=
+
 # Django secret key (replace this by any complex and random string)
 SECRET_KEY=1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ
 

--- a/scripts/spcgeonode/docker-compose.yml
+++ b/scripts/spcgeonode/docker-compose.yml
@@ -130,6 +130,8 @@ services:
   pgdumper:
     image: olivierdalang/spcgeonode:pgdumper-latest
     build: ./pgdumper/
+    environment:
+      - DATABASE_URL=postgres://postgres:${POSTGRES_PASSWORD}@postgres:5432/postgres
     volumes:
       - pgdumps:/spcgeonode-pgdumps/ 
     restart: on-failure

--- a/scripts/spcgeonode/docker-compose.yml
+++ b/scripts/spcgeonode/docker-compose.yml
@@ -25,7 +25,7 @@ x-common-django:
     # hardcoded
     - DEBUG=False
     - DJANGO_SETTINGS_MODULE=geonode.settings
-    - DATABASE_URL=postgres://postgres:postgres@postgres:5432/postgres
+    - DATABASE_URL=postgres://postgres:${POSTGRES_PASSWORD}@postgres:5432/postgres
     - BROKER_URL=amqp://rabbitmq:5672
     - STATIC_ROOT=/spcgeonode-static/
     - MEDIA_ROOT=/spcgeonode-media/
@@ -109,6 +109,7 @@ services:
       - HTTP_PORT=${HTTP_PORT}
       - ADMIN_USERNAME=${ADMIN_USERNAME}
       - ADMIN_PASSWORD=${ADMIN_PASSWORD}
+      - DATABASE_URL=postgres://postgres:${POSTGRES_PASSWORD}@postgres:5432/postgres
     volumes:
       - geodatadir:/spcgeonode-geodatadir/
     restart: on-failure
@@ -150,6 +151,8 @@ services:
   # PostGIS database.
   postgres:
     image: mdillon/postgis:9.6-alpine
+    environment:
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
     volumes:
       - database:/var/lib/postgresql/data/ 
     restart: on-failure

--- a/scripts/spcgeonode/geoserver/docker-entrypoint.sh
+++ b/scripts/spcgeonode/geoserver/docker-entrypoint.sh
@@ -71,7 +71,7 @@ echo "3. Wait for PostgreSQL to be ready and initialized"
 # Wait for PostgreSQL
 set +e
 for i in $(seq 60); do
-    psql -h postgres -U postgres -c "SLECT client_id FROM oauth2_provider_application" &>/dev/null && break
+    psql "$DATABASE_URL" -c "ON_ERROR_STOP=1; SELECT client_id FROM oauth2_provider_application" &>/dev/null && break
     sleep 1
 done
 if [ $? != 0 ]; then
@@ -102,8 +102,8 @@ set -e
 # Edit /spcgeonode-geodatadir/security/filter/geonode-oauth2/config.xml
 
 # Getting oauth keys and secrets from the database
-CLIENT_ID=$(psql -h postgres -U postgres -c "SELECT client_id FROM oauth2_provider_application WHERE name='GeoServer'" -t | tr -d '[:space:]')
-CLIENT_SECRET=$(psql -h postgres -U postgres -c "SELECT client_secret FROM oauth2_provider_application WHERE name='GeoServer'" -t | tr -d '[:space:]')
+CLIENT_ID=$(psql "$DATABASE_URL" -c "SELECT client_id FROM oauth2_provider_application WHERE name='GeoServer'" -t | tr -d '[:space:]')
+CLIENT_SECRET=$(psql "$DATABASE_URL" -c "SELECT client_secret FROM oauth2_provider_application WHERE name='GeoServer'" -t | tr -d '[:space:]')
 if [ -z "$CLIENT_ID" ] || [ -z "$CLIENT_SECRET" ]; then
     echo "Could not get OAuth2 ID and SECRET from database. Make sure Postgres container is started and Django has finished it's migrations."
     exit 1

--- a/scripts/spcgeonode/pgdumper/Dockerfile
+++ b/scripts/spcgeonode/pgdumper/Dockerfile
@@ -6,11 +6,14 @@ RUN apk add --no-cache postgresql-client && \
     cp /usr/bin/pg_dump /bin/pg_dump && \
     apk del BUIID_DEPS
 
+# envsubst dependency
+RUN apk add --no-cache gettext
 
 # The entrypoint creates the certificate
-ADD crontab crontab 
-RUN /usr/bin/crontab crontab
-RUN rm crontab
+ADD crontab crontab.envsubst
+ADD docker-entrypoint.sh /
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
 
 # We run cron in foreground to update the certificates
 CMD ["/usr/sbin/crond", "-f"]

--- a/scripts/spcgeonode/pgdumper/crontab
+++ b/scripts/spcgeonode/pgdumper/crontab
@@ -5,4 +5,4 @@
 # │     │     │     │     ┌───────────── day of week (0 - 6) (Sunday to Saturday; 7 is also Sunday on some systems)
 # │     │     │     │     │
 
-  0     0     *     *     *     date && pg_dump -C -h postgres -U postgres postgres > /spcgeonode-pgdumps/latest.pgdump && echo "Dump successful"
+  0     0     *     *     *     date && pg_dump -C "${DATABASE_URL}" > /spcgeonode-pgdumps/latest.pgdump && echo "Dump successful"

--- a/scripts/spcgeonode/pgdumper/docker-entrypoint.sh
+++ b/scripts/spcgeonode/pgdumper/docker-entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+envsubst '\$DATABASE_URL' < crontab.envsubst > crontab
+/usr/bin/crontab crontab
+rm crontab crontab.envsubst
+
+exec "$@"


### PR DESCRIPTION
This patch allows to setup a PostgreSQL password for SPC Geonode.

Password is not set by default (the variable is empty, thus avoiding breaking backwards compatibility), but if sets makes safer to expose Postgres port over the internal network (useful if a centralized backup system is in use).

@olivierdalang Do you know how to fix the pgdumper cron script to use an environmental variable for the password?