### PR TITLE
[Fixes #5587] Set permissions for current user when DEFAULT_ANONYMOUS…

### DIFF
--- a/geonode/templates/_permissions_form_js.html
+++ b/geonode/templates/_permissions_form_js.html
@@ -237,6 +237,14 @@
         Utils.Extend(UsersAjaxAdapter, AjaxAdapter);
 
         var initialValues = [];
+        
+        // In case resources are private we add the current user
+        {% if DEFAULT_ANONYMOUS_VIEW_PERMISSION is False %}
+            {% if request.resolver_match.url_name  == 'layer_upload' or request.resolver_match.url_name  == 'document_upload' %}
+                var initialValues = [{name: "{{request.user}}", id:"{{request.user}}"}];
+            {% endif %}
+        {% endif %}
+        
         $(default_perms).each(function (index, perm) {
             initialValues.push({ id: perm, name: perm });
         });


### PR DESCRIPTION
This is a tiny but annoying problem. When we set DEFAULT_ANONYMOUS_VIEW_PERMISSION to False and some user does not add himself to the view select the layer will be broken. This small fix 

- adds the current user in case DEFAULT_ANONYMOUS_VIEW_PERMISSION is False
- we're on the layer or document upload page.

<img width="417" alt="Bildschirmfoto 2020-02-01 um 15 35 47" src="https://user-images.githubusercontent.com/20478652/73593846-8b755980-4508-11ea-9898-ef4a4e0396f9.png">

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there are explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

