### PR TITLE
[Backport 4817 to 2.10.x] Removing a layer is broken - Celery error

### DIFF
--- a/geonode/documents/tasks.py
+++ b/geonode/documents/tasks.py
@@ -22,7 +22,7 @@ import os
 from os import access, R_OK
 from os.path import isfile
 
-from celery.app import shared_task
+from geonode.celery_app import app
 from celery.utils.log import get_task_logger
 
 from geonode.documents.models import Document
@@ -34,7 +34,7 @@ from geonode.documents.renderers import MissingPILError
 logger = get_task_logger(__name__)
 
 
-@shared_task(bind=True, queue='update')
+@app.task(bind=True, queue='update')
 def create_document_thumbnail(self, object_id):
     """
     Create thumbnail for a document.
@@ -87,13 +87,13 @@ def create_document_thumbnail(self, object_id):
     logger.debug("Thumbnail for document #{} created.".format(object_id))
 
 
-@shared_task(bind=True, queue='cleanup')
+@app.task(bind=True, queue='cleanup')
 def delete_orphaned_document_files(self):
     from geonode.documents.utils import delete_orphaned_document_files
     delete_orphaned_document_files()
 
 
-@shared_task(bind=True, queue='cleanup')
+@app.task(bind=True, queue='cleanup')
 def delete_orphaned_thumbnails(self):
     from geonode.base.utils import delete_orphaned_thumbs
     delete_orphaned_thumbs()

--- a/geonode/geoserver/tasks.py
+++ b/geonode/geoserver/tasks.py
@@ -18,7 +18,7 @@
 #
 #########################################################################
 
-from celery.app import shared_task
+from geonode.celery_app import app
 from celery.utils.log import get_task_logger
 
 from .helpers import gs_slurp
@@ -26,7 +26,7 @@ from .helpers import gs_slurp
 logger = get_task_logger(__name__)
 
 
-@shared_task(bind=True, queue='update')
+@app.task(bind=True, queue='update')
 def geoserver_update_layers(self, *args, **kwargs):
     """
     Runs update layers.

--- a/geonode/maps/tasks.py
+++ b/geonode/maps/tasks.py
@@ -20,7 +20,7 @@
 
 """celery tasks for geonode.maps."""
 
-from celery.app import shared_task
+from geonode.celery_app import app
 from celery.utils.log import get_task_logger
 
 from geonode.maps.models import Map
@@ -28,12 +28,11 @@ from geonode.maps.models import Map
 logger = get_task_logger(__name__)
 
 
-@shared_task(bind=True, queue='cleanup', expires=300)
+@app.task(bind=True, queue='cleanup', expires=300)
 def delete_map(self, object_id):
     """
     Deletes a map and the associated map layers.
     """
-
     try:
         map_obj = Map.objects.get(id=object_id)
     except Map.DoesNotExist:

--- a/geonode/qgis_server/tasks/update.py
+++ b/geonode/qgis_server/tasks/update.py
@@ -23,7 +23,7 @@ import shutil
 import socket
 
 import requests
-from celery import shared_task
+from geonode.celery_app import app
 from requests.exceptions import HTTPError
 
 
@@ -39,7 +39,7 @@ from geonode.decorators import on_ogc_backend
 logger = logging.getLogger(__name__)
 
 
