### PR TITLE
[Fixes #5486] "resolve_object" get confused when present a remote layer with alternate similar to the local one

### DIFF
--- a/geonode/layers/tests.py
+++ b/geonode/layers/tests.py
@@ -61,6 +61,7 @@ from geonode.tests.utils import NotificationsTestsHelper
 from geonode.layers.populate_layers_data import create_layer_data
 from geonode.layers import utils
 from geonode.utils import designals
+from geonode.layers.views import _resolve_layer
 
 logger = logging.getLogger(__name__)
 
@@ -121,6 +122,28 @@ class LayersTest(GeoNodeBaseTestSupport):
         lyr.save()
 
     # Layer Tests
+
+    def test_layer_name_clash(self):
+        _ll_1 = Layer.objects.create(
+            name='states',
+            store='geonode_data',
+            storeType="dataStore",
+            alternate="geonode:states"
+        )
+        _ll_2 = Layer.objects.create(
+            name='geonode:states',
+            store='httpfooremoteservce',
+            storeType="remoteStore",
+            alternate="geonode:states"
+        )
+        _ll_1.set_permissions({'users': {"bobby": ['base.view_resourcebase']}})
+        _ll_2.set_permissions({'users': {"bobby": ['base.view_resourcebase']}})
+        self.client.login(username="bobby", password="bob")
+        _request = self.client.request()
+        _request.user = get_user_model().objects.get(username="bobby")
+        _ll = _resolve_layer(_request, alternate="geonode:states")
+        self.assertIsNotNone(_ll)
+        self.assertEqual(_ll.name, _ll_1.name)
 
     # Test layer upload endpoint
     def test_upload_layer(self):
@@ -537,7 +560,6 @@ class LayersTest(GeoNodeBaseTestSupport):
         self.assertRaises(GeoNodeException, lambda: layer_type('foo.gml'))
 
     def test_get_files(self):
-
         def generate_files(*extensions):
             if extensions[0].lower() != 'shp':
                 return

--- a/geonode/layers/utils.py
+++ b/geonode/layers/utils.py
@@ -1112,17 +1112,18 @@ def create_gs_thumbnail_geonode(instance, overwrite=False, check_bbox=False):
         for layer in instance.layers:
             if layer.local:
                 # Compute Bounds
-                if layer.store:
+                _l = None
+                if layer.store and Layer.objects.filter(store=layer.store, name=layer.name).count() > 0:
                     _l = Layer.objects.get(
                         store=layer.store,
-                        alternate=layer.name)
-                else:
-                    _l = Layer.objects.get(
-                        alternate=layer.name)
-                wgs84_bbox = bbox_to_projection(_l.bbox)
-                local_bboxes.append(wgs84_bbox)
-                if _l.storeType != "remoteStore":
-                    local_layers.append(_l.alternate)
+                        name=layer.name)
+                elif Layer.objects.filter(name=layer.name).count() > 0:
+                    _l = Layer.objects.get(name=layer.name)
+                if _l:
+                    wgs84_bbox = bbox_to_projection(_l.bbox)
+                    local_bboxes.append(wgs84_bbox)
+                    if _l.storeType != "remoteStore":
+                        local_layers.append(_l.alternate)
         layers = ",".join(local_layers).encode('utf-8')
     else:
         # Compute Bounds

--- a/geonode/layers/views.py
+++ b/geonode/layers/views.py
@@ -161,12 +161,13 @@ def _resolve_layer(request, alternate, permission='base.view_resourcebase',
     """
     service_typename = alternate.split(":", 1)
     if Service.objects.filter(name=service_typename[0]).exists():
-        # service = Service.objects.filter(name=service_typename[0])
         query = {
             'alternate': service_typename[1]
         }
         if len(service_typename) > 1:
             query['store'] = service_typename[0]
+        else:
+            query['storeType'] = 'remoteStore'
         return resolve_object(
             request,
             Layer,
@@ -187,6 +188,11 @@ def _resolve_layer(request, alternate, permission='base.view_resourcebase',
                 }
         else:
             query = {'alternate': alternate}
+        test_query = Layer.objects.filter(**query)
+        if test_query.count() > 1 and test_query.exclude(storeType='remoteStore').count() == 1:
+            query = {
+                'id': test_query.exclude(storeType='remoteStore').first().id
+            }
         return resolve_object(request,
                               Layer,
                               query,


### PR DESCRIPTION

- [Fixes #5486] "resolve_object" get confused when present a remote layer with alternate similar to the local one

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there are explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
