### PR TITLE
[Fixes #5105] Error when using THESAURI

### DIFF
--- a/geonode/base/widgets.py
+++ b/geonode/base/widgets.py
@@ -30,7 +30,7 @@ class MultiThesauriWidget(forms.MultiWidget):
         for el in settings.THESAURI:
             cleaned_name = el['name'].replace("-", " ").replace("_", " ").title()
             widget_list.append(
-                autocomplete_light.MultipleChoiceWidget(
+                autocomplete_light.widgets.MultipleChoiceWidget(
                     'thesaurus_' + el['name'],
                     attrs={'placeholder': '%s - Start typing for suggestions' % cleaned_name},
                     extra_context={'thesauri_title': cleaned_name}))


### PR DESCRIPTION
This will stop the error:   

```
File "/Users/ts/github/csgis.geonode/geonode/base/widgets.py", line 33, in __init__
    autocomplete_light.MultipleChoiceWidget(
AttributeError: 'module' object has no attribute 'MultipleChoiceWidget'
```

From what I see `classautocomplete_light.MultipleChoiceWidget` is now

```
classautocomplete_light.widgets.MultipleChoiceWidget(autocomplete=None, widget_js_attributes=None, autocomplete_js_attributes=None, extra_context=None, registry=None, widget_template=None, widget_attrs=None, *args, **kwargs)
```

@afabiani @capooti this should fix the described issue however I would suggest that we continue here: https://github.com/GeoNode/geonode/issues/5158

## Checklist
- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there are explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

