### PR TITLE
[Issue #4276] Upgrade maps for Python 2.7/3 compatibility

### DIFF
--- a/geonode/maps/autocomplete_light_registry.py
+++ b/geonode/maps/autocomplete_light_registry.py
@@ -20,7 +20,7 @@
 
 from autocomplete_light.registry import register
 from autocomplete_light.autocomplete.shortcuts import AutocompleteModelTemplate
-from models import Map
+from .models import Map
 
 
 class MapAutocomplete(AutocompleteModelTemplate):

--- a/geonode/maps/management/commands/remove_broken_layers.py
+++ b/geonode/maps/management/commands/remove_broken_layers.py
@@ -31,5 +31,5 @@ class Command(BaseCommand):
         map_layers = MapLayer.objects.filter(local=True)
         for maplayer in map_layers:
             if not Layer.objects.filter(alternate=maplayer.name).exists():
-                print 'Removing broken map layer %s' % maplayer.name
+                print('Removing broken map layer {}'.format(maplayer.name)
                 maplayer.delete()

--- a/geonode/maps/qgis_server_views.py
+++ b/geonode/maps/qgis_server_views.py
@@ -42,7 +42,11 @@ from geonode.utils import default_map_config, forward_mercator, \
     llbbox_to_mercator, check_ogc_backend
 from geonode import geoserver, qgis_server
 
-import urlparse
+try:
+    from urllib.parse import urlsplit
+except ImportError:
+    # Python 2 compatibility
+    from urlparse import urlsplit
 
 if check_ogc_backend(geoserver.BACKEND_PACKAGE):
     # FIXME: The post service providing the map_status object
@@ -154,9 +158,9 @@ class MapCreateView(CreateView):
                         service = layer.remote_service
                         # Probably not a good idea to send the access token to every remote service.
                         # This should never match, so no access token should be sent to remote services.
-                        ogc_server_url = urlparse.urlsplit(
+                        ogc_server_url = urlsplit(
                             ogc_server_settings.PUBLIC_LOCATION).netloc
-                        service_url = urlparse.urlsplit(
+                        service_url = urlsplit(
                             service.base_url).netloc
 
                         if access_token and ogc_server_url == service_url and \
@@ -176,9 +180,9 @@ class MapCreateView(CreateView):
                                                   "name": service.name,
                                                   "title": "[R] %s" % service.title}))
                     else:
-                        ogc_server_url = urlparse.urlsplit(
+                        ogc_server_url = urlsplit(
                             ogc_server_settings.PUBLIC_LOCATION).netloc
-                        layer_url = urlparse.urlsplit(layer.ows_url).netloc
+                        layer_url = urlsplit(layer.ows_url).netloc
 
                         if access_token and ogc_server_url == layer_url and \
                                 'access_token' not in layer.ows_url:

--- a/geonode/maps/tests.py
+++ b/geonode/maps/tests.py
@@ -166,9 +166,9 @@ community."
         self.assertEqual(response.status_code, 200)
 
         map_obj = Map.objects.all().first()
-        self.assertEquals(map_obj.title, "Title2")
-        self.assertEquals(map_obj.abstract, "Abstract2")
-        self.assertEquals(map_obj.layer_set.all().count(), 1)
+        self.assertEqual(map_obj.title, "Title2")
+        self.assertEqual(map_obj.abstract, "Abstract2")
+        self.assertEqual(map_obj.layer_set.all().count(), 1)
 
     @dump_func_name
     def test_map_save(self):
@@ -188,18 +188,18 @@ community."
             new_map,
             data=self.viewer_config,
             content_type="text/json")
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
         map_id = int(json.loads(response.content)['id'])
         self.client.logout()
 
         # We have now 10 maps and 8 layers
-        self.assertEquals(Map.objects.all().count(), 10)
+        self.assertEqual(Map.objects.all().count(), 10)
         map_obj = Map.objects.get(id=map_id)
-        self.assertEquals(map_obj.title, "Title")
-        self.assertEquals(map_obj.abstract, "Abstract")
-        self.assertEquals(map_obj.layer_set.all().count(), 1)
-        self.assertEquals(map_obj.keyword_list(), [u"keywords", u"saving"])
-        self.assertNotEquals(map_obj.bbox_x0, None)
+        self.assertEqual(map_obj.title, "Title")
+        self.assertEqual(map_obj.abstract, "Abstract")
+        self.assertEqual(map_obj.layer_set.all().count(), 1)
+        self.assertEqual(map_obj.keyword_list(), ["keywords", "saving"])
+        self.assertNotEqual(map_obj.bbox_x0, None)
 
         # Test an invalid map creation request
         self.client.login(username=self.user, password=self.passwd)
@@ -209,7 +209,7 @@ community."
                 new_map,
                 data="not a valid viewer config",
                 content_type="text/json")
