### PR TITLE
[Backport 4573 to 2.10.x] Spcgeonode with mapstore2 and postgis

### DIFF
--- a/scripts/spcgeonode/docker-compose.yml
+++ b/scripts/spcgeonode/docker-compose.yml
@@ -49,8 +49,7 @@ x-common-django:
     - C_FORCE_ROOT=True
     # We get an exception after migrations on startup (it seems the monitoring app tries to resolve the geoserver domain name after it's migration, which can happen before oauth migrations on which geoserver startup depends...)
     - MONITORING_ENABLED=False
-    # Automated tests hang for unknown reasons using 'mapstore' by default
-    - GEONODE_CLIENT_LAYER_PREVIEW_LIBRARY=geoext
+    # - GEONODE_CLIENT_LAYER_PREVIEW_LIBRARY=geoext
   volumes:
     - static:/spcgeonode-static/
     - media:/spcgeonode-media/

--- a/scripts/spcgeonode/nginx/spcgeonode.conf
+++ b/scripts/spcgeonode/nginx/spcgeonode.conf
@@ -47,13 +47,14 @@ location /static {
 
 # Finally, send all non-media requests to the Django server.
 location / {
+    # uwsgi_params
+    include /etc/nginx/uwsgi_params;
 
     # Using a variable is a trick to let Nginx start even if upstream host is not up yet
     # (see https://sandro-keil.de/blog/2017/07/24/let-nginx-start-if-upstream-host-is-unavailable-or-down/)
     set $upstream django:8000;
-
     uwsgi_pass $upstream;
-    
-    # uwsgi_params
-    include /etc/nginx/uwsgi_params;
+
+    # when a client closes the connection then keep the channel to uwsgi open. Otherwise uwsgi throws an IOError
+    uwsgi_ignore_client_abort on;
 }


### PR DESCRIPTION
Commits ["b97e0a10b99d18961a6afccc9e85fa7869bffb55","75c5f20146468822c032109cbe97812c8ea0f4e9","b2404d678bd7210327ec78a3970f968bb6afe84b","004f2c57973dfeaf0f0c6165647920748c95306c","c3b0e85a8bcc4ecfb162f4805fc474a5c3dfd66d","5bcbe01386a8fb1b1a4bdf46aebac59fccaa7862","1c95b48057d7e64085d0d0406f1f24d4242f4f24","b1e4db7245d3c29fa9fc4d744fa4d45066c66b9a","1989f7acac587129ba1a0e3af7682d11deca27c5","f5578602835a093e4813e7374fa8771556143395","0375aa46f8451bc388437562368391bbf2b981dd"] could not be cherry-picked on top of 2.10.x
To backport manually, run these commands in your terminal:

# Fetch latest updates from GitHub.
git fetch
# Create new working tree.
git worktree add .worktrees/backport 2.10.x
# Navigate to the new directory.
cd .worktrees/backport
# Cherry-pick all the commits of this pull request and resolve the likely conflicts.
git cherry-pick b97e0a10b99d18961a6afccc9e85fa7869bffb55 75c5f20146468822c032109cbe97812c8ea0f4e9 b2404d678bd7210327ec78a3970f968bb6afe84b 004f2c57973dfeaf0f0c6165647920748c95306c c3b0e85a8bcc4ecfb162f4805fc474a5c3dfd66d 5bcbe01386a8fb1b1a4bdf46aebac59fccaa7862 1c95b48057d7e64085d0d0406f1f24d4242f4f24 b1e4db7245d3c29fa9fc4d744fa4d45066c66b9a 1989f7acac587129ba1a0e3af7682d11deca27c5 f5578602835a093e4813e7374fa8771556143395 0375aa46f8451bc388437562368391bbf2b981dd
# Create a new branch with these backported commits.
git checkout -b backport-4573-to-2.10.x
# Push it to GitHub.
git push --set-upstream origin backport-4573-to-2.10.x
# Go back to the original working tree.
cd ../..
# Delete the working tree.
git worktree remove .worktrees/backport
Then, create a pull request where the base branch is 2.10.x and the compare/head branch is backport-4573-to-2.10.x.