### PR TITLE
Fixes: #4443 issues translations on index

### DIFF
--- a/geonode/people/templates/people/profile_detail.html
+++ b/geonode/people/templates/people/profile_detail.html
@@ -176,7 +176,7 @@
   {% endif %}
 </div>
 
-<div class="col-md-9">
+<div class="col-xs-12 col-md-9">
   <h4>{% trans "Resources" %}</h4>
   <div class="col-md-12">
     {% include "people/_profile_filters.html" %}
@@ -184,7 +184,7 @@
   <!-- <div class="col-md-12">
     {% include "search/_sort_filters.html" %}
   </div> -->
-  <div class="col-md-12">
+  <div class=" col-xs-12 col-md-12">
     {% include 'base/_resourcebase_snippet.html' %}
   </div>
   <div class="col-md-12">

--- a/geonode/templates/base.html
+++ b/geonode/templates/base.html
@@ -291,9 +291,9 @@
                 <form id="search" action="{% url "search" %}" >
                   <span class="fa fa-search"></span>
                   {% if HAYSTACK_SEARCH %}
-                  <input id="search_input" type="text" placeholder="Search" name="q">
+                  <input id="search_input" type="text" placeholder="{% trans 'Search' %}" name="q">
                   {% else %}
-                  <input id="search_input" type="text" placeholder="Search" name="title__icontains">
+                  <input id="search_input" type="text" placeholder="{% trans 'Search' %}" name="title__icontains">
                   {% endif %}
                 </form>
               </div>

--- a/geonode/templates/index.html
+++ b/geonode/templates/index.html
@@ -5,7 +5,7 @@
 
 {% block title %} {% trans "Welcome!" %} - {{ block.super }} {% endblock %}
 
-{% block body_class %}{% trans "home" %}{% endblock %}
+{% block body_class %}home{% endblock %}
 
 {% block middle %}
   {{ block.super }}
@@ -40,9 +40,9 @@
       			<form id="search" action="{% url "search" %}" >
       				<span class="fa fa-search fa-3x"></span>
       				{% if HAYSTACK_SEARCH %}
-      				<input id="search_input" type="text" placeholder="Search" class="form-control" name="q">
+      				<input id="search_input" type="text" placeholder="{% trans 'Search' %}" class="form-control" name="q">
       				{% else %}
-      				<input id="search_input" type="text" placeholder="Search" class="form-control" name="title__icontains">
+      				<input id="search_input" type="text" placeholder="{% trans 'Search' %}" class="form-control" name="title__icontains">
       				{% endif %}
       			</form>
       		</div>


### PR DESCRIPTION
The current index page has minor issues regarding translations:

1. the base class which is used in body tag is used for styling. It shouldn't be translated otherwise the css selector will fail:

https://github.com/GeoNode/geonode/blob/master/geonode/templates/index.html#L8

2. the search box placeholder should be translated

https://github.com/GeoNode/geonode/blob/master/geonode/templates/index.html#L43
https://github.com/GeoNode/geonode/blob/master/geonode/templates/base.html#L294