### PR TITLE
#4358 fix thumbnail creation with different bbox

### DIFF
--- a/geonode/layers/utils.py
+++ b/geonode/layers/utils.py
@@ -1031,7 +1031,7 @@ def create_gs_thumbnail_geonode(instance, overwrite=False, check_bbox=False):
     if local_bboxes:
         for _bbox in local_bboxes:
             if bbox is None:
-                bbox = _bbox
+                bbox = list(_bbox)
             else:
                 if bbox[0] > _bbox[0]:
                     bbox[0] = _bbox[0]


### PR DESCRIPTION
I think there is a little bug in create_gs_thumbnail_geonode.

```
    if local_bboxes:
        for _bbox in local_bboxes:
            if bbox is None:
                bbox = _bbox
            else:
                if bbox[0] > _bbox[0]:
                    bbox[0] = _bbox[0]
                  [...]
``` 

Let´s say we save a map with several layers and bbox is None for the first.
_bbox will be assigned. In this case bbox is now a tuple looking something like

`['14.4841477044', '14.484949669', '40.750922921', '40.7518136301', 'EPSG:4326']
`

Now the next layer has a bbox and tries to update it which will fail with Error 500 as tuples are immutable

`TypeError at /maps/new/data 'tuple' object does not support item assignment`

My fix just converts the tuple to a list making it mutable if needed.

Closes: #4358 