### PR TITLE
[Issue #4276] Upgrade security for Python 2.7/3 compatibility

### DIFF
--- a/geonode/security/middleware.py
+++ b/geonode/security/middleware.py
@@ -56,13 +56,7 @@ else:
         '/static/*',
     )
 
-white_list = map(
-    compile,
-    white_list_paths +
-    getattr(
-        settings,
-        "AUTH_EXEMPT_URLS",
-        ()))
+white_list = [compile(x) for x in white_list_paths + getattr(settings, "AUTH_EXEMPT_URLS", ())]
 
 
 class LoginRequiredMiddleware(object):

--- a/geonode/security/tests.py
+++ b/geonode/security/tests.py
@@ -23,7 +23,10 @@ from geonode.tests.base import GeoNodeBaseTestSupport
 import os
 import json
 import base64
-import urllib2
+try:
+    from urllib.request import urlopen, Request
+except ImportError:
+    from urllib2 import urlopen, Request
 import logging
 import gisdata
 import contextlib
@@ -206,14 +209,14 @@ class SecurityViewsTests(ResourceTestCaseMixin, GeoNodeBaseTestSupport):
         resp = self.client.post(reverse('attributes_sats_refresh'), data)
         if resp.status_code == 200:
             self.assertHttpOK(resp)
-            self.assertEquals(layer_attributes.count(), test_layer.attributes.count())
+            self.assertEqual(layer_attributes.count(), test_layer.attributes.count())
 
             from geonode.geoserver.helpers import set_attributes_from_geoserver
             test_layer.attribute_set.all().delete()
             test_layer.save()
 
             set_attributes_from_geoserver(test_layer, overwrite=True)
-            self.assertEquals(layer_attributes.count(), test_layer.attributes.count())
+            self.assertEqual(layer_attributes.count(), test_layer.attributes.count())
 
             # Remove permissions to anonymous users and try to refresh attributes again
             test_layer.set_permissions({'users': {'AnonymousUser': []}})
@@ -221,7 +224,7 @@ class SecurityViewsTests(ResourceTestCaseMixin, GeoNodeBaseTestSupport):
             test_layer.save()
 
             set_attributes_from_geoserver(test_layer, overwrite=True)
-            self.assertEquals(layer_attributes.count(), test_layer.attributes.count())
+            self.assertEqual(layer_attributes.count(), test_layer.attributes.count())
         else:
             # If GeoServer is unreachable, this view now returns a 302 error
             self.assertEqual(resp.status_code, 302)
@@ -268,15 +271,15 @@ class BulkPermissionsTests(ResourceTestCaseMixin, GeoNodeBaseTestSupport):
             purge_geofence_all()
             # Reset GeoFence Rules
             geofence_rules_count = get_geofence_rules_count()
-            self.assertEquals(geofence_rules_count, 0)
+            self.assertEqual(geofence_rules_count, 0)
 
         layers = Layer.objects.all()[:2].values_list('id', flat=True)
-        layers_id = map(lambda x: str(x), layers)
+        layers_id = [str(x) for x in layers]
         test_perm_layer = Layer.objects.get(id=layers[0])
 
         self.client.login(username='admin', password='admin')
         resp = self.client.get(self.list_url)
