### PR TITLE
[Fixes #4635] Encoding issues when uploading layers using a shapefile

### DIFF
--- a/geonode/upload/upload.py
+++ b/geonode/upload/upload.py
@@ -215,7 +215,7 @@ def upload(
 
     utils.run_import(upload_session, async_upload=False)
 
-    final_step(upload_session, user)
+    final_step(upload_session, user, charset=charset)
 
 
 def _get_next_id():
@@ -276,7 +276,8 @@ def save_step(user, layer, spatial_files, overwrite=True, mosaic=False,
               mosaic_time_regex=None, mosaic_time_value=None,
               time_presentation=None, time_presentation_res=None,
               time_presentation_default_value=None,
-              time_presentation_reference_value=None):
+              time_presentation_reference_value=None,
+              charset_encoding="UTF-8"):
     logger.debug(
         'Uploading layer: {}, files {!r}'.format(layer, spatial_files))
     if len(spatial_files) > 1:
@@ -340,14 +341,16 @@ def save_step(user, layer, spatial_files, overwrite=True, mosaic=False,
                     files_to_upload[1:],
                     use_url=False,
                     # import_id=next_id,
-                    target_store=target_store
+                    target_store=target_store,
+                    charset_encoding=charset_encoding
                 )
             else:
                 import_session = gs_uploader.upload_files(
                     files_to_upload,
                     use_url=False,
                     # import_id=next_id,
-                    target_store=target_store
+                    target_store=target_store,
+                    charset_encoding=charset_encoding
                 )
             next_id = import_session.id if import_session else None
             if not next_id:
@@ -359,7 +362,8 @@ def save_step(user, layer, spatial_files, overwrite=True, mosaic=False,
                 use_url=False,
                 import_id=next_id,
                 mosaic=False,
-                target_store=None
+                target_store=None,
+                charset_encoding=charset_encoding
             )
         upload.import_id = import_session.id
         upload.save()
@@ -545,7 +549,7 @@ def srs_step(upload_session, source, target):
     upload_session.import_session = import_session
 
 
-def final_step(upload_session, user):
+def final_step(upload_session, user, charset="UTF-8"):
     from geonode.geoserver.helpers import get_sld_for
     import_session = upload_session.import_session
     _log('Reloading session %s to check validity', import_session.id)
@@ -564,6 +568,7 @@ def final_step(upload_session, user):
     # FIXME: Put this in gsconfig.py
 
     task = import_session.tasks[0]
+    task.set_charset(charset)
 
     # @todo see above in save_step, regarding computed unique name
     name = task.layer.name

--- a/geonode/upload/views.py
+++ b/geonode/upload/views.py
@@ -196,9 +196,10 @@ def save_step_view(req, session):
             time_presentation=form.cleaned_data['time_presentation'],
             time_presentation_res=form.cleaned_data['time_presentation_res'],
             time_presentation_default_value=form.cleaned_data['time_presentation_default_value'],
-            time_presentation_reference_value=form.cleaned_data['time_presentation_reference_value']
+            time_presentation_reference_value=form.cleaned_data['time_presentation_reference_value'],
+            charset_encoding=form.cleaned_data["charset"]
         )
-
+        import_session.tasks[0].set_charset(form.cleaned_data["charset"])
         sld = None
         if spatial_files[0].sld_files:
             sld = spatial_files[0].sld_files[0]

--- a/requirements.txt
+++ b/requirements.txt
@@ -82,7 +82,7 @@ geonode-agon-ratings==0.3.8
 arcrest>=10.0
 geonode-dialogos==1.2
 geoserver-restconfig==1.0.4
-gn-gsimporter==1.0.12
+gn-gsimporter==1.0.15
 gisdata==0.5.4
 
 # haystack/elasticsearch


### PR DESCRIPTION
 - Fixes #4635 : Encoding issues when uploading layers using a shapefile

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there are explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
