### PR TITLE
[Fixes #4881] Improve initial generate thumbnail quality

### DIFF
--- a/geonode/geoserver/helpers.py
+++ b/geonode/geoserver/helpers.py
@@ -1909,6 +1909,19 @@ def _render_thumbnail(req_body, width=240, height=180):
     try:
         req, content = http_client.post(
             url, data=data, headers=headers)
+        # Optimize the Thumbnail size and resolution
+        from PIL import Image
+        from io import BytesIO
+        content_data = BytesIO(content)
+        im = Image.open(content_data)
+        im_width, im_height = im.size
+        right = min(width, im_width)
+        bottom = min(height, im_height)
+        size = right, bottom
+        im.thumbnail(size, Image.ANTIALIAS)
+        imgByteArr = BytesIO()
+        im.save(imgByteArr, format='JPEG')
+        content = imgByteArr.getvalue()
     except BaseException as e:
         logger.warning('Error generating thumbnail')
         logger.exception(e)

--- a/geonode/utils.py
+++ b/geonode/utils.py
@@ -345,7 +345,7 @@ def bounds_to_zoom_level(bounds, width, height):
     latZoom = zoom(float(height), WORLD_DIM['height'], latFraction)
     lngZoom = zoom(float(width), WORLD_DIM['width'], lngFraction)
     ratio = float(max(width, height)) / float(min(width, height))
-    z_offset = 0 if ratio >= 1.5 else -1
+    z_offset = 0 if ratio >= 2 else -1
     zoom = int(max(latZoom, lngZoom) + z_offset)
     zoom = 0 if zoom > ZOOM_MAX else zoom
     return max(zoom, 0)


### PR DESCRIPTION
<Include a few sentences describing the overall goals for this Pull Request>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there are explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
