### PR TITLE
Backport  5074 to 2.10.x

### DIFF
--- a/docs/install/core/index.rst
+++ b/docs/install/core/index.rst
@@ -304,9 +304,9 @@ We will also perform several optimizations to:
     OpenJDK 64-Bit Server VM (build 25.212-b03, mixed mode)
 
   # Install Apache Tomcat 8
-  sudo wget http://www-us.apache.org/dist/tomcat/tomcat-8/v8.5.46/bin/apache-tomcat-8.5.46.tar.gz
-  sudo tar xzf apache-tomcat-8.5.46.tar.gz
-  sudo mv apache-tomcat-8.5.46 /usr/local/apache-tomcat8
+  sudo wget http://www-us.apache.org/dist/tomcat/tomcat-8/v8.5.47/bin/apache-tomcat-8.5.47.tar.gz
+  sudo tar xzf apache-tomcat-8.5.47.tar.gz
+  sudo mv apache-tomcat-8.5.47 /usr/local/apache-tomcat8
   sudo useradd -m -U -s /bin/false tomcat
   sudo usermod -a -G www-data tomcat
   sudo sed -i -e 's/xom-\*\.jar/xom-\*\.jar,bcprov\*\.jar/g' /usr/local/apache-tomcat8/conf/catalina.properties
@@ -673,8 +673,7 @@ Serving {“geonode”, “geoserver”} via NGINX
     gzip_min_length 1100;
     gzip_comp_level 6;
     gzip_proxied any;
-    gzip_types video/mp4 text/plain text/css application/x-javascript text/xml application/xml application/xml+rss text/javascript image/jpeg;
-
+    gzip_types video/mp4 text/plain application/javascript application/x-javascript text/javascript text/xml text/css image/jpeg;
     ##
     # Virtual Host Configs
     ##

--- a/docs/install/core/index.rst
+++ b/docs/install/core/index.rst
@@ -674,6 +674,7 @@ Serving {“geonode”, “geoserver”} via NGINX
     gzip_comp_level 6;
     gzip_proxied any;
     gzip_types video/mp4 text/plain application/javascript application/x-javascript text/javascript text/xml text/css image/jpeg;
+    
     ##
     # Virtual Host Configs
     ##


### PR DESCRIPTION
Commits ["17cc5c767a4df811539e47395db0bbfd4e6fde03","0bb703c93dc2f4b8ef289b31e75c00b7736d48f1"] could not be cherry-picked on top of 2.10.x
To backport manually, run these commands in your terminal:

# Fetch latest updates from GitHub.
git fetch
# Create new working tree.
git worktree add .worktrees/backport 2.10.x
# Navigate to the new directory.
cd .worktrees/backport
# Cherry-pick all the commits of this pull request and resolve the likely conflicts.
git cherry-pick 17cc5c767a4df811539e47395db0bbfd4e6fde03 0bb703c93dc2f4b8ef289b31e75c00b7736d48f1
# Create a new branch with these backported commits.
git checkout -b backport-5074-to-2.10.x
# Push it to GitHub.
git push --set-upstream origin backport-5074-to-2.10.x
# Go back to the original working tree.
cd ../..
# Delete the working tree.
git worktree remove .worktrees/backport
Then, create a pull request where the base branch is 2.10.x and the compare/head branch is backport-5074-to-2.10.x.