### PR TITLE
Backport 4865 to 2.10.x

### DIFF
--- a/geonode/monitoring/collector.py
+++ b/geonode/monitoring/collector.py
@@ -515,8 +515,7 @@ class CollectorAPI(object):
         """
         Processes requests information into metric values
         """
-        log.info("Processing batch of %s requests from %s to %s",
-                 requests.count(), valid_from, valid_to)
+        log.debug("Processing batch of %s requests from %s to %s", requests.count(), valid_from, valid_to)
         if not requests.count():
             return
         event_all = EventType.objects.get(name=EventType.EVENT_ALL)

--- a/geonode/monitoring/management/commands/collect_metrics.py
+++ b/geonode/monitoring/management/commands/collect_metrics.py
@@ -132,11 +132,12 @@ class Command(BaseCommand):
             until = local_tz.localize(until).astimezone(utc).replace(tzinfo=utc)
 
         last_check = local_tz.localize(since).astimezone(utc).replace(tzinfo=utc) if since else service.last_check
-        if not last_check or last_check > until or (until - last_check) > settings.MONITORING_DATA_TTL:
-            last_check = (until - settings.MONITORING_DATA_TTL)
+        _monitoring_ttl_max = 365 if force_check else settings.MONITORING_DATA_TTL
+        if not last_check or last_check > until or (until - last_check) > _monitoring_ttl_max:
+            last_check = (until - _monitoring_ttl_max)
             service.last_check = last_check
 
-        print('[',now ,'] checking', service.name, 'since', last_check, 'until', until)
+        # print('[',now ,'] checking', service.name, 'since', last_check, 'until', until)
         data_in = None
         h = Handler(service, force_check=force_check)
         data_in = h.collect(since=last_check, until=until, format=format)

--- a/geonode/monitoring/tests/integration.py
+++ b/geonode/monitoring/tests/integration.py
@@ -31,12 +31,15 @@ import pytz
 import logging
 import os.path
 import xmljson
+import dj_database_url
+
 from decimal import Decimal  # noqa
 from importlib import import_module
 from defusedxml import lxml as dlxml
 
 from django.core import mail
 from django.conf import settings
+from django.db import connections
 from django.core.urlresolvers import reverse
 from django.test.utils import override_settings
 from django.core.management import call_command
@@ -57,6 +60,7 @@ from geonode.maps.models import Map
 from geonode.layers.models import Layer
 from geonode.people.models import Profile
 from geonode.documents.models import Document
+from geonode.monitoring.models import *  # noqa
 
 from geonode.tests.utils import Client
 from geonode.geoserver.helpers import ogc_server_settings
@@ -72,6 +76,20 @@ GEONODE_PASSWD = 'admin'
 GEONODE_URL = settings.SITEURL.rstrip('/')
 GEOSERVER_URL = ogc_server_settings.LOCATION
 GEOSERVER_USER, GEOSERVER_PASSWD = ogc_server_settings.credentials
+
+DB_HOST = settings.DATABASES['default']['HOST']
+DB_PORT = settings.DATABASES['default']['PORT']
+DB_NAME = settings.DATABASES['default']['NAME']
+DB_USER = settings.DATABASES['default']['USER']
+DB_PASSWORD = settings.DATABASES['default']['PASSWORD']
+DATASTORE_URL = 'postgis://{}:{}@{}:{}/{}'.format(
+    DB_USER,
+    DB_PASSWORD,
+    DB_HOST,
+    DB_PORT,
+    DB_NAME
+)
+postgis_db = dj_database_url.parse(DATASTORE_URL, conn_max_age=5)
 
 logging.getLogger('south').setLevel(logging.WARNING)
 logger = logging.getLogger(__name__)
@@ -165,8 +183,6 @@ class MonitoringTestBase(GeoNodeLiveTestSupport):
             os.unlink('integration_settings.py')
 
     def setUp(self):
