### PR TITLE
Bump gn-gsimporter from 1.0.10 to 1.0.11

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -80,7 +80,7 @@ geonode-agon-ratings==0.3.8
 arcrest>=10.0
 geonode-dialogos==1.2
 geoserver-restconfig==1.0.3
-gn-gsimporter==1.0.10
+gn-gsimporter==1.0.11
 gisdata==0.5.4
 
 # haystack/elasticsearch


### PR DESCRIPTION
Bumps [gn-gsimporter](https://github.com/GeoNode/gsimporter) from1.0.10 to 1.0.11.
<details>
<summary>Commits</summary>

- [`40ce139af2a78eeb9938cff16bd0a2735c348abe`](https://github.com/GeoNode/gsimporter/commit/40ce139af2a78eeb9938cff16bd0a2735c348abe) - bump to version 1.0.11
- [`63d1f0760dc1abfdec324b16f439f9c980d63901`](https://github.com/GeoNode/gsimporter/commit/63d1f0760dc1abfdec324b16f439f9c980d63901) - Skip SSL Cert verification
- See full diff in [compare view](https://github.com/GeoNode/gsimporter/compare/1.0.10...1.0.11)
</details>
<br />
