### PR TITLE
[Issue #4276] Upgrade layers for Python 2.7/3 compatibility

### DIFF
--- a/geonode/layers/autocomplete_light_registry.py
+++ b/geonode/layers/autocomplete_light_registry.py
@@ -20,7 +20,7 @@
 
 from autocomplete_light.registry import register
 from autocomplete_light.autocomplete.shortcuts import AutocompleteModelTemplate
-from models import Layer
+from .models import Layer
 from guardian.shortcuts import get_objects_for_user
 
 from django.conf import settings

--- a/geonode/layers/management/commands/importlayers.py
+++ b/geonode/layers/management/commands/importlayers.py
@@ -184,12 +184,12 @@ class Command(BaseCommand):
         if len(keywords) == 1 and keywords[0] == '':
             keywords = []
         else:
-            keywords = map(str.strip, keywords)
+            keywords = [k.strip() for k in keywords]
         regions = options.get('regions').split(',')
         if len(regions) == 1 and regions[0] == '':
             regions = []
         else:
-            regions = map(str.strip, regions)
+            regions = [r.strip() for r in regions]
         start = datetime.datetime.now(timezone.get_current_timezone())
         output = []
 
@@ -230,21 +230,21 @@ class Command(BaseCommand):
         duration_rounded = round(duration, 2)
 
         if verbosity > 1:
-            print "\nDetailed report of failures:"
+            print("\nDetailed report of failures:")
             for dict_ in output:
                 if dict_['status'] == 'failed':
-                    print "\n\n", dict_['file'], "\n================"
+                    print("\n\n", dict_['file'], "\n================")
                     traceback.print_exception(dict_['exception_type'],
                                               dict_['error'],
                                               dict_['traceback'])
 
         if verbosity > 0:
-            print "\n\nFinished processing %d layers in %s seconds.\n" % (
-                len(output), duration_rounded)
-            print "%d Created layers" % len(created)
-            print "%d Updated layers" % len(updated)
-            print "%d Skipped layers" % len(skipped)
-            print "%d Failed layers" % len(failed)
+            print("\n\nFinished processing {} layers in {} seconds.\n".format(
+                len(output), duration_rounded))
+            print("{} Created layers".format(len(created)))
+            print("{} Updated layers".format(len(updated)))
+            print("{} Skipped layers".format(len(skipped)))
+            print("{} Failed layers".format(len(failed)))
 
             if len(output) > 0:
-                print "%f seconds per layer" % (duration * 1.0 / len(output))
+                print("{} seconds per layer".format(duration * 1.0 / len(output)))

--- a/geonode/layers/models.py
+++ b/geonode/layers/models.py
@@ -83,6 +83,9 @@ class Style(models.Model, PermissionLevelMixin):
     def __unicode__(self):
         return u"%s" % self.name
 
+    def __str__(self):
+        return self.__unicode__().encode('utf-8')
+
     def absolute_url(self):
         if self.sld_url:
             if self.sld_url.startswith(
@@ -279,6 +282,9 @@ class Layer(ResourceBase):
         # else:
         #     return "Unamed Layer"
 
+    def __str__(self):
+        return self.__unicode__().encode('utf-8')
+
     class Meta:
         # custom permissions,
         # change and delete are standard in django-guardian
@@ -337,11 +343,15 @@ class UploadSession(models.Model):
         return self.processed and self.errors is None
 
     def __unicode__(self):
+        _s = "[Upload session-id: {}]".format(self.id)
         try:
-            _s = '[Upload session-id: {}] - {}'.format(self.id, self.resource.title)
+            _s += " - {}".format(self.resource.title)
         except BaseException:
-            _s = '[Upload session-id: {}]'.format(self.id)
+            pass
         return u"{0}".format(_s)
+
+    def __str__(self):
+        return self.__unicode__().encode('utf-8')
 
 
 class LayerFile(models.Model):
@@ -520,7 +530,7 @@ def pre_save_layer(instance, sender, **kwargs):
             logger.exception(e)
 
     if instance.abstract == '' or instance.abstract is None:
-        instance.abstract = unicode(_('No abstract provided'))
+        instance.abstract = u'No abstract provided'
     if instance.title == '' or instance.title is None:
         instance.title = instance.name
 

--- a/geonode/layers/tests.py
+++ b/geonode/layers/tests.py
@@ -27,7 +27,7 @@ import gisdata
 import logging
 import zipfile
 import tempfile
-import StringIO
+import io
 import contextlib
 
 from datetime import datetime
@@ -85,26 +85,26 @@ class LayersTest(GeoNodeBaseTestSupport):
     def test_data(self):
         '''/data/ -> Test accessing the data page'''
         response = self.client.get(reverse('layer_browse'))
-        self.failUnlessEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
 
     def test_describe_data_2(self):
         '''/data/geonode:CA/metadata -> Test accessing the description of a layer '''
         self.assertEqual(10, get_user_model().objects.all().count())
         response = self.client.get(reverse('layer_metadata', args=('geonode:CA',)))
         # Since we are not authenticated, we should not be able to access it
-        self.failUnlessEqual(response.status_code, 302)
+        self.assertEqual(response.status_code, 302)
         # but if we log in ...
         self.client.login(username='admin', password='admin')
         # ... all should be good
         response = self.client.get(reverse('layer_metadata', args=('geonode:CA',)))
-        self.failUnlessEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
 
     def test_describe_data_3(self):
         '''/data/geonode:CA/metadata_detail -> Test accessing the description of a layer '''
         self.client.login(username='admin', password='admin')
         # ... all should be good
         response = self.client.get(reverse('layer_metadata_detail', args=('geonode:CA',)))
-        self.failUnlessEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Approved", count=1, status_code=200, msg_prefix='', html=False)
         self.assertContains(response, "Published", count=1, status_code=200, msg_prefix='', html=False)
         self.assertContains(response, "Featured", count=1, status_code=200, msg_prefix='', html=False)
@@ -116,7 +116,7 @@ class LayersTest(GeoNodeBaseTestSupport):
         lyr.group = group
         lyr.save()
         response = self.client.get(reverse('layer_metadata_detail', args=('geonode:CA',)))
-        self.failUnlessEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
         self.assertContains(response, "<dt>Group</dt>", count=1, status_code=200, msg_prefix='', html=False)
         lyr.group = None
         lyr.save()
@@ -127,24 +127,24 @@ class LayersTest(GeoNodeBaseTestSupport):
     def test_upload_layer(self):
         # Test redirection to login form when not logged in
         response = self.client.get(reverse('layer_upload'))
-        self.assertEquals(response.status_code, 302)
+        self.assertEqual(response.status_code, 302)
 
         # Test return of upload form when logged in
         self.client.login(username="bobby", password="bob")
         response = self.client.get(reverse('layer_upload'))
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
 
     def test_describe_data(self):
         '''/data/geonode:CA/metadata -> Test accessing the description of a layer '''
         self.assertEqual(10, get_user_model().objects.all().count())
         response = self.client.get(reverse('layer_metadata', args=('geonode:CA',)))
         # Since we are not authenticated, we should not be able to access it
-        self.failUnlessEqual(response.status_code, 302)
+        self.assertEqual(response.status_code, 302)
         # but if we log in ...
         self.client.login(username='admin', password='admin')
         # ... all should be good
         response = self.client.get(reverse('layer_metadata', args=('geonode:CA',)))
-        self.failUnlessEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
 
     def test_layer_attributes(self):
         lyr = Layer.objects.all().first()
@@ -189,14 +189,14 @@ class LayersTest(GeoNodeBaseTestSupport):
             bbox_to_projection([float(coord) for coord in layer_bbox] + [lyr.srid, ],
                                target_srid=4326)[:4])
         logger.info(projected_bbox)
-        self.assertEquals(projected_bbox, [-180.0, -90.0, 180.0, 90.0])
+        self.assertEqual(projected_bbox, [-180.0, -90.0, 180.0, 90.0])
         logger.info(lyr.ll_bbox)
-        self.assertEquals(lyr.ll_bbox, [-180.0, 180.0, -90.0, 90.0, u'EPSG:4326'])
+        self.assertEqual(lyr.ll_bbox, [-180.0, 180.0, -90.0, 90.0, 'EPSG:4326'])
         projected_bbox = decimal_encode(
             bbox_to_projection([float(coord) for coord in layer_bbox] + [lyr.srid, ],
                                target_srid=3857)[:4])
         logger.info(projected_bbox)
-        self.assertEquals(projected_bbox, [-20037397.0233, -74299743.4007, 20037397.0233, 74299743.4006])
+        self.assertEqual(projected_bbox, [-20037397.0233, -74299743.4007, 20037397.0233, 74299743.4006])
 
     def test_layer_attributes_feature_catalogue(self):
         """ Test layer feature catalogue functionality
@@ -204,14 +204,14 @@ class LayersTest(GeoNodeBaseTestSupport):
         # test a non-existing layer
         url = reverse('layer_feature_catalogue', args=('bad_layer',))
         response = self.client.get(url)
-        self.assertEquals(response.status_code, 404)
+        self.assertEqual(response.status_code, 404)
 
         # Get the layer to work with
         layer = Layer.objects.all()[3]
         url = reverse('layer_feature_catalogue', args=(layer.alternate,))
         response = self.client.get(url)
-        self.assertEquals(response.status_code, 200)
-        self.assertEquals(response['content-type'], 'application/xml')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['content-type'], 'application/xml')
 
     def test_layer_attribute_config(self):
         lyr = Layer.objects.all().first()
@@ -271,13 +271,13 @@ class LayersTest(GeoNodeBaseTestSupport):
 
         self.client.login(username='admin', password='admin')
         response = self.client.get(reverse('layer_detail', args=(lyr.alternate,)))
-        self.failUnlessEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
 
         response = self.client.get(reverse('layer_detail', args=(":%s" % lyr.alternate,)))
-        self.failUnlessEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
 
         response = self.client.get(reverse('layer_metadata', args=(lyr.alternate,)))
-        self.failUnlessEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
 
         from geonode.base.models import HierarchicalKeyword as hk
         keywords = hk.dump_bulk_tree()
@@ -302,68 +302,68 @@ class LayersTest(GeoNodeBaseTestSupport):
 
     def test_layer_links(self):
         lyr = Layer.objects.filter(storeType="dataStore").first()
-        self.assertEquals(lyr.storeType, "dataStore")
+        self.assertEqual(lyr.storeType, "dataStore")
         if check_ogc_backend(geoserver.BACKEND_PACKAGE):
             links = Link.objects.filter(resource=lyr.resourcebase_ptr, link_type="metadata")
             self.assertIsNotNone(links)
-            self.assertEquals(len(links), 7)
+            self.assertEqual(len(links), 7)
             for ll in links:
-                self.assertEquals(ll.link_type, "metadata")
+                self.assertEqual(ll.link_type, "metadata")
 
             _def_link_types = (
                 'data', 'image', 'original', 'html', 'OGC:WMS', 'OGC:WFS', 'OGC:WCS')
             Link.objects.filter(resource=lyr.resourcebase_ptr, link_type__in=_def_link_types).delete()
             links = Link.objects.filter(resource=lyr.resourcebase_ptr, link_type="data")
             self.assertIsNotNone(links)
-            self.assertEquals(len(links), 0)
+            self.assertEqual(len(links), 0)
 
             set_resource_default_links(lyr, lyr)
 
             links = Link.objects.filter(resource=lyr.resourcebase_ptr, link_type="metadata")
             self.assertIsNotNone(links)
-            self.assertEquals(len(links), 7)
+            self.assertEqual(len(links), 7)
             for ll in links:
-                self.assertEquals(ll.link_type, "metadata")
+                self.assertEqual(ll.link_type, "metadata")
 
             links = Link.objects.filter(resource=lyr.resourcebase_ptr, link_type="data")
             self.assertIsNotNone(links)
-            self.assertEquals(len(links), 6)
+            self.assertEqual(len(links), 6)
 
             links = Link.objects.filter(resource=lyr.resourcebase_ptr, link_type="image")
             self.assertIsNotNone(links)
-            self.assertEquals(len(links), 5)
+            self.assertEqual(len(links), 5)
 
         lyr = Layer.objects.filter(storeType="coverageStore").first()
-        self.assertEquals(lyr.storeType, "coverageStore")
+        self.assertEqual(lyr.storeType, "coverageStore")
         if check_ogc_backend(geoserver.BACKEND_PACKAGE):
             links = Link.objects.filter(resource=lyr.resourcebase_ptr, link_type="metadata")
             self.assertIsNotNone(links)
-            self.assertEquals(len(links), 7)
+            self.assertEqual(len(links), 7)
             for ll in links:
-                self.assertEquals(ll.link_type, "metadata")
+                self.assertEqual(ll.link_type, "metadata")
 
             _def_link_types = (
                 'data', 'image', 'original', 'html', 'OGC:WMS', 'OGC:WFS', 'OGC:WCS')
             Link.objects.filter(resource=lyr.resourcebase_ptr, link_type__in=_def_link_types).delete()
             links = Link.objects.filter(resource=lyr.resourcebase_ptr, link_type="data")
             self.assertIsNotNone(links)
-            self.assertEquals(len(links), 0)
+            self.assertEqual(len(links), 0)
 
             set_resource_default_links(lyr, lyr)
 
             links = Link.objects.filter(resource=lyr.resourcebase_ptr, link_type="metadata")
             self.assertIsNotNone(links)
-            self.assertEquals(len(links), 7)
+            self.assertEqual(len(links), 7)
             for ll in links:
-                self.assertEquals(ll.link_type, "metadata")
+                self.assertEqual(ll.link_type, "metadata")
 
             links = Link.objects.filter(resource=lyr.resourcebase_ptr, link_type="data")
             self.assertIsNotNone(links)
-            self.assertEquals(len(links), 2)
+            self.assertEqual(len(links), 2)
 
             links = Link.objects.filter(resource=lyr.resourcebase_ptr, link_type="image")
             self.assertIsNotNone(links)
-            self.assertEquals(len(links), 8)
+            self.assertEqual(len(links), 8)
 
     def test_get_valid_user(self):
         # Verify it accepts an admin user
@@ -474,8 +474,8 @@ class LayersTest(GeoNodeBaseTestSupport):
 
     def testZipValidation(self):
         the_zip = zipfile.ZipFile('test_upload.zip', 'w')
-        in_memory_file = StringIO.StringIO()
-        in_memory_file.write('test')
+        in_memory_file = io.StringIO()
+        in_memory_file.write(u'test')
         the_zip.writestr('foo.shp', in_memory_file.getvalue())
         the_zip.writestr('foo.dbf', in_memory_file.getvalue())
         the_zip.writestr('foo.shx', in_memory_file.getvalue())
@@ -495,12 +495,12 @@ class LayersTest(GeoNodeBaseTestSupport):
         self.assertTrue(form.is_valid())
 
         tempdir = form.write_files()[0]
-        self.assertEquals(set(os.listdir(tempdir)),
-                          set(['foo.shp', 'foo.shx', 'foo.dbf', 'foo.prj']))
+        self.assertEqual(set(os.listdir(tempdir)),
+                         {'foo.shp', 'foo.shx', 'foo.dbf', 'foo.prj'})
 
         the_zip = zipfile.ZipFile('test_upload.zip', 'w')
-        in_memory_file = StringIO.StringIO()
-        in_memory_file.write('test')
+        in_memory_file = io.StringIO()
+        in_memory_file.write(u'test')
         the_zip.writestr('foo.shp', in_memory_file.getvalue())
         the_zip.writestr('foo.dbf', in_memory_file.getvalue())
         the_zip.writestr('foo.shx', in_memory_file.getvalue())
@@ -510,49 +510,57 @@ class LayersTest(GeoNodeBaseTestSupport):
         form = LayerUploadForm(dict(), files)
         self.assertTrue(form.is_valid())
         tempdir = form.write_files()[0]
-        self.assertEquals(set(os.listdir(tempdir)),
-                          set(['foo.shp', 'foo.shx', 'foo.dbf', 'foo.prj']))
+        self.assertEqual(set(os.listdir(tempdir)),
+                         {'foo.shp', 'foo.shx', 'foo.dbf', 'foo.prj'})
         os.remove('test_upload.zip')
 
     def test_layer_type(self):
-        self.assertEquals(layer_type('foo.shp'), 'vector')
-        self.assertEquals(layer_type('foo.SHP'), 'vector')
-        self.assertEquals(layer_type('foo.sHp'), 'vector')
-        self.assertEquals(layer_type('foo.tif'), 'raster')
-        self.assertEquals(layer_type('foo.TIF'), 'raster')
-        self.assertEquals(layer_type('foo.TiF'), 'raster')
-        self.assertEquals(layer_type('foo.geotif'), 'raster')
-        self.assertEquals(layer_type('foo.GEOTIF'), 'raster')
-        self.assertEquals(layer_type('foo.gEoTiF'), 'raster')
-        self.assertEquals(layer_type('foo.tiff'), 'raster')
-        self.assertEquals(layer_type('foo.TIFF'), 'raster')
-        self.assertEquals(layer_type('foo.TiFf'), 'raster')
-        self.assertEquals(layer_type('foo.geotiff'), 'raster')
-        self.assertEquals(layer_type('foo.GEOTIFF'), 'raster')
-        self.assertEquals(layer_type('foo.gEoTiFf'), 'raster')
-        self.assertEquals(layer_type('foo.asc'), 'raster')
-        self.assertEquals(layer_type('foo.ASC'), 'raster')
-        self.assertEquals(layer_type('foo.AsC'), 'raster')
+        self.assertEqual(layer_type('foo.shp'), 'vector')
+        self.assertEqual(layer_type('foo.SHP'), 'vector')
+        self.assertEqual(layer_type('foo.sHp'), 'vector')
+        self.assertEqual(layer_type('foo.tif'), 'raster')
+        self.assertEqual(layer_type('foo.TIF'), 'raster')
+        self.assertEqual(layer_type('foo.TiF'), 'raster')
+        self.assertEqual(layer_type('foo.geotif'), 'raster')
+        self.assertEqual(layer_type('foo.GEOTIF'), 'raster')
+        self.assertEqual(layer_type('foo.gEoTiF'), 'raster')
+        self.assertEqual(layer_type('foo.tiff'), 'raster')
+        self.assertEqual(layer_type('foo.TIFF'), 'raster')
+        self.assertEqual(layer_type('foo.TiFf'), 'raster')
+        self.assertEqual(layer_type('foo.geotiff'), 'raster')
+        self.assertEqual(layer_type('foo.GEOTIFF'), 'raster')
+        self.assertEqual(layer_type('foo.gEoTiFf'), 'raster')
+        self.assertEqual(layer_type('foo.asc'), 'raster')
+        self.assertEqual(layer_type('foo.ASC'), 'raster')
+        self.assertEqual(layer_type('foo.AsC'), 'raster')
 
         # basically anything else should produce a GeoNodeException
         self.assertRaises(GeoNodeException, lambda: layer_type('foo.gml'))
 
     def test_get_files(self):
+        def generate_files(*extensions):
+            if extensions[0].lower() != 'shp':
+                return
+            d = None
+            expected_files = None
+            try:
+                d = tempfile.mkdtemp()
+                fnames = ["foo." + ext for ext in extensions]
+                expected_files = {ext.lower(): fname for ext, fname in zip(extensions, fnames)}
+                for f in fnames:
+                    path = os.path.join(d, f)
+                    # open and immediately close to create empty file
+                    open(path, 'w').close()
+            finally:
+                return d, expected_files
 
         # Check that a well-formed Shapefile has its components all picked up
         d = None
         try:
-            d = tempfile.mkdtemp()
-            for f in ("foo.shp", "foo.shx", "foo.prj", "foo.dbf"):
-                path = os.path.join(d, f)
-                # open and immediately close to create empty file
-                open(path, 'w').close()
-
+            d, expected_files = generate_files("shp", "shx", "prj", "dbf")
             gotten_files = get_files(os.path.join(d, "foo.shp"))
-            gotten_files = dict((k, v[len(d) + 1:])
-                                for k, v in gotten_files.iteritems())
-            self.assertEquals(gotten_files, dict(shp="foo.shp", shx="foo.shx",
-                                                 prj="foo.prj", dbf="foo.dbf"))
+            gotten_files = {k: os.path.basename(v) for k, v in gotten_files.items()}
+            self.assertEquals(gotten_files, expected_files)
         finally:
             if d is not None:
                 shutil.rmtree(d)
@@ -561,92 +569,46 @@ class LayersTest(GeoNodeBaseTestSupport):
         # exception
         d = None
         try:
-            d = tempfile.mkdtemp()
-            for f in ("foo.shp", "foo.shx", "foo.prj"):
-                path = os.path.join(d, f)
-                # open and immediately close to create empty file
-                open(path, 'w').close()
-
-            self.assertRaises(
-                GeoNodeException,
-                lambda: get_files(
-                    os.path.join(
-                        d,
-                        "foo.shp")))
+            d, expected_files = generate_files("shp", "shx", "prj")
+            self.assertRaises(GeoNodeException, lambda: get_files(os.path.join(d, "foo.shp")))
         finally:
             if d is not None:
                 shutil.rmtree(d)
 
         # Check that including an SLD with a valid shapefile results in the SLD
         # getting picked up
-        if check_ogc_backend(geoserver.BACKEND_PACKAGE):
-            d = None
-            try:
-                d = tempfile.mkdtemp()
-                for f in ("foo.shp", "foo.shx", "foo.prj", "foo.dbf", "foo.sld"):
-                    path = os.path.join(d, f)
-                    # open and immediately close to create empty file
-                    open(path, 'w').close()
-
+        d = None
+        try:
+            if check_ogc_backend(geoserver.BACKEND_PACKAGE):
+                d, expected_files = generate_files("shp", "shx", "prj", "dbf", "sld")
                 gotten_files = get_files(os.path.join(d, "foo.shp"))
-                gotten_files = dict((k, v[len(d) + 1:])
-                                    for k, v in gotten_files.iteritems())
-                self.assertEquals(
-                    gotten_files,
-                    dict(
-                        shp="foo.shp",
-                        shx="foo.shx",
-                        prj="foo.prj",
-                        dbf="foo.dbf",
-                        sld="foo.sld"))
-            finally:
-                if d is not None:
-                    shutil.rmtree(d)
+                gotten_files = {k: os.path.basename(v) for k, v in gotten_files.items()}
+                self.assertEquals(gotten_files, expected_files)
+        finally:
+            if d is not None:
+                shutil.rmtree(d)
 
         # Check that including a QML with a valid shapefile
         # results in the QML
         # getting picked up
-        if check_ogc_backend(qgis_server.BACKEND_PACKAGE):
-            d = None
-            try:
-                d = tempfile.mkdtemp()
-                for f in (
-                        "foo.shp", "foo.shx", "foo.prj", "foo.dbf", "foo.qml",
-                        "foo.json"):
-                    path = os.path.join(d, f)
-                    # open and immediately close to create empty file
-                    open(path, 'w').close()
-
+        d = None
+        try:
+            if check_ogc_backend(qgis_server.BACKEND_PACKAGE):
+                d, expected_files = generate_files("shp", "shx", "prj", "dbf", "qml", "json")
                 gotten_files = get_files(os.path.join(d, "foo.shp"))
-                gotten_files = dict((k, v[len(d) + 1:])
-                                    for k, v in gotten_files.iteritems())
-                self.assertEquals(
-                    gotten_files,
-                    dict(
-                        shp="foo.shp",
-                        shx="foo.shx",
-                        prj="foo.prj",
-                        dbf="foo.dbf",
-                        qml="foo.qml",
-                        json="foo.json"))
-            finally:
-                if d is not None:
-                    shutil.rmtree(d)
+                gotten_files = {k: os.path.basename(v) for k, v in gotten_files.items()}
+                self.assertEquals(gotten_files, expected_files)
+        finally:
+            if d is not None:
+                shutil.rmtree(d)
 
         # Check that capitalized extensions are ok
         d = None
         try:
-            d = tempfile.mkdtemp()
-            for f in ("foo.SHP", "foo.SHX", "foo.PRJ", "foo.DBF"):
-                path = os.path.join(d, f)
-                # open and immediately close to create empty file
-                open(path, 'w').close()
-
+            d, expected_files = generate_files("SHP", "SHX", "PRJ", "DBF")
             gotten_files = get_files(os.path.join(d, "foo.SHP"))
-            gotten_files = dict((k, v[len(d) + 1:])
-                                for k, v in gotten_files.iteritems())
-            self.assertEquals(gotten_files, dict(shp="foo.SHP", shx="foo.SHX",
-                                                 prj="foo.PRJ", dbf="foo.DBF"))
+            gotten_files = {k: os.path.basename(v) for k, v in gotten_files.items()}
+            self.assertEquals(gotten_files, expected_files)
         finally:
             if d is not None:
                 shutil.rmtree(d)
@@ -654,17 +616,10 @@ class LayersTest(GeoNodeBaseTestSupport):
         # Check that mixed capital and lowercase extensions are ok
         d = None
         try:
-            d = tempfile.mkdtemp()
-            for f in ("foo.SHP", "foo.shx", "foo.pRJ", "foo.DBF"):
-                path = os.path.join(d, f)
-                # open and immediately close to create empty file
-                open(path, 'w').close()
-
+            d, expected_files = generate_files("SHP", "shx", "pRJ", "DBF")
             gotten_files = get_files(os.path.join(d, "foo.SHP"))
-            gotten_files = dict((k, v[len(d) + 1:])
-                                for k, v in gotten_files.iteritems())
-            self.assertEquals(gotten_files, dict(shp="foo.SHP", shx="foo.shx",
-                                                 prj="foo.pRJ", dbf="foo.DBF"))
+            gotten_files = {k: os.path.basename(v) for k, v in gotten_files.items()}
+            self.assertEquals(gotten_files, expected_files)
         finally:
             if d is not None:
                 shutil.rmtree(d)
@@ -673,36 +628,12 @@ class LayersTest(GeoNodeBaseTestSupport):
         # exception
         d = None
         try:
-            d = tempfile.mkdtemp()
-            files = (
-                "foo.SHP",
-                "foo.SHX",
-                "foo.PRJ",
-                "foo.DBF",
-                "foo.shp",
-                "foo.shx",
-                "foo.prj",
-                "foo.dbf")
-            for f in files:
-                path = os.path.join(d, f)
-                # open and immediately close to create empty file
-                open(path, 'w').close()
+            d, expected_files = generate_files("SHP", "SHX", "PRJ", "DBF", "shp", "shx", "prj", "dbf")
 
             # Only run the tests if this is a case sensitive OS
-            if len(os.listdir(d)) == len(files):
-                self.assertRaises(
-                    GeoNodeException,
-                    lambda: get_files(
-                        os.path.join(
-                            d,
-                            "foo.SHP")))
-                self.assertRaises(
-                    GeoNodeException,
-                    lambda: get_files(
-                        os.path.join(
-                            d,
-                            "foo.shp")))
-
+            if len(os.listdir(d)) == len(expected_files):
+                self.assertRaises(GeoNodeException, lambda: get_files(os.path.join(d, "foo.SHP")))
+                self.assertRaises(GeoNodeException, lambda: get_files(os.path.join(d, "foo.shp")))
         finally:
             if d is not None:
                 shutil.rmtree(d)
@@ -711,92 +642,56 @@ class LayersTest(GeoNodeBaseTestSupport):
         # special-cased in the implementation)
         d = None
         try:
-            d = tempfile.mkdtemp()
-            files = ("foo.SHP", "foo.SHX", "foo.PRJ", "foo.DBF", "foo.prj")
-            for f in files:
-                path = os.path.join(d, f)
-                # open and immediately close to create empty file
-                open(path, 'w').close()
+            d, expected_files = generate_files("SHP", "SHX", "PRJ", "DBF", "prj")
 
             # Only run the tests if this is a case sensitive OS
-            if len(os.listdir(d)) == len(files):
-                self.assertRaises(
-                    GeoNodeException,
-                    lambda: get_files(
-                        os.path.join(
-                            d,
-                            "foo.SHP")))
-                self.assertRaises(
-                    GeoNodeException,
-                    lambda: get_files(
-                        os.path.join(
-                            d,
-                            "foo.shp")))
+            if len(os.listdir(d)) == len(expected_files):
+                self.assertRaises(GeoNodeException, lambda: get_files(os.path.join(d, "foo.SHP")))
+                self.assertRaises(GeoNodeException, lambda: get_files(os.path.join(d, "foo.shp")))
         finally:
             if d is not None:
                 shutil.rmtree(d)
 
         # Check that including both capital and lowercase SLD (this is
         # special-cased in the implementation)
-        if check_ogc_backend(geoserver.BACKEND_PACKAGE):
-            d = None
-            try:
-                d = tempfile.mkdtemp()
-                files = (
-                    "foo.SHP",
-                    "foo.SHX",
-                    "foo.PRJ",
-                    "foo.DBF",
-                    "foo.SLD",
-                    "foo.sld")
-                for f in files:
-                    path = os.path.join(d, f)
-                    # open and immediately close to create empty file
-                    open(path, 'w').close()
+        d = None
+        try:
+            if check_ogc_backend(geoserver.BACKEND_PACKAGE):
+                d, expected_files = generate_files("SHP", "SHX", "PRJ", "DBF", "SLD", "sld")
 
                 # Only run the tests if this is a case sensitive OS
-                if len(os.listdir(d)) == len(files):
-                    self.assertRaises(
-                        GeoNodeException,
-                        lambda: get_files(
-                            os.path.join(
-                                d,
-                                "foo.SHP")))
-                    self.assertRaises(
-                        GeoNodeException,
-                        lambda: get_files(
-                            os.path.join(
-                                d,
-                                "foo.shp")))
-            finally:
-                if d is not None:
-                    shutil.rmtree(d)
+                if len(os.listdir(d)) == len(expected_files):
+                    self.assertRaises(GeoNodeException, lambda: get_files(os.path.join(d, "foo.SHP")))
+                    self.assertRaises(GeoNodeException, lambda: get_files(os.path.join(d, "foo.shp")))
+        finally:
+            if d is not None:
+                shutil.rmtree(d)
 
     def test_get_valid_name(self):
-        self.assertEquals(get_valid_name("blug"), "blug")
-        self.assertEquals(get_valid_name("<-->"), "_")
-        self.assertEquals(get_valid_name("<ab>"), "_ab_")
-        self.assertNotEquals(get_valid_name("CA"), "CA_1")
-        self.assertNotEquals(get_valid_name("CA"), "CA_1")
+        self.assertEqual(get_valid_name("blug"), "blug")
+        self.assertEqual(get_valid_name("<-->"), "_")
+        self.assertEqual(get_valid_name("<ab>"), "_ab_")
+        self.assertNotEqual(get_valid_name("CA"), "CA_1")
+        self.assertNotEqual(get_valid_name("CA"), "CA_1")
 
     def test_get_valid_layer_name(self):
-        self.assertEquals(get_valid_layer_name("blug", False), "blug")
-        self.assertEquals(get_valid_layer_name("blug", True), "blug")
+        self.assertEqual(get_valid_layer_name("blug", False), "blug")
+        self.assertEqual(get_valid_layer_name("blug", True), "blug")
 
-        self.assertEquals(get_valid_layer_name("<ab>", False), "_ab_")
-        self.assertEquals(get_valid_layer_name("<ab>", True), "<ab>")
+        self.assertEqual(get_valid_layer_name("<ab>", False), "_ab_")
+        self.assertEqual(get_valid_layer_name("<ab>", True), "<ab>")
 
-        self.assertEquals(get_valid_layer_name("<-->", False), "_")
-        self.assertEquals(get_valid_layer_name("<-->", True), "<-->")
+        self.assertEqual(get_valid_layer_name("<-->", False), "_")
+        self.assertEqual(get_valid_layer_name("<-->", True), "<-->")
 
-        self.assertNotEquals(get_valid_layer_name("CA", False), "CA_1")
-        self.assertNotEquals(get_valid_layer_name("CA", False), "CA_1")
-        self.assertEquals(get_valid_layer_name("CA", True), "CA")
-        self.assertEquals(get_valid_layer_name("CA", True), "CA")
+        self.assertNotEqual(get_valid_layer_name("CA", False), "CA_1")
+        self.assertNotEqual(get_valid_layer_name("CA", False), "CA_1")
+        self.assertEqual(get_valid_layer_name("CA", True), "CA")
+        self.assertEqual(get_valid_layer_name("CA", True), "CA")
 
         layer = Layer.objects.get(name="CA")
-        self.assertNotEquals(get_valid_layer_name(layer, False), "CA_1")
-        self.assertEquals(get_valid_layer_name(layer, True), "CA")
+        self.assertNotEqual(get_valid_layer_name(layer, False), "CA_1")
+        self.assertEqual(get_valid_layer_name(layer, True), "CA")
 
         self.assertRaises(GeoNodeException, get_valid_layer_name, 12, False)
         self.assertRaises(GeoNodeException, get_valid_layer_name, 12, True)
@@ -845,7 +740,7 @@ class LayersTest(GeoNodeBaseTestSupport):
 
         # Check there are no ratings matching the remove layer
         rating = OverallRating.objects.filter(category=2, object_id=layer_id)
-        self.assertEquals(rating.count(), 0)
+        self.assertEqual(rating.count(), 0)
 
     def test_layer_remove(self):
         """Test layer remove functionality
@@ -855,7 +750,7 @@ class LayersTest(GeoNodeBaseTestSupport):
 
         # test unauthenticated
         response = self.client.get(url)
-        self.assertEquals(response.status_code, 302)
+        self.assertEqual(response.status_code, 302)
 
         # test a user without layer removal permission
         self.client.login(username='norman', password='norman')
@@ -872,18 +767,18 @@ class LayersTest(GeoNodeBaseTestSupport):
 
         # test the page with a valid user with layer removal permission
         response = self.client.get(url)
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
 
         # test the post method that actually removes the layer and redirects
         response = self.client.post(url)
-        self.assertEquals(response.status_code, 302)
+        self.assertEqual(response.status_code, 302)
         self.assertTrue('/layers/' in response['Location'])
 
         # test that the layer is actually removed
-        self.assertEquals(Layer.objects.filter(pk=layer.pk).count(), 0)
+        self.assertEqual(Layer.objects.filter(pk=layer.pk).count(), 0)
 
         # test that all styles associated to the layer are removed
-        self.assertEquals(Style.objects.count(), 0)
+        self.assertEqual(Style.objects.count(), 0)
 
     def test_non_cascading(self):
         """
@@ -897,23 +792,23 @@ class LayersTest(GeoNodeBaseTestSupport):
         layer2.default_style = layer1.default_style
         layer2.save()
 
-        self.assertEquals(layer1.default_style, layer2.default_style)
+        self.assertEqual(layer1.default_style, layer2.default_style)
 
         # Now test with a valid user
         self.client.login(username='admin', password='admin')
 
         # test the post method that actually removes the layer and redirects
         response = self.client.post(url)
-        self.assertEquals(response.status_code, 302)
+        self.assertEqual(response.status_code, 302)
         self.assertTrue('/layers/' in response['Location'])
 
         # test that the layer is actually removed
 
-        self.assertEquals(Layer.objects.filter(pk=layer1.pk).count(), 0)
-        self.assertEquals(Layer.objects.filter(pk=layer2.pk).count(), 1)
+        self.assertEqual(Layer.objects.filter(pk=layer1.pk).count(), 0)
+        self.assertEqual(Layer.objects.filter(pk=layer2.pk).count(), 1)
 
         # test that all styles associated to the layer are removed
-        self.assertEquals(Style.objects.count(), 1)
+        self.assertEqual(Style.objects.count(), 1)
 
     def test_category_counts(self):
         topics = TopicCategory.objects.all()
@@ -921,7 +816,7 @@ class LayersTest(GeoNodeBaseTestSupport):
             **{'layer_count': Count('resourcebase__layer__category')})
         location = topics.get(identifier='location')
         # there are three layers with location category
-        self.assertEquals(location.layer_count, 3)
+        self.assertEqual(location.layer_count, 3)
 
         # change the category of one layers_count
         layer = Layer.objects.filter(category=location)[0]
@@ -934,19 +829,19 @@ class LayersTest(GeoNodeBaseTestSupport):
             **{'layer_count': Count('resourcebase__layer__category')})
         location = topics.get(identifier='location')
         elevation = topics.get(identifier='elevation')
-        self.assertEquals(location.layer_count, 2)
-        self.assertEquals(elevation.layer_count, 4)
+        self.assertEqual(location.layer_count, 2)
+        self.assertEqual(elevation.layer_count, 4)
 
         # delete a layer and check the count update
         # use the first since it's the only one which has styles
         layer = Layer.objects.all().first()
         elevation = topics.get(identifier='elevation')
-        self.assertEquals(elevation.layer_count, 4)
+        self.assertEqual(elevation.layer_count, 4)
         layer.delete()
         topics = topics.annotate(
             **{'layer_count': Count('resourcebase__layer__category')})
         elevation = topics.get(identifier='elevation')
-        self.assertEquals(elevation.layer_count, 3)
+        self.assertEqual(elevation.layer_count, 3)
 
     def test_assign_change_layer_data_perm(self):
         """
@@ -977,37 +872,37 @@ class LayersTest(GeoNodeBaseTestSupport):
             reverse(view, args=(ids,)),
             data={'group': group.pk},
         )