-        self.assertEquals(len(self.deserialize(resp)['objects']), 8)
+        self.assertEqual(len(self.deserialize(resp)['objects']), 8)
         data = {
             'permissions': json.dumps(self.perm_spec),
             'resources': layers_id
@@ -288,17 +291,17 @@ class BulkPermissionsTests(ResourceTestCaseMixin, GeoNodeBaseTestSupport):
             # Check GeoFence Rules have been correctly created
             geofence_rules_count = get_geofence_rules_count()
             _log("1. geofence_rules_count: %s " % geofence_rules_count)
-            self.assertEquals(geofence_rules_count, 4)
+            self.assertEqual(geofence_rules_count, 4)
             set_geofence_all(test_perm_layer)
             geofence_rules_count = get_geofence_rules_count()
             _log("2. geofence_rules_count: %s " % geofence_rules_count)
-            self.assertEquals(geofence_rules_count, 5)
+            self.assertEqual(geofence_rules_count, 5)
 
         self.client.logout()
 
         self.client.login(username='bobby', password='bob')
         resp = self.client.get(self.list_url)
-        self.assertEquals(len(self.deserialize(resp)['objects']), 7)
+        self.assertEqual(len(self.deserialize(resp)['objects']), 7)
 
         if check_ogc_backend(geoserver.BACKEND_PACKAGE):
             perms = get_users_with_perms(test_perm_layer)
@@ -308,7 +311,7 @@ class BulkPermissionsTests(ResourceTestCaseMixin, GeoNodeBaseTestSupport):
             # Check GeoFence Rules have been correctly created
             geofence_rules_count = get_geofence_rules_count()
             _log("4. geofence_rules_count: %s " % geofence_rules_count)
-            self.assertEquals(geofence_rules_count, 5)
+            self.assertEqual(geofence_rules_count, 5)
 
             # Validate maximum priority
             geofence_rules_highest_priority = get_highest_priority()
@@ -326,14 +329,14 @@ class BulkPermissionsTests(ResourceTestCaseMixin, GeoNodeBaseTestSupport):
             from requests.auth import HTTPBasicAuth
             r = requests.get(url + 'gwc/rest/seed/%s.json' % test_perm_layer.alternate,
                              auth=HTTPBasicAuth(user, passwd))
-            self.assertEquals(r.status_code, 400)
+            self.assertEqual(r.status_code, 400)
 
         geofence_rules_count = 0
         if check_ogc_backend(geoserver.BACKEND_PACKAGE):
             purge_geofence_all()
             # Reset GeoFence Rules
             geofence_rules_count = get_geofence_rules_count()
-            self.assertEquals(geofence_rules_count, 0)
+            self.assertEqual(geofence_rules_count, 0)
 
     def test_bobby_cannot_set_all(self):
         """Test that Bobby can set the permissions only only on the ones
@@ -368,43 +371,43 @@ class BulkPermissionsTests(ResourceTestCaseMixin, GeoNodeBaseTestSupport):
         # Reset GeoFence Rules
         purge_geofence_all()
         geofence_rules_count = get_geofence_rules_count()
-        self.assertEquals(geofence_rules_count, 0)
+        self.assertEqual(geofence_rules_count, 0)
 
         perm_spec = {'users': {'AnonymousUser': []}}
         layer.set_permissions(perm_spec)
         geofence_rules_count = get_geofence_rules_count()
         _log("1. geofence_rules_count: %s " % geofence_rules_count)
-        self.assertEquals(geofence_rules_count, 0)
+        self.assertEqual(geofence_rules_count, 0)
 
         perm_spec = {
             "users": {"admin": ["view_resourcebase"]}, "groups": {}}
         layer.set_permissions(perm_spec)
         geofence_rules_count = get_geofence_rules_count()
         _log("2. geofence_rules_count: %s " % geofence_rules_count)
-        self.assertEquals(geofence_rules_count, 2)
+        self.assertEqual(geofence_rules_count, 2)
 
         perm_spec = {'users': {"admin": ['change_layer_data']}}
         layer.set_permissions(perm_spec)
         geofence_rules_count = get_geofence_rules_count()
         _log("3. geofence_rules_count: %s " % geofence_rules_count)
-        self.assertEquals(geofence_rules_count, 2)
+        self.assertEqual(geofence_rules_count, 2)
 
         perm_spec = {'groups': {'bar': ['view_resourcebase']}}
         layer.set_permissions(perm_spec)
         geofence_rules_count = get_geofence_rules_count()
         _log("4. geofence_rules_count: %s " % geofence_rules_count)
-        self.assertEquals(geofence_rules_count, 2)
+        self.assertEqual(geofence_rules_count, 2)
 
         perm_spec = {'groups': {'bar': ['change_resourcebase']}}
         layer.set_permissions(perm_spec)
         geofence_rules_count = get_geofence_rules_count()
         _log("5. geofence_rules_count: %s " % geofence_rules_count)
-        self.assertEquals(geofence_rules_count, 0)
+        self.assertEqual(geofence_rules_count, 0)
 
         # Reset GeoFence Rules
         purge_geofence_all()
         geofence_rules_count = get_geofence_rules_count()
-        self.assertEquals(geofence_rules_count, 0)
+        self.assertEqual(geofence_rules_count, 0)
 
     @on_ogc_backend(geoserver.BACKEND_PACKAGE)
     def test_layer_upload_with_time(self):
@@ -485,12 +488,12 @@ class BulkPermissionsTests(ResourceTestCaseMixin, GeoNodeBaseTestSupport):
             from requests.auth import HTTPBasicAuth
             r = requests.get(url + rest_path,
                              auth=HTTPBasicAuth(user, passwd))
-            self.assertEquals(r.status_code, 200)
+            self.assertEqual(r.status_code, 200)
             _log(r.text)
 
             featureType = etree.ElementTree(dlxml.fromstring(r.text))
             metadata = featureType.findall('./[metadata]')
-            self.assertEquals(len(metadata), 0)
+            self.assertEqual(len(metadata), 0)
 
             payload = """<featureType>
             <metadata>
@@ -517,17 +520,17 @@ class BulkPermissionsTests(ResourceTestCaseMixin, GeoNodeBaseTestSupport):
                                  'Content-type': 'application/xml'
                              },
                              auth=HTTPBasicAuth(user, passwd))