-            self.assertEquals(response.status_code, 400)
+            self.assertEqual(response.status_code, 400)
         except BaseException:
             pass
 
@@ -222,13 +222,13 @@ community."
         map_obj = Map.objects.all().first()
         map_obj.set_default_permissions()
         response = self.client.get(reverse('map_json', args=(map_obj.id,)))
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
         cfg = json.loads(response.content)
-        self.assertEquals(
+        self.assertEqual(
             cfg["about"]["abstract"],
             'GeoNode default map abstract')
-        self.assertEquals(cfg["about"]["title"], 'GeoNode Default Map')
-        self.assertEquals(len(cfg["map"]["layers"]), 5)
+        self.assertEqual(cfg["about"]["title"], 'GeoNode Default Map')
+        self.assertEqual(len(cfg["map"]["layers"]), 5)
 
     @dump_func_name
     def test_map_to_json(self):
@@ -236,10 +236,10 @@ community."
             to a JSON map configuration"""
         map_obj = Map.objects.all().first()
         cfg = map_obj.viewer_json(None)
-        self.assertEquals(
+        self.assertEqual(
             cfg['about']['abstract'],
             'GeoNode default map abstract')
-        self.assertEquals(cfg['about']['title'], 'GeoNode Default Map')
+        self.assertEqual(cfg['about']['title'], 'GeoNode Default Map')
 
         def is_wms_layer(x):
             if 'source' in x:
@@ -247,7 +247,7 @@ community."
             return False
         layernames = [x['name']
                       for x in cfg['map']['layers'] if is_wms_layer(x)]
-        self.assertEquals(layernames, ['geonode:CA', ])
+        self.assertEqual(layernames, ['geonode:CA', ])
 
     @dump_func_name
     def test_map_to_wmc(self):
@@ -259,7 +259,7 @@ community."
         map_obj = Map.objects.all().first()
         map_obj.set_default_permissions()
         response = self.client.get(reverse('map_wmc', args=(map_obj.id,)))
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
 
         # check specific XPaths
         wmc = dlxml.fromstring(response.content)
@@ -269,8 +269,8 @@ community."
         abstract = '{ns}General/{ns}Abstract'.format(ns=namespace)
 
         self.assertIsNotNone(wmc.attrib.get('id'))
-        self.assertEquals(wmc.find(title).text, 'GeoNode Default Map')
-        self.assertEquals(
+        self.assertEqual(wmc.find(title).text, 'GeoNode Default Map')
+        self.assertEqual(
             wmc.find(abstract).text,
             'GeoNode default map abstract')
 
@@ -280,7 +280,7 @@ community."
             to a new JSON map configuration"""
         response = self.client.get(reverse('new_map_json'))
         cfg = json.loads(response.content)
-        self.assertEquals(cfg['defaultSourceType'], "gxp_wmscsource")
+        self.assertEqual(cfg['defaultSourceType'], "gxp_wmscsource")
 
     @dump_func_name
     def test_map_details(self):
@@ -288,14 +288,14 @@ community."
         map_obj = Map.objects.all().first()
         map_obj.set_default_permissions()
         response = self.client.get(reverse('map_detail', args=(map_obj.id,)))
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
 
     @dump_func_name
     def test_describe_map(self):
         map_obj = Map.objects.all().first()
         map_obj.set_default_permissions()
         response = self.client.get(reverse('map_metadata_detail', args=(map_obj.id,)))
-        self.failUnlessEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Approved", count=1, status_code=200, msg_prefix='', html=False)
         self.assertContains(response, "Published", count=1, status_code=200, msg_prefix='', html=False)
         self.assertContains(response, "Featured", count=1, status_code=200, msg_prefix='', html=False)
@@ -306,7 +306,7 @@ community."
         map_obj.group = group
         map_obj.save()
         response = self.client.get(reverse('map_metadata_detail', args=(map_obj.id,)))
-        self.failUnlessEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
         self.assertContains(response, "<dt>Group</dt>", count=1, status_code=200, msg_prefix='', html=False)
         map_obj.group = None
         map_obj.save()
@@ -349,7 +349,7 @@ community."
             url(invalid_mapid),
             data=json.dumps(self.perm_spec),
             content_type="application/json")