-@shared_task(
+@app.task(
     name='geonode.qgis_server.tasks.update.create_qgis_server_thumbnail',
     queue='update',
     autoretry_for=(QGISServerLayer.DoesNotExist, ),
@@ -109,7 +109,7 @@ def create_qgis_server_thumbnail(instance, overwrite=False, bbox=None):
         return False
 
 
-@shared_task(
+@app.task(
     name='geonode.qgis_server.tasks.update.cache_request',
     queue='update')
 @on_ogc_backend(qgis_server.BACKEND_PACKAGE)

--- a/geonode/services/tasks.py
+++ b/geonode/services/tasks.py
@@ -23,22 +23,22 @@ from __future__ import absolute_import
 
 import logging
 
-from celery import shared_task
 from django.db import transaction
 
 from . import enumerations
 from . import models
 from .serviceprocessors import get_service_handler
 
+from geonode.celery_app import app
 from geonode.layers.models import Layer
 from geonode.catalogue.models import catalogue_post_save
 
 logger = logging.getLogger(__name__)
 
 
-@shared_task(bind=True,
-             name='geonode.services.tasks.update.harvest_resource',
-             queue='update',)
+@app.task(bind=True,
+          name='geonode.services.tasks.update.harvest_resource',
+          queue='update',)
 def harvest_resource(self, harvest_job_id):
     harvest_job = models.HarvestJob.objects.get(pk=harvest_job_id)
     harvest_job.update_status(

--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -1565,10 +1565,14 @@ LOCAL_SIGNALS_BROKER_URL = 'memory://'
 if ASYNC_SIGNALS:
     _BROKER_URL = os.environ.get('BROKER_URL', RABBITMQ_SIGNALS_BROKER_URL)
     # _BROKER_URL =  = os.environ.get('BROKER_URL', REDIS_SIGNALS_BROKER_URL)
-
     CELERY_RESULT_BACKEND = _BROKER_URL
 else:
     _BROKER_URL = LOCAL_SIGNALS_BROKER_URL
+    CELERY_RESULT_BACKEND_PATH = os.getenv(
+        'CELERY_RESULT_BACKEND_PATH', os.path.join(PROJECT_ROOT, 'results'))
+    if not os.path.exists(CELERY_RESULT_BACKEND_PATH):
+        os.makedirs(CELERY_RESULT_BACKEND_PATH)
+    CELERY_RESULT_BACKEND = 'file:///%s' % CELERY_RESULT_BACKEND_PATH
 
 # Note:BROKER_URL is deprecated in favour of CELERY_BROKER_URL
 CELERY_BROKER_URL = _BROKER_URL
@@ -1580,6 +1584,7 @@ CELERY_ACKS_LATE = True
 
 # Set this to False in order to run async
 CELERY_TASK_ALWAYS_EAGER = False if ASYNC_SIGNALS else True
+CELERY_TASK_EAGER_PROPAGATES = False if ASYNC_SIGNALS else True
 CELERY_TASK_IGNORE_RESULT = True
 
 # I use these to debug kombu crashes; we get a more informative message.

--- a/geonode/tasks/tasks.py
+++ b/geonode/tasks/tasks.py
@@ -18,7 +18,7 @@
 #
 #########################################################################
 
-from celery.app import shared_task
+from geonode.celery_app import app
 from celery.utils.log import get_task_logger
 from django.conf import settings
 from django.core.mail import send_mail
@@ -26,9 +26,9 @@ from django.core.mail import send_mail
 logger = get_task_logger(__name__)
 
 
-@shared_task(bind=True,
-             name='geonode.tasks.email.send_mail',
-             queue='email',)
+@app.task(bind=True,
+          name='geonode.tasks.email.send_mail',
+          queue='email',)
 def send_email(self, *args, **kwargs):
     """
     Sends an email using django's send_mail functionality.
@@ -37,9 +37,9 @@ def send_email(self, *args, **kwargs):
     send_mail(*args, **kwargs)
 
 
-@shared_task(bind=True,
-             name='geonode.tasks.notifications.send_queued_notifications',
-             queue='email',)
+@app.task(bind=True,
+          name='geonode.tasks.notifications.send_queued_notifications',
+          queue='email',)
 def send_queued_notifications(self, *args):
     """Sends queued notifications.
 


### PR DESCRIPTION
```
Commits ["5d36229a00983d4a3cdc0907b959218993efc389","64c9ff49813cf36902426089aef978721c707da1"] could not be cherry-picked on top of 2.10.x
```
To backport manually, run these commands in your terminal:
```bash
# Fetch latest updates from GitHub.
git fetch
# Create new working tree.
git worktree add .worktrees/backport 2.10.x
# Navigate to the new directory.
cd .worktrees/backport
# Cherry-pick all the commits of this pull request and resolve the likely conflicts.
git cherry-pick 5d36229a00983d4a3cdc0907b959218993efc389 64c9ff49813cf36902426089aef978721c707da1
# Create a new branch with these backported commits.
git checkout -b backport-4817-to-2.10.x
# Push it to GitHub.
git push --set-upstream origin backport-4817-to-2.10.x
# Go back to the original working tree.
cd ../..
# Delete the working tree.
git worktree remove .worktrees/backport
```
Then, create a pull request where the `base` branch is `2.10.x` and the `compare`/`head` branch is `backport-4817-to-2.10.x`.