### PR TITLE
[Fixes #5520] Change assertTrue to assertEqual to verify response content type value.

### DIFF
--- a/geonode/documents/renderers.py
+++ b/geonode/documents/renderers.py
@@ -119,5 +119,5 @@ def generate_thumbnail_content(image_path, size=(200, 150)):
         content = output.getvalue()
         output.close()
         return content
-    except BaseException:
-        return None
+    except BaseException as e:
+        raise e

--- a/geonode/geoserver/helpers.py
+++ b/geonode/geoserver/helpers.py
@@ -1987,6 +1987,9 @@ def _render_thumbnail(req_body, width=240, height=200):
             retries=2,
             headers=headers,
             user=_user)
+        if not isinstance(content, bytes):
+            raise Exception(content)
+
         # Optimize the Thumbnail size and resolution
         from PIL import Image
         from io import BytesIO
@@ -2004,7 +2007,7 @@ def _render_thumbnail(req_body, width=240, height=200):
         content = imgByteArr.getvalue()
     except BaseException as e:
         logger.debug(e)
-        return
+        raise e
 
     return content
 
@@ -2026,11 +2029,13 @@ def _prepare_thumbnail_body_from_opts(request_body, request=None):
         if isinstance(request_body, string_types):
             try:
                 request_body = json.loads(request_body)
-            except BaseException:
+            except BaseException as e:
+                logger.debug(e)
                 try:
                     image = _render_thumbnail(
                         request_body, width=width, height=height)
-                except BaseException:
+                except BaseException as e:
+                    logger.debug(e)
                     image = None
 
         if image is not None:
@@ -2199,6 +2204,7 @@ def _prepare_thumbnail_body_from_opts(request_body, request=None):
         logger.warning('Error generating thumbnail')
         logger.exception(e)
         image = None
+        raise e
 
     return image
 

--- a/geonode/layers/views.py
+++ b/geonode/layers/views.py
@@ -1378,7 +1378,8 @@ def layer_thumbnail(request, layername):
     try:
         try:
             preview = json.loads(request.body).get('preview', None)
-        except BaseException:
+        except BaseException as e:
+            logger.debug(e)
             preview = None
 
         if preview and preview == 'react':
@@ -1390,7 +1391,8 @@ def layer_thumbnail(request, layername):
             try:
                 image = _prepare_thumbnail_body_from_opts(
                     request.body, request=request)
-            except BaseException:
+            except BaseException as e:
+                logger.debug(e)
                 image = _render_thumbnail(request.body)
 
         is_image = False
@@ -1411,9 +1413,9 @@ def layer_thumbnail(request, layername):
         layer_obj.save_thumbnail(filename, image)
 
         return HttpResponse('Thumbnail saved')
-    except BaseException:
+    except BaseException as e:
         return HttpResponse(
-            content='error saving thumbnail',
+            content='error saving thumbnail: %s' % str(e),
             status=500,
             content_type='text/plain'
         )

--- a/geonode/security/tests.py
+++ b/geonode/security/tests.py
@@ -779,7 +779,10 @@ class PermissionsTest(GeoNodeBaseTestSupport):
         request.add_header("Authorization", "Basic {}".format(basic_auth.decode("utf-8")))
         response = urlopen(request)
         _content_type = response.getheader('Content-Type').lower()
-        # self.assertEqual(_content_type, 'image/png')
+        self.assertEqual(
+            _content_type,
+            'application/vnd.ogc.se_xml;charset=utf-8'
+        )
 
         # test change_layer_style
         url = 'http://localhost:8080/geoserver/rest/workspaces/geonode/styles/san_andres_y_providencia_poi.xml'


### PR DESCRIPTION

- [Fixes #5520] Change assertTrue to assertEqual to verify response content type value.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there are explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
