### PR TITLE
[Fixes #4831] GeoNode Importer mode not really asynchronous

### DIFF
--- a/geonode/layers/templates/layers/layer_detail.html
+++ b/geonode/layers/templates/layers/layer_detail.html
@@ -12,6 +12,9 @@
 {% block title %}{{ resource.title|default:resource.alternate }} — {{ block.super }}{% endblock %}
 
 {% block head %}
+
+  <META HTTP-EQUIV="Access-Control-Allow-Origin" CONTENT="{{ SITEURL }}">
+
   {% if TWITTER_CARD %}
     {% include "base/_resourcebase_twittercard.html" %}
   {% endif %}

--- a/geonode/upload/tests/integration.py
+++ b/geonode/upload/tests/integration.py
@@ -296,17 +296,13 @@ class UploaderBase(GeoNodeBaseTestSupport):
             return
         upload = None
         try:
-            # AF: TODO Headhakes here... nose is not accessing to the test
-            # db!!!
-            uploads = Upload.objects.all()
-            if uploads:
-                upload = Upload.objects.filter(name=str(original_name)).last()
+            upload = Upload.objects.filter(name=str(original_name)).last()
         except Upload.DoesNotExist:
             self.fail('expected to find Upload object for %s' % original_name)
 
-        # AF: TODO Headhakes here... nose is not accessing to the test db!!!
-        if upload:
-            self.assertTrue(upload.complete)
+        # Making sure the Upload object is present on the DB and
+        # the import session is COMPLETE
+        self.assertTrue(upload.complete)
 
     def check_layer_complete(self, layer_page, original_name):
         '''check everything to verify the layer is complete'''

--- a/geonode/upload/upload.py
+++ b/geonode/upload/upload.py
@@ -211,7 +211,7 @@ def upload(
               presentation_strategy, precision_value, precision_step,
               end_time_attribute=end_time_attribute,
               end_time_transform_type=end_time_transform_type,
-              time_format=None, srs=None, use_big_date=use_big_date)
+              time_format=None)
 
     utils.run_import(upload_session, async_upload=False)
 
@@ -306,7 +306,7 @@ def save_step(user, layer, spatial_files, overwrite=True, mosaic=False,
         max_length = Upload._meta.get_field('name').max_length
         name = name[:max_length]
         # save record of this whether valid or not - will help w/ debugging
-        upload = Upload.objects.create(
+        upload, _ = Upload.objects.get_or_create(
             user=user,
             name=name,
             state=Upload.STATE_INVALID,


### PR DESCRIPTION
<Include a few sentences describing the overall goals for this Pull Request>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there are explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [x] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