-            self.assertEquals(r.status_code, 200)
+            self.assertEqual(r.status_code, 200)
 
             r = requests.get(url + rest_path,
                              auth=HTTPBasicAuth(user, passwd))
-            self.assertEquals(r.status_code, 200)
+            self.assertEqual(r.status_code, 200)
             _log(r.text)
 
             featureType = etree.ElementTree(dlxml.fromstring(r.text))
             metadata = featureType.findall('./[metadata]')
             _log(etree.tostring(metadata[0], encoding='utf8', method='xml'))
-            self.assertEquals(len(metadata), 1)
+            self.assertEqual(len(metadata), 1)
 
             saved_layer.set_default_permissions()
 
@@ -560,62 +563,63 @@ class BulkPermissionsTests(ResourceTestCaseMixin, GeoNodeBaseTestSupport):
                                     break
 
             self.assertIsNotNone(all_times)
-            self.assertEquals(all_times,
-                              ['2000-03-01T00:00:00.000Z', '2000-03-02T00:00:00.000Z',
-                               '2000-03-03T00:00:00.000Z', '2000-03-04T00:00:00.000Z',
-                               '2000-03-05T00:00:00.000Z', '2000-03-06T00:00:00.000Z',
-                               '2000-03-07T00:00:00.000Z', '2000-03-08T00:00:00.000Z',
-                               '2000-03-09T00:00:00.000Z', '2000-03-10T00:00:00.000Z',
-                               '2000-03-11T00:00:00.000Z', '2000-03-12T00:00:00.000Z',
-                               '2000-03-13T00:00:00.000Z', '2000-03-14T00:00:00.000Z',
-                               '2000-03-15T00:00:00.000Z', '2000-03-16T00:00:00.000Z',
-                               '2000-03-17T00:00:00.000Z', '2000-03-18T00:00:00.000Z',
-                               '2000-03-19T00:00:00.000Z', '2000-03-20T00:00:00.000Z',
-                               '2000-03-21T00:00:00.000Z', '2000-03-22T00:00:00.000Z',
-                               '2000-03-23T00:00:00.000Z', '2000-03-24T00:00:00.000Z',
-                               '2000-03-25T00:00:00.000Z', '2000-03-26T00:00:00.000Z',
-                               '2000-03-27T00:00:00.000Z', '2000-03-28T00:00:00.000Z',
-                               '2000-03-29T00:00:00.000Z', '2000-03-30T00:00:00.000Z',
-                               '2000-03-31T00:00:00.000Z', '2000-04-01T00:00:00.000Z',
-                               '2000-04-02T00:00:00.000Z', '2000-04-03T00:00:00.000Z',
-                               '2000-04-04T00:00:00.000Z', '2000-04-05T00:00:00.000Z',
-                               '2000-04-06T00:00:00.000Z', '2000-04-07T00:00:00.000Z',
-                               '2000-04-08T00:00:00.000Z', '2000-04-09T00:00:00.000Z',
-                               '2000-04-10T00:00:00.000Z', '2000-04-11T00:00:00.000Z',
-                               '2000-04-12T00:00:00.000Z', '2000-04-13T00:00:00.000Z',
-                               '2000-04-14T00:00:00.000Z', '2000-04-15T00:00:00.000Z',
-                               '2000-04-16T00:00:00.000Z', '2000-04-17T00:00:00.000Z',
-                               '2000-04-18T00:00:00.000Z', '2000-04-19T00:00:00.000Z',
-                               '2000-04-20T00:00:00.000Z', '2000-04-21T00:00:00.000Z',
-                               '2000-04-22T00:00:00.000Z', '2000-04-23T00:00:00.000Z',
-                               '2000-04-24T00:00:00.000Z', '2000-04-25T00:00:00.000Z',
-                               '2000-04-26T00:00:00.000Z', '2000-04-27T00:00:00.000Z',
-                               '2000-04-28T00:00:00.000Z', '2000-04-29T00:00:00.000Z',
-                               '2000-04-30T00:00:00.000Z', '2000-05-01T00:00:00.000Z',
-                               '2000-05-02T00:00:00.000Z', '2000-05-03T00:00:00.000Z',
-                               '2000-05-04T00:00:00.000Z', '2000-05-05T00:00:00.000Z',
-                               '2000-05-06T00:00:00.000Z', '2000-05-07T00:00:00.000Z',
-                               '2000-05-08T00:00:00.000Z', '2000-05-09T00:00:00.000Z',
-                               '2000-05-10T00:00:00.000Z', '2000-05-11T00:00:00.000Z',
-                               '2000-05-12T00:00:00.000Z', '2000-05-13T00:00:00.000Z',
-                               '2000-05-14T00:00:00.000Z', '2000-05-15T00:00:00.000Z',
-                               '2000-05-16T00:00:00.000Z', '2000-05-17T00:00:00.000Z',
-                               '2000-05-18T00:00:00.000Z', '2000-05-19T00:00:00.000Z',
-                               '2000-05-20T00:00:00.000Z', '2000-05-21T00:00:00.000Z',
-                               '2000-05-22T00:00:00.000Z', '2000-05-23T00:00:00.000Z',
-                               '2000-05-24T00:00:00.000Z', '2000-05-25T00:00:00.000Z',
-                               '2000-05-26T00:00:00.000Z', '2000-05-27T00:00:00.000Z',
-                               '2000-05-28T00:00:00.000Z', '2000-05-29T00:00:00.000Z',
-                               '2000-05-30T00:00:00.000Z', '2000-05-31T00:00:00.000Z',
-                               '2000-06-01T00:00:00.000Z', '2000-06-02T00:00:00.000Z',
-                               '2000-06-03T00:00:00.000Z', '2000-06-04T00:00:00.000Z',
-                               '2000-06-05T00:00:00.000Z', '2000-06-06T00:00:00.000Z',
-                               '2000-06-07T00:00:00.000Z', '2000-06-08T00:00:00.000Z'])
+            self.assertEqual(all_times, [
+                '2000-03-01T00:00:00.000Z', '2000-03-02T00:00:00.000Z',
+                '2000-03-03T00:00:00.000Z', '2000-03-04T00:00:00.000Z',
+                '2000-03-05T00:00:00.000Z', '2000-03-06T00:00:00.000Z',
+                '2000-03-07T00:00:00.000Z', '2000-03-08T00:00:00.000Z',
+                '2000-03-09T00:00:00.000Z', '2000-03-10T00:00:00.000Z',
+                '2000-03-11T00:00:00.000Z', '2000-03-12T00:00:00.000Z',
+                '2000-03-13T00:00:00.000Z', '2000-03-14T00:00:00.000Z',
+                '2000-03-15T00:00:00.000Z', '2000-03-16T00:00:00.000Z',
+                '2000-03-17T00:00:00.000Z', '2000-03-18T00:00:00.000Z',
+                '2000-03-19T00:00:00.000Z', '2000-03-20T00:00:00.000Z',
+                '2000-03-21T00:00:00.000Z', '2000-03-22T00:00:00.000Z',
+                '2000-03-23T00:00:00.000Z', '2000-03-24T00:00:00.000Z',
+                '2000-03-25T00:00:00.000Z', '2000-03-26T00:00:00.000Z',
+                '2000-03-27T00:00:00.000Z', '2000-03-28T00:00:00.000Z',
+                '2000-03-29T00:00:00.000Z', '2000-03-30T00:00:00.000Z',
+                '2000-03-31T00:00:00.000Z', '2000-04-01T00:00:00.000Z',
+                '2000-04-02T00:00:00.000Z', '2000-04-03T00:00:00.000Z',
+                '2000-04-04T00:00:00.000Z', '2000-04-05T00:00:00.000Z',
+                '2000-04-06T00:00:00.000Z', '2000-04-07T00:00:00.000Z',
+                '2000-04-08T00:00:00.000Z', '2000-04-09T00:00:00.000Z',
+                '2000-04-10T00:00:00.000Z', '2000-04-11T00:00:00.000Z',
+                '2000-04-12T00:00:00.000Z', '2000-04-13T00:00:00.000Z',
+                '2000-04-14T00:00:00.000Z', '2000-04-15T00:00:00.000Z',
+                '2000-04-16T00:00:00.000Z', '2000-04-17T00:00:00.000Z',
+                '2000-04-18T00:00:00.000Z', '2000-04-19T00:00:00.000Z',
+                '2000-04-20T00:00:00.000Z', '2000-04-21T00:00:00.000Z',
+                '2000-04-22T00:00:00.000Z', '2000-04-23T00:00:00.000Z',
+                '2000-04-24T00:00:00.000Z', '2000-04-25T00:00:00.000Z',
+                '2000-04-26T00:00:00.000Z', '2000-04-27T00:00:00.000Z',
+                '2000-04-28T00:00:00.000Z', '2000-04-29T00:00:00.000Z',
+                '2000-04-30T00:00:00.000Z', '2000-05-01T00:00:00.000Z',
+                '2000-05-02T00:00:00.000Z', '2000-05-03T00:00:00.000Z',
+                '2000-05-04T00:00:00.000Z', '2000-05-05T00:00:00.000Z',
+                '2000-05-06T00:00:00.000Z', '2000-05-07T00:00:00.000Z',
+                '2000-05-08T00:00:00.000Z', '2000-05-09T00:00:00.000Z',
+                '2000-05-10T00:00:00.000Z', '2000-05-11T00:00:00.000Z',
+                '2000-05-12T00:00:00.000Z', '2000-05-13T00:00:00.000Z',
+                '2000-05-14T00:00:00.000Z', '2000-05-15T00:00:00.000Z',
+                '2000-05-16T00:00:00.000Z', '2000-05-17T00:00:00.000Z',
+                '2000-05-18T00:00:00.000Z', '2000-05-19T00:00:00.000Z',
+                '2000-05-20T00:00:00.000Z', '2000-05-21T00:00:00.000Z',
+                '2000-05-22T00:00:00.000Z', '2000-05-23T00:00:00.000Z',
+                '2000-05-24T00:00:00.000Z', '2000-05-25T00:00:00.000Z',
+                '2000-05-26T00:00:00.000Z', '2000-05-27T00:00:00.000Z',
+                '2000-05-28T00:00:00.000Z', '2000-05-29T00:00:00.000Z',
+                '2000-05-30T00:00:00.000Z', '2000-05-31T00:00:00.000Z',
+                '2000-06-01T00:00:00.000Z', '2000-06-02T00:00:00.000Z',
+                '2000-06-03T00:00:00.000Z', '2000-06-04T00:00:00.000Z',
+                '2000-06-05T00:00:00.000Z', '2000-06-06T00:00:00.000Z',
+                '2000-06-07T00:00:00.000Z', '2000-06-08T00:00:00.000Z',
+            ])
 
             saved_layer.set_default_permissions()
             url = reverse('layer_metadata', args=[saved_layer.service_typename])
             resp = self.client.get(url)
