### PR TITLE
[Fixes #5577] Vector layer does NOT have geometry or any attributes

### DIFF
--- a/geonode/geoserver/helpers.py
+++ b/geonode/geoserver/helpers.py
@@ -990,7 +990,7 @@ def set_attributes_from_geoserver(layer, overwrite=False):
         try:
             # The code below will fail if http_client cannot be imported or WFS not supported
             req, body = http_client.get(dft_url, user=_user)
-            doc = dlxml.fromstring(body)
+            doc = dlxml.fromstring(body.encode())
             path = ".//{xsd}extension/{xsd}sequence/{xsd}element".format(
                 xsd="{http://www.w3.org/2001/XMLSchema}")
             attribute_map = [[n.attrib["name"], n.attrib["type"]] for n in doc.findall(
@@ -1038,7 +1038,7 @@ def set_attributes_from_geoserver(layer, overwrite=False):
         })
         try:
             req, body = http_client.get(dc_url, user=_user)
-            doc = dlxml.fromstring(body)
+            doc = dlxml.fromstring(body.encode())
             path = ".//{wcs}Axis/{wcs}AvailableKeys/{wcs}Key".format(
                 wcs="{http://www.opengis.net/wcs/1.1.1}")
             attribute_map = [[n.text, "raster"] for n in doc.findall(path)]
@@ -1652,7 +1652,7 @@ def wps_execute_layer_attribute_statistics(layer_name, field):
         timeout=5,
         retries=1)
 
-    exml = dlxml.fromstring(content)
+    exml = dlxml.fromstring(content.encode())
 
     result = {}
 

--- a/geonode/layers/utils.py
+++ b/geonode/layers/utils.py
@@ -528,7 +528,7 @@ def file_upload(filename,
                     lyr = inDataSource.GetLayer(str(layer.name))
                     if not lyr:
                         raise Exception(
-                            _("You are attempting to replace a vector layer with an incompatible source."))
+                            _("Please ensure the name is consistent with the file you are trying to replace."))
                     schema_is_compliant = False
                     _ff = json.loads(lyr.GetFeature(0).ExportToJson())
                     if not gtype:
@@ -538,7 +538,8 @@ def file_upload(filename,
                         schema_is_compliant = True
                     elif not schema_is_compliant:
                         raise Exception(
-                            _("You are attempting to replace a vector layer with an incompatible schema."))
+                            _("Please ensure there is at least one geometry type \
+                                that is consistent with the file you are trying to replace."))
                 except BaseException as e:
                     raise Exception(
                         _("Some error occurred while trying to access the uploaded schema: %s" % str(e)))


### PR DESCRIPTION
<Include a few sentences describing the overall goals for this Pull Request>
Fix #5577. 

The `lxml.fromstring()` function is unable to parse XML documents with an encoding defined within the actual document and raises a 

` ValueError: Unicode strings with encoding declaration are not supported. Please use bytes input or XML fragments without declaration`

The correct way to parse those XML documents is to load them as a bytes objects, which this PR implements. 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there are explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
