### PR TITLE
Bump django-mapstore-adapter from 1.0.5 to 1.0.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -70,7 +70,7 @@ geonode-oauth-toolkit==1.1.4.6
 
 # GeoNode org maintained apps.
 django-geoexplorer==4.0.43
-django-mapstore-adapter==1.0.5
+django-mapstore-adapter==1.0.6
 django-geonode-mapstore-client==1.4.0
 django-geonode-client==1.0.9
 geonode-user-messages==0.1.14


### PR DESCRIPTION
### Main features

- Install `pip install django-mapstore-adapter==1.0.6` instructions [Here](https://pypi.org/project/django-mapstore-adapter/1.0.6/)
- GeoNode MapStore client v1.4.0
- Based on [MapStore2 - v2019.02.00](https://github.com/geosolutions-it/MapStore2/releases/tag/v2019.02.00)

[GeoNode MapStore Adapter](https://github.com/GeoNode/django-mapstore-adapter/issues?q=is%3Aissue+is%3Aclosed+milestone%3A1.0.6) the list of issues solved.

[GeoNode MapStore Adapter](https://github.com/GeoNode/django-mapstore-adapter/pulls?q=is%3Apr+is%3Aclosed+milestone%3A1.0.6) the list of PR closed.

[MapStore2](https://github.com/geosolutions-it/MapStore2/issues?q=is%3Aissue+milestone%3A2019.02.00+is%3Aclosed) the list of MapStore2 issues solved.

---

## Full Changelog

### 1.0.6 [2019-09-05]

<li> 2019-09-05: afabiani <a href="https://github.com/GeoNode/django-mapstore-adapter/commit/27c67b7cce30fe4feb4b645b386f220c15858985" target="blank"> [Fixes #5] geostore plugin "project_to_mercator" returns wrong SRID</a></li>
<li> 2019-08-27: gioscarda <a href="https://github.com/GeoNode/django-mapstore-adapter/commit/2ead0bbf8c691a9922a9fb2ee77712f8ee640c30" target="blank"> safe backward compatibility</a></li>
<li> 2019-08-23: gioscarda <a href="https://github.com/GeoNode/django-mapstore-adapter/commit/781ae56712209591f1c5b15be414dc1d4ec41bcc" target="blank"> [Fixes #3] registering map creation/update events for monitoring</a></li>
<li> 2019-08-22: afabiani <a href="https://github.com/GeoNode/django-mapstore-adapter/commit/7b59bb521b69364b6eca83dd622a30943d691427" target="blank"> Updated CHANGELOG</a></li> 