-        self.assertEquals(response.status_code, 302)
+        self.assertEqual(response.status_code, 302)
         resources = Model.objects.filter(id__in=[r.pk for r in resources])
         for resource in resources:
-            self.assertEquals(resource.group, group)
+            self.assertEqual(resource.group, group)
         # test owner change
         owner = get_user_model().objects.first()
         response = self.client.post(
             reverse(view, args=(ids,)),
             data={'owner': owner.pk},
         )
-        self.assertEquals(response.status_code, 302)
+        self.assertEqual(response.status_code, 302)
         resources = Model.objects.filter(id__in=[r.pk for r in resources])
         for resource in resources:
-            self.assertEquals(resource.owner, owner)
+            self.assertEqual(resource.owner, owner)
         # test license change
         license = License.objects.first()
         response = self.client.post(
             reverse(view, args=(ids,)),
             data={'license': license.pk},
         )
-        self.assertEquals(response.status_code, 302)
+        self.assertEqual(response.status_code, 302)
         resources = Model.objects.filter(id__in=[r.pk for r in resources])
         for resource in resources:
-            self.assertEquals(resource.license, license)
+            self.assertEqual(resource.license, license)
         # test regions change
         region = Region.objects.first()
         response = self.client.post(
             reverse(view, args=(ids,)),
             data={'region': region.pk},
         )