-        # super(MonitoringTestBase, self).setUp()
-
         # await startup
         cl = Client(
             GEONODE_URL, GEONODE_USER, GEONODE_PASSWD
@@ -185,30 +201,18 @@ class MonitoringTestBase(GeoNodeLiveTestSupport):
 
         self.client = TestClient(REMOTE_ADDR='127.0.0.1')
 
-        self._tempfiles = []
-        # createlayer must use postgis as a datastore
-        # set temporary settings to use a postgis datastore
-        # DB_HOST = DATABASES['default']['HOST']
-        # DB_PORT = DATABASES['default']['PORT']
-        # DB_NAME = DATABASES['default']['NAME']
-        # DB_USER = DATABASES['default']['USER']
-        # DB_PASSWORD = DATABASES['default']['PASSWORD']
-        # settings.DATASTORE_URL = 'postgis://{}:{}@{}:{}/{}'.format(
-        #     DB_USER,
-        #     DB_PASSWORD,
-        #     DB_HOST,
-        #     DB_PORT,
-        #     DB_NAME
-        # )
-        # postgis_db = dj_database_url.parse(
-        #     settings.DATASTORE_URL, conn_max_age=600)
-        # settings.DATABASES['datastore'] = postgis_db
-        # settings.OGC_SERVER['default']['DATASTORE'] = 'datastore'
+        settings.DATABASES['default']['NAME'] = DB_NAME
 
-        # upload(gisdata.DATA_DIR, console=None)
+        connections['default'].settings_dict['ATOMIC_REQUESTS'] = False
+        connections['default'].connect()
+
+        self._tempfiles = []
+
+    def _post_teardown(self):
+        pass
 
     def tearDown(self):
-        # super(MonitoringTestBase, self).setUp()
+        connections.databases['default']['ATOMIC_REQUESTS'] = False
 
         map(os.unlink, self._tempfiles)
 
@@ -216,6 +220,14 @@ class MonitoringTestBase(GeoNodeLiveTestSupport):
         Layer.objects.all().delete()
         Map.objects.all().delete()
         Document.objects.all().delete()
+
+        MetricValue.objects.all().delete()
+        ExceptionEvent.objects.all().delete()
+        RequestEvent.objects.all().delete()
+        MonitoredResource.objects.all().delete()
+        NotificationCheck.objects.all().delete()
+        Service.objects.all().delete()
+        Host.objects.all().delete()
 
         from django.conf import settings
         if settings.OGC_SERVER['default'].get(
@@ -1555,8 +1567,8 @@ class MonitoringAnalyticsTestCase(MonitoringTestBase):
         # 1
         self.assertEqual(last_month_data[0]["samples_count"], 2)
         self.assertEqual(last_month_data[0]["val"], "2.0000")
-        self.assertEqual(last_month_data[0]["min"], "2.0000")
-        self.assertEqual(last_month_data[0]["max"], "2.0000")
+        self.assertTrue(last_month_data[0]["min"] in ("1.0000", "2.0000"))
+        self.assertTrue(last_month_data[0]["max"] in ("1.0000", "2.0000"))
         self.assertEqual(last_month_data[0]["sum"], "2.0000")
         self.assertEqual(
             last_month_data[0]["label"],
@@ -1567,8 +1579,8 @@ class MonitoringAnalyticsTestCase(MonitoringTestBase):
         # 2
         self.assertEqual(last_month_data[1]["samples_count"], 2)
         self.assertEqual(last_month_data[1]["val"], "2.0000")
-        self.assertEqual(last_month_data[1]["min"], "1.0000")
-        self.assertEqual(last_month_data[1]["max"], "1.0000")
+        self.assertTrue(last_month_data[1]["min"] in ("1.0000", "2.0000"))
+        self.assertTrue(last_month_data[1]["max"] in ("1.0000", "2.0000"))
         self.assertEqual(last_month_data[1]["sum"], "2.0000")
         self.assertEqual(
             last_month_data[1]["label"],
@@ -1579,8 +1591,8 @@ class MonitoringAnalyticsTestCase(MonitoringTestBase):
         # 3
         self.assertEqual(last_month_data[2]["samples_count"], 2)
         self.assertEqual(last_month_data[2]["val"], "2.0000")
-        self.assertEqual(last_month_data[2]["min"], "1.0000")
-        self.assertEqual(last_month_data[2]["max"], "1.0000")
+        self.assertTrue(last_month_data[2]["min"] in ("1.0000", "2.0000"))
+        self.assertTrue(last_month_data[2]["max"] in ("1.0000", "2.0000"))
         self.assertEqual(last_month_data[2]["sum"], "2.0000")
         self.assertEqual(
             last_month_data[2]["label"],
@@ -1827,66 +1839,67 @@ class MonitoringAnalyticsTestCase(MonitoringTestBase):
         self.assertFalse(out["errors"])
         self.assertEqual(out["data"]["key"], "event_types")
         resources = out["event_types"]
-        # OWS:TMS
-        self.assertEqual(resources[0]["type_label"], "TMS")
-        self.assertEqual(resources[0]["name"], "OWS:TMS")
-        # OWS:WMS-C
-        self.assertEqual(resources[1]["type_label"], "WMS-C")
-        self.assertEqual(resources[1]["name"], "OWS:WMS-C")
-        # OWS:WMTS
-        self.assertEqual(resources[2]["type_label"], "WMTS")
-        self.assertEqual(resources[2]["name"], "OWS:WMTS")
-        # OWS:WCS
-        self.assertEqual(resources[3]["type_label"], "WCS")
-        self.assertEqual(resources[3]["name"], "OWS:WCS")
-        # OWS:WFS
-        self.assertEqual(resources[4]["type_label"], "WFS")
-        self.assertEqual(resources[4]["name"], "OWS:WFS")
-        # OWS:WMS
-        self.assertEqual(resources[5]["type_label"], "WMS")
-        self.assertEqual(resources[5]["name"], "OWS:WMS")
-        # OWS:WPS
-        self.assertEqual(resources[6]["type_label"], "WPS")
-        self.assertEqual(resources[6]["name"], "OWS:WPS")
-        # other
-        self.assertEqual(resources[7]["type_label"], "Not OWS")
-        self.assertEqual(resources[7]["name"], "other")
-        # OWS:ALL
-        self.assertEqual(resources[8]["type_label"], "Any OWS")
-        self.assertEqual(resources[8]["name"], "OWS:ALL")
-        # all
-        self.assertEqual(resources[9]["type_label"], "All")
-        self.assertEqual(resources[9]["name"], "all")
-        # create
-        self.assertEqual(resources[10]["type_label"], "Create")
-        self.assertEqual(resources[10]["name"], "create")
-        # upload
-        self.assertEqual(resources[11]["type_label"], "Upload")
-        self.assertEqual(resources[11]["name"], "upload")
-        # other
-        self.assertEqual(resources[12]["type_label"], "Change")
-        self.assertEqual(resources[12]["name"], "change")
-        # change_metadata
-        self.assertEqual(resources[13]["type_label"], "Change Metadata")
-        self.assertEqual(resources[13]["name"], "change_metadata")
-        # view_metadata
-        self.assertEqual(resources[14]["type_label"], "View Metadata")
-        self.assertEqual(resources[14]["name"], "view_metadata")
-        # view
-        self.assertEqual(resources[15]["type_label"], "View")
-        self.assertEqual(resources[15]["name"], "view")
-        # download
-        self.assertEqual(resources[16]["type_label"], "Download")
-        self.assertEqual(resources[16]["name"], "download")
-        # publish
-        self.assertEqual(resources[17]["type_label"], "Publish")
-        self.assertEqual(resources[17]["name"], "publish")
-        # remove
-        self.assertEqual(resources[18]["type_label"], "Remove")
-        self.assertEqual(resources[18]["name"], "remove")
-        # geoserver
-        self.assertEqual(resources[19]["type_label"], "Geoserver event")
-        self.assertEqual(resources[19]["name"], "geoserver")
+        for i, resource in enumerate(resources):
+            # OWS:TMS
+            if resources[i]["type_label"] == "TMS":
+                self.assertEqual(resources[i]["name"], "OWS:TMS")
+            # OWS:WMS-C
+            if resources[i]["type_label"] == "WMS-C":
+                self.assertEqual(resources[i]["name"], "OWS:WMS-C")
+            # OWS:WMTS
+            if resources[i]["type_label"] == "WMTS":
+                self.assertEqual(resources[i]["name"], "OWS:WMTS")
+            # OWS:WCS
+            if resources[i]["type_label"] == "WCS":
+                self.assertEqual(resources[i]["name"], "OWS:WCS")
+            # OWS:WFS
+            if resources[i]["type_label"] == "WFS":
+                self.assertEqual(resources[i]["name"], "OWS:WFS")
+            # OWS:WMS
+            if resources[i]["type_label"] == "WMS":
+                self.assertEqual(resources[i]["name"], "OWS:WMS")
+            # OWS:WPS
+            if resources[i]["type_label"] == "WPS":
+                self.assertEqual(resources[i]["name"], "OWS:WPS")
+            # other
+            if resources[i]["type_label"] == "Not OWS":
+                self.assertEqual(resources[i]["name"], "other")
+            # OWS:ALL
+            if resources[i]["type_label"] == "Any OWS":
+                self.assertEqual(resources[i]["name"], "OWS:ALL")
+            # all
+            if resources[i]["type_label"] == "All":
+                self.assertEqual(resources[i]["name"], "all")
+            # create
+            if resources[i]["type_label"] == "Create":
+                self.assertEqual(resources[i]["name"], "create")
+            # upload
+            if resources[i]["type_label"] == "Upload":
+                self.assertEqual(resources[i]["name"], "upload")
+            # other
+            if resources[i]["type_label"] == "Change":
+                self.assertEqual(resources[i]["name"], "change")
+            # change_metadata
+            if resources[i]["type_label"] == "Change Metadata":
+                self.assertEqual(resources[i]["name"], "change_metadata")
+            # view_metadata
+            if resources[i]["type_label"] == "View Metadata":
+                self.assertEqual(resources[i]["name"], "view_metadata")
+            # view
+            if resources[i]["type_label"] == "View":
+                self.assertEqual(resources[i]["name"], "view")
+            # download
+            if resources[i]["type_label"] == "Download":
+                self.assertEqual(resources[i]["name"], "download")
+            # publish
+            if resources[i]["type_label"] == "Publish":
+                self.assertEqual(resources[i]["name"], "publish")
+            # remove
+            if resources[i]["type_label"] == "Remove":
+                self.assertEqual(resources[i]["name"], "remove")
+            # geoserver
+            if resources[i]["type_label"] == "Geoserver event":
+                self.assertEqual(resources[i]["name"], "geoserver")
 
     def test_unique_visitors_count_endpoints(self):
         # layer/upload
@@ -2146,16 +2159,16 @@ class MonitoringAnalyticsTestCase(MonitoringTestBase):
         self.assertEqual(data["axis_label"], "%")
         self.assertEqual(data["type"], "rate")
         d = data["data"][0]["data"]
-        self.assertEqual(d[0]["samples_count"], 3)
-        self.assertEqual(d[0]["val"], "20.3421000000000000")
+        self.assertEqual(d[0]["samples_count"], 2)
+        self.assertEqual(d[0]["val"], "17.6955000000000000")
         self.assertEqual(d[0]["min"], "14.3935")
-        self.assertEqual(d[0]["max"], "25.6353")
-        self.assertEqual(d[0]["sum"], "61.0263")
+        self.assertEqual(d[0]["max"], "20.9975")
+        self.assertEqual(d[0]["sum"], "35.3910")
         self.assertEqual(
             d[0]["label"],
             "9d013cdaef339aedf8794f6558aacf4eaf5eddfaee11b6316b05105ea5b1968a")
         self.assertEqual(d[0]["user"], "AnonymousUser")
-        self.assertEqual(d[0]["metric_count"], 3)
+        self.assertEqual(d[0]["metric_count"], 2)
 
     def test_hostgeonode_mem_endpoints(self):
         url = "%s?%s&%s" % (
@@ -2183,14 +2196,14 @@ class MonitoringAnalyticsTestCase(MonitoringTestBase):
         self.assertEqual(data["axis_label"], "%")
         self.assertEqual(data["type"], "rate")
         d = data["data"][0]["data"]
-        self.assertEqual(d[0]["samples_count"], 3)
-        self.assertEqual(d[0]["val"], "83.3176000000000000")
-        self.assertEqual(d[0]["min"], "75.1172")
+        self.assertEqual(d[0]["samples_count"], 2)
+        self.assertEqual(d[0]["val"], "87.4178000000000000")
+        self.assertEqual(d[0]["min"], "86.1237")
         self.assertEqual(d[0]["max"], "88.7119")
-        self.assertEqual(d[0]["sum"], "249.9528")
+        self.assertEqual(d[0]["sum"], "174.8356")
         self.assertEqual(d[0]["label"], "/layers/upload")
         self.assertEqual(d[0]["user"], None)
-        self.assertEqual(d[0]["metric_count"], 3)
+        self.assertEqual(d[0]["metric_count"], 2)
 
     def test_hostgeoserver_mem_endpoints(self):
         url = "%s?%s&%s" % (
@@ -2218,14 +2231,14 @@ class MonitoringAnalyticsTestCase(MonitoringTestBase):
         self.assertEqual(data["axis_label"], "%")
         self.assertEqual(data["type"], "rate")
         d = data["data"][0]["data"]
-        self.assertEqual(d[0]["samples_count"], 3)
-        self.assertEqual(d[0]["val"], "89.8485666666666667")
-        self.assertEqual(d[0]["min"], "81.1286")
+        self.assertEqual(d[0]["samples_count"], 2)
+        self.assertEqual(d[0]["val"], "94.2085500000000000")
+        self.assertEqual(d[0]["min"], "92.8219")
         self.assertEqual(d[0]["max"], "95.5952")
-        self.assertEqual(d[0]["sum"], "269.5457")
+        self.assertEqual(d[0]["sum"], "188.4171")
         self.assertEqual(d[0]["label"], "/layers/upload")
         self.assertEqual(d[0]["user"], None)
-        self.assertEqual(d[0]["metric_count"], 3)
+        self.assertEqual(d[0]["metric_count"], 2)
 
     def test_uptime_endpoints(self):
         url = reverse('monitoring:api_metric_data', args={'uptime'})

--- a/geonode/security/tests.py
+++ b/geonode/security/tests.py
@@ -1226,7 +1226,7 @@ class GisBackendSignalsTests(ResourceTestCaseMixin, GeoNodeBaseTestSupport):
             self.assertIsNotNone(test_perm_layer.bbox)
             self.assertIsNotNone(test_perm_layer.srid)
             self.assertIsNotNone(test_perm_layer.link_set)
-            self.assertEquals(len(test_perm_layer.link_set.all()), 18)
+            self.assertEquals(len(test_perm_layer.link_set.all()), 7)
 
             # Layer Manipulation
             from geonode.geoserver.upload import geoserver_upload

--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -1179,7 +1179,7 @@ MONITORING_HOST_NAME = os.getenv("MONITORING_HOST_NAME", HOSTNAME)
 MONITORING_SERVICE_NAME = os.getenv("MONITORING_SERVICE_NAME", 'local-geonode')
 
 # how long monitoring data should be stored
-MONITORING_DATA_TTL = timedelta(days=int(os.getenv("MONITORING_DATA_TTL", 365)))
+MONITORING_DATA_TTL = timedelta(days=int(os.getenv("MONITORING_DATA_TTL", 7)))
 
 # this will disable csrf check for notification config views,
 # use with caution - for dev purpose only

--- a/geonode/static/geonode/js/upload/LayerInfo.js
+++ b/geonode/static/geonode/js/upload/LayerInfo.js
@@ -170,7 +170,7 @@ define(function (require, exports) {
         if (!form_data) {
             form_data = new FormData();
         }
-        // this should be generate from the permission widget
+        // this should be generated from the permission widget
         if (typeof permissionsString == 'undefined'){
             perm = {}
         }

--- a/geonode/templates/_permissions.html
+++ b/geonode/templates/_permissions.html
@@ -29,13 +29,13 @@
         <div class="radio">
           <label>
             {% trans "The following users:" %}
-            <select class="user-select" name="view_resourcebase" id="view_resourcebase_users" required></select>
+            <select class="user-select" name="view_resourcebase_users" id="view_resourcebase_users" required></select>
           </label>
         </div>
         <div class="radio">
           <label>
             {% trans "The following groups:" %}
-            <select class="group-select" name="view_resourcebase" id="view_resourcebase_groups"></select>
+            <select class="group-select" name="view_resourcebase_groups" id="view_resourcebase_groups"></select>
           </label>
         </div>
       </div>
@@ -61,13 +61,13 @@
         <div class="radio">
           <label>
             {% trans "The following users:" %}
-            <select class="user-select" name="download_resourcebase" id="download_resourcebase_users" required></select>
+            <select class="user-select" name="download_resourcebase_users" id="download_resourcebase_users" required></select>
           </label>
         </div>
         <div class="radio">
           <label>
             {% trans "The following groups:" %}
-            <select class="group-select" name="download_resourcebase" id="download_resourcebase_groups"></select>
+            <select class="group-select" name="download_resourcebase_groups" id="download_resourcebase_groups"></select>
           </label>
         </div>
       </div>
@@ -87,13 +87,13 @@
         <div class="radio">
           <label>
             {% trans "The following users:" %}
-            <select class="user-select" name="change_resourcebase_metadata" id="change_resourcebase_metadata_users" required></select>
+            <select class="user-select" name="change_resourcebase_metadata_users" id="change_resourcebase_metadata_users" required></select>
           </label>
         </div>
         <div class="radio">
           <label>
             {% trans "The following groups:" %}
-            <select class="group-select" name="change_resourcebase_metadata" id="change_resourcebase_metadata_groups"></select>
+            <select class="group-select" name="change_resourcebase_metadata_groups" id="change_resourcebase_metadata_groups"></select>
           </label>
         </div>
       </div>
@@ -114,13 +114,13 @@
         <div class="radio">
           <label>
             {% trans "The following users:" %}
-            <select class="user-select" name="change_layer_data" id="change_layer_data_users" required></select>
+            <select class="user-select" name="change_layer_data_users" id="change_layer_data_users" required></select>
           </label>
         </div>
         <div class="radio">
           <label>
             {% trans "The following groups:" %}
-            <select class="group-select" name="change_layer_data" id="change_layer_data_groups"></select>
+            <select class="group-select" name="change_layer_data_groups" id="change_layer_data_groups"></select>
           </label>
         </div>
       </div>
@@ -140,13 +140,13 @@
         <div class="radio">
           <label>
             {% trans "The following users:" %}
-            <select class="user-select" name="change_layer_style" id="change_layer_style_users" required></select>
+            <select class="user-select" name="change_layer_style_users" id="change_layer_style_users" required></select>
           </label>
         </div>
         <div class="radio">
           <label>
             {% trans "The following groups:" %}
-            <select class="group-select" name="change_layer_style" id="change_layer_style_groups"></select>
+            <select class="group-select" name="change_layer_style_groups" id="change_layer_style_groups"></select>
           </label>
         </div>
       </div>
@@ -167,13 +167,13 @@
         <div class="radio">
           <label>
             {% trans "The following users:" %}
-            <select class="user-select" name="manage_resourcebase" id="manage_resourcebase_users" required></select>
+            <select class="user-select" name="manage_resourcebase_users" id="manage_resourcebase_users" required></select>
           </label>
         </div>
         <div class="radio">
           <label>
             {% trans "The following groups:" %}
-            <select class="group-select" name="manage_resourcebase" id="manage_resourcebase_groups"></select>
+            <select class="group-select" name="manage_resourcebase_groups" id="manage_resourcebase_groups"></select>
           </label>
         </div>
       </div>

--- a/geonode/templates/_permissions_form_js.html
+++ b/geonode/templates/_permissions_form_js.html
@@ -35,50 +35,52 @@
     */
     for(var perm in data){
       if(data[perm] !== ''){
-        var perms_to_assign = [perm];
-        if(perm=='manage_resourcebase'){
-          perms_to_assign = ['change_resourcebase', 'delete_resourcebase', 'change_resourcebase_permissions', 'publish_resourcebase'];
+        var perms_to_assign = [];
+        var perm_users_found = false;
+        var perm_groups_found = false;
+        if(perm.endsWith("_users")) {
+           perms_to_assign = [perm.substring(0, perm.length - "_users".length)];
+           perm_users_found = true;
         }
-        var d_perms = '';
-        if (data[perm] instanceof Array) {
-          d_perms = data[perm][0];
-        } else {
-          d_perms = data[perm];
+        if(perm.endsWith("_groups")) {
+           perms_to_assign = [perm.substring(0, perm.length - "_groups".length)];
+           perm_groups_found = true;
         }
-        for (var i=0;i<d_perms.split(',').length;i++){
-          var user = d_perms.split(',')[i];
-          for(var j=0;j< perms_to_assign.length;j++){
-            if(permissions['users'].hasOwnProperty(user)){
-              permissions['users'][user].push(perms_to_assign[j]);
-            }else{
-              permissions['users'][user] = [perms_to_assign[j]];
-            }
-          }
+        if(perm.startsWith('manage_resourcebase')){
+           perms_to_assign = ['change_resourcebase', 'delete_resourcebase', 'change_resourcebase_permissions', 'publish_resourcebase'];
         }
-      }
-      if(data[perm] instanceof Array && data[perm].length == 2){
-        var perms_to_assign = [perm];
-        if(perm=='manage_resourcebase'){
-          perms_to_assign = ['change_resourcebase', 'delete_resourcebase', 'change_resourcebase_permissions', 'publish_resourcebase'];
-        }
-        var d_perms = '';
-        if (data[perm] instanceof Array) {
-          d_perms = data[perm][1];
-        } else {
-          d_perms = data[perm];
-        }
-        for (var i=0;i<d_perms.split(',').length;i++){
-          var group = d_perms.split(',')[i];
-          for(var j=0;j< perms_to_assign.length;j++){
-            if(permissions['groups'].hasOwnProperty(group)){
-              permissions['groups'][group].push(perms_to_assign[j]);
-            }else{
-              permissions['groups'][group] = [perms_to_assign[j]];
+        
+        if (perm_users_found || perm_groups_found) {
+          var perm_key = perm_users_found ? 'users' : 'groups';
+          var d_perms = data[perm];
+
+          if (d_perms instanceof Array) {
+            for (var i=0;i<d_perms.length;i++){
+              var perm_value = d_perms[i];
+              for(var j=0;j< perms_to_assign.length;j++){
+                if(permissions[perm_key].hasOwnProperty(perm_value)){
+                  permissions[perm_key][perm_value].push(perms_to_assign[j]);
+                }else{
+                  permissions[perm_key][perm_value] = [perms_to_assign[j]];
+                }
+              }
+            }             
+          } else {
+            for (var i=0;i<d_perms.split(',').length;i++){
+              var perm_value = d_perms.split(',')[i];
+              for(var j=0;j< perms_to_assign.length;j++){
+                if(permissions[perm_key].hasOwnProperty(perm_value)){
+                  permissions[perm_key][perm_value].push(perms_to_assign[j]);
+                }else{
+                  permissions[perm_key][perm_value] = [perms_to_assign[j]];
+                }
+              }
             }
           }
         }
       }
     }
+
     return permissions
   };
 
@@ -163,12 +165,8 @@
                   users[user_perms[i]].push(user);
                 }
               }
-              // $('#' + perm + '_users').val(users[perm].join());
-              $(users[perm]).each(function( index ) {
-                $('#' + perm + '_users').append(new Option(this, this));
-              });
+              addSelectUsers('#' + perm + '_users', users[perm]);
             }
-            addSelectUsers();
 
             /*
             * Compile the groups fields after receiving the current permissions status from the server
@@ -181,6 +179,7 @@
               change_layer_style: [],
               manage_resourcebase: []
             };
+
             var perms_groups = perms.groups;
             for (var group in perms_groups){
               if (group !== 'anonymous'){
@@ -198,24 +197,18 @@
                 }
               }
             }
+
             for (var perm in groups){
-              // $('#' + perm + '_groups').val(groups[perm].join());
-              $(groups[perm]).each(function( index ) {
-                $('#' + perm + '_groups').append(new Option(this, this));
-              });
+              addSelectGroups('#' + perm + '_groups', groups[perm]);
             }
-            addSelectGroups();
           }
         }
       );
-      {% else %}
-      addSelectUsers();
-      addSelectGroups();
       {% endif %}
     });
 
-    function addSelectUsers(){
-      $(".user-select").select2({
+    function addSelectUsers(id, default_perms){
+      $(id).select2({
         placeholder: '{% trans "Choose users..." %}',
         minimumInputLength: 1,
         multiple: true,
@@ -254,12 +247,19 @@
             };
           },
           cache: true
+        },
+        initSelection: function (element, callback) {
+          var data = [];
+          $(default_perms).each(function (index, perm) {
+            data.push({id: perm, text: perm});
+          });
+          callback(data);
         }
       });
     }
 
-    function addSelectGroups(){
-      $(".group-select").select2({
+    function addSelectGroups(id, default_perms){
+      $(id).select2({
         placeholder: '{% trans "Choose groups..." %}',
         minimumInputLength: 1,
         multiple: true,
@@ -295,6 +295,13 @@
             };
           },
           cache: true
+        },
+        initSelection: function (element, callback) {
+          var data = [];
+          $(default_perms).each(function (index, perm) {
+            data.push({id: perm, text: perm});
+          });
+          callback(data);
         }
       });
     }

--- a/geonode/upload/tests/test_settings.py
+++ b/geonode/upload/tests/test_settings.py
@@ -58,6 +58,11 @@ if 'geonode.security.middleware.SessionControlMiddleware' in MIDDLEWARE_CLASSES:
     _middleware.remove('geonode.security.middleware.SessionControlMiddleware')
     MIDDLEWARE_CLASSES = tuple(_middleware)
 
+# Django 1.11 ParallelTestSuite
+TEST_RUNNER = 'geonode.tests.suite.runner.GeoNodeBaseSuiteDiscoverRunner'
+TEST_RUNNER_KEEPDB = os.environ.get('TEST_RUNNER_KEEPDB', 1)
+TEST_RUNNER_PARALLEL = os.environ.get('TEST_RUNNER_PARALLEL', 1)
+
 # Backend
 DATABASES = {
     'default': {
@@ -70,10 +75,9 @@ DATABASES = {
         'CONN_MAX_AGE': 5,
         'CONN_TOUT': 5,
         'OPTIONS': {
-            'connect_timeout': 5,
+            'connect_timeout': 5
         }
     },
-    # vector datastore for uploads
     'datastore': {
         'ENGINE': 'django.contrib.gis.db.backends.postgis',
         'NAME': 'upload_test',
@@ -84,7 +88,7 @@ DATABASES = {
         'CONN_MAX_AGE': 5,
         'CONN_TOUT': 5,
         'OPTIONS': {
-            'connect_timeout': 5,
+            'connect_timeout': 5
         }
     }
 }
@@ -191,7 +195,7 @@ MONITORING_HOST_NAME = os.getenv("MONITORING_HOST_NAME", HOSTNAME)
 MONITORING_SERVICE_NAME = os.getenv("MONITORING_SERVICE_NAME", 'local-geonode')
 
 # how long monitoring data should be stored
-MONITORING_DATA_TTL = timedelta(days=int(os.getenv("MONITORING_DATA_TTL", 365)))
+MONITORING_DATA_TTL = timedelta(days=int(os.getenv("MONITORING_DATA_TTL", 7)))
 
 # this will disable csrf check for notification config views,
 # use with caution - for dev purpose only

--- a/geonode/upload/utils.py
+++ b/geonode/upload/utils.py
@@ -282,6 +282,7 @@ def _advance_step(req, upload_session):
 
 
 def next_step_response(req, upload_session, force_ajax=True):
+    _force_ajax = '&force_ajax=true' if force_ajax and 'force_ajax' not in req.GET else ''
     import_session = upload_session.import_session
     # if the current step is the view POST for this step, advance one
     if req.method == 'POST':
@@ -289,7 +290,9 @@ def next_step_response(req, upload_session, force_ajax=True):
             _advance_step(req, upload_session)
         else:
             upload_session.completed_step = 'save'
+
     next = get_next_step(upload_session)
+
     if next == 'error':
         return json_response(
             {'status': 'error',
@@ -302,17 +305,17 @@ def next_step_response(req, upload_session, force_ajax=True):
     if next == 'check':
         # @TODO we skip time steps for coverages currently
         store_type = import_session.tasks[0].target.store_type
-        if store_type == 'coverageStore':
+        if store_type == 'coverageStore' or _force_ajax:
             upload_session.completed_step = 'check'
-            return next_step_response(req, upload_session, force_ajax)
+            return next_step_response(req, upload_session, force_ajax=True)
     if next == 'check' and force_ajax:
-        url = reverse('data_upload') + "?id=%s" % import_session.id
+        url = reverse('data_upload') + "?id=%s" % (import_session.id)
         return json_response(
             {'url': url,
              'status': 'incomplete',
              'success': True,
              'id': import_session.id,
-             'redirect_to': settings.SITEURL + 'upload/check' + "?id=%s" % import_session.id,
+             'redirect_to': settings.SITEURL + 'upload/check' + "?id=%s%s" % (import_session.id, _force_ajax),
              }
         )
 
@@ -331,46 +334,46 @@ def next_step_response(req, upload_session, force_ajax=True):
         upload_session.completed_step = 'time'
         return next_step_response(req, upload_session, force_ajax)
     if next == 'time' and force_ajax:
-        url = reverse('data_upload') + "?id=%s" % import_session.id
+        url = reverse('data_upload') + "?id=%s" % (import_session.id)
         return json_response(
             {'url': url,
              'status': 'incomplete',
              'success': True,
              'id': import_session.id,
-             'redirect_to': settings.SITEURL + 'upload/time' + "?id=%s" % import_session.id,
+             'redirect_to': settings.SITEURL + 'upload/time' + "?id=%s%s" % (import_session.id, _force_ajax),
              }
         )
 
     if next == 'mosaic' and force_ajax:
-        url = reverse('data_upload') + "?id=%s" % import_session.id
+        url = reverse('data_upload') + "?id=%s" % (import_session.id)
         return json_response(
             {'url': url,
              'status': 'incomplete',
              'success': True,
              'id': import_session.id,
-             'redirect_to': settings.SITEURL + 'upload/mosaic' + "?id=%s" % import_session.id,
+             'redirect_to': settings.SITEURL + 'upload/mosaic' + "?id=%s%s" % (import_session.id, _force_ajax),
              }
         )
 
     if next == 'srs' and force_ajax:
-        url = reverse('data_upload') + "?id=%s" % import_session.id
+        url = reverse('data_upload') + "?id=%s" % (import_session.id)
         return json_response(
             {'url': url,
              'status': 'incomplete',
              'success': True,
              'id': import_session.id,
-             'redirect_to': settings.SITEURL + 'upload/srs' + "?id=%s" % import_session.id,
+             'redirect_to': settings.SITEURL + 'upload/srs' + "?id=%s%s" % (import_session.id, _force_ajax),
              }
         )
 
     if next == 'csv' and force_ajax:
-        url = reverse('data_upload') + "?id=%s" % import_session.id
+        url = reverse('data_upload') + "?id=%s" % (import_session.id)
         return json_response(
             {'url': url,
              'status': 'incomplete',
              'success': True,
              'id': import_session.id,
-             'redirect_to': settings.SITEURL + 'upload/csv' + "?id=%s" % import_session.id,
+             'redirect_to': settings.SITEURL + 'upload/csv' + "?id=%s%s" % (import_session.id, _force_ajax),
              }
         )
 
@@ -387,9 +390,9 @@ def next_step_response(req, upload_session, force_ajax=True):
                                       force_ajax=force_ajax)
     session_id = None
     if 'id' in req.GET:
-        session_id = "?id=%s" % req.GET['id']
+        session_id = "?id=%s" % (req.GET['id'])
     elif import_session and import_session.id:
-        session_id = "?id=%s" % import_session.id
+        session_id = "?id=%s" % (import_session.id)
 
     if req.is_ajax() or force_ajax:
         content_type = 'text/html' if not req.is_ajax() else None

--- a/requirements.txt
+++ b/requirements.txt
@@ -70,7 +70,7 @@ geonode-oauth-toolkit==1.1.4.6
 
 # GeoNode org maintained apps.
 django-geoexplorer==4.0.43
-django-mapstore-adapter==1.0.6
+django-mapstore-adapter==1.0.7
 django-geonode-mapstore-client==1.4.0
 django-geonode-client==1.0.9
 geonode-user-messages==0.1.14
@@ -80,7 +80,7 @@ geonode-agon-ratings==0.3.8
 arcrest>=10.0
 geonode-dialogos==1.2
 geoserver-restconfig==1.0.3
-gn-gsimporter==1.0.10
+gn-gsimporter==1.0.12
 gisdata==0.5.4
 
 # haystack/elasticsearch


### PR DESCRIPTION
The backport to `2.10.x` failed:

```
Commits ["6e2634652553a89cf108bda7b44e6e0ecd1f0ae0","fd5148212d72af929bd7e3d927958a18d455fac0"] could not be cherry-picked on top of 2.10.x
```
To backport manually, run these commands in your terminal:
```bash
# Fetch latest updates from GitHub.
git fetch
# Create new working tree.
git worktree add .worktrees/backport 2.10.x
# Navigate to the new directory.
cd .worktrees/backport
# Cherry-pick all the commits of this pull request and resolve the likely conflicts.
git cherry-pick 6e2634652553a89cf108bda7b44e6e0ecd1f0ae0 fd5148212d72af929bd7e3d927958a18d455fac0
# Create a new branch with these backported commits.
git checkout -b backport-4865-to-2.10.x
# Push it to GitHub.
git push --set-upstream origin backport-4865-to-2.10.x
# Go back to the original working tree.
cd ../..
# Delete the working tree.
git worktree remove .worktrees/backport
```
Then, create a pull request where the `base` branch is `2.10.x` and the `compare`/`head` branch is `backport-4865-to-2.10.x`.