### PR TITLE
[Issue #4276] Upgrade api for Python 2.7/3 compatibility

### DIFF
--- a/geonode/api/api.py
+++ b/geonode/api/api.py
@@ -128,7 +128,7 @@ class TypeFilteredResource(ModelResource):
 
         orm_filters = super(TypeFilteredResource, self).build_filters(filters)
 
-        if 'type' in filters and filters['type'] in FILTER_TYPES.keys():
+        if 'type' in filters and filters['type'] in list(FILTER_TYPES.keys()):
             self.type_filter = FILTER_TYPES[filters['type']]
         else:
             self.type_filter = None
@@ -598,7 +598,7 @@ class QGISStyleResource(ModelResource):
             filters, **kwargs)
         # Convert layer__ filters into layer_styles__layer__
         updated_filters = {}
-        for key, value in filters.iteritems():
+        for key, value in filters.items():
             key = key.replace('layer__', 'layer_styles__layer__')
             updated_filters[key] = value
         return updated_filters
@@ -762,7 +762,7 @@ class GeoserverStyleResource(ModelResource):
             filters, **kwargs)
         # Convert layer__ filters into layer_styles__layer__
         updated_filters = {}
-        for key, value in filters.iteritems():
+        for key, value in filters.items():
             key = key.replace('layer__', 'layer_default_style__')
             updated_filters[key] = value
         return updated_filters

--- a/geonode/api/resourcebase_api.py
+++ b/geonode/api/resourcebase_api.py
@@ -158,7 +158,7 @@ class CommonModelApi(ModelResource):
         orm_filters = super(CommonModelApi, self).build_filters(
             filters=filters, ignore_bad_filters=ignore_bad_filters, **kwargs)
         if 'type__in' in filters and filters[
-                'type__in'] in FILTER_TYPES.keys():
+                'type__in'] in list(FILTER_TYPES.keys()):
             orm_filters.update({'type': filters.getlist('type__in')})
         if 'extent' in filters:
             orm_filters.update({'extent': filters['extent']})
@@ -181,7 +181,7 @@ class CommonModelApi(ModelResource):
         filtered = None
         if types:
             for the_type in types:
-                if the_type in LAYER_SUBTYPES.keys():
+                if the_type in list(LAYER_SUBTYPES.keys()):
                     super_type = the_type
                     if 'vector_time' == the_type:
                         super_type = 'vector'
@@ -274,7 +274,7 @@ class CommonModelApi(ModelResource):
         returns the modified query
         """
         bbox = bbox.split(',')  # TODO: Why is this different when done through haystack?
-        bbox = map(str, bbox)  # 2.6 compat - float to decimal conversion
+        bbox = list(map(str, bbox))  # 2.6 compat - float to decimal conversion
         intersects = ~(Q(bbox_x0__gt=bbox[2]) | Q(bbox_x1__lt=bbox[0]) |
                        Q(bbox_y0__gt=bbox[3]) | Q(bbox_y1__lt=bbox[1]))
 
@@ -330,7 +330,7 @@ class CommonModelApi(ModelResource):
                 if type in ["map", "layer", "document", "user"]:
                     # Type is one of our Major Types (not a sub type)
                     types.append(type)
-                elif type in LAYER_SUBTYPES.keys():
+                elif type in list(LAYER_SUBTYPES.keys()):
                     subtypes.append(type)
 
             if 'vector' in subtypes and 'vector_time' not in subtypes:
@@ -537,7 +537,7 @@ class CommonModelApi(ModelResource):
                 "total_count": total_count,
                 "facets": facets,
             },
-            "objects": map(lambda x: self.get_haystack_api_fields(x), objects),
+            "objects": [self.get_haystack_api_fields(x) for x in objects],
         }
 
         self.log_throttled_access(request)
@@ -545,7 +545,7 @@ class CommonModelApi(ModelResource):
 
     def get_haystack_api_fields(self, haystack_object):
         object_fields = dict(
-            (k, v) for k, v in haystack_object.get_stored_fields().items() if not re.search(
+            (k, v) for k, v in list(haystack_object.get_stored_fields().items()) if not re.search(
                 '_exact$|_sortable$', k))
         return object_fields
 

--- a/geonode/api/tests.py
+++ b/geonode/api/tests.py
@@ -57,7 +57,7 @@ class PermissionsApiTests(ResourceTestCaseMixin, GeoNodeBaseTestSupport):
 
         resp = self.api_client.get(self.list_url)
         self.assertValidJSONResponse(resp)
-        self.assertEquals(len(self.deserialize(resp)['objects']), 8)
+        self.assertEqual(len(self.deserialize(resp)['objects']), 8)
 
     def test_layers_get_list_unauth_some_public(self):
         """
