### PR TITLE
Fixes: #4374, added missing quote to trans

### DIFF
--- a/geonode/services/templates/services/service_list.html
+++ b/geonode/services/templates/services/service_list.html
@@ -14,7 +14,7 @@
   <thead>
   	<th>{% trans "Title" %}</th>
   	<th>{% trans "URL" %}</th>
-    <th>{% trans Type" %}</th>
+    <th>{% trans "Type" %}</th>
   </thead>
   {% for service in services %}
   <tr>


### PR DESCRIPTION
Missing quotes makes service page fail. This PR corrects it:

`<th>{% trans Type" %}</th>`
https://github.com/GeoNode/geonode/blob/master/geonode/services/templates/services/service_list.html#L17

Closes: #4374