-        self.assertEquals(response.status_code, 404)
+        self.assertEqual(response.status_code, 404)
 
         # Test that GET returns permissions
         response = self.client.get(url(mapid))
@@ -362,20 +362,20 @@ community."
             url(mapid),
             data=json.dumps(self.perm_spec),
             content_type="application/json")
-        self.assertEquals(response.status_code, 401)
+        self.assertEqual(response.status_code, 401)
 
         # Next Test with a user that does NOT have the proper perms
         logged_in = self.client.login(username='foo', password='pass')
-        self.assertEquals(logged_in, True)
+        self.assertEqual(logged_in, True)
         response = self.client.post(
             url(mapid),
             data=json.dumps(self.perm_spec),
             content_type="application/json")
-        self.assertEquals(response.status_code, 401)
+        self.assertEqual(response.status_code, 401)
 
         # Login as a user with the proper permission and test the endpoint
         logged_in = self.client.login(username='admin', password='admin')
-        self.assertEquals(logged_in, True)
+        self.assertEqual(logged_in, True)
 
         response = self.client.post(
             url(mapid),
@@ -383,7 +383,7 @@ community."
             content_type="application/json")
 
         # Test that the method returns 200
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
 
         # Test that the permissions specification is applied
 
@@ -400,7 +400,7 @@ community."
             new_map,
             data=self.viewer_config,
             content_type="text/json")
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
         map_id = int(json.loads(response.content)['id'])
         self.client.logout()
 
@@ -408,7 +408,7 @@ community."
 
         # test unauthenticated user to modify map metadata
         response = self.client.post(url)
-        self.assertEquals(response.status_code, 302)
+        self.assertEqual(response.status_code, 302)
 
         # test a user without metadata modify permission
         self.client.login(username='foo', password='pass')
@@ -419,12 +419,12 @@ community."
         # Now test with a valid user using GET method
         self.client.login(username=self.user, password=self.passwd)
         response = self.client.get(url)
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
 
         # Now test with a valid user using POST method
         self.client.login(username=self.user, password=self.passwd)
         response = self.client.post(url)
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
 
         # TODO: only invalid mapform is tested
 
@@ -441,7 +441,7 @@ community."
             new_map,
             data=self.viewer_config,
             content_type="text/json")
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
         map_id = int(json.loads(response.content)['id'])
         self.client.logout()
 
@@ -449,7 +449,7 @@ community."
 
         # test unauthenticated user to remove map
         response = self.client.post(url)
-        self.assertEquals(response.status_code, 302)
+        self.assertEqual(response.status_code, 302)
 
         # test a user without map removal permission
         self.client.login(username='foo', password='pass')
@@ -460,17 +460,17 @@ community."
         # Now test with a valid user using GET method
         self.client.login(username=self.user, password=self.passwd)
         response = self.client.get(url)
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
 
         # Now test with a valid user using POST method,
         # which removes map and associated layers, and redirects webpage
         response = self.client.post(url)
-        self.assertEquals(response.status_code, 302)
+        self.assertEqual(response.status_code, 302)
         self.assertTrue('/maps/' in response['Location'])
 
         # After removal, map is not existent
         response = self.client.get(url)
-        self.assertEquals(response.status_code, 404)
+        self.assertEqual(response.status_code, 404)
 
         # Prepare map object for later test that if it is completely removed
         # map_obj = Map.objects.all().first()
@@ -489,7 +489,7 @@ community."
             new_map,
             data=self.viewer_config,
             content_type="text/json")
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
         map_id = int(json.loads(response.content)['id'])
         self.client.logout()
 
@@ -499,8 +499,8 @@ community."
                 'map_download_leaflet', args=(map_id, )))
 
         # download map leafleT should return OK