-            self.assertEquals(resp.status_code, 200)
+            self.assertEqual(resp.status_code, 200)
         finally:
             # Clean up and completely delete the layer
             try:
@@ -682,7 +686,7 @@ class BulkPermissionsTests(ResourceTestCaseMixin, GeoNodeBaseTestSupport):
 
             geofence_rules_count = get_geofence_rules_count()
             _log("0. geofence_rules_count: %s " % geofence_rules_count)
-            self.assertEquals(geofence_rules_count, 2)
+            self.assertEqual(geofence_rules_count, 2)
 
             # Set the layer private for not authenticated users
             layer.set_permissions({'users': {'AnonymousUser': []}})
@@ -696,8 +700,8 @@ class BulkPermissionsTests(ResourceTestCaseMixin, GeoNodeBaseTestSupport):
                 '&WIDTH=217&HEIGHT=512'
 
             # test view_resourcebase permission on anonymous user
-            request = urllib2.Request(url)
-            response = urllib2.urlopen(request)
+            request = Request(url)
+            response = urlopen(request)
             self.assertTrue(
                 response.info().getheader('Content-Type'),
                 'application/vnd.ogc.se_xml;charset=UTF-8'
@@ -705,11 +709,11 @@ class BulkPermissionsTests(ResourceTestCaseMixin, GeoNodeBaseTestSupport):
 
             # test WMS with authenticated user that has not view_resourcebase:
             # the layer must be not accessible (response is xml)
-            request = urllib2.Request(url)
+            request = Request(url)
             base64string = base64.encodestring(
                 '%s:%s' % ('bobby', 'bob')).replace('\n', '')
             request.add_header("Authorization", "Basic %s" % base64string)
-            response = urllib2.urlopen(request)
+            response = urlopen(request)
             self.assertTrue(
                 response.info().getheader('Content-Type'),
                 'application/vnd.ogc.se_xml;charset=UTF-8'
@@ -718,11 +722,11 @@ class BulkPermissionsTests(ResourceTestCaseMixin, GeoNodeBaseTestSupport):
             # test WMS with authenticated user that has view_resourcebase: the layer
             # must be accessible (response is image)
             assign_perm('view_resourcebase', bobby, layer.get_self_resource())
-            request = urllib2.Request(url)
+            request = Request(url)
             base64string = base64.encodestring(
                 '%s:%s' % ('bobby', 'bob')).replace('\n', '')
             request.add_header("Authorization", "Basic %s" % base64string)
-            response = urllib2.urlopen(request)
+            response = urlopen(request)
             self.assertTrue(response.info().getheader('Content-Type'), 'image/png')
 
             # test change_layer_data
@@ -768,7 +772,7 @@ class BulkPermissionsTests(ResourceTestCaseMixin, GeoNodeBaseTestSupport):
             # user without change_layer_style cannot edit it
             self.assertTrue(self.client.login(username='bobby', password='bob'))
             response = self.client.put(url, sld, content_type='application/vnd.ogc.sld+xml')
-            self.assertEquals(response.status_code, 404)
+            self.assertEqual(response.status_code, 404)
 
             # user with change_layer_style can edit it
             assign_perm('change_layer_style', bobby, layer)
@@ -901,7 +905,7 @@ class PermissionsTest(GeoNodeBaseTestSupport):
         # Test that previous permissions for users other than ones specified in
         # the perm_spec (and the layers owner) were removed
         current_perms = layer.get_all_level_info()
-        self.assertEqual(len(current_perms['users'].keys()), 2)
+        self.assertEqual(len(current_perms['users']), 2)
 
         # Test that the User permissions specified in the perm_spec were
         # applied properly
@@ -923,7 +927,7 @@ class PermissionsTest(GeoNodeBaseTestSupport):
                 'resource_permissions', args=(
                     invalid_layer_id,)), data=json.dumps(
                 self.perm_spec), content_type="application/json")
