### PR TITLE
[Fixes #4907] Add the possibility of enabling "captcha" on GeoNode si…

### DIFF
--- a/docs/basic/settings/index.rst
+++ b/docs/basic/settings/index.rst
@@ -28,6 +28,13 @@ ACCESS_TOKEN_EXPIRE_SECONDS
 
     When a user logs into GeoNode, if no ``ACCESS_TOKEN`` exists, a new one will be created with a default expiration time of ``ACCESS_TOKEN_EXPIRE_SECONDS`` seconds (1 day by default).
 
+ACCOUNT_ADAPTER
+---------------
+
+    | Default: ``geonode.people.adapters.LocalAccountAdapter``
+
+    Custom GeoNode People (Users) Account Adapter.
+
 ACCOUNT_APPROVAL_REQUIRED
 -------------------------
 
@@ -89,9 +96,20 @@ ACCOUNT_OPEN_SIGNUP
 -------------------
 
     | Default: ``True``
+    | Env: ``ACCOUNT_OPEN_SIGNUP``
 
     This is a `django-user-accounts setting <https://django-user-accounts.readthedocs.io/en/latest/settings.html>`__
     Whether or not people are allowed to self-register to GeoNode or not.
+
+ACCOUNT_SIGNUP_FORM_CLASS
+-------------------------
+
+    | Default: ``geonode.people.forms.AllauthReCaptchaSignupForm``
+    | Env: ``ACCOUNT_SIGNUP_FORM_CLASS``
+
+    Enabled only when the :ref:`recaptcha_enabled` option is ``True``.
+
+    Ref. to :ref:`recaptcha_enabled`
 
 ACTSTREAM_SETTINGS
 ------------------
@@ -1300,12 +1318,12 @@ PROXY_URL
 PYCSW
 -----
 
-  A dict with pycsw's configuration.  Of note are the sections
-  ``metadata:main`` to set CSW server metadata and ``metadata:inspire``
-  to set INSPIRE options.  Setting ``metadata:inspire['enabled']`` to ``true``
-  will enable INSPIRE support.   Server level configurations can be overridden
-  in the ``server`` section.  See http://docs.pycsw.org/en/latest/configuration.html
-  for full pycsw configuration details.
+    A dict with pycsw's configuration.  Of note are the sections
+    ``metadata:main`` to set CSW server metadata and ``metadata:inspire``
+    to set INSPIRE options.  Setting ``metadata:inspire['enabled']`` to ``true``
+    will enable INSPIRE support.   Server level configurations can be overridden
+    in the ``server`` section.  See http://docs.pycsw.org/en/latest/configuration.html
+    for full pycsw configuration details.
 
 R
 =
@@ -1316,6 +1334,73 @@ RABBITMQ_SIGNALS_BROKER_URL
     Default: ``amqp://localhost:5672``
 
     The Rabbitmq endpoint
+
+.. _recaptcha_enabled:
+
+RECAPTCHA_ENABLED
+-----------------
+
+    | Default: ``False``
+    | Env: ``RECAPTCHA_ENABLED``
+
+    Allows enabling reCaptcha field on signup form.
+    Valid Captcha Public and Private keys will be needed as specifice here https://pypi.org/project/django-recaptcha/#installation
+
+    More options will be available by enabling this setting:
+
+    * **ACCOUNT_SIGNUP_FORM_CLASS**
+
+        | Default: ``geonode.people.forms.AllauthReCaptchaSignupForm``
+        | Env: ``ACCOUNT_SIGNUP_FORM_CLASS``
+
+        Enabled only when the :ref:`recaptcha_enabled` option is ``True``.
+    
+    * **INSTALLED_APPS**
+    
+        The ``captcha`` must be present on ``INSTALLED_APPS``, otherwise you'll get an error.
+
+        When enabling the :ref:`recaptcha_enabled` option through the ``environment``, this setting will be automatically added by GeoNode as follows:
+
+        .. code:: python
+
+            if 'captcha' not in INSTALLED_APPS:
+                    INSTALLED_APPS += ('captcha',)        
+
+    * **RECAPTCHA_PUBLIC_KEY**
+
+        | Default: ``geonode_RECAPTCHA_PUBLIC_KEY``
+        | Env: ``RECAPTCHA_PUBLIC_KEY``
+
+        In order to generate reCaptcha keys, please see:
+
+        #. https://pypi.org/project/django-recaptcha/#installation
+        #. https://pypi.org/project/django-recaptcha/#local-development-and-functional-testing
+
+    * **RECAPTCHA_PRIVATE_KEY**
+
+        | Default: ``geonode_RECAPTCHA_PRIVATE_KEY``
+        | Env: ``RECAPTCHA_PRIVATE_KEY``
+
+        In order to generate reCaptcha keys, please see:
+
+        #. https://pypi.org/project/django-recaptcha/#installation
+        #. https://pypi.org/project/django-recaptcha/#local-development-and-functional-testing
+
+RECAPTCHA_PUBLIC_KEY
+--------------------
+
+    | Default: ``geonode_RECAPTCHA_PUBLIC_KEY``
+    | Env: ``RECAPTCHA_PUBLIC_KEY``
+
+    Ref. to :ref:`recaptcha_enabled`
+
+RECAPTCHA_PRIVATE_KEY
+---------------------
+
+    | Default: ``geonode_RECAPTCHA_PRIVATE_KEY``
+    | Env: ``RECAPTCHA_PRIVATE_KEY``
+
+    Ref. to :ref:`recaptcha_enabled`
 
 REDIS_SIGNALS_BROKER_URL
 ------------------------

--- a/geonode/people/forms.py
+++ b/geonode/people/forms.py
@@ -27,8 +27,19 @@ from django.utils.translation import ugettext as _
 from geonode.people.models import Profile
 from geonode.base.models import ContactRole
 
+from captcha.fields import ReCaptchaField
+
 # Ported in from django-registration
 attrs_dict = {'class': 'required'}
+
+
+class AllauthReCaptchaSignupForm(forms.Form):
+
+    captcha = ReCaptchaField()
+
+    def signup(self, request, user):
+        """ Required, or else it thorws deprecation warnings """
+        pass
 
 
 class ProfileCreationForm(UserCreationForm):

--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -1172,6 +1172,23 @@ if FAVORITE_ENABLED:
     if 'geonode.favorite' not in INSTALLED_APPS:
         INSTALLED_APPS += ('geonode.favorite',)
 
+
+# Settings for RECAPTCHA plugin
+RECAPTCHA_ENABLED = ast.literal_eval(os.environ.get('RECAPTCHA_ENABLED', 'False'))
+
+if RECAPTCHA_ENABLED:
+    if 'captcha' not in INSTALLED_APPS:
+        INSTALLED_APPS += ('captcha',)
+    ACCOUNT_SIGNUP_FORM_CLASS = os.getenv("ACCOUNT_SIGNUP_FORM_CLASS",
+                                          'geonode.people.forms.AllauthReCaptchaSignupForm')
+    """
+     In order to generate reCaptcha keys, please see:
+      - https://pypi.org/project/django-recaptcha/#installation
+      - https://pypi.org/project/django-recaptcha/#local-development-and-functional-testing
+    """
+    RECAPTCHA_PUBLIC_KEY = os.getenv("RECAPTCHA_PUBLIC_KEY", 'geonode_RECAPTCHA_PUBLIC_KEY')
+    RECAPTCHA_PRIVATE_KEY = os.getenv("RECAPTCHA_PRIVATE_KEY", 'geonode_RECAPTCHA_PRIVATE_KEY')
+
 # Settings for MONITORING plugin
 MONITORING_ENABLED = ast.literal_eval(os.environ.get('MONITORING_ENABLED', 'True'))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -66,6 +66,7 @@ django-autocomplete-light==2.3.3 # pinned because >=2.3.4 throw an exception on 
 django-basic-authentication-decorator==0.9
 django-leaflet==0.24.0
 django-invitations<=1.9.2
+django-recaptcha==2.0.5
 geonode-oauth-toolkit==1.1.4.6
 
 # GeoNode org maintained apps.


### PR DESCRIPTION
…gnup form

<Include a few sentences describing the overall goals for this Pull Request>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there are explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [x] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
