### PR TITLE
[Issue #5520] Change assertTrue to assertEqual to verify response content type value.

### DIFF
--- a/geonode/security/tests.py
+++ b/geonode/security/tests.py
@@ -707,7 +707,7 @@ class BulkPermissionsTests(ResourceTestCaseMixin, GeoNodeBaseTestSupport):
             # test view_resourcebase permission on anonymous user
             request = Request(url)
             response = urlopen(request)
-            self.assertTrue(
+            self.assertEqual(
                 response.info().getheader('Content-Type'),
                 'application/vnd.ogc.se_xml;charset=UTF-8'
             )
@@ -719,7 +719,7 @@ class BulkPermissionsTests(ResourceTestCaseMixin, GeoNodeBaseTestSupport):
                 '%s:%s' % ('bobby', 'bob')).replace('\n', '')
             request.add_header("Authorization", "Basic %s" % base64string)
             response = urlopen(request)
-            self.assertTrue(
+            self.assertEqual(
                 response.info().getheader('Content-Type'),
                 'application/vnd.ogc.se_xml;charset=UTF-8'
             )
@@ -732,7 +732,7 @@ class BulkPermissionsTests(ResourceTestCaseMixin, GeoNodeBaseTestSupport):
                 '%s:%s' % ('bobby', 'bob')).replace('\n', '')
             request.add_header("Authorization", "Basic %s" % base64string)
             response = urlopen(request)
-            self.assertTrue(response.info().getheader('Content-Type'), 'image/png')
+            self.assertEqual(response.info().getheader('Content-Type'), 'image/png')
 
             # test change_layer_data
             # would be nice to make a WFS/T request and test results, but this


### PR DESCRIPTION
Changing the assertTrue statements to assertEqual for the layer permissions test to correctly assert the value of the response 'Content-Type'. 

This will cause the tests to fail due to the underlying error in the response. See Issue #5520

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [X] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [X] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [X] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [X] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [X] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there are explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [X] This PR passes the QA checks: flake8 geonode
- [X] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
