### PR TITLE
[Fixes #5366] Sentinel Cloudless Background should use JPEG format rather than PNG

### DIFF
--- a/docs/basic/settings/index.rst
+++ b/docs/basic/settings/index.rst
@@ -1070,7 +1070,7 @@ MAPSTORE_BASELAYERS
             }, {
                 "type": "wms",
                 "title": "Sentinel-2 cloudless - https://s2maps.eu",
-                "format": "image/png8",
+                "format": "image/jpeg",
                 "id": "s2cloudless",
                 "name": "s2cloudless:s2cloudless",
                 "url": "https://maps.geo-solutions.it/geoserver/wms",
@@ -1117,7 +1117,7 @@ MAPSTORE_BASELAYERS
             }, {
                 "type": "wms",
                 "title": "Sentinel-2 cloudless - https://s2maps.eu",
-                "format": "image/png8",
+                "format": "image/jpeg",
                 "id": "s2cloudless",
                 "name": "s2cloudless:s2cloudless",
                 "url": "https://maps.geo-solutions.it/geoserver/wms",

--- a/geonode/local_settings.py.geoserver.sample
+++ b/geonode/local_settings.py.geoserver.sample
@@ -564,7 +564,7 @@ if GEONODE_CLIENT_LAYER_PREVIEW_LIBRARY == 'mapstore':
         {
             "type": "wms",
             "title": "Sentinel-2 cloudless - https://s2maps.eu",
-            "format": "image/png8",
+            "format": "image/jpeg",
             "id": "s2cloudless",
             "name": "s2cloudless:s2cloudless",
             "url": "https://maps.geo-solutions.it/geoserver/wms",

--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -1580,7 +1580,7 @@ if GEONODE_CLIENT_LAYER_PREVIEW_LIBRARY == 'mapstore':
             }, {
                 "type": "wms",
                 "title": "Sentinel-2 cloudless - https://s2maps.eu",
-                "format": "image/png8",
+                "format": "image/jpeg",
                 "id": "s2cloudless",
                 "name": "s2cloudless:s2cloudless",
                 "url": "https://maps.geo-solutions.it/geoserver/wms",


### PR DESCRIPTION

 - Fixes #5366 : Sentinel Cloudless Background should use JPEG format rather than PNG

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there are explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [x] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
