### PR TITLE
Add import path for pip 20.0+, retain backup hack pip session in case…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,11 +20,20 @@
 
 try:  # for pip >= 10
     from pip._internal.req import parse_requirements
-    pip_session = 'hack'
+    try:
+        from pip._internal.download import PipSession
+        pip_session = PipSession()
+    except ImportError:  # for pip >= 20
+        from pip._internal.network.session import PipSession
+        pip_session = PipSession()
 except ImportError:  # for pip <= 9.0.3
-    from pip.req import parse_requirements
-    from pip.download import PipSession
-    pip_session = PipSession()
+    try:
+        from pip.req import parse_requirements
+        from pip.download import PipSession
+        pip_session = PipSession()
+    except ImportError:  # backup in case of further pip changes
+        pip_session = 'hack'
+
 from distutils.core import setup
 
 from setuptools import find_packages


### PR DESCRIPTION
… of future changes

A quick fix on top of https://github.com/GeoNode/geonode/commit/3b5155e8896466b432686e6946675b356046920b

Add new import path for pip 20.0+, but retain the `pip_session` backup hack in case of future regressions.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there are explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [x] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
