### PR TITLE
[Issue #4276] Upgrade favorite for Python 2.7/3 compatibility

### DIFF
--- a/geonode/favorite/models.py
+++ b/geonode/favorite/models.py
@@ -32,14 +32,7 @@ from geonode.maps.models import Map
 class FavoriteManager(models.Manager):
 
     def favorites_for_user(self, user):
-        result = self.filter(user=user)
-        cleaned_data = []
-        for r in result:
-            if r.content_object:
-                cleaned_data.append(r)
-            else:
-                r.delete()
-        return cleaned_data
+        return self.filter(user=user)
 
     def _favorite_ct_for_user(self, user, model):
         content_type = ContentType.objects.get_for_model(model)

--- a/geonode/favorite/utils.py
+++ b/geonode/favorite/utils.py
@@ -19,7 +19,7 @@
 #########################################################################
 
 from django.core.urlresolvers import reverse
-import models
+from . import models
 
 
 def get_favorite_info(user, content_object):

--- a/geonode/favorite/views.py
+++ b/geonode/favorite/views.py
@@ -31,7 +31,7 @@ from django.shortcuts import render
 from geonode.documents.models import Document
 from geonode.layers.models import Layer
 from geonode.maps.models import Map
-import models
+from . import models
 
 
 @login_required


### PR DESCRIPTION
PR to update `favorite` app to be Python 2.7/3 cross-compatible as part of #4276.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there are explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [x] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
