### PR TITLE
[Backport to 2.10.x][Fixes #4924] Add member to Group is broken

### DIFF
--- a/geonode/groups/forms.py
+++ b/geonode/groups/forms.py
@@ -85,9 +85,10 @@ class GroupUpdateForm(forms.ModelForm):
 class GroupMemberForm(forms.Form):
     user_identifiers = forms.CharField(
         label=_("User Identifiers"),
-        widget=forms.TextInput(
+        widget=forms.Select(
             attrs={
-                'class': 'user-select'
+                'class': 'user-select',
+                'style': 'width:300px'
             }
         )
     )

--- a/geonode/groups/templates/groups/group_members.html
+++ b/geonode/groups/templates/groups/group_members.html
@@ -2,6 +2,15 @@
 {% load i18n %}
 {% load bootstrap_tags %}
 
+{% block head %}
+{{ block.super }}
+<style>
+.select2-container--default .select2-search--inline .select2-search__field {
+  width: 300px !important;
+}
+</style>
+{% endblock head %}
+
 {% block sidebar %}
 <div class="row">
   <div class="col-md-12">
@@ -102,7 +111,7 @@
         <h3>{% trans "Add new members" %}</h3>
         <form method="POST" action="{% url "group_members_add" group.slug %}">
             {% csrf_token %}
-            <div id="member_form_container">
+            <div id="member_form_container"
                 {{ member_form|as_bootstrap }}<br/><br/>
             </div>
             <input type="submit" value="{% trans "Add Group Members" %}" class="btn btn-primary"/>


### PR DESCRIPTION
Commits ["28755ed905bd8c0dd446e878ad8b887e0c90247a"] could not be cherry-picked on top of 2.10.x
To backport manually, run these commands in your terminal:

# Fetch latest updates from GitHub.
git fetch
# Create new working tree.
git worktree add .worktrees/backport 2.10.x
# Navigate to the new directory.
cd .worktrees/backport
# Cherry-pick all the commits of this pull request and resolve the likely conflicts.
git cherry-pick 28755ed905bd8c0dd446e878ad8b887e0c90247a
# Create a new branch with these backported commits.
git checkout -b backport-4925-to-2.10.x
# Push it to GitHub.
git push --set-upstream origin backport-4925-to-2.10.x
# Go back to the original working tree.
cd ../..
# Delete the working tree.
git worktree remove .worktrees/backport
Then, create a pull request where the base branch is 2.10.x and the compare/head branch is backport-4925-to-2.10.x.