-        self.assertEquals(response.status_code, 404)
+        self.assertEqual(response.status_code, 404)
 
         # Test that GET returns permissions
         response = self.client.get(
@@ -942,21 +946,21 @@ class PermissionsTest(GeoNodeBaseTestSupport):
                 'resource_permissions', args=(
                     valid_layer_typename,)), data=json.dumps(
                 self.perm_spec), content_type="application/json")
-        self.assertEquals(response.status_code, 401)
+        self.assertEqual(response.status_code, 401)
 
         # Next Test with a user that does NOT have the proper perms
         logged_in = self.client.login(username='bobby', password='bob')
-        self.assertEquals(logged_in, True)
+        self.assertEqual(logged_in, True)
         response = self.client.post(
             reverse(
                 'resource_permissions', args=(
                     valid_layer_typename,)), data=json.dumps(
                 self.perm_spec), content_type="application/json")
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
 
         # Login as a user with the proper permission and test the endpoint
         logged_in = self.client.login(username='admin', password='admin')
-        self.assertEquals(logged_in, True)
+        self.assertEqual(logged_in, True)
 
         response = self.client.post(
             reverse(
@@ -965,7 +969,7 @@ class PermissionsTest(GeoNodeBaseTestSupport):
                 self.perm_spec), content_type="application/json")
 
         # Test that the method returns 200
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
 
         # Test that the permissions specification is applied
 
