### PR TITLE
#4348 fix failing read_the_docs

### DIFF
--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -75,7 +75,7 @@ poster==0.8.1
 psutil==5.6.1
 psycopg2==2.7.7
 pycountry
-pycsw==2.2.0
+#pycsw==2.2.0
 pyopenssl==19.0.0
 pyproj==1.9.5.1
 pytest==4.3.1
@@ -88,7 +88,7 @@ python-memcached==1.59
 pytz==2018.9
 pyyaml>=4.2b1
 requests>=2.20.0
-Shapely==1.5.17
+#Shapely==1.5.17
 simplejson==3.16.0
 splinter==0.10.0
 # SQLAlchemy is a mandatory dependency of pycsw 2.2.0


### PR DESCRIPTION
As #4348 describes read the docs is failing because of Shapely. I think it could be fixed by installing libgeos-dev before building. Anyways I do not see a way how to force read_the_docs to do so.

Hence I would comment Shapely and pycsw (shapely is a requirement) in requirements_docs.txt. (_I do not see a reason why those would be needed for sphinx._)

Closes: #4348  