### PR TITLE
Fix mixed content when logged in

### DIFF
--- a/docs/install/core/index.rst
+++ b/docs/install/core/index.rst
@@ -954,9 +954,10 @@ Install and enable HTTPS secured connection through the Let's Encrypt provider
     # Change everywhere 'http' to 'https'
     %s/http/https/g
 
-    # Add two more 'env' variables to the configuration
+    # Add three more 'env' variables to the configuration
     env = SECURE_SSL_REDIRECT=True
     env = SECURE_HSTS_INCLUDE_SUBDOMAINS=True
+    env = AVATAR_GRAVATAR_SSL=True
 
     # Restart the service
     sudo service uwsgi restart


### PR DESCRIPTION
Following the instructions for the first time install a warning stating `mixed content` appeared.
Finally found out it was related to Gravatar because an environment variable was missing in the setup.
This PR adds it to the documentation so nobody will see the same error.

## Checklist

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
