### PR TITLE
[Backport 2.10.x][Fixes #5486] "resolve_object" get confused when present a remote lay…

### DIFF
--- a/geonode/layers/utils.py
+++ b/geonode/layers/utils.py
@@ -1107,17 +1107,18 @@ def create_gs_thumbnail_geonode(instance, overwrite=False, check_bbox=False):
         for layer in instance.layers:
             if layer.local:
                 # Compute Bounds
-                if layer.store:
+                _l = None
+                if layer.store and Layer.objects.filter(store=layer.store, name=layer.name).count() > 0:
                     _l = Layer.objects.get(
                         store=layer.store,
-                        alternate=layer.name)
-                else:
-                    _l = Layer.objects.get(
-                        alternate=layer.name)
-                wgs84_bbox = bbox_to_projection(_l.bbox)
-                local_bboxes.append(wgs84_bbox)
-                if _l.storeType != "remoteStore":
-                    local_layers.append(_l.alternate)
+                        name=layer.name)
+                elif Layer.objects.filter(name=layer.name).count() > 0:
+                    _l = Layer.objects.get(name=layer.name)
+                if _l:
+                    wgs84_bbox = bbox_to_projection(_l.bbox)
+                    local_bboxes.append(wgs84_bbox)
+                    if _l.storeType != "remoteStore":
+                        local_layers.append(_l.alternate)
         layers = ",".join(local_layers).encode('utf-8')
     else:
         # Compute Bounds

--- a/geonode/layers/views.py
+++ b/geonode/layers/views.py
@@ -153,12 +153,13 @@ def _resolve_layer(request, alternate, permission='base.view_resourcebase',
     """
     service_typename = alternate.split(":", 1)
     if Service.objects.filter(name=service_typename[0]).exists():
-        # service = Service.objects.filter(name=service_typename[0])
         query = {
             'alternate': service_typename[1]
         }
         if len(service_typename) > 1:
             query['store'] = service_typename[0]
+        else:
+            query['storeType'] = 'remoteStore'
         return resolve_object(
             request,
             Layer,
@@ -179,6 +180,11 @@ def _resolve_layer(request, alternate, permission='base.view_resourcebase',
                 }
         else:
             query = {'alternate': alternate}
+        test_query = Layer.objects.filter(**query)
+        if test_query.count() > 1 and test_query.exclude(storeType='remoteStore').count() == 1:
+            query = {
+                'id': test_query.exclude(storeType='remoteStore').first().id
+            }
         return resolve_object(request,
                               Layer,
                               query,


### PR DESCRIPTION
…er with alternate similar to the local one

(cherry picked from commit b9f0b196278d22f0616ab0418721fd763c1c6a75)

The backport to `2.10.x` failed:
```
The process 'git' failed with exit code 128
```
To backport manually, run these commands in your terminal:
```bash
# Fetch latest updates from GitHub
git fetch
# Create a new working tree
git worktree add .worktrees/backport-2.10.x 2.10.x
# Navigate to the new working tree
cd .worktrees/backport-2.10.x
# Create a new branch
git switch --create backport-5492-to-2.10.x
# Cherry-pick the merged commit of this pull request and resolve the conflicts
git cherry-pick be113336e240ca999020ec4acf7fdb165b609a8d
# Push it to GitHub
git push --set-upstream origin backport-5492-to-2.10.x
# Go back to the original working tree
cd ../..
# Delete the working tree
git worktree remove .worktrees/backport-2.10.x
```
Then, create a pull request where the `base` branch is `2.10.x` and the `compare`/`head` branch is `backport-5492-to-2.10.x`.
