### PR TITLE
[Backport 4259 to 2.10.x] Test standard docker setup with geonode-sel…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -159,10 +159,15 @@ matrix:
             MONITORING_ENABLED: 'False'
             SESSION_EXPIRED_CONTROL_ENABLED: 'True'
             CELERY_ALWAYS_EAGER: 'True'
-    - name: "Selenium Integration Tests"
+    - name: "Selenium Integration Tests Core"
       python: 3.5
       env:
           - TEST_RUN_SELENIUM: 'True'
+    - name: "Selenium Integration Tests SPCGeonode"
+      python: 3.5
+      env:
+          - TEST_RUN_SELENIUM: 'True'
+          - SPCGEONODE: 'True'
 
 branches:
   only:
@@ -241,8 +246,12 @@ before_script:
     fi
 
 script:
-  - if [ "$TEST_RUN_SELENIUM" = "True" ]; then
+  - if [ "$TEST_RUN_SELENIUM" = "True" ] && [ "$SPCGEONODE" = "True" ]; then
       geonode-selenium/test-docker.sh;
+    elif [ "$TEST_RUN_SELENIUM" = "True" ]; then
+      docker-compose -f docker-compose.yml -f docker-compose.override.localhost.yml up --build -d;
+      URL="http://localhost";
+      GEONODE_USER=admin GEONODE_PASS=admin GEONODE_URL="$URL" geonode-selenium/test-core.sh;
     else
       paver run_tests --coverage --local false;
     fi


### PR DESCRIPTION
Commits ["ced835ebccd6e49fbb98fcbba86ba4b52d20b216","c4a29c3a518eee8f404af8e2c03d10495487c548","91b7ebab4a59f738e3f68551b2aa022f9ce9b63f","a41a8b4ea98eef3ebbb5a59718d8a96eded19c63","b6916e9d592f1b337f9b640d21f41c32eee93d65","67d6930a03105a377654bd4648af67e7335cab46","f1605888f8ad2c0d2789d9fd08e0334fb914587d","2405346a3cbd4508a57e99985db05f2ebe210f2b","fc763f2551bc6fe36d57d09fa5c7139a4fa4c470","38e8f241f4330cc06ebc695da910bf379d59cc5a"] could not be cherry-picked on top of 2.10.x
To backport manually, run these commands in your terminal:

# Fetch latest updates from GitHub.
git fetch
# Create new working tree.
git worktree add .worktrees/backport 2.10.x
# Navigate to the new directory.
cd .worktrees/backport
# Cherry-pick all the commits of this pull request and resolve the likely conflicts.
git cherry-pick ced835ebccd6e49fbb98fcbba86ba4b52d20b216 c4a29c3a518eee8f404af8e2c03d10495487c548 91b7ebab4a59f738e3f68551b2aa022f9ce9b63f a41a8b4ea98eef3ebbb5a59718d8a96eded19c63 b6916e9d592f1b337f9b640d21f41c32eee93d65 67d6930a03105a377654bd4648af67e7335cab46 f1605888f8ad2c0d2789d9fd08e0334fb914587d 2405346a3cbd4508a57e99985db05f2ebe210f2b fc763f2551bc6fe36d57d09fa5c7139a4fa4c470 38e8f241f4330cc06ebc695da910bf379d59cc5a
# Create a new branch with these backported commits.
git checkout -b backport-4259-to-2.10.x
# Push it to GitHub.
git push --set-upstream origin backport-4259-to-2.10.x
# Go back to the original working tree.
cd ../..
# Delete the working tree.
git worktree remove .worktrees/backport
Then, create a pull request where the base branch is 2.10.x and the compare/head branch is backport-4259-to-2.10.x.