### PR TITLE
[Issue #4276] Upgrade upload for Python 2.7/3 compatibility

### DIFF
--- a/geonode/upload/files.py
+++ b/geonode/upload/files.py
@@ -30,7 +30,11 @@ from geonode.utils import fixup_shp_columnnames
 from geoserver.resource import FeatureType, Coverage
 from django.utils.translation import ugettext as _
 
-from UserList import UserList
+try:
+    from collections import UserList
+except ImportError:
+    # Python 2 compatibility
+    from UserList import UserList
 import zipfile
 import os
 import re
@@ -225,7 +229,7 @@ def _find_file_type(file_names, extension):
     """
     Returns files that end with the given extension from a list of file names.
     """
-    return filter(lambda f: f.lower().endswith(extension), file_names)
+    return [f for f in file_names if f.lower().endswith(extension)]
 
 
 def clean_macosx_dir(file_names):

--- a/geonode/upload/forms.py
+++ b/geonode/upload/forms.py
@@ -102,11 +102,8 @@ class LayerUploadForm(forms.Form):
 
     def _get_uploaded_files(self):
         """Return a list with all of the uploaded files"""
-        uploaded = []
-        for field_name, django_file in self.files.iteritems():
-            if field_name != "base_file":
-                uploaded.append(django_file)
-        return uploaded
+        return [django_file for field_name, django_file in self.files.items()
+                if field_name != "base_file"]
 
 
 class TimeForm(forms.Form):

--- a/geonode/upload/models.py
+++ b/geonode/upload/models.py
@@ -18,7 +18,7 @@
 #
 #########################################################################
 
-import cPickle as pickle
+import pickle
 import logging
 import shutil
 

--- a/geonode/upload/tests/__init__.py
+++ b/geonode/upload/tests/__init__.py
@@ -46,7 +46,7 @@ def create_files(names, zipped=False):
             except IOError:
                 # windows fails at writing special characters
                 # need to do something better here
-                print "Test does not work in Windows"
+                print("Test does not work in Windows")
     if zipped:
         basefile = os.path.join(tmpdir, 'files.zip')
         zf = zipfile.ZipFile(basefile, 'w')
@@ -92,8 +92,8 @@ class FilesTests(GeoNodeBaseTestSupport):
         """
         exts = ('.shp', '.shx', '.sld', '.xml', '.prj', '.dbf')
 
-        with create_files(map(lambda s: 'san_andres_y_providencia_location{0}'.format(s), exts)) as tests:
-            shp = filter(lambda s: s.endswith('.shp'), tests)[0]
+        with create_files(['san_andres_y_providencia_location{0}'.format(s) for s in exts]) as tests:
+            shp = [s for s in tests if s.endswith('.shp')][0]
             spatial_files = scan_file(shp)
             self.assertTrue(isinstance(spatial_files, SpatialFiles))
 
@@ -103,10 +103,10 @@ class FilesTests(GeoNodeBaseTestSupport):
             self.assertEqual(len(spatial_file.auxillary_files), 3)
             self.assertEqual(len(spatial_file.xml_files), 1)
             self.assertTrue(
-                all(map(lambda s: s.endswith('xml'), spatial_file.xml_files)))
+                all(s.endswith('xml') for s in spatial_file.xml_files))
             self.assertEqual(len(spatial_file.sld_files), 1)
             self.assertTrue(
-                all(map(lambda s: s.endswith('sld'), spatial_file.sld_files)))
+                all(s.endswith('sld') for s in spatial_file.sld_files))
 
         # Test the scan_file function with a zipped spatial file that needs to
         # be renamed.
@@ -122,7 +122,7 @@ class FilesTests(GeoNodeBaseTestSupport):
             self.assertEqual(len(spatial_file.xml_files), 1)
             self.assertEqual(len(spatial_file.sld_files), 1)
             self.assertTrue(
-                all(map(lambda s: s.endswith('xml'), spatial_file.xml_files)))
+                all(s.endswith('xml') for s in spatial_file.xml_files))
 
             basedir = os.path.dirname(spatial_file.base_file)
             for f in file_names:

--- a/geonode/upload/tests/test_settings.py
+++ b/geonode/upload/tests/test_settings.py
@@ -19,7 +19,11 @@
 #########################################################################
 
 import os
-from urlparse import urlparse, urlunparse
+try:
+    from urllib.parse import urlparse, urlunparse
+except ImportError:
+    # Python 2 compatibility
+    from urlparse import urlparse, urlunparse
 from geonode.settings import *
 
 PROJECT_ROOT = os.path.abspath(os.path.dirname(__file__))

--- a/geonode/upload/upload.py
+++ b/geonode/upload/upload.py
@@ -40,6 +40,7 @@ import shutil
 import uuid
 import zipfile
 import traceback
+from six import string_types
 
 from django.conf import settings
 from django.db.models import Max
@@ -176,7 +177,7 @@ def upload(
 
     if user is None:
         user = get_default_user()
-    if isinstance(user, basestring):
+    if isinstance(user, string_types):
         user = get_user_model().objects.get(username=user)
     import_session = save_step(
         user,
@@ -221,8 +222,8 @@ def upload(
 def _get_next_id():
     # importer tracks ids by autoincrement but is prone to corruption
     # which potentially may reset the id - hopefully prevent this...
-    upload_next_id = Upload.objects.all().aggregate(
-        Max('import_id')).values()[0]
+    upload_next_id = list(Upload.objects.all().aggregate(
+        Max('import_id')).values())[0]
     upload_next_id = upload_next_id if upload_next_id else 0
     # next_id = next_id + 1 if next_id else 1
     importer_sessions = gs_uploader.get_sessions()

--- a/geonode/upload/utils.py
+++ b/geonode/upload/utils.py
@@ -29,6 +29,7 @@ from osgeo import ogr
 from lxml import etree
 from itertools import islice
 from defusedxml import lxml as dlxml
+from six import string_types, text_type
 
 from django.conf import settings
 from django.core.urlresolvers import reverse
@@ -165,7 +166,7 @@ def json_loads_byteified(json_text, charset):
 
 def _byteify(data, ignore_dicts=False):
     # if this is a unicode string, return its string representation
-    if isinstance(data, unicode):
+    if isinstance(data, text_type):
         return data.encode('utf-8')
     # if this is a list of values, return list of byteified values
     if isinstance(data, list):
@@ -175,7 +176,7 @@ def _byteify(data, ignore_dicts=False):
     if isinstance(data, dict) and not ignore_dicts:
         return {
             _byteify(key, ignore_dicts=True): _byteify(value, ignore_dicts=True)
-            for key, value in data.iteritems()
+            for key, value in data.items()
         }
     # if it's anything else, return it in its original form
     return data
@@ -442,8 +443,7 @@ def check_import_session_is_valid(request, upload_session, import_session):
     if store_type == 'dataStore':
         try:
             layer = import_session.tasks[0].layer
-            invalid = filter(
-                lambda a: str(a.name).find(' ') >= 0, layer.attributes)
+            invalid = [a for a in layer.attributes if str(a.name).find(' ') >= 0]
             if invalid:
                 att_list = "<pre>%s</pre>" % '. '.join(
                     [a.name for a in invalid])
@@ -749,7 +749,7 @@ def import_imagemosaic_granules(
              'fetch size': '1000',
              'host': db['HOST'],
              'port': db['PORT'] if isinstance(
-                 db['PORT'], basestring) else str(db['PORT']) or '5432',
+                 db['PORT'], string_types) else str(db['PORT']) or '5432',
              'database': db['NAME'],
              'user': db['USER'],
              'passwd': db['PASSWORD'],


### PR DESCRIPTION
PR to update `upload` app to be Python 2.7/3 cross-compatible as part of #4276.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there are explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [x] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
