### PR TITLE
[Backport 4868 to 2.10.x] [Fixes #4827] Line layer uploaded to GeoNode is rendered as point layer (#4868)

### DIFF
--- a/geonode/geoserver/helpers.py
+++ b/geonode/geoserver/helpers.py
@@ -248,10 +248,14 @@ def get_sld_for(gs_catalog, layer):
         traceback.print_exc()
         pass
 
-    if _default_style is None:
+    try:
         gs_catalog._cache.clear()
+        gs_layer = gs_catalog.get_layer(layer.name)
+    except BaseException:
+        traceback.print_exc()
+
+    if _default_style is None:
         try:
-            gs_layer = gs_catalog.get_layer(layer.name)
             name = gs_layer.default_style.name if gs_layer.default_style is not None else "raster"
         except BaseException:
             traceback.print_exc()

--- a/geonode/tests/integration.py
+++ b/geonode/tests/integration.py
@@ -220,7 +220,7 @@ class NormalUserTest(GeoNodeLiveTestSupport):
             set_layer_style(saved_layer, saved_layer.alternate, sld)
 
             fixup_style(gs_catalog, saved_layer.alternate, None)
-            self.assertIsNone(get_sld_for(gs_catalog, saved_layer))
+            self.assertIsNotNone(get_sld_for(gs_catalog, saved_layer))
             _log("3. ------------ %s " % get_sld_for(gs_catalog, saved_layer))
 
             create_gs_thumbnail(saved_layer, overwrite=True)


### PR DESCRIPTION
Commits ["5dc3ef0a6478ead4ba5ce7ed0e6eb8f920514cfa","94574f42c0ccdc9a5334fc98419bb85a1166f14d"] could not be cherry-picked on top of 2.10.x
To backport manually, run these commands in your terminal:

# Fetch latest updates from GitHub.
git fetch
# Create new working tree.
git worktree add .worktrees/backport 2.10.x
# Navigate to the new directory.
cd .worktrees/backport
# Cherry-pick all the commits of this pull request and resolve the likely conflicts.
git cherry-pick 5dc3ef0a6478ead4ba5ce7ed0e6eb8f920514cfa 94574f42c0ccdc9a5334fc98419bb85a1166f14d
# Create a new branch with these backported commits.
git checkout -b backport-4868-to-2.10.x
# Push it to GitHub.
git push --set-upstream origin backport-4868-to-2.10.x
# Go back to the original working tree.
cd ../..
# Delete the working tree.
git worktree remove .worktrees/backport
Then, create a pull request where the base branch is 2.10.x and the compare/head branch is backport-4868-to-2.10.x.