### PR TITLE
[Fixes #4772] Get rid of deprecated "Publish local map layers as WMS …

### DIFF
--- a/geonode/maps/models.py
+++ b/geonode/maps/models.py
@@ -49,6 +49,7 @@ from geonode.utils import (GXPMapBase,
 from geonode import geoserver, qgis_server  # noqa
 from geonode.utils import check_ogc_backend
 
+from deprecated import deprecated
 from agon_ratings.models import OverallRating
 
 logger = logging.getLogger("geonode.maps.models")
@@ -360,6 +361,7 @@ class Map(ResourceBase, GXPMapBase):
         else:
             return None
 
+    @deprecated(version='2.10.1', reason="APIs have been changed on geospatial service")
     def publish_layer_group(self):
         """
         Publishes local map layers as WMS layer group on local OWS.

--- a/geonode/maps/templates/maps/map_detail.html
+++ b/geonode/maps/templates/maps/map_detail.html
@@ -257,22 +257,6 @@
           </li>
         {% endif %}
 
-
-        {% if resource.is_public and "change_resourcebase" in perms_list or resource.layer_group %}
-        <li class="list-group-item">
-          <h4>{% trans "Map WMS" %}</h4>
-          <dl>{% if resource.layer_group %}
-            <dt>{% trans "WMS layer group for local map layers" %}:</dt>
-            <dd><em>{{ resource.layer_group.catalog.name }}</em> ({% trans "on" %} <a href="{{ resource.layer_group.ows }}?service=WMS&request=GetCapabilities">{% trans "local OWS" %}</a>)</dd>
-            {% endif %}</dl>
-          {% if "change_resourcebase" in perms_list %}
-          <p>{% trans "Publish local map layers as WMS layer group" %}</p>
-          <a id="layer-group" href="{%url "map_wms" resource.id %}" class="btn btn-default btn-md btn-block">{% trans "Publish Map WMS" %}</a>
-          {% endif %}
-          <dl id="layer-group-dl"></dl>
-        </li>
-        {% endif %}
-
         {% include "base/_resourcebase_contact_snippet.html" %}
 
       </ul>

--- a/geonode/maps/urls.py
+++ b/geonode/maps/urls.py
@@ -76,7 +76,6 @@ urlpatterns = [
     url(r'^(?P<mapid>[^/]+)/edit$', map_edit, name='map_edit'),
     url(r'^(?P<mapid>[^/]+)/data$', map_json, name='map_json'),
     url(r'^(?P<mapid>[^/]+)/wmc$', views.map_wmc, name='map_wmc'),
-    url(r'^(?P<mapid>[^/]+)/wms$', views.map_wms, name='map_wms'),
     url(r'^(?P<mapid>[^/]+)/remove$', views.map_remove, name='map_remove'),
     url(r'^(?P<mapid>[^/]+)/metadata$', views.map_metadata, name='map_metadata'),
     url(r'^(?P<mapid>[^/]+)/metadata_advanced$', views.map_metadata_advanced, name='map_metadata_advanced'),

--- a/geonode/maps/views.py
+++ b/geonode/maps/views.py
@@ -74,6 +74,7 @@ from .tasks import delete_map
 from geonode.monitoring import register_event
 from geonode.monitoring.models import EventType
 from requests.compat import urljoin
+from deprecated import deprecated
 
 if check_ogc_backend(geoserver.BACKEND_PACKAGE):
     # FIXME: The post service providing the map_status object
@@ -1147,6 +1148,7 @@ def map_wmc(request, mapid, template="maps/wmc.xml"):
     }, content_type='text/xml')
 
 
+@deprecated(version='2.10.1', reason="APIs have been changed on geospatial service")
 def map_wms(request, mapid):
     """
     Publish local map layers as group layer in local OWS.

--- a/geonode/utils.py
+++ b/geonode/utils.py
@@ -274,14 +274,14 @@ def _v(coord, x, source_srid=4326, target_srid=3857):
     if source_srid == 4326 and x and abs(coord) != 180.0:
         coord = coord - (round(coord / 360.0) * 360.0)
     if source_srid == 4326 and target_srid != 4326:
-        if x and coord >= 180.0:
+        if x and float(coord) >= 179.999:
             return 179.999
-        elif x and coord <= -180.0:
+        elif x and float(coord) <= -179.999:
             return -179.999
 
-        if not x and coord >= 90.0:
+        if not x and float(coord) >= 89.999:
             return 89.999
-        elif not x and coord <= -90.0:
+        elif not x and float(coord) <= -89.999:
             return -89.999
     return coord
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,8 @@ kombu==4.6.4
 boto<=2.49.0
 six<1.11.0 # https://github.com/benjaminp/six/issues/210
 tqdm==4.35.0
+Deprecated==1.2.6
+wrapt==1.11.2
 
 # Django Apps
 django-allauth==0.40.0


### PR DESCRIPTION
…layer group"

<Include a few sentences describing the overall goals for this Pull Request>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there are explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
