### PR TITLE
[Fixes #1784][Fixes #2161][Fixes #2164][Fixes #5052]

### DIFF
--- a/docs/basic/settings/index.rst
+++ b/docs/basic/settings/index.rst
@@ -216,10 +216,18 @@ AUTH_EXEMPT_URLS
     ``AUTH_EXEMPT_URLS = ('/maps',)`` will allow unauthenticated users to
     browse maps.
 
+AUTO_ASSIGN_REGISTERED_MEMBERS_TO_REGISTERED_MEMBERS_GROUP_NAME
+---------------------------------------------------------------
+
+    | Default: ``False``
+    | Env: ``AUTO_ASSIGN_REGISTERED_MEMBERS_TO_REGISTERED_MEMBERS_GROUP_NAME``
+
+    Auto assign users to a default "Registered Users" private group after activation.
+
 AUTO_GENERATE_AVATAR_SIZES
 --------------------------
 
-    Default: ``20, 30, 32, 40, 50, 65, 70, 80, 100, 140, 200, 240``
+    | Default: ``20, 30, 32, 40, 50, 65, 70, 80, 100, 140, 200, 240``
 
     An iterable of integers representing the sizes of avatars to generate on upload. This can save rendering time later on if you pre-generate the resized versions.
 

--- a/docs/basic/theme/index.rst
+++ b/docs/basic/theme/index.rst
@@ -247,7 +247,7 @@ You can see on `line 189 of the GeoNode base.html template <https://github.com/G
                 {% if not custom_theme.jumbotron_cta_hide %}
                     <p>
                         <a class="btn btn-default btn-lg" target="_blank" role="button"
-                          href="{{custom_theme.jumbotron_cta_link|default:_('http://docs.geonode.org/en/2.10.x/usage/')}}">
+                          href="{{custom_theme.jumbotron_cta_link|default:_('http://docs.geonode.org/en/2.10.x/usage/index.html')}}">
                             {{custom_theme.jumbotron_cta_text|default:_("Get Started &raquo;")}}
                         </a>
                     </p>

--- a/geonode/api/api.py
+++ b/geonode/api/api.py
@@ -356,7 +356,7 @@ class GroupResource(ModelResource):
     resource_counts = fields.CharField()
 
     class Meta:
-        queryset = Group.objects.all()
+        queryset = Group.objects.exclude(groupprofile=None)
         resource_name = 'groups'
         allowed_methods = ['get']
         filtering = {
@@ -364,6 +364,26 @@ class GroupResource(ModelResource):
             'group_profile': ALL_WITH_RELATIONS,
         }
         ordering = ['name', 'last_modified']
+
+    def apply_filters(self, request, applicable_filters):
+        user = request.user
+        semi_filtered = super(
+            GroupResource,
+            self).apply_filters(
+            request,
+            applicable_filters)
+
+        filtered = semi_filtered
+        if not user.is_authenticated() or user.is_anonymous:
+            filtered = semi_filtered.exclude(groupprofile__access='private')
+        elif not user.is_superuser:
+            groups_member_of = user.group_list_all()
+            filtered = semi_filtered.filter(
+                Q(groupprofile__in=groups_member_of) |
+                ~Q(groupprofile__access='private')
+            )
+
+        return filtered
 
     def dehydrate(self, bundle):
         """Provide additional resource counts"""
@@ -406,6 +426,7 @@ class ProfileResource(TypeFilteredResource):
 
         if 'name__icontains' in filters:
             orm_filters['username__icontains'] = filters['name__icontains']
+
         return orm_filters
 
     def apply_filters(self, request, applicable_filters):

--- a/geonode/base/fixtures/profiles_test_data.json
+++ b/geonode/base/fixtures/profiles_test_data.json
@@ -1,50 +1,5 @@
 [
     {
-      "pk": 1,
-      "model": "auth.group",
-      "fields": {
-        "name": "bar",
-        "permissions": []
-      }
-    },
-    {
-        "fields": {
-            "access": "private",
-            "description": "Registered Members",
-            "slug": "registered-members",
-            "last_modified": "2019-09-09 15:45:34",
-            "created": "2019-09-09 15:45:34",
-            "group": 2,
-            "title": "Registered Members"
-        },
-        "model": "groups.groupprofile",
-        "pk": 1
-    },
-    {
-        "fields": {
-            "access": "public",
-            "description": "baz",
-            "logo": "people_peoplegroup/cactuar_1.jpg",
-            "slug": "bar",
-            "last_modified": "2011-06-09 15:45:34",
-            "created": "2011-06-09 15:45:34",
-            "group": 1,
-            "title": "bar"
-        },
-        "model": "groups.groupprofile",
-        "pk": 2
-    },
-    {
-        "fields": {
-            "group": 2,
-            "joined": "2012-02-28 14:47:22",
-            "role": "manager",
-            "user": 1
-        },
-        "model": "groups.groupmember",
-        "pk": 1
-    },
-    {
         "fields": {
             "date_joined": "2011-06-09 15:15:27",
             "email": "ad@m.in",

--- a/geonode/groups/conf/__init__.py
+++ b/geonode/groups/conf/__init__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+#########################################################################
+#
+# Copyright (C) 2016 OSGeo
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#########################################################################

--- a/geonode/groups/conf/settings.py
+++ b/geonode/groups/conf/settings.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+#########################################################################
+#
+# Copyright (C) 2016 OSGeo
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#########################################################################
+from django.conf import settings
+
+try:
+    REGISTERED_MEMBERS_GROUP_NAME = settings.REGISTERED_MEMBERS_GROUP_NAME
+except AttributeError:
+    REGISTERED_MEMBERS_GROUP_NAME = "registered-members"
+
+
+AUTO_ASSIGN_REGISTERED_MEMBERS_TO_REGISTERED_MEMBERS_GROUP_NAME = getattr(
+    settings, 'AUTO_ASSIGN_REGISTERED_MEMBERS_TO_REGISTERED_MEMBERS_GROUP_NAME', True)

--- a/geonode/groups/tests.py
+++ b/geonode/groups/tests.py
@@ -36,6 +36,7 @@ from geonode.documents.models import Document
 from geonode.layers.models import Layer
 from geonode.maps.models import Map
 from geonode.security.views import _perms_info_json
+from geonode.groups.conf import settings as groups_settings
 
 logger = logging.getLogger(__name__)
 
@@ -58,6 +59,51 @@ class SmokeTest(GeoNodeBaseTestSupport):
         self.test_user.groups.add(Group.objects.get(name='anonymous'))
         self.bar = GroupProfile.objects.get(slug='bar')
         self.anonymous_user = get_anonymous_user()
+
+    def test_registered_group_exists(self):
+        """
+        Ensures that a default group and grouprofile 'registered-users' has been
+        created at initialization time.
+        """
+        self.assertTrue(
+            groups_settings.AUTO_ASSIGN_REGISTERED_MEMBERS_TO_REGISTERED_MEMBERS_GROUP_NAME)
+        group = Group.objects.filter(
+            name=groups_settings.REGISTERED_MEMBERS_GROUP_NAME).first()
+        groupprofile = GroupProfile.objects.filter(
+            slug=groups_settings.REGISTERED_MEMBERS_GROUP_NAME).first()
+        self.assertTrue(group)
+        self.assertTrue(groupprofile)
+        self.assertEquals(groupprofile.group, group)
+        self.assertEquals(group.groupprofile, groupprofile)
+
+    def test_users_belongs_registered_group(self):
+        """
+        1. Ensures that a superuser is manager of a group despite the actual membership.
+
+        2. Ensures that any user on the system, except "AnonymousUser" belongs to
+           groups_settings.REGISTERED_MEMBERS_GROUP_NAME.
+        """
+        anonymous = get_user_model().objects.get(username="AnonymousUser")
+        norman = get_user_model().objects.get(username="norman")
+        admin = get_user_model().objects.get(username='admin')
+
+        # Make sure norman is not a user until login
+        groupprofile = GroupProfile.objects.filter(
+            slug=groups_settings.REGISTERED_MEMBERS_GROUP_NAME).first()
+        self.assertFalse(groupprofile.user_is_member(norman))
+        self.assertTrue(self.client.login(username="norman", password="norman"))
+        self.assertTrue(groupprofile.user_is_member(norman))
+
+        # Ensure anonymous is not in the managers queryset
+        self.assertFalse(groupprofile.user_is_member(anonymous))
+
+        # Ensure norman is not in the managers queryset
+        self.assertTrue(norman not in groupprofile.get_managers())
+
+        # Ensure admin is in the managers queryset
+        self.assertTrue(groupprofile.user_is_member(admin))
+        self.assertTrue(groupprofile.user_is_role(admin, 'manager'))
+        self.assertFalse(admin in groupprofile.get_managers())
 
     def test_group_permissions_extend_to_user(self):
         """

--- a/geonode/locale/ar/LC_MESSAGES/django.po
+++ b/geonode/locale/ar/LC_MESSAGES/django.po
@@ -6266,8 +6266,8 @@ msgid "GeoNode is an open source platform for sharing geospatial data and maps."
 msgstr "GeoNode هو منصة مفتوحة المصدر لتبادل البيانات الجغرافية والخرائط."
 
 #: geonode/templates/index.html:23
-msgid "http://docs.geonode.org/en/2.10.x/usage"
-msgstr "http://docs.geonode.org/en/2.10.x/usage"
+msgid "http://docs.geonode.org/en/2.10.x/usage/index.html"
+msgstr "http://docs.geonode.org/en/2.10.x/usage/index.html"
 
 #: geonode/templates/index.html:23
 msgid "Get Started &raquo;"

--- a/geonode/locale/de/LC_MESSAGES/django.po
+++ b/geonode/locale/de/LC_MESSAGES/django.po
@@ -1084,8 +1084,8 @@ msgstr "GeoNode ist eine Open-Source-Plattform zur Veröffentlichung von Geodate
 
 #: geonode/contrib/geosites/site_template/templates/site_index.html:14
 #: geonode/contrib/geosites/templates/master_index.html:15 geonode/templates/index.html:23
-msgid "http://docs.geonode.org/en/2.10.x/usage"
-msgstr "http://docs.geonode.org/en/2.10.x/usage"
+msgid "http://docs.geonode.org/en/2.10.x/usage/index.html"
+msgstr "http://docs.geonode.org/en/2.10.x/usage/index.html"
 
 #: geonode/contrib/geosites/site_template/templates/site_index.html:15
 #: geonode/contrib/geosites/templates/master_index.html:16 geonode/templates/index.html:23

--- a/geonode/locale/el/LC_MESSAGES/django.po
+++ b/geonode/locale/el/LC_MESSAGES/django.po
@@ -1182,8 +1182,8 @@ msgstr ""
 #: geonode/contrib/geosites/site_template/templates/site_index.html:14
 #: geonode/contrib/geosites/templates/master_index.html:15
 #: geonode/templates/index.html:23
-msgid "http://docs.geonode.org/en/2.10.x/usage"
-msgstr ""
+msgid "http://docs.geonode.org/en/2.10.x/usage/index.html"
+msgstr "http://docs.geonode.org/en/2.10.x/usage/index.html"
 
 #: geonode/contrib/geosites/site_template/templates/site_index.html:15
 #: geonode/contrib/geosites/templates/master_index.html:16

--- a/geonode/locale/en/LC_MESSAGES/django.po
+++ b/geonode/locale/en/LC_MESSAGES/django.po
@@ -6666,8 +6666,8 @@ msgstr ""
 "GeoNode is an open source platform for sharing geospatial data and maps."
 
 #: geonode/templates/index.html:24
-msgid "http://docs.geonode.org/en/2.10.x/usage"
-msgstr "http://docs.geonode.org/en/2.10.x/usage"
+msgid "http://docs.geonode.org/en/2.10.x/usage/index.html"
+msgstr "http://docs.geonode.org/en/2.10.x/usage/index.html"
 
 #: geonode/templates/index.html:25
 msgid "Get Started &raquo;"

--- a/geonode/locale/fr/LC_MESSAGES/django.po
+++ b/geonode/locale/fr/LC_MESSAGES/django.po
@@ -6704,8 +6704,8 @@ msgid "home"
 msgstr "Si vous avez des questions concernant le logiciel ou des services s'y rapportant, joignez-nous sur notre <a href=\"http://lists.osgeo.org/cgi-bin/mailman/listinfo/geonode-users\">mailing list</a>"
 
 #: geonode/templates/index.html:23
-msgid "http://docs.geonode.org/en/2.10.x/usage"
-msgstr ""
+msgid "http://docs.geonode.org/en/2.10.x/usage/index.html"
+msgstr "http://docs.geonode.org/en/2.10.x/usage/index.html"
 
 #: geonode/templates/index.html:23
 msgid "Get Started &raquo;"

--- a/geonode/locale/it/LC_MESSAGES/django.po
+++ b/geonode/locale/it/LC_MESSAGES/django.po
@@ -6627,8 +6627,8 @@ msgstr ""
 "geospaziali e mappe."
 
 #: geonode/templates/index.html:24
-msgid "http://docs.geonode.org/en/2.10.x/usage"
-msgstr "http://docs.geonode.org/en/2.10.x/usage"
+msgid "http://docs.geonode.org/en/2.10.x/usage/index.html"
+msgstr "http://docs.geonode.org/en/2.10.x/usage/index.html"
 
 #: geonode/templates/index.html:25
 msgid "Get Started &raquo;"

--- a/geonode/templates/index.html
+++ b/geonode/templates/index.html
@@ -21,7 +21,7 @@
 		<p>{{custom_theme.jumbotron_welcome_content|default:_("GeoNode is an open source platform for sharing geospatial data and maps.")}}</p>
 		{% if not custom_theme.jumbotron_cta_hide %}
   		<p><a class="btn btn-default btn-lg" target="_blank"
-  				href="{{custom_theme.jumbotron_cta_link|default:_("http://docs.geonode.org/en/2.10.x/usage")}}"
+  				href="{{custom_theme.jumbotron_cta_link|default:_("http://docs.geonode.org/en/2.10.x/usage/index.html")}}"
   				role="button">{{custom_theme.jumbotron_cta_text|default:_("Get Started &raquo;")}}</a></p>
 		{% endif %}
 	</div>

--- a/geonode/tests/bdd/conftest.py
+++ b/geonode/tests/bdd/conftest.py
@@ -77,7 +77,7 @@ def bdd_server(request, live_server):
 def geonode_db_setup(django_db_setup, django_db_blocker):
     with django_db_blocker.unblock():
         call_command('loaddata', 'initial_data.json')
-        call_command('loaddata', 'group_test_data.json')
+        call_command('loaddata', 'profiles_test_data.json')
         call_command('loaddata', 'default_oauth_apps.json')
 
 


### PR DESCRIPTION
* Fixes #1784
* Fixes #2161
* Fixes #2164
* Fixes #5052

This PR adds the following improvements to GeoNode Groups:

 1. Hide "private" groups to "non-members"
    The groups with access of type "private" won't be listed/visible to non-members at all.

 2. A "superuser" can always "manage" a Group, despite it is a member or not
   It won't be possible to exclude a "superuser" from a Group anymore.

 3. "Registered Members" Group concept
   By default, GeoNode will create a group called "Registered Members" allowing a resource owner to provide access to all members.
   At login, GeoNode will check for active membership to this default group.
   This group won't be accessible nor visible to anonymous users.

