### PR TITLE
[Fixes #5223] Layer details broken if no store identified

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -5,7 +5,7 @@ codecov:
 coverage:
   precision: 2
   round: down
-  range: "70...100"
+  range: "60...100"
 
   status:
     project: yes

--- a/geonode/layers/tests.py
+++ b/geonode/layers/tests.py
@@ -273,6 +273,9 @@ class LayersTest(GeoNodeBaseTestSupport):
         response = self.client.get(reverse('layer_detail', args=(lyr.alternate,)))
         self.failUnlessEqual(response.status_code, 200)
 
+        response = self.client.get(reverse('layer_detail', args=(":%s" % lyr.alternate,)))
+        self.failUnlessEqual(response.status_code, 200)
+
         response = self.client.get(reverse('layer_metadata', args=(lyr.alternate,)))
         self.failUnlessEqual(response.status_code, 200)
 

--- a/geonode/layers/views.py
+++ b/geonode/layers/views.py
@@ -170,13 +170,17 @@ def _resolve_layer(request, alternate, permission='base.view_resourcebase',
             **kwargs)
     else:
         if len(service_typename) > 1 and ':' in service_typename[1]:
-            query = {
-                'store': service_typename[0],
-                'alternate': service_typename[1]
-            }
+            if service_typename[0]:
+                query = {
+                    'store': service_typename[0],
+                    'alternate': service_typename[1]
+                }
+            else:
+                query = {
+                    'alternate': service_typename[1]
+                }
         else:
             query = {'alternate': alternate}
-
         return resolve_object(request,
                               Layer,
                               query,

--- a/geonode/version.py
+++ b/geonode/version.py
@@ -35,20 +35,18 @@ def get_version(version=None):
     # main = X.Y[.Z]
     # sub = .devN - for pre-alpha releases
     #     | {a|b|c}N - for alpha, beta and rc releases
-
+    git_changeset = get_git_changeset()
     parts = 2 if version[2] == 0 else 3
     main = '.'.join(str(x) for x in version[:parts])
-
     sub = ''
-    if version[3] == 'unstable':
-        git_changeset = get_git_changeset()
-        if git_changeset:
-            sub = '.dev%s' % git_changeset
-
-    elif version[3] != 'final':
+    if version[3] != 'final':
         mapping = {'beta': 'b', 'rc': 'rc'}
         sub = mapping[version[3]] + str(version[4])
-
+    if git_changeset:
+        if version[3] == 'unstable':
+            sub += '.dev%s' % git_changeset
+        else:
+            sub += '.build%s' % git_changeset
     return main + sub
 
 
@@ -59,13 +57,16 @@ def get_git_changeset():
     This value isn't guaranteed to be unique, but collisions are very unlikely,
     so it's sufficient for generating the development version numbers.
     """
-    repo_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-    git_show = subprocess.Popen('git show --pretty=format:%ct --quiet HEAD',
-                                stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                                shell=True, cwd=repo_dir, universal_newlines=True)
-    timestamp = git_show.communicate()[0].partition('\n')[0]
     try:
-        timestamp = datetime.datetime.utcfromtimestamp(int(timestamp))
-    except ValueError:
-        return None
-    return timestamp.strftime('%Y%m%d%H%M%S')
+        repo_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        git_show = subprocess.Popen('git show --pretty=format:%ct --quiet HEAD',
+                                    stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                                    shell=True, cwd=repo_dir, universal_newlines=True)
+        timestamp = git_show.communicate()[0].partition('\n')[0]
+        return timestamp
+    except BaseException:
+        try:
+            timestamp = datetime.datetime.utcfromtimestamp(int(timestamp))
+            return timestamp.strftime('%Y%m%d%H%M%S')
+        except ValueError:
+            return None

--- a/pavement.py
+++ b/pavement.py
@@ -964,7 +964,7 @@ def run_tests(options):
     if options.get('coverage'):
         prefix = 'coverage run --branch --source=geonode \
 --omit="*/__init__*,*/test*,*/wsgi*,*/version*,*/migrations*,\
-*/search_indexes*,*/management/*,*/context_processors*,*/qgis_server/*"'
+*/search_indexes*,*/management/*,*/context_processors*,*/upload/*,*/qgis_server/*"'
     else:
         prefix = 'python'
     local = options.get('local', 'false')  # travis uses default to false

--- a/requirements.txt
+++ b/requirements.txt
@@ -72,8 +72,8 @@ geonode-oauth-toolkit==1.1.4.6
 
 # GeoNode org maintained apps.
 django-geoexplorer==4.0.43
-django-mapstore-adapter==1.0.11
-django-geonode-mapstore-client==1.4.5
+django-mapstore-adapter==1.0.12
+django-geonode-mapstore-client==1.4.6
 django-geonode-client==1.0.9
 geonode-user-messages==0.1.14
 geonode-avatar==2.1.8


### PR DESCRIPTION
 - Fixes #5223 : Layer details broken if no store identified

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there are explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
