### PR TITLE
[Fixes #5599] set_layers_permissions duplicate assignment

### DIFF
--- a/geonode/geoserver/helpers.py
+++ b/geonode/geoserver/helpers.py
@@ -1987,6 +1987,9 @@ def _render_thumbnail(req_body, width=240, height=200):
             retries=2,
             headers=headers,
             user=_user)
+        if not isinstance(content, bytes):
+            return None
+
         # Optimize the Thumbnail size and resolution
         from PIL import Image
         from io import BytesIO

--- a/geonode/layers/management/commands/set_layers_permissions.py
+++ b/geonode/layers/management/commands/set_layers_permissions.py
@@ -106,5 +106,10 @@ class Command(BaseCommand):
         groups_names = options.get('groups')
         delete_flag = options.get('delete_flag')
         set_layers_permissions(
-            permissions_name, resources_names, users_usernames, groups_names, delete_flag
+            permissions_name,
+            resources_names,
+            users_usernames,
+            groups_names,
+            delete_flag,
+            verbose=True
         )

--- a/geonode/layers/tests.py
+++ b/geonode/layers/tests.py
@@ -1238,11 +1238,6 @@ class SetLayersPermissions(GeoNodeBaseTestSupport):
         perm_spec = layer_after.get_all_level_info()
         for perm in utils.WRITE_PERMISSIONS:
             self.assertNotIn(perm, perm_spec["users"][self.user])
-            _c = 0
-            for _u in perm_spec["users"]:
-                if _u == self.user:
-                    _c += 1
-            self.assertEqual(_c, 0)
 
 
 class LayersUploaderTests(GeoNodeBaseTestSupport):

--- a/geonode/layers/tests.py
+++ b/geonode/layers/tests.py
@@ -1222,17 +1222,27 @@ class SetLayersPermissions(GeoNodeBaseTestSupport):
         layer = Layer.objects.all().first()
         perm_spec = layer.get_all_level_info()
         self.assertNotIn(self.user, perm_spec["users"])
-        utils.set_layers_permissions("write", None, [self.username], None, None)
+        utils.set_layers_permissions("write", None, [self.user], None, None)
         layer_after = Layer.objects.get(name=layer.name)
         perm_spec = layer_after.get_all_level_info()
         for perm in utils.WRITE_PERMISSIONS:
             self.assertIn(perm, perm_spec["users"][self.user])
+            _c = 0
+            for _u in perm_spec["users"]:
+                if _u == self.user:
+                    _c += 1
+            self.assertEqual(_c, 1)
         # Remove
-        utils.set_layers_permissions("write", None, [self.username], None, True)
+        utils.set_layers_permissions("write", None, [self.user], None, True)
         layer_after = Layer.objects.get(name=layer.name)
         perm_spec = layer_after.get_all_level_info()
         for perm in utils.WRITE_PERMISSIONS:
             self.assertNotIn(perm, perm_spec["users"][self.user])
+            _c = 0
+            for _u in perm_spec["users"]:
+                if _u == self.user:
+                    _c += 1
+            self.assertEqual(_c, 0)
 
 
 class LayersUploaderTests(GeoNodeBaseTestSupport):

--- a/geonode/security/models.py
+++ b/geonode/security/models.py
@@ -65,7 +65,6 @@ class PermissionLevelMixin(object):
     """
 
     def get_all_level_info(self):
-
         resource = self.get_self_resource()
         users = get_users_with_perms(resource)
         groups = get_groups_with_perms(resource,
@@ -101,10 +100,9 @@ class PermissionLevelMixin(object):
                         info['users'][user] = info['users'][user] + info_layer['users'][user]
                     else:
                         info['users'][user] = info_layer['users'][user]
-
                 for group in info_layer['groups']:
                     if group in info['groups']:
-                        info['groups'][group] = info['groups'][group] + info_layer['groups'][group]
+                        info['groups'][group] = list(dict.fromkeys(info['groups'][group] + info_layer['groups'][group]))
                     else:
                         info['groups'][group] = info_layer['groups'][group]
         except BaseException:


### PR DESCRIPTION
 - [Fixes #5599] set_layers_permissions duplicate assignment

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there are explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
