### PR TITLE
[Draft] Make templates use static url set by Django

### DIFF
--- a/geonode/static/geonode/js/search/cart.js
+++ b/geonode/static/geonode/js/search/cart.js
@@ -70,10 +70,10 @@
         );
       };
     })
-    .directive('resourceCart', [function(){
+    .directive('resourceCart', ['$sce', function($sce){
       return {
         restrict: 'EA',
-        templateUrl: siteUrl + "static/geonode/js/templates/cart.html",
+        templateUrl: $sce.trustAsResourceUrl(staticUrl + "geonode/js/templates/cart.html"),
         link: function($scope, $element){
           // Don't use isolateScope, but add to parent scope
           $scope.facetType = $element.attr("data-facet-type");

--- a/geonode/static/geonode/js/status/main.js
+++ b/geonode/static/geonode/js/status/main.js
@@ -13,7 +13,7 @@ requirejs.config({
      },
      waitSeconds: 5
   },
-  baseUrl: siteUrl + 'static/lib/js',
+  baseUrl: staticUrl + 'lib/js',
   shim: {
     'underscore': { exports: '_'}
   },

--- a/geonode/static/geonode/js/upload/csv.js
+++ b/geonode/static/geonode/js/upload/csv.js
@@ -13,7 +13,7 @@ requirejs.config({
      },
      waitSeconds: 5
   },
-  baseUrl: siteUrl + 'static/lib/js',
+  baseUrl: staticUrl + 'lib/js',
   shim: {
     'underscore': { exports: '_'}
   },

--- a/geonode/static/geonode/js/upload/main.js
+++ b/geonode/static/geonode/js/upload/main.js
@@ -13,7 +13,7 @@ requirejs.config({
      },
      waitSeconds: 5
   },
-  baseUrl: siteUrl + 'static/lib/js',
+  baseUrl: staticUrl + 'lib/js',
   shim: {
     'underscore': { exports: '_'}
   },

--- a/geonode/static/geonode/js/upload/srs.js
+++ b/geonode/static/geonode/js/upload/srs.js
@@ -13,7 +13,7 @@ requirejs.config({
      },
      waitSeconds: 5
   },
-  baseUrl: siteUrl + 'static/lib/js',
+  baseUrl: staticUrl + 'lib/js',
   shim: {
     'underscore': { exports: '_'}
   },

--- a/geonode/static/geonode/js/upload/time.js
+++ b/geonode/static/geonode/js/upload/time.js
@@ -12,7 +12,7 @@ requirejs.config({
      },
      waitSeconds: 5
   },
-  baseUrl: siteUrl + 'static/lib/js',
+  baseUrl: staticUrl + 'lib/js',
   shim: {
     'underscore': { exports: '_'}
   },

--- a/geonode/static/geonode/js/utils/batch_ops.js
+++ b/geonode/static/geonode/js/utils/batch_ops.js
@@ -13,7 +13,7 @@ requirejs.config({
      },
      waitSeconds: 5
   },
-  baseUrl: siteUrl + 'static/lib/js',
+  baseUrl: staticUrl + 'lib/js',
   shim: {
     'underscore': { exports: '_'}
   },

--- a/geonode/templates/base.html
+++ b/geonode/templates/base.html
@@ -203,6 +203,7 @@
 
     <script>
         var siteUrl = '{{ SITEURL }}'.replace(/\/?$/, '/');
+        var staticUrl = '{% static '' %}';
     </script>
 
   </head>


### PR DESCRIPTION
Replaces manual generation of URLs for static assets in various templates
with using Django's `{% static %}` tag to retrieve the base URL for static
assets.

Fixes https://github.com/GeoNode/geonode/issues/3738