### PR TITLE
[Fixes #4959] By using UPLOADER=geonode.rest we are facing a timing i…

### DIFF
--- a/geonode/messaging/consumer.py
+++ b/geonode/messaging/consumer.py
@@ -132,7 +132,7 @@ class Consumer(ConsumerMixin):
             _update_layer_data(body, self.last_message)
             self.last_message = json.loads(body)
         except BaseException:
-            logger.info("Could not encode message {!r}".format(body))
+            logger.debug("Could not encode message {!r}".format(body))
         message.ack()
         logger.debug("on_geoserver_catalog: finished")
         self._check_message_limit()
@@ -143,7 +143,7 @@ class Consumer(ConsumerMixin):
             _update_layer_data(body, self.last_message)
             self.last_message = json.loads(body)
         except BaseException:
-            logger.info("Could not encode message {!r}".format(body))
+            logger.debug("Could not encode message {!r}".format(body))
         message.ack()
         logger.debug("on_geoserver_data: finished")
         self._check_message_limit()

--- a/geonode/tests/csw.py
+++ b/geonode/tests/csw.py
@@ -115,12 +115,10 @@ class GeoNodeCSWTest(GeoNodeBaseTestSupport):
         record = csw.catalogue.records.values()[0]
 
         # test that the ISO title maps correctly in Dublin Core
-        self.assertEqual(record.title, 'San Andres Y Providencia Location',
-                         'Expected a specific title in Dublin Core model')
+        self.assertEquals(record.title, 'San Andres Y Providencia Location')
 
         # test that the ISO abstract maps correctly in Dublin Core
-        self.assertEqual(record.abstract, 'No abstract provided',
-                         'Expected a specific abstract in Dublin Core model')
+        self.assertEquals(record.abstract, None)
 
         # test for correct service link articulation
         for link in record.references:
@@ -160,35 +158,17 @@ class GeoNodeCSWTest(GeoNodeBaseTestSupport):
         record = csw.catalogue.records.values()[0]
 
         # test that the ISO title maps correctly in Dublin Core
-        self.assertEqual(
-            record.identification.title,
-            'San Andres Y Providencia Location',
-            'Expected a specific title in ISO model')
+        self.assertEquals(record.identification.title, 'San Andres Y Providencia Location')
 
         # test that the ISO abstract maps correctly in Dublin Core
-        self.assertEqual(
-            record.identification.abstract,
-            'No abstract provided',
-            'Expected a specific abstract in ISO model')
+        self.assertEquals(record.identification.abstract, None)
 
         # test BBOX properties in Dublin Core
         from decimal import Decimal
-        self.assertEqual(
-            Decimal(record.identification.bbox.minx),
-            Decimal('-81.8593555'),
-            'Expected a specific minx coordinate value in ISO model')
-        self.assertEqual(
-            Decimal(record.identification.bbox.miny),
-            Decimal('12.1665322'),
-            'Expected a specific minx coordinate value in ISO model')
-        self.assertEqual(
-            Decimal(record.identification.bbox.maxx),
-            Decimal('-81.356409'),
-            'Expected a specific maxx coordinate value in ISO model')
-        self.assertEqual(
-            Decimal(record.identification.bbox.maxy),
-            Decimal('13.396306'),
-            'Expected a specific maxy coordinate value in ISO model')
+        self.assertEquals(Decimal(record.identification.bbox.minx), Decimal('-81.8593555'))
+        self.assertEquals(Decimal(record.identification.bbox.miny), Decimal('12.1665322'))
+        self.assertEquals(Decimal(record.identification.bbox.maxx), Decimal('-81.356409'))
+        self.assertEquals(Decimal(record.identification.bbox.maxy), Decimal('13.396306'))
 
         # test for correct link articulation
         for link in record.distribution.online:
@@ -237,30 +217,15 @@ class GeoNodeCSWTest(GeoNodeBaseTestSupport):
             record = csw.catalogue.records.values()[0]
 
             # test CRS constructs in Dublin Core
-            self.assertEqual(
-                record.bbox.crs.code,
-                4326,
-                'Expected a specific CRS code value in Dublin Core model')
+            self.assertEquals(record.bbox.crs.code, 4326)
             # test BBOX properties in Dublin Core
             from decimal import Decimal
             logger.debug([Decimal(record.bbox.minx), Decimal(record.bbox.miny),
                           Decimal(record.bbox.maxx), Decimal(record.bbox.maxy)])
-            self.assertEqual(
-                Decimal(record.bbox.minx),
-                Decimal('-81.8593555'),
-                'Expected a specific minx coordinate value in Dublin Core model')
-            self.assertEqual(
-                Decimal(record.bbox.miny),
-                Decimal('12.1665322'),
-                'Expected a specific minx coordinate value in Dublin Core model')
-            self.assertEqual(
-                Decimal(record.bbox.maxx),
-                Decimal('-81.356409'),
-                'Expected a specific maxx coordinate value in Dublin Core model')
-            self.assertEqual(
-                Decimal(record.bbox.maxy),
-                Decimal('13.396306'),
-                'Expected a specific maxy coordinate value in Dublin Core model')
+            self.assertEquals(Decimal(record.bbox.minx), Decimal('-81.8593555'))
+            self.assertEquals(Decimal(record.bbox.miny), Decimal('12.1665322'))
+            self.assertEquals(Decimal(record.bbox.maxx), Decimal('-81.356409'))
+            self.assertEquals(Decimal(record.bbox.maxy), Decimal('13.396306'))
 
     def test_csw_outputschema_fgdc(self):
         """Verify that GeoNode CSW can handle ISO metadata with FGDC outputSchema"""
@@ -279,16 +244,10 @@ class GeoNodeCSWTest(GeoNodeBaseTestSupport):
             record = csw.catalogue.records.values()[0]
 
             # test that the ISO title maps correctly in FGDC
-            self.assertEqual(
-                record.idinfo.citation.citeinfo['title'],
-                'San Andres Y Providencia Location',
-                'Expected a specific title in FGDC model')
+            self.assertEquals(record.idinfo.citation.citeinfo['title'], 'San Andres Y Providencia Location')
 
             # test that the ISO abstract maps correctly in FGDC
-            self.assertEqual(
-                record.idinfo.descript.abstract,
-                'No abstract provided',
-                'Expected a specific abstract in FGDC model')
+            self.assertEquals(record.idinfo.descript.abstract, None)
 
     def test_csw_query_bbox(self):
         """Verify that GeoNode CSW can handle bbox queries"""
@@ -296,10 +255,7 @@ class GeoNodeCSWTest(GeoNodeBaseTestSupport):
         csw = get_catalogue()
         csw.catalogue.getrecords(bbox=[-140, -70, 80, 70])
         logger.debug(csw.catalogue.results)
-        self.assertEqual(
-            csw.catalogue.results,
-            {'matches': 7, 'nextrecord': 0, 'returned': 7},
-            'Expected a specific bbox query result set')
+        self.assertEquals(csw.catalogue.results, {'matches': 7, 'nextrecord': 0, 'returned': 7})
 
     def test_csw_upload_fgdc(self):
         """Verify that GeoNode CSW can handle FGDC metadata upload"""
@@ -324,84 +280,48 @@ class GeoNodeCSWTest(GeoNodeBaseTestSupport):
                 record=md_doc)
 
             # test that FGDC document was successfully inserted
