### PR TITLE
[Fixes #4942] Download layer filter not sending CQL filter anymore

### DIFF
--- a/geonode/layers/templates/layers/layer_detail.html
+++ b/geonode/layers/templates/layers/layer_detail.html
@@ -845,7 +845,7 @@
         attribute_data_schema = $("#attribute_list li.selected a").attr('data-schema');
         if(attribute_list == null || operator_list == null || single_value_input == "" ||  logical_operator_dropdown == null){
           if($("#missing-values").length == 0) {
-            $( "#query-filter-tools" ).after( "<p id='missing-values'> Select all values from menus.</p>" );
+            $("#query-filter-tools").after( "<p id='missing-values'> Select all values from menus.</p>" );
           }
         } else {
             if($("#missing-values").length !== 0) {
@@ -854,7 +854,7 @@
             // validation that user enters a string for a string attribute or a number for a number attribute
             var single_value_input = '';
             try {
-                single_value_input = ($('#single_value').select2('data').text).trim();
+                single_value_input = ($('#single_value').select2('data')[0].text).trim();
             } catch (err) {
                 single_value_input = '';
             }
@@ -863,7 +863,7 @@
               if($("#wrong-data-type").length !== 0) {
                   $('#wrong-data-type').empty();
               }
-              $( "#query-filter-tools" ).after( "<p id='wrong-data-type'> You entered a string. Not a number.</p>" );
+              $("#query-filter-tools").after( "<p id='wrong-data-type'> You entered a string. Not a number.</p>" );
             } else {
               $( "p" ).remove( "#wrong-data-type" );
               // check of single_value_input; string or number


### PR DESCRIPTION
 - Fixes #4942 : Download layer filter not sending CQL filter anymore

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there are explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
