### PR TITLE
Merge pull request #5490 from GeoNode/dependabot/pip/django-mapstore-adapter-1.0.16

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -72,7 +72,7 @@ geonode-oauth-toolkit==1.1.4.6
 
 # GeoNode org maintained apps.
 django-geoexplorer==4.0.43
-django-mapstore-adapter==1.0.15
+django-mapstore-adapter==1.0.16
 django-geonode-mapstore-client==1.4.8
 django-geonode-client==1.0.9
 geonode-user-messages==0.1.14


### PR DESCRIPTION
Bump django-mapstore-adapter from 1.0.15 to 1.0.16

The backport to 2.10.x failed:

The process 'git' failed with exit code 128
To backport manually, run these commands in your terminal:

# Fetch latest updates from GitHub
git fetch
# Create a new working tree
git worktree add .worktrees/backport-2.10.x 2.10.x
# Navigate to the new working tree
cd .worktrees/backport-2.10.x
# Create a new branch
git switch --create backport-5490-to-2.10.x
# Cherry-pick the merged commit of this pull request and resolve the conflicts
git cherry-pick ed21f274e2aa5c1860eb5f8cf94afb661d48b4de
# Push it to GitHub
git push --set-upstream origin backport-5490-to-2.10.x
# Go back to the original working tree
cd ../..
# Delete the working tree
git worktree remove .worktrees/backport-2.10.x
Then, create a pull request where the base branch is 2.10.x and the compare/head branch is backport-5490-to-2.10.x.
