### PR TITLE
8 KB buffer for spc uwsgi

### DIFF
--- a/scripts/spcgeonode/docker-compose.yml
+++ b/scripts/spcgeonode/docker-compose.yml
@@ -55,7 +55,7 @@ services:
       retries: 1
       start_period: 60s
     entrypoint: ["/spcgeonode/scripts/spcgeonode/django/docker-entrypoint.sh"]
-    command: "uwsgi --chdir=/spcgeonode --module=geonode.wsgi --socket=:8000 --http=127.0.0.1:8001 --processes=5"
+    command: "uwsgi --chdir=/spcgeonode --module=geonode.wsgi --socket=:8000 --http=127.0.0.1:8001 --processes=5 --buffer-size=8192"
 
   # Celery worker that executes celery tasks created by Django.
   celery:


### PR DESCRIPTION
This patch fixes this kind of errors, which result in a HTTP 502:

```
invalid request block size: 6871 (max 4096)...skip
invalid request block size: 6817 (max 4096)...skip
invalid request block size: 6824 (max 4096)...skip
invalid request block size: 6798 (max 4096)...skip
```