### PR TITLE
[Backport 2.10.x] Update django-modeltranslation requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,7 @@ django-jsonfield<1.3.2
 django-jsonfield-compat<=0.4.4
 django-taggit==0.24.0
 django-mptt==0.9.1
-django-modeltranslation>=0.11,<0.13.5
+django-modeltranslation>=0.11,<0.15.0
 django-treebeard==4.3
 django-guardian<=1.4.9
 django-downloadview<=1.9


### PR DESCRIPTION
Commits ["17357ae00727a48c150786e35a4909602e1d89fe"] could not be cherry-picked on top of 2.10.x
To backport manually, run these commands in your terminal:

# Fetch latest updates from GitHub.
git fetch
# Create new working tree.
git worktree add .worktrees/backport 2.10.x
# Navigate to the new directory.
cd .worktrees/backport
# Cherry-pick all the commits of this pull request and resolve the likely conflicts.
git cherry-pick 17357ae00727a48c150786e35a4909602e1d89fe
# Create a new branch with these backported commits.
git checkout -b backport-5266-to-2.10.x
# Push it to GitHub.
git push --set-upstream origin backport-5266-to-2.10.x
# Go back to the original working tree.
cd ../..
# Delete the working tree.
git worktree remove .worktrees/backport
Then, create a pull request where the base branch is 2.10.x and the compare/head branch is backport-5266-to-2.10.x.