-        self.assertEquals(response.status_code, 200)
-        self.assertEquals(response.get('Content-Type'), 'html')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get('Content-Type'), 'html')
 
     @on_ogc_backend(geoserver.BACKEND_PACKAGE)
     @dump_func_name
@@ -517,7 +517,7 @@ community."
             new_map,
             data=self.viewer_config,
             content_type="text/json")
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
         map_id = int(json.loads(response.content)['id'])
         self.client.logout()
 
@@ -527,7 +527,7 @@ community."
         # Now test with a map id
         self.client.login(username=self.user, password=self.passwd)
         response = self.client.get(url)
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
 
         # The embedded map is exempt from X-FRAME-OPTIONS restrictions.
         if hasattr(response, 'xframe_options_exempt'):
@@ -537,23 +537,23 @@ community."
         map_obj = Map.objects.get(id=map_id)
         config_map = map_obj.viewer_json(None)
         response_config_dict = json.loads(response.context['config'])
-        self.assertEquals(
+        self.assertEqual(
             config_map['about']['abstract'],
             response_config_dict['about']['abstract'])
-        self.assertEquals(
+        self.assertEqual(
             config_map['about']['title'],
             response_config_dict['about']['title'])
 
         # Now test without a map id
         response = self.client.get(url_no_id)
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
         # Config equals to that of the default map
         config_default = default_map_config(None)[0]
         response_config_dict = json.loads(response.context['config'])
-        self.assertEquals(
+        self.assertEqual(
             config_default['about']['abstract'],
             response_config_dict['about']['abstract'])
-        self.assertEquals(
+        self.assertEqual(
             config_default['about']['title'],
             response_config_dict['about']['title'])
 
@@ -571,7 +571,7 @@ community."
             new_map,
             data=self.viewer_config,
             content_type="text/json")
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
         map_id = int(json.loads(response.content)['id'])
         self.client.logout()
 
@@ -579,29 +579,29 @@ community."
 
         # test unauthenticated user to view map
         response = self.client.get(url)
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
         # TODO: unauthenticated user can still access the map view
 
         # test a user without map view permission
         self.client.login(username='norman', password='norman')
         response = self.client.get(url)
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
         self.client.logout()
         # TODO: the user can still access the map view without permission
 
         # Now test with a valid user using GET method
         self.client.login(username=self.user, password=self.passwd)
         response = self.client.get(url)
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
 
         # Config equals to that of the map whose id is given
         map_obj = Map.objects.get(id=map_id)
         config_map = map_obj.viewer_json(None)
         response_config_dict = json.loads(response.context['config'])
-        self.assertEquals(
+        self.assertEqual(
             config_map['about']['abstract'],
             response_config_dict['about']['abstract'])
-        self.assertEquals(
+        self.assertEqual(
             config_map['about']['title'],
             response_config_dict['about']['title'])
 
@@ -622,36 +622,36 @@ community."
 
         # Test GET method with COPY
         response = self.client.get(url, {'copy': map_id})
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
         map_obj = Map.objects.get(id=map_id)
         config_map = map_obj.viewer_json(None)
         response_config_dict = json.loads(response.content)
-        self.assertEquals(
+        self.assertEqual(
             config_map['map']['layers'],
             response_config_dict['map']['layers'])
 
         # Test GET method no COPY and no layer in params
         response = self.client.get(url)
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
         config_default = default_map_config(None)[0]
         response_config_dict = json.loads(response.content)
-        self.assertEquals(
+        self.assertEqual(
             config_default['about']['abstract'],
             response_config_dict['about']['abstract'])
-        self.assertEquals(
+        self.assertEqual(
             config_default['about']['title'],
             response_config_dict['about']['title'])
 
         # Test GET method no COPY but with layer in params
         response = self.client.get(url, {'layer': layer_name})
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
         response_dict = json.loads(response.content)
-        self.assertEquals(response_dict['fromLayer'], True)
+        self.assertEqual(response_dict['fromLayer'], True)
 
         # Test POST method without authentication
         self.client.logout()
         response = self.client.post(url, {'layer': layer_name})
-        self.assertEquals(response.status_code, 401)
+        self.assertEqual(response.status_code, 401)
 
         # Test POST method with authentication and a layer in params
         self.client.login(username='admin', password='admin')
@@ -659,14 +659,14 @@ community."
         try:
             response = self.client.post(url, {'layer': layer_name})
             # Should not accept the request
-            self.assertEquals(response.status_code, 400)
+            self.assertEqual(response.status_code, 400)
 
             # Test POST method with map data in json format
             response = self.client.post(
                 url,
                 data=self.viewer_config,
                 content_type="text/json")
-            self.assertEquals(response.status_code, 200)
+            self.assertEqual(response.status_code, 200)
             map_id = int(json.loads(response.content)['id'])
             # Check new map saved
             map_obj = Map.objects.get(id=map_id)
@@ -685,7 +685,7 @@ community."
 
             # Test methods other than GET or POST and no layer in params
             response = self.client.put(url)
-            self.assertEquals(response.status_code, 405)
+            self.assertEqual(response.status_code, 405)
         except BaseException:
             pass
 
@@ -719,14 +719,14 @@ community."
             logger.info("Remove the map")
             try:
                 response = self.client.post(reverse('map_remove', args=(map_id,)))
-                self.assertEquals(response.status_code, 302)
+                self.assertEqual(response.status_code, 302)
             except BaseException as e:
                 logger.exception(e)
 
             logger.info("Check there are no ratings matching the removed map")
             try:
                 rating = OverallRating.objects.filter(object_id=map_id)
-                self.assertEquals(rating.count(), 0)
+                self.assertEqual(rating.count(), 0)
             except BaseException as e:
                 logger.exception(e)
 
@@ -749,7 +749,7 @@ community."
 
         fix_baselayers(map_id)
 
-        self.assertEquals(map_obj.layer_set.all().count(), n_baselayers + n_locallayers)
+        self.assertEqual(map_obj.layer_set.all().count(), n_baselayers + n_locallayers)
 
     @dump_func_name
     def test_batch_edit(self):
@@ -768,37 +768,37 @@ community."
             reverse(view, args=(ids,)),
             data={'group': group.pk},
         )
-        self.assertEquals(response.status_code, 302)
+        self.assertEqual(response.status_code, 302)
         resources = Model.objects.filter(id__in=[r.pk for r in resources])
         for resource in resources:
-            self.assertEquals(resource.group, group)
+            self.assertEqual(resource.group, group)
         # test owner change
         owner = get_user_model().objects.first()
         response = self.client.post(
             reverse(view, args=(ids,)),
             data={'owner': owner.pk},
         )
-        self.assertEquals(response.status_code, 302)
+        self.assertEqual(response.status_code, 302)
         resources = Model.objects.filter(id__in=[r.pk for r in resources])
         for resource in resources:
-            self.assertEquals(resource.owner, owner)
+            self.assertEqual(resource.owner, owner)
         # test license change
         license = License.objects.first()
         response = self.client.post(
             reverse(view, args=(ids,)),
             data={'license': license.pk},
         )
-        self.assertEquals(response.status_code, 302)
+        self.assertEqual(response.status_code, 302)
         resources = Model.objects.filter(id__in=[r.pk for r in resources])
         for resource in resources:
-            self.assertEquals(resource.license, license)
+            self.assertEqual(resource.license, license)
         # test regions change
         region = Region.objects.first()
         response = self.client.post(
             reverse(view, args=(ids,)),
             data={'region': region.pk},
         )
-        self.assertEquals(response.status_code, 302)
+        self.assertEqual(response.status_code, 302)
         resources = Model.objects.filter(id__in=[r.pk for r in resources])
         for resource in resources:
             if resource.regions.all():
@@ -810,13 +810,14 @@ community."
             reverse(view, args=(ids,)),
             data={'date': date},
         )
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
         resources = Model.objects.filter(id__in=[r.pk for r in resources])
         for resource in resources:
             today = date.today()
             todoc = resource.date.today()
-            self.assertEquals((today.day, today.month, today.year),
-                              (todoc.day, todoc.month, todoc.year))
+            self.assertEqual(today.day, todoc.day)
+            self.assertEqual(today.month, todoc.month)
+            self.assertEqual(today.year, todoc.year)
 
         # test language change
         language = 'eng'
@@ -826,7 +827,7 @@ community."
         )
         resources = Model.objects.filter(id__in=[r.pk for r in resources])
         for resource in resources:
-            self.assertEquals(resource.language, language)
+            self.assertEqual(resource.language, language)
         # test keywords change
         keywords = 'some,thing,new'
         response = self.client.post(
@@ -862,7 +863,7 @@ class MapModerationTestCase(GeoNodeBaseTestSupport):
             response = self.client.post(new_map,
                                         data=VIEWER_CONFIG,
                                         content_type="text/json")
-            self.assertEquals(response.status_code, 200)
+            self.assertEqual(response.status_code, 200)
             map_id = int(json.loads(response.content)['id'])
             _l = Map.objects.get(id=map_id)
 
@@ -874,7 +875,7 @@ class MapModerationTestCase(GeoNodeBaseTestSupport):
             response = self.client.post(new_map,
                                         data=VIEWER_CONFIG,
                                         content_type="text/json")
-            self.assertEquals(response.status_code, 200)
+            self.assertEqual(response.status_code, 200)
             map_id = int(json.loads(response.content)['id'])
             _l = Map.objects.get(id=map_id)
 
@@ -903,7 +904,7 @@ class MapsNotificationsTestCase(NotificationsTestsHelper):
             response = self.client.post(new_map,
                                         data=VIEWER_CONFIG,
                                         content_type="text/json")
-            self.assertEquals(response.status_code, 200)
+            self.assertEqual(response.status_code, 200)
             map_id = int(json.loads(response.content)['id'])
             _l = Map.objects.get(id=map_id)
             self.assertTrue(self.check_notification_out('map_created', self.u))

--- a/geonode/maps/utils.py
+++ b/geonode/maps/utils.py
@@ -58,7 +58,7 @@ def _layer_json(layers, sources):
         server_lookup[json.dumps(source)] = str(i)
 
     def source_lookup(source):
-        for k, v in sources.iteritems():
+        for k, v in sources.items():
             if v == source:
                 return k
         return None

--- a/geonode/maps/views.py
+++ b/geonode/maps/views.py
@@ -20,9 +20,15 @@
 
 import math
 import logging
-import urlparse
+try:
+    from urllib.parse import quote, urlsplit
+except ImportError:
+    # Python 2 compatibility
+    from urllib import quote
+    from urlparse import urlsplit
 import traceback
 from itertools import chain
+from six import string_types
 
 from guardian.shortcuts import get_perms
 
@@ -713,7 +719,7 @@ def map_edit(request, mapid, snapshot=None, template='maps/map_edit.html'):
 
 
 def clean_config(conf):
-    if isinstance(conf, basestring):
+    if isinstance(conf, string_types):
         config = json.loads(conf)
         config_extras = [
             "tools",
@@ -884,7 +890,6 @@ def add_layers_to_map_config(
             return [_bbox[0], _bbox[2], _bbox[1], _bbox[3]]
 
         def sld_definition(style):
-            from urllib import quote
             _sld = {
                 "title": style.sld_title or style.name,
                 "legend": {
@@ -1038,9 +1043,9 @@ def add_layers_to_map_config(
                                 source_params=json.dumps(source_params)
                                 )
         else:
-            ogc_server_url = urlparse.urlsplit(
+            ogc_server_url = urlsplit(
                 ogc_server_settings.PUBLIC_LOCATION).netloc
-            layer_url = urlparse.urlsplit(layer.ows_url).netloc
+            layer_url = urlsplit(layer.ows_url).netloc
 
             access_token = request.session['access_token'] if request and 'access_token' in request.session else None
             if access_token and ogc_server_url == layer_url and 'access_token' not in layer.ows_url:
@@ -1268,7 +1273,7 @@ def snapshot_config(snapshot, map_obj, request):
 
     # Match up the layer with it's source
     def snapsource_lookup(source, sources):
-        for k, v in sources.iteritems():
+        for k, v in sources.items():
             if v.get("id") == source.get("id"):
                 return k
         return None
@@ -1360,7 +1365,7 @@ def snapshot_create(request):
     """
     conf = request.body
 
-    if isinstance(conf, basestring):
+    if isinstance(conf, string_types):
         config = json.loads(conf)
         snapshot = MapSnapshot.objects.create(
             config=clean_config(conf),


### PR DESCRIPTION
PR to update `maps` app to be Python 2.7/3 cross-compatible as part of #4276.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there are explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [x] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
