### PR TITLE
Add new GeoTIFF for Travis CI (Fixes #4497)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -197,6 +197,7 @@ install:
   - if [ "$TEST_RUN_SELENIUM" = "True" ]; then
       pip install -r geonode-selenium/requirements.txt;
       wget https://download.osgeo.org/geotiff/samples/spot/chicago/UTM2GTIF.TIF -P geonode-selenium/data;
+      wget https://download.osgeo.org/geotiff/samples/made_up/ntf_nord.tif -P geonode-selenium/data;
       wget https://github.com/mozilla/geckodriver/releases/download/$GECKODRIVER_VERSION/geckodriver-$GECKODRIVER_VERSION-linux64.tar.gz -O geckodriver.tar.gz;
       mkdir bin;
       tar zxf geckodriver.tar.gz -C bin;


### PR DESCRIPTION
In order to fix the Selenium tests for the regular Docker setup, we are going to switch to a different GeoTIFF file. In order not to break the CI system, I will just add this new file first, before updating geonode-selenium.