### PR TITLE
[Fixes #5325] Improve Featured Datasets thumbs layout on main page

### DIFF
--- a/geonode/templates/index.html
+++ b/geonode/templates/index.html
@@ -295,21 +295,17 @@
       			</div>
 			</div>
 			<div ng-app="featured" ng-if="featured.length > 0" ng-cloak class="row">
-				<div class="container text-center">
-					<h2>{% trans "Featured Datasets" %}</h2>
-					<div class="row">
-						{% verbatim %}
-						<div>
-							<div ng-repeat="item in featured | limitTo:4">
-								<div class="col-md-3">
-									<a href="{{ item.detail_url }}"><img ng-src="{{ item.thumbnail_url }}" /></a>
-									<h4>{{ item.title | limitTo: 20 }}{{item.title.length > 20 ? '...' : ''}}</h4>
-								</div>
-							</div>
-						</div>
-						{% endverbatim %}
-					</div>
-				</div>
+			 	<div class="container text-center">
+			 		<h2>{% trans "Featured Datasets" %}</h2>
+			 		<div class="row">
+			 			{% verbatim %}
+			 			<div ng-repeat="item in featured" class="col-xs-6 col-sm-6 col-md-3">
+			 				<a href="{{ item.detail_url }}"><img ng-src="{{ item.thumbnail_url }}" style="width: 240px;" /></a>
+			 				<h4>{{ item.title | limitTo: 20 }}{{item.title.length > 20 ? '...' : ''}}</h4>
+			 			</div>
+			 			{% endverbatim %}
+			 		</div>
+			 	</div>
 			</div>
 		  </div>
       </section>


### PR DESCRIPTION
 - Fixes #5325 : Improve Featured Datasets thumbs layout on main page

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there are explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
