### PR TITLE
Solve letsencrypt ssl error

### DIFF
--- a/scripts/spcgeonode/letsencrypt/Dockerfile
+++ b/scripts/spcgeonode/letsencrypt/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.6
 
 # 1-2. Install system dependencies
-RUN apk add --no-cache certbot
+RUN apk add --no-cache certbot py-pip && pip install pyopenssl==16.0.0
 
 # Installing scripts
 ADD docker-entrypoint.sh /docker-entrypoint.sh

--- a/scripts/spcgeonode/letsencrypt/Dockerfile
+++ b/scripts/spcgeonode/letsencrypt/Dockerfile
@@ -1,7 +1,8 @@
 FROM alpine:3.6
 
 # 1-2. Install system dependencies
-RUN apk add --no-cache certbot py-pip && pip install pyopenssl==16.0.0
+RUN apk add --no-cache certbot py-pip && pip install pyopenssl==16.0.0 # Need to downgrade PyOpenSSL to 16.0.0 to avoid conflicts and solve the cryptography error : https://github.com/plesk/letsencrypt-plesk/issues/117
+
 
 # Installing scripts
 ADD docker-entrypoint.sh /docker-entrypoint.sh


### PR DESCRIPTION
For more information watch here : https://github.com/plesk/letsencrypt-plesk/issues/117

Before, error was like this : 

```
pkg_resources.ContextualVersionConflict: (cryptography 1.8.1 (/usr/lib/python2.7/site-packages), Requirement.parse('cryptography>=2.1.4'), set(['PyOpenSSL']))
```