### PR TITLE
[Issue #4276] Upgrade messaging for Python 2.7/3 compatibility

### DIFF
--- a/geonode/messaging/consumer.py
+++ b/geonode/messaging/consumer.py
@@ -32,10 +32,16 @@ from geonode.layers.views import layer_view_counter
 from geonode.layers.models import Layer
 from geonode.geoserver.helpers import gs_slurp
 
-from queues import queue_email_events, queue_geoserver_events,\
-    queue_notifications_events, queue_all_events,\
-    queue_geoserver_catalog, queue_geoserver_data,\
-    queue_geoserver, queue_layer_viewers
+from .queues import (
+    queue_email_events,
+    queue_geoserver_events,
+    queue_notifications_events,
+    queue_all_events,
+    queue_geoserver_catalog,
+    queue_geoserver_data,
+    queue_geoserver,
+    queue_layer_viewers
+)
 
 logger = logging.getLogger(__package__)
 

--- a/geonode/messaging/producer.py
+++ b/geonode/messaging/producer.py
@@ -26,8 +26,12 @@ import traceback
 from decorator import decorator
 from kombu import BrokerConnection
 from kombu.common import maybe_declare
-from queues import queue_email_events, queue_geoserver_events,\
-    queue_notifications_events, queue_layer_viewers
+from .queues import (
+    queue_email_events,
+    queue_geoserver_events,
+    queue_notifications_events,
+    queue_layer_viewers
+)
 
 from . import (url,
                producers,


### PR DESCRIPTION
PR to update `messaging` app to be Python 2.7/3 cross-compatible as part of #4276.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there are explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [x] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
