### PR TITLE
[Issue #4276] Upgrade groups for Python 2.7/3 compatibility

### DIFF
--- a/geonode/groups/templatetags/groups_tags.py
+++ b/geonode/groups/templatetags/groups_tags.py
@@ -1,3 +1,5 @@
+from six import string_types
+
 from django import template
 from django.contrib.staticfiles.storage import staticfiles_storage
 
@@ -13,7 +15,7 @@ def group_profile_image(group_profile, css_classes="", size=None):
 
     """
 
-    if isinstance(css_classes, basestring):
+    if isinstance(css_classes, string_types):
         class_attr = 'class="{}" '.format(css_classes)
     else:
         try:

--- a/geonode/groups/tests.py
+++ b/geonode/groups/tests.py
@@ -22,6 +22,7 @@ from geonode.tests.base import GeoNodeBaseTestSupport
 
 import json
 import logging
+from six import string_types
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
 from django.core.files.uploadedfile import SimpleUploadedFile
@@ -73,8 +74,8 @@ class SmokeTest(GeoNodeBaseTestSupport):
             slug=groups_settings.REGISTERED_MEMBERS_GROUP_NAME).first()
         self.assertTrue(group)
         self.assertTrue(groupprofile)
-        self.assertEquals(groupprofile.group, group)
-        self.assertEquals(group.groupprofile, groupprofile)
+        self.assertEqual(groupprofile.group, group)
+        self.assertEqual(group.groupprofile, groupprofile)
 
     def test_users_belongs_registered_group(self):
         """
@@ -83,10 +84,10 @@ class SmokeTest(GeoNodeBaseTestSupport):
         2. Ensures that any user on the system, except "AnonymousUser" belongs to
            groups_settings.REGISTERED_MEMBERS_GROUP_NAME.
         """
-        self.assertEquals(
+        self.assertEqual(
             groups_settings.AUTO_ASSIGN_REGISTERED_MEMBERS_TO_REGISTERED_MEMBERS_GROUP_NAME, True)
 
-        self.assertEquals(
+        self.assertEqual(
             groups_settings.AUTO_ASSIGN_REGISTERED_MEMBERS_TO_REGISTERED_MEMBERS_GROUP_AT, 'activation')
 
         anonymous = get_user_model().objects.get(username="AnonymousUser")
@@ -261,8 +262,7 @@ class SmokeTest(GeoNodeBaseTestSupport):
             js = json.loads(response.content)
             permissions = js.get('permissions', dict())
 
-            if isinstance(permissions, unicode) or isinstance(
-                    permissions, str):
+            if isinstance(permissions, string_types):
                 permissions = json.loads(permissions)
 
             # Ensure the groups value is empty by default
@@ -274,9 +274,7 @@ class SmokeTest(GeoNodeBaseTestSupport):
                 expected_permissions.setdefault(
                     u'anonymous', []).append(u'view_resourcebase')
 
-            self.assertItemsEqual(
-                permissions.get('groups'),
-                expected_permissions)
+            self.assertItemsEqual(permissions.get('groups'), expected_permissions)
 
             permissions = {
                 'groups': {
@@ -306,8 +304,7 @@ class SmokeTest(GeoNodeBaseTestSupport):
             js = json.loads(response.content)
             permissions = js.get('permissions', dict())
 
-            if isinstance(permissions, unicode) or isinstance(
-                    permissions, str):
+            if isinstance(permissions, string_types):
                 permissions = json.loads(permissions)
 
             # Make sure the bar group now has write permissions
@@ -337,8 +334,7 @@ class SmokeTest(GeoNodeBaseTestSupport):
             js = json.loads(response.content)
             permissions = js.get('permissions', dict())
 
-            if isinstance(permissions, unicode) or isinstance(
-                    permissions, str):
+            if isinstance(permissions, string_types):
                 permissions = json.loads(permissions)
 
             # Assert the bar group no longer has permissions
@@ -574,8 +570,8 @@ class MembershipTest(GeoNodeBaseTestSupport):
         normal = get_user_model().objects.get(username="norman")
         group = GroupProfile.objects.get(slug="bar")
 
-        self.assert_(not group.user_is_member(anon))
-        self.assert_(not group.user_is_member(normal))
+        self.assertFalse(group.user_is_member(anon))
+        self.assertFalse(group.user_is_member(normal))
 
     def test_group_add_member(self):
         """
@@ -586,7 +582,7 @@ class MembershipTest(GeoNodeBaseTestSupport):
         normal = get_user_model().objects.get(username="norman")
         group = GroupProfile.objects.get(slug="bar")
         group.join(normal)
-        self.assert_(group.user_is_member(normal))
+        self.assertTrue(group.user_is_member(normal))
         self.assertRaises(ValueError, lambda: group.join(anon))
 
     def test_profile_is_member_of_group(self):


### PR DESCRIPTION
PR to update `groups` app to be Python 2.7/3 cross-compatible as part of #4276.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there are explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [x] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
