### PR TITLE
Backport 5211 to 2.10.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -73,7 +73,7 @@ geonode-oauth-toolkit==1.1.4.6
 # GeoNode org maintained apps.
 django-geoexplorer==4.0.43
 django-mapstore-adapter==1.0.11
-django-geonode-mapstore-client==1.4.4
+django-geonode-mapstore-client==1.4.5
 django-geonode-client==1.0.9
 geonode-user-messages==0.1.14
 geonode-avatar==2.1.8


### PR DESCRIPTION
Commits ["763c5ef085f5010f714711ddececb64fdfa6810e"] could not be cherry-picked on top of 2.10.1
To backport manually, run these commands in your terminal:

# Fetch latest updates from GitHub.
git fetch
# Create new working tree.
git worktree add .worktrees/backport 2.10.1
# Navigate to the new directory.
cd .worktrees/backport
# Cherry-pick all the commits of this pull request and resolve the likely conflicts.
git cherry-pick 763c5ef085f5010f714711ddececb64fdfa6810e
# Create a new branch with these backported commits.
git checkout -b backport-5211-to-2.10.1
# Push it to GitHub.
git push --set-upstream origin backport-5211-to-2.10.1
# Go back to the original working tree.
cd ../..
# Delete the working tree.
git worktree remove .worktrees/backport
Then, create a pull request where the base branch is 2.10.1 and the compare/head branch is backport-5211-to-2.10.1.