### PR TITLE
Removes Old Python Dependencies

### DIFF
--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -354,29 +354,19 @@ INSTALLED_APPS = (
     'leaflet',
     'bootstrap3_datetime',
     'django_filters',
-    'django_extensions',
     'django_basic_auth',
     'autocomplete_light',
     'mptt',
-    # 'crispy_forms',
-
-    # 'djkombu',
-    # 'djcelery',
-    # 'kombu.transport.django',
-
     'storages',
     'floppyforms',
 
     # Theme
-    "pinax_theme_bootstrap",
     'django_forms_bootstrap',
 
     # Social
     'avatar',
     'dialogos',
-    # 'pinax.comments',
     'agon_ratings',
-    # 'pinax.ratings',
     'announcements',
     'actstream',
     'user_messages',
@@ -392,9 +382,6 @@ INSTALLED_APPS = (
     'allauth',
     'allauth.account',
     'allauth.socialaccount',
-
-    # Django REST Framework
-    'rest_framework',
 
     # GeoNode
     'geonode',

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,30 +12,16 @@ Django==1.11.20 # python-django (1.8.19 in our ppa) FIXME
 
 # Other
 amqp==2.2.2 # (python-amqp 2.2.2 in our ppa)
-anyjson<=0.3.3 # (python-anyjson 0.3.3 in our ppa)
-arrow==0.12.1 # (python-arrow 0.12.1 in our ppa)
-attrs==17.4.0 # (python-attrs 17.4.0 in our ppa)
 pyyaml>=4.2b1 # (python-pyyaml 3.12 in out ppa)
 beautifulsoup4<=4.4.1 # python-bs4 (4.4.1)
-billiard<=3.5.0.3 # (python-billiard 3.5.0.3 in our ppa)
-MultipartPostHandler<=0.1.0 # python-multipartposthandler (0.1.0)
 httplib2<=0.10.3 # python-httplib2 (0.10.3 in our ppa)
-transifex-client<=0.12.4 # transifex-client (0.11.1)
 Paver<=1.2.4 # python-paver (1.2.4)
-Unidecode<=0.4.19 # python-unidecode (0.04.19)
-django-nose<=1.4.5 # python-django-nose (1.4.5 in our ppa)
 nose<=1.3.7 # python-nose (1.3.7)
-Markdown==2.6.11
-MarkupSafe==1.0
 awesome-slugify<=1.6.5 # python-awesome-slugify (1.6.5)
 django-floppyforms<=1.7.0 # python-django-floppyforms (1.7.0 in our ppa)
-chardet<=3.0.4 # python-chardet (3.0.4 in our ppa)
 decorator<=4.1.2 # python-decorator (4.1.2 in our ppa)
 celery==4.2.1 # python-celery (4.1.0)
 kombu==4.2.1 # python-kombu (4.1.0 in our ppa)
-certifi<=2018.1.18 # depends on python-elasticsearch - python-certifi (2018.1.18 in our ppa)
-click==6.7 # python-click (6.7 in our ppa)
-coreapi==2.3.3 # python-coreapi (2.3.3 in our ppa)
 coreschema==0.0.4 # python-coreschema (0.0.4 in our ppa)
 autoflake<=0.7 # python-autoflake (0.7 in our ppa)
 flake8>=2.6.2,<=3.5.0 # python-flake8 (2.5.4) FIXME
@@ -44,14 +30,11 @@ pyflakes>=1.2.3,<=1.6.0 # python-pyflakes (1.6.0 in our ppa) FIXME
 pep8<=1.7.1 # python-pep8 (1.7.1 in our ppa)
 boto<=2.38.0 # python-boto (2.38.0)
 six<1.11.0 # https://github.com/benjaminp/six/issues/210 (1.10.0 in ppa)
-diff-match-patch<=20121119 # (20121119 in ppa)
 tqdm==4.23.3
 
 # Django Apps
 dj-pagination<=2.3.2 # python-dj-pagination (2.3.2 in our ppa)
 django-celery-monitor<=1.1.2
-django-crispy-forms==1.7.2
-django-extensions>=1.2.5,<=2.0.7 # python-django-extensions (2.0.3 in our ppa)
 django-filter==1.1.0 # python-django-filter (1.1.0 in our ppa)
 django-jsonfield<=1.0.1 # python-django-jsonfield (0.9.15, 1.0.1 in our ppa)
 django-jsonfield-compat<=0.4.4 # python-django-jsonfield-compat (0.4.4 in our ppa)
@@ -62,27 +45,12 @@ django-treebeard<=4.2.1 # django-treebeard (4.2.1 in our ppa)
 django-guardian<=1.4.9 # django-guardian (1.4.9 in our ppa)
 django-downloadview<=1.9 # python-django-downloadview (1.9 in our ppa)
 django-polymorphic<2.0 # python-django-polymorphic (1.3)
-django-reversion<=2.0.13 # python-django-reversion (2.0.13 in our ppa)
-django-suit<=0.2.26 # python-django-suit (0.2.26 in our ppa)
 django-tastypie<=0.14.0 # python-django-tastypie (0.14.0 in our ppa)
 django-invitations<=1.9.2 # python-django-invitations (1.9.2 in our ppa)
-djangorestframework==3.8.2
-# djangorestframework-gis<=0.12 # TODO
-# django-rest-swagger==2.1.2 # python-django-rest-swagger (2.1.2 in our ppa)
-# drf-nested-routers==0.90.0 # python-drf-nested-routers (0.90.0 in our ppa)
-# drf-openapi==1.3.0 # python-drf-openapi (1.3.0 in our ppa)
 geonode-oauth-toolkit>=1.1.2rc0 # python-django-oauth-toolkit (0.12.0 in our ppa)
 oauthlib==2.1.0 # python-oauthlib (2.0.6 in our ppa) FIXME
-requests-oauthlib==1.0.0
-asn1crypto==0.24.0
-cffi==1.11.5
-cryptography==2.3.1
-idna>=2.5,<2.7  # (2.6 in our ppa)
-pycparser==2.18
-pyopenssl==18.0.0
 
 # geopython dependencies
-proj==0.1.0
 pyproj>=1.9.5,<=1.9.5.1 # python-pyproj (1.9.5.1)
 OWSLib==0.16.0 # python-owslib (0.15.0 in our ppa) FIXME
 pycsw==2.2.0 # python-pycsw (1.10.1, 2.0.0, 2.0.3 in our ppa) FIXME
@@ -95,27 +63,14 @@ mercantile==1.0.4
 # Django Apps
 dj-database-url<=0.4.2 # , python-dj-database-url (0.4.1 in ppa)
 Pinax<=0.9a2 # python-pinax (0.9a2 in our ppa)
-# pinax-comments==0.1.1
 pinax-notifications==4.1.0 # (4.1.0 in our ppa)
-pinax-theme-bootstrap<=8.0.1 # python-pinax-theme-bootstrap (8.0.1 in our ppa)
 django-forms-bootstrap<=3.1.0 # python-django-forms-bootstrap (3.1.0 in our ppa)
 django-allauth<=0.34.0 # python-django-allauth (0.34.0 in our ppa)
 django-activity-stream<=0.6.5 # python-django-activity-stream (0.6.5 in our ppa)
 django-appconf<=1.0.2 # (1.0.2 in ppa)
-django-apptemplates==1.4 # # python-django-apptemplates (1.4 in our ppa)
 django-autocomplete-light==2.3.3 # (2.3.3.1 in ppa) # pinned because >=2.3.4 throw an exception on startup
-django-autofixture<=0.12.1 # python-django-autofixture (0.12.1 in our ppa)
-django-autoslug<=1.9.3 # python-django-autoslug (1.9.3 in our ppa)
-django-braces<=1.12.0 # pytnon-django-braces (1.12.0 in our ppa)
-django-celery-beat==1.1.1 # python-django-celery-beat (1.1.1 in our ppa)
-django-celery-results==1.0.1 # python-django-celery-results (1.0.1 in our ppa)
 django-geonode-client>=1.0.0 # python-django-geonode-client (1.0.0 in our ppa)
-django-model-utils==3.1.1 # python-django-model-utils (3.1.1 in our ppa)
 django-modeltranslation>=0.11,<=0.12.2 # python-django-modeltranslation (0.12 Debian) FIXME
-django-simple-history<=1.9.0 # python-django-simple-history (1.9.0 in our ppa)
-django-import-export<=1.0.0 # python-django-import-export (1.0.0 in our ppa)
-django-js-asset<=1.0.0 # python-django-js-asset (1.0.0 in our ppa)
-django-utils<=0.0.2 # python-django-utils (0.0.2 in our ppa)
 django-basic-authentication-decorator==0.9 # python-django-basic-authentication-decorator (0.9 in our ppa)
 
 # GeoNode org maintained apps.
@@ -144,44 +99,23 @@ django-storages<=1.6.5 # python-django-storages (1.6.5 in our ppa)
 python-memcached<=1.59 # python-memcached (1.59 in our ppa)
 
 # Contribs
-et-xmlfile<=1.0.1 # python-et-xmlfile (1.0.1 in our ppa)
-unicodecsv<=0.14.1 # python-unicodecsv (0.14.1 in our ppa)
-urllib3==1.24.1
-vine<=1.1.4 # (1.1.4 in our ppa)
-xlrd<=1.1.0 # (1.1.0 in ppa)
-xlwt<=1.3.0 # (1.3.0 in our ppa)
 xmltodict<=0.10.2 # (0.9.2 in ppa)
-funcsigs<=1.0.2 # (1.0.2 in our ppa)
-geolinks<=0.2.0 # python-geolinks (0.2.0 in ppa)
 inflection<=0.3.1  # python-inflection (0.3.1 in our ppa)
-ipaddress<=1.0.18 # (1.0.18 in our ppa)
 jdcal<=1.3 # (1.3 in our ppa)
-mccabe>=0.5.3,<=0.6.1 # (0.4.0 in our ppa) FIXME
 mock<=2.0.0 # (1.3.0 in ppa) FIXME
-numpy<=1.13.1 # (1.11.0 in ppa) FIXME
-odfpy<=1.3.6 # python-odfpy (1.3.6 in our ppa)
-openpyxl<=2.5.0 # (2.5.0 in our ppa)
-pbr<=3.1.1 # (1.8.0 in ppa) FIXME
 python-dateutil<=2.6.1 # (2.6.1 in our ppa)
-python-gnupg<=0.4.1 # (0.4.1 in our ppa)
-python-mimeparse<=1.6.0 # (1.6.0 in our ppa)
 pytz<=2018.3 # python-pytz (2018.3 in our ppa)
-regex<=2016.7.21 # (0.1.20160110 in ppa)
 requests>=2.20.0 # (2.18.4 in our ppa) FIXME
 simplejson<=3.13.2 # (3.13.2 in our ppa)
-tablib<=0.12.1 # (0.12.1 in our ppa)
 timeout-decorator==0.4.0 # TODO
-typing<=3.6.4 # python-typing (3.6.4 in our ppa)
 
 # required by monitoring
 psutil==5.4.8 # (3.4.2 in ppa)
 django-cors-headers<=2.2.0 # python-django-cors-headers (2.2.0 in our ppa)
-django-cuser==2017.3.16 # python-django-cuser (2017.3.16 in our ppa)
 django-multi-email-field<=0.5.1 # python-django-multi-email-field (0.5.1 in our ppa)
 # WeasyPrint
 user-agents # python-user-agents (1.1.0 in our ppa)
 xmljson # python-xmljson (0.1.9 in our ppa)
-geoip2==2.8.0
 django-ipware<2.2
 # no version here, use latest one with fresh data
 pycountry
@@ -203,16 +137,10 @@ invoke==0.22.1
 
 # tests
 coverage<=4.5.1
-factory-boy<=2.9.2
-Faker<=0.8.4
-more-itertools==4.1.0
-parse==1.8.2
 parse-type==0.4.1
 poster~=0.8.1
-py==1.5.3
 pytest==3.5.0
 pytest-bdd==2.20.0
-selenium==3.9.0
 splinter==0.7.7
 pytest-splinter==1.8.5
 pytest-django==3.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,6 +49,7 @@ django-tastypie<=0.14.0 # python-django-tastypie (0.14.0 in our ppa)
 django-invitations<=1.9.2 # python-django-invitations (1.9.2 in our ppa)
 geonode-oauth-toolkit>=1.1.2rc0 # python-django-oauth-toolkit (0.12.0 in our ppa)
 oauthlib==2.1.0 # python-oauthlib (2.0.6 in our ppa) FIXME
+pyopenssl==18.0.0
 
 # geopython dependencies
 pyproj>=1.9.5,<=1.9.5.1 # python-pyproj (1.9.5.1)


### PR DESCRIPTION
Removes unnecessary dependencies from the requirements.txt and settings.py files.  This PR is connected to issue https://github.com/GeoNode/geonode/issues/4255.  I verified that the tests pass locally.  They're also working on Travis CI now as well.

All of these dependencies were checked against the Python codebase to make sure they weren't being used, and the tests seem to agree.  I also did some manual smoke testing to make sure nothing was broken.  If the Travis CI tests show anything different, or if anyone sees a dependency they think we still need I'll take a look and add them back if necessary.  