@@ -1042,7 +1046,7 @@ class PermissionsTest(GeoNodeBaseTestSupport):
                 layer.get_self_resource()))
 
         response = self.client.get(reverse('layer_detail', args=(layer.alternate,)))
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
         # 1.2 has not view_resourcebase: verify that bobby can not access the
         # layer detail page
         remove_perm('view_resourcebase', bob, layer.get_self_resource())
@@ -1055,7 +1059,7 @@ class PermissionsTest(GeoNodeBaseTestSupport):
         # 2.1 has not change_resourcebase: verify that bobby cannot access the
         # layer replace page
         response = self.client.get(reverse('layer_replace', args=(layer.alternate,)))
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
         # 2.2 has change_resourcebase: verify that bobby can access the layer
         # replace page
         assign_perm('change_resourcebase', bob, layer.get_self_resource())
@@ -1064,13 +1068,13 @@ class PermissionsTest(GeoNodeBaseTestSupport):
                 'change_resourcebase',
                 layer.get_self_resource()))
         response = self.client.get(reverse('layer_replace', args=(layer.alternate,)))
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
 
         # 3. delete_resourcebase
         # 3.1 has not delete_resourcebase: verify that bobby cannot access the
         # layer delete page
         response = self.client.get(reverse('layer_remove', args=(layer.alternate,)))
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
         # 3.2 has delete_resourcebase: verify that bobby can access the layer
         # delete page
         assign_perm('delete_resourcebase', bob, layer.get_self_resource())
