### PR TITLE
Bump django-mapstore-adapter from 1.0.6 to 1.0.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -70,7 +70,7 @@ geonode-oauth-toolkit==1.1.4.6
 
 # GeoNode org maintained apps.
 django-geoexplorer==4.0.43
-django-mapstore-adapter==1.0.6
+django-mapstore-adapter==1.0.7
 django-geonode-mapstore-client==1.4.0
 django-geonode-client==1.0.9
 geonode-user-messages==0.1.14


### PR DESCRIPTION
Bumps [django-mapstore-adapter ](https://github.com/GeoNode/django-mapstore-adapter) from1.0.6 to 1.0.7.
<details>
<summary>Commits</summary>

- 2019-09-09: afabiani <a href="https://github.com/GeoNode/django-mapstore-adapter/commit/cf3d57f661d0865cc06c6529d0cdc0267dc2b16e" target="blank"> [Fixes #6] geonode plugin center error: get_zoom() expects a GEOS Geometry with an SRID of 4326</a>
- See full diff in [compare view](https://github.com/GeoNode/django-mapstore-adapter/compare/v1.0.6...v1.0.7)
</details>
<br />
