### PR TITLE
Bump gn-gsimporter from 1.0.10 to 1.0.12

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -80,7 +80,7 @@ geonode-agon-ratings==0.3.8
 arcrest>=10.0
 geonode-dialogos==1.2
 geoserver-restconfig==1.0.3
-gn-gsimporter==1.0.10
+gn-gsimporter==1.0.12
 gisdata==0.5.4
 
 # haystack/elasticsearch


### PR DESCRIPTION
Bumps [gn-gsimporter](https://github.com/GeoNode/gsimporter) from1.0.10 to 1.0.12.
<details>
<summary>Commits</summary>

- [`ea90668b432f678e01eb3cc205eae9f1679db034`](https://github.com/GeoNode/gsimporter/commit/ea90668b432f678e01eb3cc205eae9f1679db034) - bump to version 1.0.12
- [`00d010d3444f97b190bb45386e4aa45997f0fe76`](https://github.com/GeoNode/gsimporter/commit/00d010d3444f97b190bb45386e4aa45997f0fe76) - [Fixes Regression] - Skip SSL Cert verification causes error with HTTP scheme
- See full diff in [compare view](https://github.com/GeoNode/gsimporter/compare/1.0.10...1.0.12)
</details>
<br />
