### PR TITLE
[Fixes #5121] ResourceBase API returns an error if a curated thumbnail img file is not existing anymore

### DIFF
--- a/geonode/api/resourcebase_api.py
+++ b/geonode/api/resourcebase_api.py
@@ -606,7 +606,10 @@ class CommonModelApi(ModelResource):
 
             # replace thumbnail_url with curated_thumbs
             if hasattr(obj, 'curatedthumbnail'):
-                formatted_obj['thumbnail_url'] = obj.curatedthumbnail.img_thumbnail.url
+                if hasattr(obj.curatedthumbnail.img_thumbnail, 'url'):
+                    formatted_obj['thumbnail_url'] = obj.curatedthumbnail.img_thumbnail.url
+                else:
+                    formatted_obj['thumbnail_url'] = ''
 
             formatted_objects.append(formatted_obj)
 
@@ -992,7 +995,10 @@ class MapResource(CommonModelApi):
 
             # replace thumbnail_url with curated_thumbs
             if hasattr(obj, 'curatedthumbnail'):
-                formatted_obj['thumbnail_url'] = obj.curatedthumbnail.img_thumbnail.url
+                if hasattr(obj.curatedthumbnail.img_thumbnail, 'url'):
+                    formatted_obj['thumbnail_url'] = obj.curatedthumbnail.img_thumbnail.url
+                else:
+                    formatted_obj['thumbnail_url'] = ''
 
             formatted_objects.append(formatted_obj)
         return formatted_objects
@@ -1046,7 +1052,10 @@ class DocumentResource(CommonModelApi):
 
             # replace thumbnail_url with curated_thumbs
             if hasattr(obj, 'curatedthumbnail'):
-                formatted_obj['thumbnail_url'] = obj.curatedthumbnail.img_thumbnail.url
+                if hasattr(obj.curatedthumbnail.img_thumbnail, 'url'):
+                    formatted_obj['thumbnail_url'] = obj.curatedthumbnail.img_thumbnail.url
+                else:
+                    formatted_obj['thumbnail_url'] = ''
 
             formatted_objects.append(formatted_obj)
         return formatted_objects


### PR DESCRIPTION
[Fixes #5121] ResourceBase API returns an error if a curated thumbnail img file is not existing anymore

## Checklist

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there are explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
