### PR TITLE
[Fixes #5392][Performance] Put meaningful generic thumbs if thumbnail generation fails some some reason

### DIFF
--- a/geonode/catalogue/views.py
+++ b/geonode/catalogue/views.py
@@ -225,9 +225,9 @@ def data_json(request):
         record['description'] = resource.abstract
         record['keyword'] = resource.keyword_csv.split(',')
         record['modified'] = resource.csw_insert_date.isoformat()
-        record['publisher'] = resource.poc.organization
-        record['contactPoint'] = resource.poc.name_long
-        record['mbox'] = resource.poc.email
+        record['publisher'] = resource.poc.organization if resource.poc else None
+        record['contactPoint'] = resource.poc.name_long if resource.poc else None
+        record['mbox'] = resource.poc.email if resource.poc else None
         record['identifier'] = resource.uuid
         if resource.is_published:
             record['accessLevel'] = 'public'

--- a/geonode/documents/admin.py
+++ b/geonode/documents/admin.py
@@ -29,9 +29,9 @@ class DocumentAdminForm(ResourceBaseAdminForm):
     class Meta:
         model = Document
         fields = '__all__'
-        exclude = (
-            'resource',
-        )
+        # exclude = (
+        #     'resource',
+        # )
 
 
 class DocumentAdmin(MediaTranslationAdmin):


### PR DESCRIPTION
- Fixes #5392 : [Performance] Put meaningful generic thumbs if thumbnail generation fails some some reason

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there are explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
