### PR TITLE
Backport 5474 to 2.10.x

### DIFF
--- a/docs/install/core/index.rst
+++ b/docs/install/core/index.rst
@@ -304,9 +304,9 @@ We will also perform several optimizations to:
     OpenJDK 64-Bit Server VM (build 25.212-b03, mixed mode)
 
   # Install Apache Tomcat 8
-  sudo wget http://www-us.apache.org/dist/tomcat/tomcat-8/v8.5.47/bin/apache-tomcat-8.5.47.tar.gz
-  sudo tar xzf apache-tomcat-8.5.47.tar.gz
-  sudo mv apache-tomcat-8.5.47 /usr/local/apache-tomcat8
+  sudo wget http://www-us.apache.org/dist/tomcat/tomcat-8/v8.5.50/bin/apache-tomcat-8.5.50.tar.gz
+  sudo tar xzf apache-tomcat-8.5.50.tar.gz
+  sudo mv apache-tomcat-8.5.50 /usr/local/apache-tomcat8
   sudo useradd -m -U -s /bin/false tomcat
   sudo usermod -a -G www-data tomcat
   sudo sed -i -e 's/xom-\*\.jar/xom-\*\.jar,bcprov\*\.jar/g' /usr/local/apache-tomcat8/conf/catalina.properties

--- a/geonode/layers/templates/layers/layer_detail.html
+++ b/geonode/layers/templates/layers/layer_detail.html
@@ -35,7 +35,13 @@
 <div class="page-header">
     <style>
     #paneltbar {
-        margin-top: 1px !important;
+      margin-top: 1px !important;
+    }
+
+    .msgapi #mapstore-print-panel.modal-dialog {
+      height: 400px;
+      width: 100%;
+      position: absolute;
     }
     </style>
 

--- a/geonode/maps/templates/maps/map_detail.html
+++ b/geonode/maps/templates/maps/map_detail.html
@@ -31,7 +31,13 @@
 <div class="page-header">
     <style>
     #paneltbar {
-        margin-top: 1px !important;
+      margin-top: 1px !important;
+    }
+
+    .msgapi #mapstore-print-panel.modal-dialog {
+      height: 400px;
+      width: 100%;
+      position: absolute;
     }
     </style>
 


### PR DESCRIPTION
The backport to `2.10.x` failed:
```
The process 'git' failed with exit code 128
```
To backport manually, run these commands in your terminal:
```bash
# Fetch latest updates from GitHub
git fetch
# Create a new working tree
git worktree add .worktrees/backport-2.10.x 2.10.x
# Navigate to the new working tree
cd .worktrees/backport-2.10.x
# Create a new branch
git switch --create backport-5474-to-2.10.x
# Cherry-pick the merged commit of this pull request and resolve the conflicts
git cherry-pick eac2b2cd0e07472f3ec58e05d9c7fff638986101
# Push it to GitHub
git push --set-upstream origin backport-5474-to-2.10.x
# Go back to the original working tree
cd ../..
# Delete the working tree
git worktree remove .worktrees/backport-2.10.x
```
Then, create a pull request where the `base` branch is `2.10.x` and the `compare`/`head` branch is `backport-5474-to-2.10.x`.