### PR TITLE
[Fixes  #5335] Auto assignment of users to "registered-members" group is not working under certain conditions

### DIFF
--- a/docs/basic/settings/index.rst
+++ b/docs/basic/settings/index.rst
@@ -233,6 +233,8 @@ AUTO_ASSIGN_REGISTERED_MEMBERS_TO_REGISTERED_MEMBERS_GROUP_AT
 
     Auto assign users to a default ``REGISTERED_MEMBERS_GROUP_NAME`` private group after {"registration" | "activation" | "login"}.
 
+    Notice that whenever ``ACCOUNT_EMAIL_VERIFICATION == True`` and ``ACCOUNT_APPROVAL_REQUIRED == False``, users will be able to register and they became ``active`` already, even if they won't be able to login until the email has been verified.
+
 AUTO_GENERATE_AVATAR_SIZES
 --------------------------
 
@@ -368,11 +370,6 @@ CACHES
     A dictionary containing the settings for all caches to be used with Django.
     This is a `Django setting <https://docs.djangoproject.com/en/2.2/ref/settings/#std:setting-CACHES>`__
 
-CACHE_TIME
-----------
-
-    | Default: ``0``
-    | Env: ``CACHE_TIME``
 
 CASCADE_WORKSPACE
 -----------------

--- a/geonode/groups/tests.py
+++ b/geonode/groups/tests.py
@@ -93,24 +93,15 @@ class SmokeTest(GeoNodeBaseTestSupport):
         norman = get_user_model().objects.get(username="norman")
         admin = get_user_model().objects.get(username='admin')
 
-        # Make sure norman is not a member until login
+        # Make sure norman is a member by default (active and created)
         groupprofile = GroupProfile.objects.filter(
             slug=groups_settings.REGISTERED_MEMBERS_GROUP_NAME).first()
-        self.assertFalse(groupprofile.user_is_member(norman))
-        self.assertTrue(self.client.login(username="norman", password="norman"))
-        self.assertFalse(groupprofile.user_is_member(norman))
-
-        norman.is_active = True
-        norman.save()
-        # The first time the signal won't be triggered
-        self.assertFalse(groupprofile.user_is_member(norman))
+        self.assertTrue(groupprofile.user_is_member(norman))
 
         norman.is_active = False
         norman.save()
-        norman.is_active = True
-        norman.save()
         # the signal is triggered when a user "becomes" active
-        self.assertTrue(groupprofile.user_is_member(norman))
+        self.assertFalse(groupprofile.user_is_member(norman))
 
         # Ensure anonymous is not in the managers queryset
         self.assertFalse(groupprofile.user_is_member(anonymous))

--- a/geonode/people/signals.py
+++ b/geonode/people/signals.py
@@ -135,7 +135,8 @@ def profile_post_save(instance, sender, **kwargs):
     instance.groups.add(anon_group)
 
     if groups_settings.AUTO_ASSIGN_REGISTERED_MEMBERS_TO_REGISTERED_MEMBERS_GROUP_AT == 'activation':
-        became_active = instance.is_active and not instance._previous_active_state
+        created = kwargs.get('created', False)
+        became_active = instance.is_active and (not instance._previous_active_state or created)
         if became_active:
             _add_user_to_registered_members(instance)
         elif not instance.is_active:


### PR DESCRIPTION
 - Fixes  #5335 : Auto assignment of users to "registered-members" group is not working under certain conditions

#  Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there are explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [x] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
