### PR TITLE
[Issue #4276] Upgrade proxy for Python 2.7/3 compatibility

### DIFF
--- a/geonode/proxy/templatetags/proxy_lib_tags.py
+++ b/geonode/proxy/templatetags/proxy_lib_tags.py
@@ -23,7 +23,11 @@ from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext as _
 from django.core.files.storage import FileSystemStorage
 
-from urlparse import urlsplit, urljoin
+try:
+    from urllib.parse import urlsplit, urljoin
+except ImportError:
+    # Python 2 compatibility
+    from urlparse import urlsplit, urljoin
 
 from geonode.utils import resolve_object
 from geonode.layers.models import Layer, LayerFile

--- a/geonode/proxy/tests.py
+++ b/geonode/proxy/tests.py
@@ -137,7 +137,7 @@ class DownloadResourceTestCase(GeoNodeBaseTestSupport):
         # ... all should be good
         response = self.client.get(reverse('download', args=(layer.id,)))
         # Espected 404 since there are no files available for this layer
-        self.failUnlessEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 404)
         data = response.content
         self.assertTrue(
             "No files have been found for this resource. Please, contact a system administrator." in data)

--- a/geonode/proxy/views.py
+++ b/geonode/proxy/views.py
@@ -24,10 +24,16 @@ import shutil
 import logging
 import tempfile
 import traceback
+import io
+import gzip
 
 from hyperlink import URL
 from slugify import slugify
-from urlparse import urlparse, urlsplit, urljoin
+try:
+    from urllib.parse import urlparse, urlsplit, urljoin
+except ImportError:
+    # Python 2 compatibility
+    from urlparse import urlparse, urlsplit, urljoin
 
 from django.conf import settings
 from django.http import HttpResponse
@@ -177,9 +183,7 @@ def proxy(request, url=None, response_callback=None,
     # decompress GZipped responses if not enabled
     # if content and response and response.getheader('Content-Encoding') == 'gzip':
     if content and content_type and content_type == 'gzip':
-        from StringIO import StringIO
-        import gzip
-        buf = StringIO(content)
+        buf = io.BytesIO(content)
         f = gzip.GzipFile(fileobj=buf)
         content = f.read()
 


### PR DESCRIPTION
PR to update `proxy` app to be Python 2.7/3 cross-compatible as part of #4276.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there are explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [x] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
