### PR TITLE
[Backport to 2.10.x][Fixes #5416] LIKE filter on layer download tab doesn't let setting a pattern value

### DIFF
--- a/geonode/layers/templates/layers/layer_detail.html
+++ b/geonode/layers/templates/layers/layer_detail.html
@@ -379,7 +379,7 @@
                                   </div>
                                 </div>
                               </div>
-                              <input type="text" class="form-control js-data-array" style="position:static;" id="single_value" placeholder="" data-toggle="tooltip" title="">
+                              <select class="form-control js-data-array" style="position:static;" id="single_value" placeholder="" data-toggle="tooltip" title=""></select>
                               <div class="input-group-btn" id="button_query">
                                 <a href="#" id="query_part" class="btn btn-primary btn-mg" data-toggle="modal" data-target="#myModal" title=""><span class="glyphicon glyphicon-plus"></span></a>
                               </div>
@@ -881,11 +881,15 @@
             } else {
               $( "p" ).remove( "#wrong-data-type" );
               // check of single_value_input; string or number
-              if (isNaN(single_value_input)){
-                let checkArr = ["=", "<>", ">", "<", ">=", "<="];
-                if (checkArr.includes(operator_list)) {
+              let checkArr = ["=", "<>", ">", "<", ">=", "<="];
+              if (checkArr.includes(operator_list)) {
+                if (isNaN(single_value_input)){
                   single_value_input = "'" + single_value_input + "'";
-                } else if (operator_list == " LIKE ") {
+                }
+              } else if (operator_list == " LIKE ") {
+                if(single_value_input.indexOf('%') >= 0) {
+                  single_value_input = "'" + single_value_input.replace(/%/g, '%25') + "'";
+                } else {
                   single_value_input = "'%25" + single_value_input + "%25'";
                 }
               }
@@ -929,7 +933,7 @@
         }
         idValue = $(this).attr("id");
 
-        if (typeof all_urls !== 'undefined') {
+        if (idValue !== "original-dataset" && typeof all_urls !== 'undefined') {
             url_main = all_urls[idValue]
           if(cql_filters.length >1) {
             addressValue = url_main + complete_cql
@@ -971,29 +975,21 @@
 
                   // functionality added for the autocomplete
                   property_name = $("#modal-button-attributes:first-child").text();
-
                   attribute_values = data['feature_properties'];
                   selected_data = attribute_values[$.trim(property_name)];
-
                   selected_data_prepare = [];
                   for (i = 0; i < selected_data.length; i++) {
-                    jsonString = {
+                    var jsonString = {
                       id: i,
                       text: selected_data[i].toString()
                     };
-                    selected_data_val = jsonString;
-                    selected_data_prepare.push(selected_data_val);
+                    selected_data_prepare.push(jsonString);
                   }
+
                   $(".js-data-array").select2({
                     data: selected_data_prepare,
                     // allow new values by the user
-                    createSearchChoice:function(term, data) {
-                      if ($(data).filter( function() {
-                        return this.text.localeCompare(term)===0;
-                      }).length===0) {
-                        return {id:term, text:term};
-                      }
-                    },
+                    tags: true
                   })
                 });
                 ajax_loaded = true;


### PR DESCRIPTION
[Fixes #5416] LIKE filter on layer download tab doesn't let setting a pattern value

The backport to `2.10.x` failed:
```
The process 'git' failed with exit code 128
```
To backport manually, run these commands in your terminal:
```bash
# Fetch latest updates from GitHub
git fetch
# Create a new working tree
git worktree add .worktrees/backport-2.10.x 2.10.x
# Navigate to the new working tree
cd .worktrees/backport-2.10.x
# Create a new branch
git switch --create backport-5417-to-2.10.x
# Cherry-pick the merged commit of this pull request and resolve the conflicts
git cherry-pick 46fdb0661ff74322da39932b904816d800cc7518
# Push it to GitHub
git push --set-upstream origin backport-5417-to-2.10.x
# Go back to the original working tree
cd ../..
# Delete the working tree
git worktree remove .worktrees/backport-2.10.x
```
Then, create a pull request where the `base` branch is `2.10.x` and the `compare`/`head` branch is `backport-5417-to-2.10.x`.