-        self.assertEquals(response.status_code, 302)
+        self.assertEqual(response.status_code, 302)
         resources = Model.objects.filter(id__in=[r.pk for r in resources])
         for resource in resources:
             if resource.regions.all():
@@ -1019,13 +914,14 @@ class LayersTest(GeoNodeBaseTestSupport):
             reverse(view, args=(ids,)),
             data={'date': date},
         )
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
         resources = Model.objects.filter(id__in=[r.pk for r in resources])
         for resource in resources:
             today = date.today()
             todoc = resource.date.today()
-            self.assertEquals((today.day, today.month, today.year),
-                              (todoc.day, todoc.month, todoc.year))
+            self.assertEqual(today.day, todoc.day)
+            self.assertEqual(today.month, todoc.month)
+            self.assertEqual(today.year, todoc.year)
 
         # test language change
         language = 'eng'
@@ -1035,7 +931,7 @@ class LayersTest(GeoNodeBaseTestSupport):
         )
         resources = Model.objects.filter(id__in=[r.pk for r in resources])
         for resource in resources:
-            self.assertEquals(resource.language, language)
+            self.assertEqual(resource.language, language)
         # test keywords change
         keywords = 'some,thing,new'
         response = self.client.post(
@@ -1070,7 +966,7 @@ class LayersTest(GeoNodeBaseTestSupport):
                 'mode': 'set'
             },
         )
