### PR TITLE
[Backport 2.10.x][Fixes #5497] W*S on QGis not authenticating

### DIFF
--- a/geonode/geoserver/tests/test_helpers.py
+++ b/geonode/geoserver/tests/test_helpers.py
@@ -20,6 +20,7 @@
 from geonode.tests.base import GeoNodeBaseTestSupport
 
 import os
+import re
 import gisdata
 
 from geonode import geoserver
@@ -28,6 +29,8 @@ from geonode.decorators import on_ogc_backend
 from geonode.layers.models import Layer
 from geonode.layers.utils import file_upload
 from geonode.layers.populate_layers_data import create_layer_data
+
+from geonode.geoserver.views import _response_callback
 
 import logging
 logger = logging.getLogger(__name__)
@@ -82,3 +85,112 @@ class HelperTest(GeoNodeBaseTestSupport):
         replaced = file_upload(filename, layer=vector_layer, overwrite=True, gtype='LineString')
         self.assertIsNotNone(replaced)
         self.assertTrue(replaced.is_vector())
+
+    @on_ogc_backend(geoserver.BACKEND_PACKAGE)
+    def test_replace_callback(self):
+        content = """<Layer>
+      <Title>GeoNode Local GeoServer</Title>
+      <Abstract>This is a description of your Web Map Server.</Abstract>
+      <!--Limited list of EPSG projections:-->
+      <CRS>EPSG:4326</CRS>
+      <CRS>EPSG:3785</CRS>
+      <CRS>EPSG:3857</CRS>
+      <CRS>EPSG:900913</CRS>
+      <CRS>EPSG:32647</CRS>
+      <CRS>EPSG:32736</CRS>
+      <CRS>CRS:84</CRS>
+      <EX_GeographicBoundingBox>
+        <westBoundLongitude>-124.731422</westBoundLongitude>
+        <eastBoundLongitude>12.512771464573753</eastBoundLongitude>
+        <southBoundLatitude>12.4801497</southBoundLatitude>
+        <northBoundLatitude>49.371735</northBoundLatitude>
+      </EX_GeographicBoundingBox>
+      <BoundingBox CRS="CRS:84" ..../>
+      <BoundingBox CRS="EPSG:4326" ..../>
+      <BoundingBox CRS="EPSG:3785" ..../>
+      <BoundingBox CRS="EPSG:3857" ..../>
+      <BoundingBox CRS="EPSG:900913" ..../>
+      <BoundingBox CRS="EPSG:32647" ..../>
+      <BoundingBox CRS="EPSG:32736" ..../>
+      <Layer queryable="1" opaque="0">
+        <Name>geonode:DE_USNG_UTM18</Name>
+        <Title>DE_USNG_UTM18</Title>
+        <Abstract>No abstract provided</Abstract>
+        <KeywordList>
+          <Keyword>DE_USNG_UTM18</Keyword>
+          <Keyword>features</Keyword>
+        </KeywordList>
+        <CRS>EPSG:26918</CRS>
+        <CRS>CRS:84</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-75.93570725669369</westBoundLongitude>
+          <eastBoundLongitude>-75.00000000000001</eastBoundLongitude>
+          <southBoundLatitude>38.3856300861002</southBoundLatitude>
+          <northBoundLatitude>39.89406880610797</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84" .01" maxy="39.89406880610797"/>
+        <BoundingBox CRS="EPSG:26918" ..../>
+        <BoundingBox CRS="EPSG:4326" ..../>
+        <BoundingBox CRS="EPSG:3785" ..../>
+        <BoundingBox CRS="EPSG:3857" ..../>
+        <BoundingBox CRS="EPSG:900913" ..../>
+        <BoundingBox CRS="EPSG:32647" ..../>
+        <BoundingBox CRS="EPSG:32736" ..../>
+        <MetadataURL type="other">
+          <Format>other</Format>
+          <OnlineResource xlink:type="simple"
+xlink:href="http://localhost:8080/catalogue/csw?outputschema=...."/>
+        </MetadataURL>
+        <MetadataURL type="other">
+          <Format>other</Format>
+          <OnlineResource xlink:type="simple"
+xlink:href="http://localhost:8080/catalogue/csw?outputschema=...."/>
+        </MetadataURL>
+        <MetadataURL type="other">
+          <Format>other</Format>
+          <OnlineResource xlink:type="simple"
+xlink:href="http://localhost:8080/catalogue/csw?outputschema=...."/>
+        </MetadataURL>
+        <MetadataURL type="other">
+          <Format>other</Format>
+          <OnlineResource xlink:type="simple"
+xlink:href="http://localhost:8080/catalogue/csw?outputschema=...."/>
+        </MetadataURL>
+        <MetadataURL type="FGDC">
+          <Format>text/xml</Format>
+          <OnlineResource xlink:type="simple"
+xlink:href="http://localhost:8080/catalogue/csw?outputschema=...."/>
+        </MetadataURL>
+        <MetadataURL type="other">
+          <Format>other</Format>
+          <OnlineResource xlink:type="simple"
+xlink:href="http://localhost:8080/catalogue/csw?outputschema=...."/>
+        </MetadataURL>
+        <MetadataURL type="other">
+          <Format>other</Format>
+          <OnlineResource xlink:type="simple"
+xlink:href="http://localhost:8080/showmetadata/xsl/584"/>
+        </MetadataURL>
+        <Style>
+          <Name>geonode:DE_USNG_UTM18</Name>
+          <Title>Default Polygon</Title>
+          <Abstract>A sample style that draws a polygon</Abstract>
+          <LegendURL width="20" height="20">
+            <Format>image/png</Format>
+            <OnlineResource
+xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple"
+xlink:href="http://localhost:8080/geoserver/ows?service=WMS&amp;request=GetLegendGraphic&...."/>
+          </LegendURL>
+        </Style>
+      </Layer>"""
+        kwargs = {'content': content,
+                  'status': 200,
+                  'content_type': 'application/xml'}
+        _content = _response_callback(**kwargs)
+        self.assertTrue(re.findall('http://localhost:8000/gs/ows', str(_content)))
+
+        kwargs = {'content': content,
+                  'status': 200,
+                  'content_type': 'text/xml; charset=UTF-8'}
+        _content = _response_callback(**kwargs)
+        self.assertTrue(re.findall('http://localhost:8000/gs/ows', str(_content)))

--- a/geonode/geoserver/views.py
+++ b/geonode/geoserver/views.py
@@ -539,7 +539,8 @@ def _response_callback(**kwargs):
     content_type = kwargs['content_type']
 
     # Replace Proxy URL
-    if content_type in ('application/xml', 'text/xml', 'text/plain', 'application/json', 'text/json'):
+    content_type_list = ['application/xml', 'text/xml', 'text/plain', 'application/json', 'text/json']
+    if re.findall(r"(?=(\b" + '|'.join(content_type_list) + r"\b))", content_type):
         _gn_proxy_url = urljoin(settings.SITEURL, '/gs/')
         content = content\
             .replace(ogc_server_settings.LOCATION, _gn_proxy_url)\


### PR DESCRIPTION
The backport to 2.10.x failed:

The process 'git' failed with exit code 128
To backport manually, run these commands in your terminal:

# Fetch latest updates from GitHub
git fetch
# Create a new working tree
git worktree add .worktrees/backport-2.10.x 2.10.x
# Navigate to the new working tree
cd .worktrees/backport-2.10.x
# Create a new branch
git switch --create backport-5498-to-2.10.x
# Cherry-pick the merged commit of this pull request and resolve the conflicts
git cherry-pick 1d4b03759c9990993c2fd0a0a6ac2d81f0474422
# Push it to GitHub
git push --set-upstream origin backport-5498-to-2.10.x
# Go back to the original working tree
cd ../..
# Delete the working tree
git worktree remove .worktrees/backport-2.10.x
Then, create a pull request where the base branch is 2.10.x and the compare/head branch is backport-5498-to-2.10.x.