@@ -1079,13 +1083,13 @@ class PermissionsTest(GeoNodeBaseTestSupport):
                 'delete_resourcebase',
                 layer.get_self_resource()))
         response = self.client.get(reverse('layer_remove', args=(layer.alternate,)))
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
 
         # 4. change_resourcebase_metadata
         # 4.1 has not change_resourcebase_metadata: verify that bobby cannot
         # access the layer metadata page
         response = self.client.get(reverse('layer_metadata', args=(layer.alternate,)))
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
         # 4.2 has delete_resourcebase: verify that bobby can access the layer
         # delete page
         assign_perm('change_resourcebase_metadata', bob, layer.get_self_resource())
@@ -1094,7 +1098,7 @@ class PermissionsTest(GeoNodeBaseTestSupport):
                 'change_resourcebase_metadata',
                 layer.get_self_resource()))
         response = self.client.get(reverse('layer_metadata', args=(layer.alternate,)))
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
 
         if check_ogc_backend(geoserver.BACKEND_PACKAGE):
             perms = get_users_with_perms(layer)
@@ -1104,7 +1108,7 @@ class PermissionsTest(GeoNodeBaseTestSupport):
             # Check GeoFence Rules have been correctly created
             geofence_rules_count = get_geofence_rules_count()
             _log("3. geofence_rules_count: %s " % geofence_rules_count)
-            self.assertEquals(geofence_rules_count, 1)
+            self.assertEqual(geofence_rules_count, 1)
 
         # 5. change_resourcebase_permissions
         # should be impossible for the user without change_resourcebase_permissions
@@ -1120,7 +1124,7 @@ class PermissionsTest(GeoNodeBaseTestSupport):
         if check_ogc_backend(geoserver.BACKEND_PACKAGE):
             # Only for geoserver backend
             response = self.client.get(reverse('layer_style_manage', args=(layer.alternate,)))
-            self.assertEquals(response.status_code, 200)
+            self.assertEqual(response.status_code, 200)
         # 7.2 has change_layer_style: verify that bobby can access the
         # change layer style page
         if check_ogc_backend(geoserver.BACKEND_PACKAGE):
@@ -1131,14 +1135,14 @@ class PermissionsTest(GeoNodeBaseTestSupport):
                     'change_layer_style',
                     layer))
             response = self.client.get(reverse('layer_style_manage', args=(layer.alternate,)))
-            self.assertEquals(response.status_code, 200)
+            self.assertEqual(response.status_code, 200)
 
         geofence_rules_count = 0
         if check_ogc_backend(geoserver.BACKEND_PACKAGE):
             purge_geofence_all()
             # Reset GeoFence Rules
             geofence_rules_count = get_geofence_rules_count()
-            self.assertEquals(geofence_rules_count, 0)
+            self.assertEqual(geofence_rules_count, 0)
 
     def test_anonymus_permissions(self):
 