-        self.assertEquals(response.status_code, 302)
+        self.assertEqual(response.status_code, 302)
         resources = Model.objects.filter(id__in=[r.pk for r in resources])
         for resource in resources:
             perm_spec = resource.get_all_level_info()
@@ -1085,7 +981,7 @@ class LayersTest(GeoNodeBaseTestSupport):
                 'mode': 'set'
             },
         )
-        self.assertEquals(response.status_code, 302)
+        self.assertEqual(response.status_code, 302)
         resources = Model.objects.filter(id__in=[r.pk for r in resources])
         for resource in resources:
             perm_spec = resource.get_all_level_info()
@@ -1117,12 +1013,12 @@ class UnpublishedObjectTests(GeoNodeBaseTestSupport):
         # access to layer detail page gives 200 if layer is published or
         # unpublished
         response = self.client.get(reverse('layer_detail', args=('geonode:CA',)))
-        self.failUnlessEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
         layer = Layer.objects.filter(title='CA')[0]
         layer.is_published = False
         layer.save()
         response = self.client.get(reverse('layer_detail', args=('geonode:CA',)))
-        self.failUnlessEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
 
     @override_settings(ADMIN_MODERATE_UPLOADS=True)
     @override_settings(RESOURCE_PUBLISHING=True)
@@ -1136,26 +1032,26 @@ class UnpublishedObjectTests(GeoNodeBaseTestSupport):
         self.client.login(username='foo', password='pass')
         # 404 if layer is unpublished
         response = self.client.get(reverse('layer_detail', args=('geonode:CA',)))
-        self.failUnlessEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 404)
 
         # 404 if layer is unpublished but user has permission but does not belong to the group
         assign_perm('publish_resourcebase', user, layer.get_self_resource())
         response = self.client.get(reverse('layer_detail', args=('geonode:CA',)))
-        self.failUnlessEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 404)
 
         # 200 if layer is unpublished and user is owner
         remove_perm('publish_resourcebase', user, layer.get_self_resource())
         layer.owner = user
         layer.save()
         response = self.client.get(reverse('layer_detail', args=('geonode:CA',)))
-        self.failUnlessEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
 
         # 200 if layer is published
         layer.is_published = True
         layer.save()
 
         response = self.client.get(reverse('layer_detail', args=('geonode:CA',)))
-        self.failUnlessEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
 
         layer.is_published = True
         layer.save()


### PR DESCRIPTION
PR to update `layers` app to be Python 2.7/3 cross-compatible as part of #4276.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there are explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [x] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
