### PR TITLE
[Issue #4276] Upgrade monitoring for Python 2.7/3 compatibility

### DIFF
--- a/geonode/monitoring/__init__.py
+++ b/geonode/monitoring/__init__.py
@@ -22,7 +22,7 @@ import logging
 from django.utils.translation import ugettext_noop as _
 from django.conf import settings
 from functools import wraps
-import types
+from six import string_types
 
 from geonode.notifications_helper import NotificationsAppConfigBase, has_notifications
 from django.db.models.signals import post_migrate
@@ -89,7 +89,7 @@ def register_event(request, event_type, resource):
     if not settings.MONITORING_ENABLED:
         return
     from geonode.base.models import ResourceBase
-    if isinstance(resource, types.StringTypes):
+    if isinstance(resource, string_types):
         resource_type = 'url'
         resource_name = request.path
         resource_id = None

--- a/geonode/monitoring/aggregation.py
+++ b/geonode/monitoring/aggregation.py
@@ -256,7 +256,7 @@ def aggregate_period(period_start, period_end, metric_data_q, cleanup=True):
         try:
             value_q = per_metric_q.aggregate(fvalue=f,
                                              fsamples_count=Sum(F('samples_count')))
-        except TypeError, err:
+        except TypeError as err:
             raise ValueError(f, m, err)
         value = value_q['fvalue']
         samples_count = value_q['fsamples_count']

--- a/geonode/monitoring/collector.py
+++ b/geonode/monitoring/collector.py
@@ -23,6 +23,7 @@ import pytz
 from datetime import datetime, timedelta
 from decimal import Decimal
 from itertools import chain
+from six import string_types, integer_types
 
 from django.conf import settings
 from django.db import models
@@ -161,7 +162,7 @@ class CollectorAPI(object):
             if metric_name is None:
                 continue
             value = metric_data['value']
-            if isinstance(value, (str, unicode,)):
+            if isinstance(value, string_types):
                 value = value.replace(',', '.')
             mdata = {'value': value,
                      'value_raw': value,
@@ -201,7 +202,7 @@ class CollectorAPI(object):
                                    service=service)\
             .delete()
 
-        for ifname, ifdata in data['data']['network'].iteritems():
+        for ifname, ifdata in data['data']['network'].items():
             for tx_label, tx_value in ifdata['traffic'].items():
                 mdata = {'value': tx_value,
                          'value_raw': tx_value,
@@ -456,7 +457,7 @@ class CollectorAPI(object):
                                   'label': label,
                                   'samples_count': samples,
                                   'value_raw': value or 0,
-                                  'value_num': value if isinstance(value, (int, float, long, Decimal,)) else None})
+                                  'value_num': value if isinstance(value, integer_types + (float, Decimal,)) else None})
             log.debug(MetricValue.add(**metric_values))
 
     def process(self, service, data, valid_from, valid_to, *args, **kwargs):

--- a/geonode/monitoring/management/commands/collect_metrics.py
+++ b/geonode/monitoring/management/commands/collect_metrics.py
@@ -97,7 +97,7 @@ class Command(BaseCommand):
                                until=options['until'],
                                force_check=options['force_check'],
                                format=options['format'])
-            except Exception, err:
+            except Exception as err:
                 log.error("Cannot collect from %s: %s", s, err, exc_info=err)
                 if options['halt_on_errors']:
                     raise

--- a/geonode/monitoring/management/commands/render_metrics.py
+++ b/geonode/monitoring/management/commands/render_metrics.py
@@ -26,6 +26,7 @@ import argparse
 import timeout_decorator
 
 from datetime import datetime, timedelta
+from six import string_types
 
 from django.core.management.base import BaseCommand, CommandError
 from django.utils.translation import ugettext_noop as _
@@ -90,7 +91,7 @@ class Command(BaseCommand):
         label = options['label']
         if not metric_names:
             raise CommandError("No metric name")
