### PR TITLE
[Implements #5149] Add documentation for migrating GeoNode from 2.4 to 2.10.1

### DIFF
--- a/docs/admin/upgrade/index.rst
+++ b/docs/admin/upgrade/index.rst
@@ -1,6 +1,8 @@
 Upgrade from 2.8.x
 ==================
 
+
+
 Upgrade from 2.7.x
 ==================
 
@@ -9,3 +11,119 @@ Upgrade from 2.6.x
 
 Upgrade from 2.4.x
 ==================
+
+These are the notes of a migration from 2.4.x to 2.10.1.
+These notes could possibly works also when migrating from 2.6.x, 2.7.x, 2.8.x but were not tested in that scenarios.
+You should run this procedure on your local machine and once you successfully migrated the database move the backup to your GeoNode 2.10.1 production instance.
+
+PostgreSQL
+----------
+
+Create a role and a database for Django GeoNode 2.4:
+
+.. code-block:: sql
+
+    create role user with superuser login with password '***';
+    create database gn_24 with owner user;
+    \c gn_24
+    create extension postgis;
+
+Restore backup from your production backup:
+
+.. code-block:: shell
+
+    psql gn_24 < gn_24.sql
+
+Run GeoNode migrations
+----------------------
+
+Activate your GeoNode virtualenv and set the env vars:
+
+.. code-block:: sql
+
+    . env/bin/Activate
+    export vars_210
+
+Here are the variables to export - update them to your environment settings:
+
+.. code-block:: shell
+
+    export DATABASE_URL=postgis://user:***@localhost:5432/dbname
+    export DEFAULT_BACKEND_DATASTORE=data
+    export GEODATABASE_URL=postgis://user:***@localhost:5432/geonode_data
+    export ALLOWED_HOSTS="['localhost', '192.168.100.10']"
+    export STATIC_ROOT=~/www/geonode/static/
+    export GEOSERVER_LOCATION=http://localhost:8080/geoserver/
+    export GEOSERVER_PUBLIC_LOCATION=http://localhost:8080/geoserver/
+    export GEOSERVER_ADMIN_PASSWORD=geoserver
+    export SESSION_EXPIRED_CONTROL_ENABLED=False
+
+Downgrade psycopg2:
+
+.. code-block:: shell
+
+    pip install psycopg2==2.7.7
+
+Apply migrations and apply basic fixtures:
+
+.. code-block:: shell
+
+    cd wfp-geonode
+    ./manage.py migrate --fake-initial
+    paver sync
+
+
+Regenerate from scratch the upload application tables in the database:
+
+.. code-block:: sql
+
+    delete from django_migrations where app = 'upload';
+    drop table upload_upload cascade;
+    drop table upload_uploadfile;
+
+Regenerate upload tables with migrate:
+
+.. code-block:: shell
+
+    ./manage.py migrate upload
+
+Upgrade psycopg2:
+
+.. code-block:: shell
+
+    pip install -r geonode/requirements.txt
+
+Create superuser
+----------------
+
+To create a superuser you should drop the following constraints (they can be re-enabled if needed):
+
+.. code-block:: sql
+
+    alter table people_profile alter column last_login drop not null;
+
+.. code-block:: shell
+
+    ./manage createsuperuser
+
+Fixes on database
+-----------------
+
+For some reason some resources were unpublished:
+
+.. code-block:: sql
+
+    UPDATE base_resourcebase SET is_published = true;
+
+Remove a foreign key from account_account which is not used anymore (GeoNode dev team: maybe even better let's remove all of the account tables, I think they are stale now):
+
+.. code-block:: sql
+
+    ALTER TABLE account_account DROP CONSTRAINT user_id_refs_id_726cb6b4;
+    ALTER TABLE account_signupcode DROP CONSTRAINT "inviter_id_refs_id_49a7c0d9";
+
+Fix the remote service layers by running this script:
+
+.. code-block:: shell
+
+    python migration/fixes_remote_layers.py


### PR DESCRIPTION
[Implements #5149] Add documentation for migrating GeoNode from 2.4 to 2.10.1


## Checklist

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there are explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
