### PR TITLE
[Fixes #5429] Layer feature info templates are not used inside maps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -228,7 +228,7 @@ install:
       export JAVA_HOME=$(readlink -f /usr/bin/java | sed "s:bin/java::");
       export PATH=$JAVA_HOME'bin/java':$PATH;
       pip install -r requirements.txt --upgrade;
-      pip install -e .;
+      pip install -e . --upgrade;
       pip install pygdal==`gdal-config --version`.*;
       pip install codecov;
     fi

--- a/docs/install/core/index.rst
+++ b/docs/install/core/index.rst
@@ -130,7 +130,7 @@ At this point your command prompt shows a ``(geonode)`` prefix, this indicates t
   # Install the Python packages
   cd /opt/geonode
   pip install -r requirements.txt --upgrade --no-cache --no-cache-dir
-  pip install -e .
+  pip install -e . --upgrade
 
   # Install GDAL Utilities for Python
   pip install pygdal=="`gdal-config --version`.*"

--- a/docs/install/project/index.rst
+++ b/docs/install/project/index.rst
@@ -135,7 +135,7 @@ Make an instance out of the ``Django Template``
   # Install the Python packages
   cd /opt/geonode_custom/my_geonode
   pip install -r requirements.txt --upgrade --no-cache --no-cache-dir
-  pip install -e .
+  pip install -e . --upgrade
 
   # Install GDAL Utilities for Python
   pip install pygdal=="`gdal-config --version`.*"

--- a/geonode/geoserver/helpers.py
+++ b/geonode/geoserver/helpers.py
@@ -74,6 +74,7 @@ from owslib.wms import WebMapService
 from geonode import GeoNodeException
 from geonode.base.auth import get_or_create_token
 from geonode.utils import http_client
+from geonode.catalogue.models import catalogue_post_save
 from geonode.layers.models import Layer, Attribute, Style
 from geonode.layers.enumerations import LAYER_ATTRIBUTE_NUMERIC_DATA_TYPES
 from geonode.security.views import _perms_info_json
@@ -1116,6 +1117,10 @@ def set_styles(layer, gs_catalog):
 
     Layer.objects.filter(id=layer.id).update(**to_update)
     layer.refresh_from_db()
+
+    # refresh catalogue metadata records
+    catalogue_post_save(instance=layer, sender=layer.__class__)
+
     try:
         set_geowebcache_invalidate_cache(layer.alternate or layer.typename)
     except BaseException as e:

--- a/geonode/geoserver/views.py
+++ b/geonode/geoserver/views.py
@@ -54,10 +54,11 @@ from geonode.layers.models import Layer, Style
 from geonode.layers.views import _resolve_layer, _PERMISSION_MSG_MODIFY
 from geonode.maps.models import Map
 from geonode.proxy.views import proxy
-from geonode.geoserver.signals import gs_catalog
 from .tasks import geoserver_update_layers
 from geonode.utils import json_response, _get_basic_auth_info, http_client
 from geoserver.catalog import FailedRequestError
+from geonode.geoserver.signals import (gs_catalog,
+                                       geoserver_post_save_local)
 from .helpers import (get_stores,
                       ogc_server_settings,
                       extract_name_from_sld,
@@ -535,8 +536,6 @@ def geoserver_proxy(request,
 
 
 def _response_callback(**kwargs):
-    # affected_layers = kwargs['affected_layers']
-    # response = kwargs['response']
     content = kwargs['content']
     status = kwargs['status']
     content_type = kwargs['content_type']
@@ -547,6 +546,10 @@ def _response_callback(**kwargs):
         content = content\
             .replace(ogc_server_settings.LOCATION, _gn_proxy_url)\
             .replace(ogc_server_settings.PUBLIC_LOCATION, _gn_proxy_url)
+
+    if 'affected_layers' in kwargs and kwargs['affected_layers']:
+        for layer in kwargs['affected_layers']:
+            geoserver_post_save_local(layer)
 
     return HttpResponse(
         content=content,

--- a/geonode/maps/models.py
+++ b/geonode/maps/models.py
@@ -530,19 +530,35 @@ class MapLayer(models.Model, GXPLayerBase):
 
     @property
     def layer_title(self):
-        if self.local:
-            title = Layer.objects.get(store=self.store, alternate=self.name).title
-        else:
+        title = None
+        try:
+            if self.local:
+                if self.store:
+                    title = Layer.objects.get(
+                        store=self.store, alternate=self.name).title
+                else:
+                    title = Layer.objects.get(alternate=self.name).title
+        except BaseException:
+            title = None
+        if title is None:
             title = self.name
         return title
 
     @property
     def local_link(self):
-        if self.local:
-            layer = Layer.objects.get(store=self.store, alternate=self.name)
-            link = "<a href=\"%s\">%s</a>" % (
-                layer.get_absolute_url(), layer.title)
-        else:
+        link = None
+        try:
+            if self.local:
+                if self.store:
+                    layer = Layer.objects.get(
+                        store=self.store, alternate=self.name)
+                else:
+                    layer = Layer.objects.get(alternate=self.name)
+                link = "<a href=\"%s\">%s</a>" % (
+                    layer.get_absolute_url(), layer.title)
+        except BaseException:
+            link = None
+        if link is None:
             link = "<span>%s</span> " % self.name
         return link
 

--- a/geonode/maps/tests.py
+++ b/geonode/maps/tests.py
@@ -170,6 +170,11 @@ community."
         self.assertEqual(map_obj.abstract, "Abstract2")
         self.assertEqual(map_obj.layer_set.all().count(), 1)
 
+        for map_layer in map_obj.layers:
+            self.assertEqual(
+                map_layer.layer_title,
+                "base:nic_admin")
+
     @dump_func_name
     def test_map_save(self):
         """POST /maps/new/data -> Test saving a new map"""
@@ -331,6 +336,23 @@ community."
         layer = Layer.objects.all().first()
         map_obj = Map.objects.all().first()
         self.client.get(reverse('add_layer') + '?layer_name=%s&map_id=%s' % (layer.alternate, map_obj.id))
+
+        map_obj = Map.objects.get(id=map_obj.id)
+        for map_layer in map_obj.layers:
+            layer_title = map_layer.layer_title
+            local_link = map_layer.local_link
+            if map_layer.name == layer.alternate:
+                self.assertTrue(
+                    layer_title in layer.alternate)
+                self.assertTrue(
+                    map_layer.name in local_link)
+            if Layer.objects.filter(alternate=map_layer.name).exists():
+                attribute_cfg = Layer.objects.get(alternate=map_layer.name).attribute_config()
+                if "getFeatureInfo" in attribute_cfg:
+                    self.assertIsNotNone(attribute_cfg["getFeatureInfo"])
+                    cfg = map_layer.layer_config()
+                    self.assertIsNotNone(cfg["getFeatureInfo"])
+                    self.assertEqual(cfg["getFeatureInfo"], attribute_cfg["getFeatureInfo"])
 
     @dump_func_name
     def test_ajax_map_permissions(self):
@@ -557,6 +579,20 @@ community."
             config_default['about']['title'],
             response_config_dict['about']['title'])
 
+        map_obj.update_from_viewer(config_map, context={})
+        title = config_map['title'] if 'title' in config_map else config_map['about']['title']
+        abstract = config_map['abstract'] if 'abstract' in config_map else config_map['about']['abstract']
+        center = config_map['map']['center'] if 'center' in config_map['map'] else settings.DEFAULT_MAP_CENTER
+        zoom = config_map['map']['zoom'] if 'zoom' in config_map['map'] else settings.DEFAULT_MAP_ZOOM
+        projection = config_map['map']['projection']
+
+        self.assertEqual(map_obj.title, title)
+        self.assertEqual(map_obj.abstract, abstract)
+        self.assertEqual(map_obj.center_x, center['x'] if isinstance(center, dict) else center[0])
+        self.assertEqual(map_obj.center_y, center['y'] if isinstance(center, dict) else center[1])
+        self.assertEqual(map_obj.zoom, zoom)
+        self.assertEqual(map_obj.projection, projection)
+
     @dump_func_name
     def test_map_view(self):
         """Test that map view can be properly rendered
@@ -604,6 +640,25 @@ community."
         self.assertEqual(
             config_map['about']['title'],
             response_config_dict['about']['title'])
+
+        map_obj.update_from_viewer(config_map, context={})
+        title = config_map['title'] if 'title' in config_map else config_map['about']['title']
+        abstract = config_map['abstract'] if 'abstract' in config_map else config_map['about']['abstract']
+        center = config_map['map']['center'] if 'center' in config_map['map'] else settings.DEFAULT_MAP_CENTER
+        zoom = config_map['map']['zoom'] if 'zoom' in config_map['map'] else settings.DEFAULT_MAP_ZOOM
+        projection = config_map['map']['projection']
+
+        self.assertEqual(map_obj.title, title)
+        self.assertEqual(map_obj.abstract, abstract)
+        self.assertEqual(map_obj.center_x, center['x'] if isinstance(center, dict) else center[0])
+        self.assertEqual(map_obj.center_y, center['y'] if isinstance(center, dict) else center[1])
+        self.assertEqual(map_obj.zoom, zoom)
+        self.assertEqual(map_obj.projection, projection)
+
+        for map_layer in map_obj.layers:
+            if Layer.objects.filter(alternate=map_layer.name).exists():
+                cfg = map_layer.layer_config()
+                self.assertIsNotNone(cfg["getFeatureInfo"])
 
     @dump_func_name
     def test_new_map_config(self):

--- a/geonode/utils.py
+++ b/geonode/utils.py
@@ -435,8 +435,8 @@ def layer_from_viewer_config(map_id, model, layer, source, ordering, save_map=Tr
     ``save_map`` if map should be saved (default: True)
     """
     layer_cfg = dict(layer)
-    for k in ["format", "store", "name", "opacity", "styles", "transparent",
-              "fixed", "group", "visibility", "source", "getFeatureInfo"]:
+    for k in ["format", "name", "opacity", "styles", "transparent",
+              "fixed", "group", "visibility", "source"]:
         if k in layer_cfg:
             del layer_cfg[k]
     layer_cfg["id"] = 1
@@ -952,7 +952,7 @@ def json_response(body=None, errors=None, url=None, redirect_to=None, exception=
     if content_type is None:
         content_type = "application/json"
     if errors:
-        if isinstance(errors, str):
+        if isinstance(errors, six.string_types):
             errors = [errors]
         body = {
             'success': False,
@@ -985,7 +985,7 @@ def json_response(body=None, errors=None, url=None, redirect_to=None, exception=
     if status is None:
         status = 200
 
-    if not isinstance(body, str):
+    if not isinstance(body, six.string_types):
         body = json.dumps(body, cls=DjangoJSONEncoder)
     return HttpResponse(body, content_type=content_type, status=status)
 
@@ -1400,7 +1400,7 @@ class HttpClient(object):
         check_ogc_backend(geoserver.BACKEND_PACKAGE) and 'Authorization' not in headers:
             if connection.cursor().db.vendor not in ('sqlite', 'sqlite3', 'spatialite'):
                 try:
-                    if user and isinstance(user, str):
+                    if user and isinstance(user, six.string_types):
                         user = get_user_model().objects.get(username=user)
                     _u = user or get_user_model().objects.get(username=self.username)
                     access_token = get_or_create_token(_u)

--- a/scripts/spcgeonode/django/Dockerfile
+++ b/scripts/spcgeonode/django/Dockerfile
@@ -44,7 +44,7 @@ RUN pip install pygdal==$(gdal-config --version).*
 RUN mkdir /spcgeonode
 WORKDIR /spcgeonode/
 ADD . /spcgeonode/
-RUN pip install -e .
+RUN pip install -e . --upgrade
 RUN chmod +x scripts/spcgeonode/django/docker-entrypoint.sh
 
 # Export ports


### PR DESCRIPTION
 - Fixes #5429 : Layer feature info templates are not used inside maps

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there are explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