@@ -1153,7 +1157,7 @@ class PermissionsTest(GeoNodeBaseTestSupport):
                 'view_resourcebase',
                 layer.get_self_resource()))
         response = self.client.get(reverse('layer_detail', args=(layer.alternate,)))
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
         # 1.2 has not view_resourcebase: verify that anonymous user can not
         # access the layer detail page
         remove_perm('view_resourcebase', self.anonymous_user, layer.get_self_resource())
@@ -1230,7 +1234,7 @@ class GisBackendSignalsTests(ResourceTestCaseMixin, GeoNodeBaseTestSupport):
             self.assertIsNotNone(test_perm_layer.bbox)
             self.assertIsNotNone(test_perm_layer.srid)
             self.assertIsNotNone(test_perm_layer.link_set)
-            self.assertEquals(len(test_perm_layer.link_set.all()), 7)
+            self.assertEqual(len(test_perm_layer.link_set.all()), 7)
 
             # Layer Manipulation
             from geonode.geoserver.upload import geoserver_upload

--- a/geonode/security/utils.py
+++ b/geonode/security/utils.py
@@ -25,8 +25,13 @@ import json
 import logging
 import traceback
 import requests
-import models
+try:
+    from . import models
+except ImportError:
+    # Python 2 compatibility
+    import models
 
+from six import string_types
 from requests.auth import HTTPBasicAuth
 from django.conf import settings
 from django.db.models import Q
@@ -158,7 +163,7 @@ def get_users_with_perms(obj):
             users[item['user_id']] = [permissions[item['permission_id']], ]
 
     profiles = {}
-    for profile in get_user_model().objects.filter(id__in=users.keys()):
+    for profile in get_user_model().objects.filter(id__in=list(users.keys())):
         profiles[profile] = users[profile.id]
 
     return profiles
@@ -449,11 +454,11 @@ def sync_geofence_with_guardian(layer, perms, user=None, group=None):
 
     _user = None
     if user:
-        _user = user if isinstance(user, basestring) else user.username
+        _user = user if isinstance(user, string_types) else user.username
     _group = None
     if group:
-        _group = group if isinstance(group, basestring) else group.name
-    for service, allowed in gf_services.iteritems():
+        _group = group if isinstance(group, string_types) else group.name
+    for service, allowed in gf_services.items():
         if allowed:
             if _user:
                 logger.debug("Adding 'user' to geofence the rule: %s %s %s" % (layer, service, _user))

--- a/geonode/security/views.py
+++ b/geonode/security/views.py
@@ -43,10 +43,8 @@ def _perms_info(obj):
 
 def _perms_info_json(obj):
     info = _perms_info(obj)
-    info['users'] = dict([(u.username, perms)
-                          for u, perms in info['users'].items()])
-    info['groups'] = dict([(g.name, perms)
-                           for g, perms in info['groups'].items()])
+    info['users'] = {u.username: perms for u, perms in info['users'].items()}
+    info['groups'] = {g.name: perms for g, perms in info['groups'].items()}
 
     return json.dumps(info)
 
@@ -74,19 +72,21 @@ def resource_permissions(request, resource_id):
             # Check Users Permissions Consistency
             view_any = False
             info = _perms_info(resource)
-            info_users = dict([(u.username, perms) for u, perms in info['users'].items()])
 
-            for user, perms in info_users.items():
-                if user == 'AnonymousUser':
-                    view_any = ('view_resourcebase' in perms)
+            for user, perms in info['users'].items():
+                if user.username == "AnonymousUser":
+                    view_any = "view_resourcebase" in perms
                     break
 
-            for user, perms in info_users.items():
-                if 'download_resourcebase' in perms and 'view_resourcebase' not in perms and not view_any:
+            for user, perms in info['users'].items():
+                if "download_resourcebase" in perms and \
+                   "view_resourcebase" not in perms and \
+                   not view_any:
+
                     success = False
-                    message = 'User ' + str(user) + ' has Download permissions but ' \
-                              'cannot access the resource. ' \
-                              'Please update permissions consistently!'
+                    message = "User {} has download permissions but cannot " \
+                              "access the resource. Please update permission " \
+                              "consistently!".format(user.username)
 
             return HttpResponse(
                 json.dumps({'success': success, 'message': message}),


### PR DESCRIPTION
PR to update `security` app to be Python 2.7/3 cross-compatible as part of #4276.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there are explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [x] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
