### PR TITLE
Enable thesauri api load only if a thesauri is defined

### DIFF
--- a/geonode/static/geonode/js/search/search.js
+++ b/geonode/static/geonode/js/search/search.js
@@ -134,7 +134,9 @@
     if ($location.search().hasOwnProperty('title__icontains')){
       params['title__icontains'] = $location.search()['title__icontains'];
     }
-    $http.get(T_KEYWORDS_ENDPOINT, {params: params}).then(successCallback, errorCallback);
+    if (enable_thesauri){
+      $http.get(T_KEYWORDS_ENDPOINT, {params: params}).then(successCallback, errorCallback);
+    }
 
     function successCallback(data) {
       //success code

--- a/geonode/templates/search/search_scripts.html
+++ b/geonode/templates/search/search_scripts.html
@@ -26,7 +26,11 @@
   GROUP_CATEGORIES_ENDPOINT = '{% url 'api_dispatch_list' api_name='api' resource_name='groupcategory' %}';
   KEYWORDS_ENDPOINT = '{% url 'api_dispatch_list' api_name='api' resource_name='keywords' %}';
   H_KEYWORDS_ENDPOINT = '{% url 'h_keywords_api' %}';
-  T_KEYWORDS_ENDPOINT = '{% url 'api_dispatch_list' api_name='api' resource_name='thesaurus/keywords' %}';
+  var enable_thesauri = false;
+  {% if THESAURI_FILTERS %}
+    var enable_thesauri = true;
+    T_KEYWORDS_ENDPOINT = '{% url 'api_dispatch_list' api_name='api' resource_name='thesaurus/keywords' %}';
+  {% endif %}
   REGIONS_ENDPOINT = '{% url 'api_dispatch_list' api_name='api' resource_name='regions' %}';
   OWNERS_ENDPOINT = '{% url 'api_dispatch_list' api_name='api' resource_name='owners' %}';
   GROUPS_ENDPOINT = '{% url 'api_dispatch_list' api_name='api' resource_name='groups' %}';


### PR DESCRIPTION
Enable thesauri api load only if a thesauri is defined

## Checklist

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [ ] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there are explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