-            self.assertEqual(
-                csw.catalogue.results['inserted'],
-                1,
-                'Expected 1 inserted record in FGDC model')
+            self.assertEquals(csw.catalogue.results['inserted'], 1)
 
             # query against FGDC typename, output FGDC
             csw.catalogue.getrecords(typenames='fgdc:metadata')
-            self.assertEqual(
-                csw.catalogue.results['matches'],
-                1,
-                'Expected 1 record in FGDC model')
+            self.assertEquals(csw.catalogue.results['matches'], 1)
 
             record = csw.catalogue.records.values()[0]
 
             # test that the FGDC title maps correctly in DC
-            self.assertEqual(
-                record.title,
-                'Census_Blockgroup_Pop_Housing',
-                'Expected a specific title in DC model')
+            self.assertEquals(record.title, 'Census_Blockgroup_Pop_Housing')
 
             # test that the FGDC type maps correctly in DC
-            self.assertEqual(
-                record.type,
-                'vector digital data',
-                'Expected a specific type in DC model')
+            self.assertEquals(record.type, 'vector digital data')
 
             # test CRS constructs in Dublin Core
-            self.assertEqual(
-                record.bbox.crs.code,
-                4326,
-                'Expected a specific CRS code value in Dublin Core model')
+            self.assertEquals(record.bbox.crs.code, 4326)
 
             # test BBOX properties in Dublin Core
             from decimal import Decimal
-            self.assertEqual(
-                Decimal(record.bbox.minx),
-                Decimal('-117.6'),
-                'Expected a specific minx coordinate value in Dublin Core model')
-            self.assertEqual(
-                Decimal(record.bbox.miny),
-                Decimal('32.53'),
-                'Expected a specific minx coordinate value in Dublin Core model')
-            self.assertEqual(
-                Decimal(record.bbox.maxx),
-                Decimal('-116.08'),
-                'Expected a specific maxx coordinate value in Dublin Core model')
-            self.assertEqual(
-                Decimal(record.bbox.maxy),
-                Decimal('33.51'),
-                'Expected a specific maxy coordinate value in Dublin Core model')
+            self.assertEquals(Decimal(record.bbox.minx), Decimal('-117.6'))
+            self.assertEquals(Decimal(record.bbox.miny), Decimal('32.53'))
+            self.assertEquals(Decimal(record.bbox.maxx), Decimal('-116.08'))
+            self.assertEquals(Decimal(record.bbox.maxy), Decimal('33.51'))
 
             # query against FGDC typename, return in ISO
             csw.catalogue.getrecords(
                 typenames='fgdc:metadata',
                 esn='brief',
                 outputschema='http://www.isotc211.org/2005/gmd')
-            self.assertEqual(
-                csw.catalogue.results['matches'],
-                1,
-                'Expected 1 record in ISO model')
+            self.assertEquals(csw.catalogue.results['matches'], 1)
 
             record = csw.catalogue.records.values()[0]
 
             # test that the FGDC title maps correctly in ISO
-            self.assertEqual(
-                record.identification.title,
-                'Census_Blockgroup_Pop_Housing',
-                'Expected a specific title in ISO model')
+            self.assertEquals(record.identification.title, 'Census_Blockgroup_Pop_Housing')
 
             # cleanup and delete inserted FGDC metadata document
             csw.catalogue.transaction(
                 ttype='delete',
                 typename='fgdc:metadata',
                 cql='fgdc:Title like "Census_Blockgroup_Pop_Housing"')
-            self.assertEqual(
-                csw.catalogue.results['deleted'],
-                1,
-                'Expected 1 deleted record in FGDC model')
+            self.assertEquals(csw.catalogue.results['deleted'], 1)
 
     def test_csw_bulk_upload(self):
         """Verify that GeoNode CSW can handle bulk upload of ISO and FGDC metadata"""


### PR DESCRIPTION
…ssues on signals

<Include a few sentences describing the overall goals for this Pull Request>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there are explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [x] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
