### PR TITLE
8 KB buffer for uwsgi

### DIFF
--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -9,3 +9,4 @@ module = geonode.wsgi:application
 master = 1
 processes = 4
 threads = 2
+buffer-size = 8192


### PR DESCRIPTION
Same as https://github.com/GeoNode/geonode/pull/4344 but for non-spc setups.