### PR TITLE
Pin geonode-oauth-toolkit version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ django-downloadview<=1.9
 django-polymorphic==2.0.3
 django-tastypie<=0.14.0
 django-invitations<=1.9.2
-geonode-oauth-toolkit>=1.1.2rc0
+geonode-oauth-toolkit==1.1.2rc0
 oauthlib==3.0.1
 pyopenssl==19.0.0
 


### PR DESCRIPTION
This fixes an error described in https://github.com/GeoNode/geonode/issues/4339#issuecomment-479649551 causing migrations to fail on new dev environments.