### PR TITLE
Fix pygdal break with recent version of numpy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -44,6 +44,7 @@ SQLAlchemy==1.3.3 # required by PyCSW
 Shapely==1.6.4.post2
 mercantile==1.0.4
 geoip2==2.9.0
+numpy==1.16.*
 
 # # Apps with packages provided in GeoNode's PPA on Launchpad.
 

--- a/scripts/spcgeonode/django/Dockerfile
+++ b/scripts/spcgeonode/django/Dockerfile
@@ -30,13 +30,15 @@ RUN echo "Updating apt-get" && \
 
 # Install python dependencies
 RUN echo "Geonode python dependencies"
-RUN pip install pygdal==$(gdal-config --version).*
 RUN pip install celery==4.1.0 # see https://github.com/GeoNode/geonode/pull/3714
 
 # Install geonode dependencies
 ADD requirements.txt /requirements.txt
 RUN pip install -r requirements.txt
 RUN rm requirements.txt
+
+# Install pygdal (after requirements https://github.com/GeoNode/geonode/pull/4599)
+RUN pip install pygdal==$(gdal-config --version).*
 
 # Install geonode
 RUN mkdir /spcgeonode


### PR DESCRIPTION
This PR fixes: https://github.com/GeoNode/geonode/issues/4593

Short Version:
Following the manual a user will install pygdal. As pygdal set's the required Version for numpy loose like `numpy>=1.0.0` we will end with `numpy==1.17.*` which has no support for python 2.7. 

By pinning the version in requirements to `1.16.*` the installation will succeed. (Of course only if requirements are installed before pygdal which the docs already suggest)