### PR TITLE
[Fixes #4827] Line layer uploaded to GeoNode is rendered as point layer

### DIFF
--- a/geonode/catalogue/models.py
+++ b/geonode/catalogue/models.py
@@ -67,12 +67,14 @@ def catalogue_post_save(instance, sender, **kwargs):
             else:
                 raise err
 
-        msg = ('Metadata record for %s does not exist,'
-               ' check the catalogue signals.' % instance.title)
-        assert record is not None, msg
+        if not record:
+            msg = ('Metadata record for %s does not exist,'
+                   ' check the catalogue signals.' % instance.title)
+            raise Exception(msg)
 
-        msg = ('Metadata record for %s should contain links.' % instance.title)
-        assert hasattr(record, 'links'), msg
+        if not hasattr(record, 'links'):
+            msg = ('Metadata record for %s should contain links.' % instance.title)
+            raise Exception(msg)
 
         # Create the different metadata links with the available formats
         for mime, name, metadata_url in record.links['metadata']:
@@ -110,7 +112,7 @@ def catalogue_post_save(instance, sender, **kwargs):
         resources.update(csw_wkt_geometry=csw_wkt_geometry)
         resources.update(csw_anytext=csw_anytext)
     except BaseException as e:
-        LOGGER.exception(e)
+        LOGGER.debug(e)
     finally:
         # Revert temporarily changed publishing state
         if not is_published:


### PR DESCRIPTION
 - Fixes #4827 : Line layer uploaded to GeoNode is rendered as point layer

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there are explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