@@ -69,7 +69,7 @@ class PermissionsApiTests(ResourceTestCaseMixin, GeoNodeBaseTestSupport):
 
         resp = self.api_client.get(self.list_url)
         self.assertValidJSONResponse(resp)
-        self.assertEquals(len(self.deserialize(resp)['objects']), 7)
+        self.assertEqual(len(self.deserialize(resp)['objects']), 7)
 
     def test_layers_get_list_auth_some_public(self):
         """
@@ -82,7 +82,7 @@ class PermissionsApiTests(ResourceTestCaseMixin, GeoNodeBaseTestSupport):
 
         resp = self.api_client.get(self.list_url)
         self.assertValidJSONResponse(resp)
-        self.assertEquals(len(self.deserialize(resp)['objects']), 8)
+        self.assertEqual(len(self.deserialize(resp)['objects']), 8)
 
     def test_layer_get_list_layer_private_to_one_user(self):
         """
@@ -93,15 +93,15 @@ class PermissionsApiTests(ResourceTestCaseMixin, GeoNodeBaseTestSupport):
         layer = Layer.objects.all()[0]
         layer.set_permissions(perm_spec)
         resp = self.api_client.get(self.list_url)
-        self.assertEquals(len(self.deserialize(resp)['objects']), 7)
+        self.assertEqual(len(self.deserialize(resp)['objects']), 7)
 
         self.api_client.client.login(username='bobby', password='bob')
         resp = self.api_client.get(self.list_url)
-        self.assertEquals(len(self.deserialize(resp)['objects']), 8)
+        self.assertEqual(len(self.deserialize(resp)['objects']), 8)
 
         self.api_client.client.login(username=self.user, password=self.passwd)
         resp = self.api_client.get(self.list_url)
-        self.assertEquals(len(self.deserialize(resp)['objects']), 8)
+        self.assertEqual(len(self.deserialize(resp)['objects']), 8)
 
         layer.is_published = False
         layer.save()
@@ -109,15 +109,15 @@ class PermissionsApiTests(ResourceTestCaseMixin, GeoNodeBaseTestSupport):
         # with resource publishing
         with self.settings(RESOURCE_PUBLISHING=True):
             resp = self.api_client.get(self.list_url)
-            self.assertEquals(len(self.deserialize(resp)['objects']), 8)
+            self.assertEqual(len(self.deserialize(resp)['objects']), 8)
 
             self.api_client.client.login(username='bobby', password='bob')
             resp = self.api_client.get(self.list_url)
-            self.assertEquals(len(self.deserialize(resp)['objects']), 8)
+            self.assertEqual(len(self.deserialize(resp)['objects']), 8)
 
             self.api_client.client.login(username=self.user, password=self.passwd)
             resp = self.api_client.get(self.list_url)
