### PR TITLE
Use python_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(name='GeoNode',
       long_description=open('README.md').read(),
       classifiers=[
           "Development Status :: 4 - Beta"],
+      python_requires='>=2.7, <3',
       keywords='',
       author='GeoNode Developers',
       author_email='dev@geonode.org',


### PR DESCRIPTION
https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires

This would also allow Dependabot to figure out the Python version we are targeting and avoid proposing Python 3 only upgrades.