### PR TITLE
[Fixes #4639] Switch library "gsconfig" to "geoserver-restoconfig"

### DIFF
--- a/geonode/geoserver/createlayer/utils.py
+++ b/geonode/geoserver/createlayer/utils.py
@@ -154,7 +154,7 @@ def get_or_create_datastore(cat, workspace=None, charset="UTF-8"):
         raise GeoNodeException(msg)
 
     try:
-        ds = cat.get_store(dsname, workspace)
+        ds = cat.get_store(dsname, workspace=workspace)
     except FailedRequestError:
         ds = cat.create_datastore(dsname, workspace=workspace)
 
@@ -177,7 +177,7 @@ def get_or_create_datastore(cat, workspace=None, charset="UTF-8"):
 
     # we need to reload the ds as gsconfig-1.0.6 apparently does not populate ds.type
     # using create_datastore (TODO fix this in gsconfig)
-    ds = cat.get_store(dsname, workspace)
+    ds = cat.get_store(dsname, workspace=workspace)
 
     return ds
 

--- a/geonode/geoserver/helpers.py
+++ b/geonode/geoserver/helpers.py
@@ -262,7 +262,7 @@ def get_sld_for(gs_catalog, layer):
     if gs_layer and gs_layer.resource and gs_layer.resource.resource_type == 'featureType':
         res = gs_layer.resource
         res.fetch()
-        ft = res.store.get_resources(res.name)
+        ft = res.store.get_resources(name=res.name)
         ft.fetch()
         for attr in ft.dom.find("attributes").getchildren():
             attr_binding = attr.find("binding")
@@ -295,7 +295,7 @@ def fixup_style(cat, resource, style):
     for lyr in layers:
         if lyr.default_style.name in _style_templates:
             logger.info("%s uses a default style, generating a new one", lyr)
-            name = _style_name(lyr)
+            name = _style_name(lyr.resource)
             if style is None:
                 sld = get_sld_for(cat, lyr)
             else:
@@ -389,9 +389,9 @@ def cascading_delete(cat, layer_name):
                 logger.debug(
                     'cascading delete was called on a layer where the workspace was not found')
                 return
-            resource = cat.get_resource(name, store=store, workspace=workspace)
+            resource = cat.get_resource(name=name, store=store, workspace=workspace)
         else:
-            resource = cat.get_resource(layer_name)
+            resource = cat.get_resource(name=layer_name)
     except EnvironmentError as e:
         if e.errno == errno.ECONNREFUSED:
             msg = ('Could not connect to geoserver at "%s"'
@@ -421,7 +421,7 @@ def cascading_delete(cat, layer_name):
             pass
         gs_styles = [x for x in cat.get_styles()]
         if settings.DEFAULT_WORKSPACE:
-            gs_styles = gs_styles + [x for x in cat.get_styles(workspace=settings.DEFAULT_WORKSPACE)]
+            gs_styles = gs_styles + [x for x in cat.get_styles(workspaces=settings.DEFAULT_WORKSPACE)]
             ws_styles = []
             for s in styles:
                 if s is not None and s.name not in _default_style_names:
@@ -549,13 +549,13 @@ def gs_slurp(
                 if store is None:
                     resources = []
                 else:
-                    resources = cat.get_resources(store=store)
+                    resources = cat.get_resources(stores=[store])
             else:
-                resources = cat.get_resources(workspace=workspace)
+                resources = cat.get_resources(workspaces=[workspace])
 
     elif store is not None:
         store = get_store(cat, store)
-        resources = cat.get_resources(store=store)
+        resources = cat.get_resources(stores=[store])
     else:
         resources = cat.get_resources()
     if remove_deleted:
@@ -1245,7 +1245,7 @@ def create_geoserver_db_featurestore(
     ds_exists = False
     try:
         if dsname:
-            ds = cat.get_store(dsname)
+            ds = cat.get_store(dsname, workspace=workspace)
         else:
             return None
         if ds is None:
@@ -1288,7 +1288,10 @@ def create_geoserver_db_featurestore(
     if ds_exists:
         ds.save_method = "PUT"
 
+    logger.info('Updating target datastore % s' % dsname)
     cat.save(ds)
+
+    logger.info('Reloading target datastore % s' % dsname)
     ds = get_store(cat, dsname, workspace=workspace)
     assert ds.enabled
 
@@ -1303,17 +1306,17 @@ def _create_featurestore(name, data, overwrite=False, charset="UTF-8", workspace
     except BaseException as e:
         logger.exception(e)
     store = get_store(cat, name, workspace=workspace)
-    return store, cat.get_resource(name, store=store, workspace=workspace)
+    return store, cat.get_resource(name=name, store=store, workspace=workspace)
 
 
 def _create_coveragestore(name, data, overwrite=False, charset="UTF-8", workspace=None):
     cat = gs_catalog
     try:
-        cat.create_coveragestore(name, data, overwrite=overwrite)
+        cat.create_coveragestore(name, path=data, overwrite=overwrite, upload_data=True)
     except BaseException as e:
         logger.exception(e)
     store = get_store(cat, name, workspace=workspace)
-    return store, cat.get_resource(name, store=store, workspace=workspace)
+    return store, cat.get_resource(name=name, store=store, workspace=workspace)
 
 
 def _create_db_featurestore(name, data, overwrite=False, charset="UTF-8", workspace=None):
@@ -1335,7 +1338,7 @@ def _create_db_featurestore(name, data, overwrite=False, charset="UTF-8", worksp
                               overwrite=overwrite,
                               workspace=workspace,
                               charset=charset)
-        resource = cat.get_resource(name, store=ds, workspace=workspace)
+        resource = cat.get_resource(name=name, store=ds, workspace=workspace)
         assert resource is not None
         return ds, resource
     except Exception:
@@ -1350,7 +1353,6 @@ def _create_db_featurestore(name, data, overwrite=False, charset="UTF-8", worksp
 
 
 def get_store(cat, name, workspace=None):
-
     # Make sure workspace is a workspace object and not a string.
     # If the workspace does not exist, continue as if no workspace had been defined.
     if isinstance(workspace, basestring):
@@ -1780,7 +1782,7 @@ def set_time_info(layer, attribute, end_attribute, presentation,
         raise ValueError('no such layer: %s' % layer.name)
     resource = layer.resource if layer else None
     if not resource:
-        resources = gs_catalog.get_resources(store=layer.name)
+        resources = gs_catalog.get_resources(stores=[layer.name])
         if resources:
             resource = resources[0]
 
@@ -1813,7 +1815,7 @@ def get_time_info(layer):
         raise ValueError('no such layer: %s' % layer.name)
     resource = layer.resource if layer else None
     if not resource:
-        resources = gs_catalog.get_resources(store=layer.name)
+        resources = gs_catalog.get_resources(stores=[layer.name])
         if resources:
             resource = resources[0]
 
@@ -2133,7 +2135,7 @@ def set_time_dimension(cat, name, workspace, time_presentation, time_presentatio
     layer = cat.get_layer(name)
     resource = layer.resource if layer else None
     if not resource:
-        resources = cat.get_resources(store=name) or cat.get_resources(store=name, workspace=workspace)
+        resources = cat.get_resources(stores=[name]) or cat.get_resources(stores=[name], workspaces=[workspace])
         if resources:
             resource = resources[0]
 

--- a/geonode/geoserver/management/commands/find_geoserver_broken_layers.py
+++ b/geonode/geoserver/management/commands/find_geoserver_broken_layers.py
@@ -29,9 +29,9 @@ from geonode.people.models import Profile
 
 def is_gs_resource_valid(layer):
     gs_resource = gs_catalog.get_resource(
-            layer.name,
-            store=layer.store,
-            workspace=layer.workspace)
+        name=layer.name,
+        store=layer.store,
+        workspace=layer.workspace)
     if gs_resource:
         return True
     else:

--- a/geonode/geoserver/upload.py
+++ b/geonode/geoserver/upload.py
@@ -165,10 +165,10 @@ def geoserver_upload(
     # Verify the resource was created
     if not gs_resource:
         gs_resource = gs_catalog.get_resource(
-            name,
+            name=name,
             workspace=workspace)
         if not gs_resource:
-            gs_resource = gs_catalog.get_resource(name)
+            gs_resource = gs_catalog.get_resource(name=name)
     if gs_resource is not None:
         assert gs_resource.name == name
     else:
@@ -221,7 +221,11 @@ def geoserver_upload(
     style = None
     if sld is not None:
         try:
-            style = cat.get_style(name, workspace=settings.DEFAULT_WORKSPACE) or cat.get_style(name)
+            style = cat.get_style(name, workspace=settings.DEFAULT_WORKSPACE)
+        except geoserver.catalog.FailedRequestError:
+            style = cat.get_style(name)
+
+        try:
             overwrite = style or False
             cat.create_style(name, sld, overwrite=overwrite, raw=True, workspace=settings.DEFAULT_WORKSPACE)
         except geoserver.catalog.ConflictingDataError as e:

--- a/geonode/local_settings.py.geoserver.sample
+++ b/geonode/local_settings.py.geoserver.sample
@@ -294,7 +294,7 @@ LOGGING = {
             "handlers": ["console"], "level": "INFO", },
         "geonode.qgis_server": {
             "handlers": ["console"], "level": "ERROR", },
-        "gsconfig.catalog": {
+        "geoserver-restconfig.catalog": {
             "handlers": ["console"], "level": "ERROR", },
         "owslib": {
             "handlers": ["console"], "level": "ERROR", },

--- a/geonode/security/tests.py
+++ b/geonode/security/tests.py
@@ -1268,7 +1268,7 @@ class GisBackendSignalsTests(ResourceTestCaseMixin, GeoNodeBaseTestSupport):
                 set_layer_style(test_perm_layer, test_perm_layer.alternate, sld)
 
             fixup_style(gs_catalog, test_perm_layer.alternate, None)
-            self.assertIsNone(get_sld_for(gs_catalog, test_perm_layer))
+            self.assertIsNotNone(get_sld_for(gs_catalog, test_perm_layer))
             _log("3. ------------ %s " % get_sld_for(gs_catalog, test_perm_layer))
 
             create_gs_thumbnail(test_perm_layer, overwrite=True)

--- a/geonode/services/serviceprocessors/wms.py
+++ b/geonode/services/serviceprocessors/wms.py
@@ -380,7 +380,10 @@ class WmsServiceHandler(base.ServiceHandlerBase,
         store = self._get_store(create=False)
         cat = store.catalog
         workspace = store.workspace
-        layer_resource = cat.get_resource(layer_meta.id, store, workspace)
+        layer_resource = cat.get_resource(
+            name=layer_meta.id,
+            store=store,
+            workspace=workspace)
         if layer_resource is None:
             layer_resource = cat.create_wmslayer(
                 workspace, store, layer_meta.id)

--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -436,7 +436,7 @@ LOGGING = {
             "handlers": ["console"], "level": "INFO", },
         "geonode.qgis_server": {
             "handlers": ["console"], "level": "ERROR", },
-        "gsconfig.catalog": {
+        "geoserver-restconfig.catalog": {
             "handlers": ["console"], "level": "ERROR", },
         "owslib": {
             "handlers": ["console"], "level": "ERROR", },

--- a/geonode/tests/integration.py
+++ b/geonode/tests/integration.py
@@ -50,8 +50,6 @@ from tastypie.test import ResourceTestCaseMixin
 
 from geonode.qgis_server.models import QGISServerLayer
 
-from geoserver.catalog import FailedRequestError
-
 # from geonode.security.models import *
 from geonode.decorators import on_ogc_backend
 from geonode.base.models import TopicCategory, Link
@@ -761,11 +759,11 @@ class GeoNodeMapTest(GeoNodeLiveTestSupport):
         ws = gs_cat.get_workspace(tif_layer.workspace)
         tif_store = gs_cat.get_store(tif_layer.store, ws)
         tif_layer.delete()
-        self.assertRaises(
-            FailedRequestError,
-            lambda: gs_cat.get_resource(
-                shp_layer.name,
-                store=tif_store))
+        self.assertIsNone(gs_cat.get_resource(
+            name=shp_layer.name,
+            store=tif_store,
+            workspace=ws)
+        )
 
     @on_ogc_backend(geoserver.BACKEND_PACKAGE)
     @timeout_decorator.timeout(LOCAL_TIMEOUT)
@@ -1248,7 +1246,8 @@ class GeoNodeThumbnailTest(GeoNodeLiveTestSupport):
 
             thumbnail_url = map_obj.get_thumbnail_url()
 
-            self.assertNotEqual(thumbnail_url, staticfiles.static(settings.MISSING_THUMBNAIL))
+            if check_ogc_backend(qgis_server.BACKEND_PACKAGE):
+                self.assertEquals(thumbnail_url, staticfiles.static(settings.MISSING_THUMBNAIL))
         finally:
             # Cleanup
             saved_layer.delete()

--- a/geonode/upload/utils.py
+++ b/geonode/upload/utils.py
@@ -581,7 +581,8 @@ def run_import(upload_session, async_upload=_ASYNC_UPLOAD):
     if ogc_server_settings.datastore_db and task.target.store_type != 'coverageStore':
         target = create_geoserver_db_featurestore(
             # store_name=ogc_server_settings.DATASTORE,
-            store_name=ogc_server_settings.datastore_db['NAME']
+            store_name=ogc_server_settings.datastore_db['NAME'],
+            workspace=settings.DEFAULT_WORKSPACE
         )
         _log(
             'setting target datastore %s %s',

--- a/geonode/utils.py
+++ b/geonode/utils.py
@@ -457,8 +457,9 @@ class GXPMapBase(object):
                        for source in sources.values() if source and 'url' in source]
 
         if 'geonode.geoserver' in settings.INSTALLED_APPS:
-            if len(sources.keys(
-            )) > 0 and not settings.MAP_BASELAYERS[0]['source']['url'] in source_urls:
+            if len(sources.keys()) > 0 and \
+                'url' in settings.MAP_BASELAYERS[0]['source'] and \
+                    not settings.MAP_BASELAYERS[0]['source']['url'] in source_urls:
                 keys = sorted(sources.keys())
                 settings.MAP_BASELAYERS[0]['source'][
                     'title'] = 'Local Geoserver'
@@ -1495,10 +1496,10 @@ def set_resource_default_links(instance, layer, prune=False, **kwargs):
         srid = instance.srid if instance.srid else getattr(settings, 'DEFAULT_MAP_CRS', 'EPSG:4326')
         try:
             gs_resource = gs_catalog.get_resource(
-                instance.name,
+                name=instance.name,
                 workspace=instance.workspace)
             if not gs_resource:
-                gs_resource = gs_catalog.get_resource(instance.name)
+                gs_resource = gs_catalog.get_resource(name=instance.name)
             bbox = gs_resource.native_bbox
 
             dx = float(bbox[1]) - float(bbox[0])

--- a/package/support/geonode.local_settings
+++ b/package/support/geonode.local_settings
@@ -490,7 +490,7 @@ LOGGING = {
             "handlers": ["console"], "level": "INFO", },
         "geonode.qgis_server": {
             "handlers": ["console"], "level": "ERROR", },
-        "gsconfig.catalog": {
+        "geoserver-restconfig.catalog": {
             "handlers": ["console"], "level": "ERROR", },
         "owslib": {
             "handlers": ["console"], "level": "ERROR", },

--- a/requirements.txt
+++ b/requirements.txt
@@ -73,7 +73,7 @@ geonode-announcements==1.0.13
 geonode-agon-ratings==0.3.8
 arcrest>=10.0
 geonode-dialogos==1.2
-gsconfig>=1.0.10
+geoserver-restconfig==1.0.1
 gn-gsimporter>=1.0.9
 gisdata>=0.5.4
 


### PR DESCRIPTION
<Include a few sentences describing the overall goals for this Pull Request>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there are explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [x] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
