### PR TITLE
[Issue #4276] Bump Celery to 4.3.0

### DIFF
--- a/geonode/maps/qgis_server_views.py
+++ b/geonode/maps/qgis_server_views.py
@@ -610,8 +610,7 @@ def set_thumbnail_map(request, mapid):
     bbox = _get_bbox_from_layers(layers)
 
     # Give thumbnail creation to celery tasks, and exit.
-    map_obj = Map.objects.get(id=mapid)
-    create_qgis_server_thumbnail.delay(map_obj, overwrite=True, bbox=bbox)
+    create_qgis_server_thumbnail.delay('maps.map', mapid, overwrite=True, bbox=bbox)
     retval = {
         'success': True
     }

--- a/geonode/qgis_server/helpers.py
+++ b/geonode/qgis_server/helpers.py
@@ -28,6 +28,7 @@ from urlparse import urljoin
 
 import requests
 from django.conf import settings
+from django.contrib.contenttypes.models import ContentType
 from django.contrib.gis.gdal import CoordTransform, SpatialReference
 from django.contrib.gis.geos import GEOSGeometry, Point
 from django.core.exceptions import ImproperlyConfigured
@@ -962,3 +963,17 @@ def delete_orphaned_qgis_server_caches():
                 shutil.rmtree(path)
             except OSError:
                 print 'Could not delete file %s' % path
+
+
+def get_model_path(instance):
+    """Get a Django model instance's app label and name.
+
+    :param instance: An instance of a Django model
+    :type instance: django.db.models.Model
+    """
+
+    model_type = ContentType.objects.get_for_model(instance)
+    return "{app_label}.{model_name}".format(
+        app_label=model_type.app_label,
+        model_name=model_type.model
+    )

--- a/geonode/qgis_server/signals.py
+++ b/geonode/qgis_server/signals.py
@@ -36,7 +36,7 @@ from geonode.layers.models import Layer
 from geonode.maps.models import Map, MapLayer
 from geonode.decorators import on_ogc_backend
 from geonode.qgis_server.gis_tools import set_attributes
-from geonode.qgis_server.helpers import create_qgis_project
+from geonode.qgis_server.helpers import create_qgis_project, get_model_path
 from geonode.qgis_server.models import QGISServerLayer, QGISServerMap
 from geonode.qgis_server.tasks.update import create_qgis_server_thumbnail
 from geonode.qgis_server.xml_utilities import update_xml
@@ -187,7 +187,10 @@ def qgis_server_post_save(instance, sender, **kwargs):
     # Create thumbnail
     overwrite = getattr(instance, 'overwrite', False)
     create_qgis_server_thumbnail.delay(
-        instance, overwrite=overwrite)
+        get_model_path(instance),
+        instance.id,
+        overwrite=overwrite
+    )
 
     # Attributes
     set_attributes(instance)
@@ -378,7 +381,10 @@ def qgis_server_post_save_map(instance, sender, **kwargs):
 
     # Generate map thumbnail
     create_qgis_server_thumbnail.delay(
-        instance, overwrite=True)
+        get_model_path(instance),
+        instance.id,
+        overwrite=True
+    )
 
 
 @on_ogc_backend(qgis_server.BACKEND_PACKAGE)

--- a/geonode/qgis_server/tasks/update.py
+++ b/geonode/qgis_server/tasks/update.py
@@ -23,6 +23,7 @@ import shutil
 import socket
 
 import requests
+from django.apps import apps
 from geonode.celery_app import app
 from requests.exceptions import HTTPError
 
@@ -45,7 +46,7 @@ logger = logging.getLogger(__name__)
     autoretry_for=(QGISServerLayer.DoesNotExist, ),
     retry_kwargs={'max_retries': 5, 'countdown': 5})
 @on_ogc_backend(qgis_server.BACKEND_PACKAGE)
-def create_qgis_server_thumbnail(instance, overwrite=False, bbox=None):
+def create_qgis_server_thumbnail(model_path, object_id, overwrite=False, bbox=None):
     """Task to update thumbnails.
 
     This task will formulate OGC url to generate thumbnail and then pass it
@@ -64,6 +65,7 @@ def create_qgis_server_thumbnail(instance, overwrite=False, bbox=None):
     :return:
     """
     thumbnail_remote_url = None
+    instance = apps.get_model(model_path).objects.get(id=object_id)
     try:
         # to make sure it is executed after the instance saved
         if isinstance(instance, Layer):

--- a/geonode/qgis_server/tests/test_helpers.py
+++ b/geonode/qgis_server/tests/test_helpers.py
@@ -38,10 +38,12 @@ from django.core.management import call_command
 from django.core.urlresolvers import reverse
 
 from geonode import qgis_server
+from geonode.base.models import Region
 from geonode.decorators import on_ogc_backend
 from geonode.layers.utils import file_upload
-from geonode.qgis_server.helpers import validate_django_settings, \
-    transform_layer_bbox, qgis_server_endpoint, tile_url_format, tile_url, \
+from geonode.qgis_server.helpers import get_model_path, \
+    validate_django_settings, transform_layer_bbox, \
+    qgis_server_endpoint, tile_url_format, tile_url, \
     style_get_url, style_add_url, style_list, style_set_default_url, \
     style_remove_url
 
@@ -296,3 +298,9 @@ class HelperTest(GeoNodeBaseTestSupport):
 
         # cleanup
         uploaded.delete()
+
+    @on_ogc_backend(qgis_server.BACKEND_PACKAGE)
+    def test_get_model_path(self):
+        region = Region.objects.first()
+        model_path = get_model_path(region)
+        self.assertEqual(model_path, 'base.region')

--- a/geonode/qgis_server/views.py
+++ b/geonode/qgis_server/views.py
@@ -851,7 +851,7 @@ def set_thumbnail(request, layername):
     bbox = [float(s) for s in bbox]
 
     # Give thumbnail creation to celery tasks, and exit.
-    create_qgis_server_thumbnail.delay(layer, overwrite=True, bbox=bbox)
+    create_qgis_server_thumbnail.delay('layers.layer', layer.id, overwrite=True, bbox=bbox)
     retval = {
         'success': True
     }

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ urllib3==1.25.7
 Paver==1.3.4
 python-slugify==4.0.0
 decorator==4.4.1
-celery==4.2.1
+celery==4.3.0
 kombu==4.6.6
 boto<=2.49.0
 six<1.14.0


### PR DESCRIPTION
PR to bump Celery to 4.3.0 as outlined under https://github.com/GeoNode/geonode/issues/4276

Had to fix a number of Celery tasks that were previously expecting a `layers.Layer` or `maps.Map` instance, as instances cannot be serialised into json.

This PR supersedes #4628 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there are explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [x] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
