### PR TITLE
Use GeoServer 2.14.4 for SPCGeoNode

### DIFF
--- a/scripts/spcgeonode/geoserver/Dockerfile
+++ b/scripts/spcgeonode/geoserver/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:8-jre-alpine
 
-ARG version=2.14.2
+ARG version=2.14.4
 ARG branch=2.14.x
 ARG plugins=
 


### PR DESCRIPTION
Fixes #4522.

We should probably update https://github.com/GeoNode/geoserver-docker, that is currently using 2.15.x instead of 2.14.x, even if on this repository we reverted that change back.

It would probably make sense to have these Docker repositories as submodules of the main Geonode repository or just copy them inside, as we do for SPCGeoNode.