### PR TITLE
[Fixes #5214] Fix regression on monitoring countries endpoint

### DIFF
--- a/geonode/monitoring/collector.py
+++ b/geonode/monitoring/collector.py
@@ -948,13 +948,18 @@ class CollectorAPI(object):
                             except Resolver404:
                                 t['href'] = ""
                 row[tcol] = t
+            return row
+
+        def check_row(r):
+            is_ok = True
             # Avoid Count label for countries
             # (it has been already fixed in "set_metric_values"
             # but the following line avoid showing the label in case of existing dirty db)
-            if not (metric_name == "request.country" and row["label"] == "count"):
-                return row
+            if metric_name == "request.country" and r["label"] == "count":
+                is_ok = False
+            return is_ok
 
-        return [postproc(row) for row in raw_sql(q, params)]
+        return [postproc(row) for row in raw_sql(q, params) if check_row(row)]
 
     def aggregate_past_periods(self, metric_data_q=None, periods=None, **kwargs):
         """

--- a/geonode/monitoring/tests/integration.py
+++ b/geonode/monitoring/tests/integration.py
@@ -2708,4 +2708,4 @@ class MonitoringAnalyticsTestCase(MonitoringTestBase):
         self.assertEqual(out["data"]["input_valid_from"], '2018-09-11T20:00:00.000000Z')
         self.assertEqual(out["data"]["input_valid_to"], '2019-09-11T20:00:00.000000Z')
         dd = data["data"][0]["data"]
-        self.assertIsNone(dd[0])
+        self.assertEqual(len(dd), 0)


### PR DESCRIPTION
<Include a few sentences describing the overall goals for this Pull Request>
This PR fixes #5214 .

It avoids "None" elements in the countries list returned by the following endpoint:
`GET /monitoring/api/metric_data/request.country/`

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there are explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [x] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