-            self.assertEquals(len(self.deserialize(resp)['objects']), 8)
+            self.assertEqual(len(self.deserialize(resp)['objects']), 8)
 
     def test_layer_get_detail_unauth_layer_not_public(self):
         """
@@ -141,11 +141,11 @@ class PermissionsApiTests(ResourceTestCaseMixin, GeoNodeBaseTestSupport):
 
                 self.client.login(username=self.user, password=self.passwd)
                 resp = self.client.get(self.list_url)
-                self.assertEquals(len(self.deserialize(resp)['objects']), 8)
+                self.assertEqual(len(self.deserialize(resp)['objects']), 8)
 
                 self.client.logout()
                 resp = self.client.get(self.list_url)
-                self.assertEquals(len(self.deserialize(resp)['objects']), 7)
+                self.assertEqual(len(self.deserialize(resp)['objects']), 7)
 
                 from geonode.people.models import Profile
                 Profile.objects.create(username='imnew',
@@ -153,7 +153,7 @@ class PermissionsApiTests(ResourceTestCaseMixin, GeoNodeBaseTestSupport):
                     6NbOXIQWWblfInIoq/Ta34FdRiPhawCIZ+sOO3YQs=')
                 self.client.login(username='imnew', password='thepwd')
                 resp = self.client.get(self.list_url)
-                self.assertEquals(len(self.deserialize(resp)['objects']), 7)
+                self.assertEqual(len(self.deserialize(resp)['objects']), 7)
 
     def test_new_user_has_access_to_old_layers(self):
         """Test that a new user can access the public available layers"""
@@ -164,7 +164,7 @@ class PermissionsApiTests(ResourceTestCaseMixin, GeoNodeBaseTestSupport):
         self.api_client.client.login(username='imnew', password='thepwd')
         resp = self.api_client.get(self.list_url)
         self.assertValidJSONResponse(resp)
-        self.assertEquals(len(self.deserialize(resp)['objects']), 8)
+        self.assertEqual(len(self.deserialize(resp)['objects']), 8)
 
         # with delayed security
         if check_ogc_backend(geoserver.BACKEND_PACKAGE):
@@ -181,15 +181,15 @@ class PermissionsApiTests(ResourceTestCaseMixin, GeoNodeBaseTestSupport):
 
                     self.client.login(username=self.user, password=self.passwd)
                     resp = self.client.get(self.list_url)
-                    self.assertEquals(len(self.deserialize(resp)['objects']), 8)
+                    self.assertEqual(len(self.deserialize(resp)['objects']), 8)
 
                     self.client.logout()
                     resp = self.client.get(self.list_url)
-                    self.assertEquals(len(self.deserialize(resp)['objects']), 7)
+                    self.assertEqual(len(self.deserialize(resp)['objects']), 7)
 
                     self.client.login(username='imnew', password='thepwd')
                     resp = self.client.get(self.list_url)
-                    self.assertEquals(len(self.deserialize(resp)['objects']), 7)
+                    self.assertEqual(len(self.deserialize(resp)['objects']), 7)
             finally:
                 _ogc_geofence_enabled['default']['GEOFENCE_SECURITY_ENABLED'] = False
 
@@ -217,16 +217,16 @@ class OAuthApiTests(ResourceTestCaseMixin, GeoNodeBaseTestSupport):
             # all public
             resp = self.api_client.get(self.list_url)
             self.assertValidJSONResponse(resp)
-            self.assertEquals(len(self.deserialize(resp)['objects']), 8)
+            self.assertEqual(len(self.deserialize(resp)['objects']), 8)
 
             perm_spec = {"users": {"admin": ['view_resourcebase']}, "groups": {}}
             layer = Layer.objects.all()[0]
             layer.set_permissions(perm_spec)
             resp = self.api_client.get(self.list_url)
-            self.assertEquals(len(self.deserialize(resp)['objects']), 7)
+            self.assertEqual(len(self.deserialize(resp)['objects']), 7)
 
             resp = self.api_client.get(self.list_url, authentication=self.auth_header)
-            self.assertEquals(len(self.deserialize(resp)['objects']), 8)
+            self.assertEqual(len(self.deserialize(resp)['objects']), 8)
 
             layer.is_published = False
             layer.save()
@@ -269,25 +269,25 @@ class SearchApiTests(ResourceTestCaseMixin, GeoNodeBaseTestSupport):
 
         resp = self.api_client.get(filter_url)
         self.assertValidJSONResponse(resp)
-        self.assertEquals(len(self.deserialize(resp)['objects']), 9)
+        self.assertEqual(len(self.deserialize(resp)['objects']), 9)
 
         filter_url = self.profiles_list_url + '?name__icontains=norm'
 
         resp = self.api_client.get(filter_url)
         self.assertValidJSONResponse(resp)
-        self.assertEquals(len(self.deserialize(resp)['objects']), 1)
+        self.assertEqual(len(self.deserialize(resp)['objects']), 1)
 
         filter_url = self.profiles_list_url + '?name__icontains=NoRmAN'
 
         resp = self.api_client.get(filter_url)
         self.assertValidJSONResponse(resp)
-        self.assertEquals(len(self.deserialize(resp)['objects']), 1)
+        self.assertEqual(len(self.deserialize(resp)['objects']), 1)
 
         filter_url = self.profiles_list_url + '?name__icontains=bar'
 
         resp = self.api_client.get(filter_url)
         self.assertValidJSONResponse(resp)
-        self.assertEquals(len(self.deserialize(resp)['objects']), 0)
+        self.assertEqual(len(self.deserialize(resp)['objects']), 0)
 
     def test_groups_filters(self):
         """Test groups filtering"""
@@ -296,25 +296,25 @@ class SearchApiTests(ResourceTestCaseMixin, GeoNodeBaseTestSupport):
 
         resp = self.api_client.get(filter_url)
         self.assertValidJSONResponse(resp)
-        self.assertEquals(len(self.deserialize(resp)['objects']), 1)
+        self.assertEqual(len(self.deserialize(resp)['objects']), 1)
 
         filter_url = self.groups_list_url + '?name__icontains=bar'
 
         resp = self.api_client.get(filter_url)
         self.assertValidJSONResponse(resp)
-        self.assertEquals(len(self.deserialize(resp)['objects']), 1)
+        self.assertEqual(len(self.deserialize(resp)['objects']), 1)
 
         filter_url = self.groups_list_url + '?name__icontains=BaR'
 
         resp = self.api_client.get(filter_url)
         self.assertValidJSONResponse(resp)
-        self.assertEquals(len(self.deserialize(resp)['objects']), 1)
+        self.assertEqual(len(self.deserialize(resp)['objects']), 1)
 
         filter_url = self.groups_list_url + '?name__icontains=foo'
 
         resp = self.api_client.get(filter_url)
         self.assertValidJSONResponse(resp)
-        self.assertEquals(len(self.deserialize(resp)['objects']), 0)
+        self.assertEqual(len(self.deserialize(resp)['objects']), 0)
 
     def test_category_filters(self):
         """Test category filtering"""
@@ -325,14 +325,14 @@ class SearchApiTests(ResourceTestCaseMixin, GeoNodeBaseTestSupport):
 
         resp = self.api_client.get(filter_url)
         self.assertValidJSONResponse(resp)
-        self.assertEquals(len(self.deserialize(resp)['objects']), 3)
+        self.assertEqual(len(self.deserialize(resp)['objects']), 3)
 
         filter_url = self.list_url + \
             '?category__identifier__in=location&category__identifier__in=biota'
 
         resp = self.api_client.get(filter_url)
         self.assertValidJSONResponse(resp)
-        self.assertEquals(len(self.deserialize(resp)['objects']), 5)
+        self.assertEqual(len(self.deserialize(resp)['objects']), 5)
 
     def test_tag_filters(self):
         """Test keywords filtering"""
@@ -343,14 +343,14 @@ class SearchApiTests(ResourceTestCaseMixin, GeoNodeBaseTestSupport):
 
         resp = self.api_client.get(filter_url)
         self.assertValidJSONResponse(resp)
-        self.assertEquals(len(self.deserialize(resp)['objects']), 1)
+        self.assertEqual(len(self.deserialize(resp)['objects']), 1)
 
         filter_url = self.list_url + \
             '?keywords__slug__in=layertagunique&keywords__slug__in=populartag'
 
         resp = self.api_client.get(filter_url)
         self.assertValidJSONResponse(resp)
-        self.assertEquals(len(self.deserialize(resp)['objects']), 8)
+        self.assertEqual(len(self.deserialize(resp)['objects']), 8)
 
     def test_owner_filters(self):
         """Test owner filtering"""
@@ -361,14 +361,14 @@ class SearchApiTests(ResourceTestCaseMixin, GeoNodeBaseTestSupport):
 
         resp = self.api_client.get(filter_url)
         self.assertValidJSONResponse(resp)
-        self.assertEquals(len(self.deserialize(resp)['objects']), 1)
+        self.assertEqual(len(self.deserialize(resp)['objects']), 1)
 
         filter_url = self.list_url + \
             '?owner__username__in=user1&owner__username__in=foo'
 
         resp = self.api_client.get(filter_url)
         self.assertValidJSONResponse(resp)
-        self.assertEquals(len(self.deserialize(resp)['objects']), 2)
+        self.assertEqual(len(self.deserialize(resp)['objects']), 2)
 
     def test_title_filter(self):
         """Test title filtering"""
@@ -379,7 +379,7 @@ class SearchApiTests(ResourceTestCaseMixin, GeoNodeBaseTestSupport):
 
         resp = self.api_client.get(filter_url)
         self.assertValidJSONResponse(resp)
-        self.assertEquals(len(self.deserialize(resp)['objects']), 1)
+        self.assertEqual(len(self.deserialize(resp)['objects']), 1)
 
     def test_date_filter(self):
         """Test date filtering"""
@@ -398,18 +398,18 @@ class SearchApiTests(ResourceTestCaseMixin, GeoNodeBaseTestSupport):
 
         resp = self.api_client.get(filter_url)
         self.assertValidJSONResponse(resp)
-        self.assertEquals(len(self.deserialize(resp)['objects']), 0)
+        self.assertEqual(len(self.deserialize(resp)['objects']), 0)
 
         d3 = to_date(now - (3 * step))
         filter_url = self.list_url + '?date__gte={}'.format(d3)
 
         resp = self.api_client.get(filter_url)
         self.assertValidJSONResponse(resp)
-        self.assertEquals(len(self.deserialize(resp)['objects']), 3)
+        self.assertEqual(len(self.deserialize(resp)['objects']), 3)
 
         d4 = to_date(now - (4 * step))
         filter_url = self.list_url + '?date__range={},{}'.format(d4, to_date(now))
 
         resp = self.api_client.get(filter_url)
         self.assertValidJSONResponse(resp)
-        self.assertEquals(len(self.deserialize(resp)['objects']), 4)
+        self.assertEqual(len(self.deserialize(resp)['objects']), 4)


### PR DESCRIPTION
PR to update `api` app to be Python 2.7/3 cross-compatible as part of https://github.com/GeoNode/geonode/issues/4276.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there are explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [x] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