-        if isinstance(metric_names, types.StringTypes):
+        if isinstance(metric_names, string_types):
             metric_names = [metric_names]
         for m in metric_names:
             #def get_metrics_for(self, metric_name, valid_from=None, valid_to=None, interval=None, service=None, label=None, resource=None):

--- a/geonode/monitoring/middleware.py
+++ b/geonode/monitoring/middleware.py
@@ -21,7 +21,7 @@
 import logging
 import pytz
 import hashlib
-import types
+from six import string_types
 
 from datetime import datetime
 from django.conf import settings
@@ -74,7 +74,7 @@ class MonitoringMiddleware(object):
         current = request.path
 
         for skip_url in settings.MONITORING_SKIP_PATHS:
-            if isinstance(skip_url, types.StringTypes):
+            if isinstance(skip_url, string_types):
                 if current.startswith(skip_url):
                     return False
             elif hasattr(skip_url, 'match'):

--- a/geonode/monitoring/probes.py
+++ b/geonode/monitoring/probes.py
@@ -132,7 +132,7 @@ class BaseProbe(object):
         """
         out = {}
         iostats = psutil.net_io_counters(True)
-        for ifname, ifdata in psutil.net_if_addrs().iteritems():
+        for ifname, ifdata in psutil.net_if_addrs().items():
             ifstats = iostats.get(ifname)
             if not ifstats:
                 continue

--- a/geonode/monitoring/tests/integration.py
+++ b/geonode/monitoring/tests/integration.py
@@ -218,7 +218,8 @@ class MonitoringTestBase(GeoNodeLiveTestSupport):
     def tearDown(self):
         connections.databases['default']['ATOMIC_REQUESTS'] = False
 
-        map(os.unlink, self._tempfiles)
+        for temp_file in self._tempfiles:
+            os.unlink(temp_file)
 
         # Cleanup
         Layer.objects.all().delete()
@@ -311,7 +312,7 @@ class RequestsTestCase(MonitoringTestBase):
         rq = RequestEvent.objects.get()
         self.assertTrue(rq.response_time > 0)
         self.assertEqual(
-            list(rq.resources.all().values_list('name', 'type')), [(_l.alternate, u'layer',)])
+            list(rq.resources.all().values_list('name', 'type')), [(_l.alternate, 'layer',)])
         self.assertEqual(rq.request_method, 'GET')
 
     def test_gn_error(self):
@@ -767,7 +768,7 @@ class MonitoringChecksTestCase(MonitoringTestBase):
                 'monitoring:api_user_notification_config', args=(nc.id,))
             nc_form = nc.get_user_form()
             self.assertTrue(nc_form)
-            self.assertTrue(nc_form.fields.keys())
+            self.assertTrue(len(nc_form.fields.keys()) > 0)
             vals = [1000000, 100000]
             data = {'emails': []}
             data['emails'] = '\n'.join(data['emails'])

--- a/geonode/monitoring/utils.py
+++ b/geonode/monitoring/utils.py
@@ -20,7 +20,7 @@
 
 import os
 import pytz
-import Queue
+import queue
 import logging
 import xmljson
 import requests
@@ -28,8 +28,13 @@ import threading
 import traceback
 
 from math import floor, ceil
-from urllib import urlencode
-from urlparse import urlsplit
+try:
+    from urllib.parse import urlencode
+    from urllib.parse import urlsplit
+except ImportError:
+    # Python 2 compatibility
+    from urllib import urlencode
+    from urlparse import urlsplit
 from bs4 import BeautifulSoup as bs
 from datetime import datetime, timedelta
 from defusedxml import lxml as dlxml
@@ -71,7 +76,7 @@ class MonitoringHandler(logging.Handler):
 
 
 class RequestToMonitoringThread(threading.Thread):
-    q = Queue.Queue()
+    q = queue.Queue()
 
     def __init__(self, service, *args, **kwargs):
         super(RequestToMonitoringThread, self).__init__(*args, **kwargs)


### PR DESCRIPTION
PR to update `monitoring` app to be Python 2.7/3 cross-compatible as part of #4276.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there are explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [x] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
