### PR TITLE
[Fixes #5646] Set skip_authorization for older setups

### DIFF
--- a/scripts/spcgeonode/django/initialize.py
+++ b/scripts/spcgeonode/django/initialize.py
@@ -91,8 +91,8 @@ app, created = Application.objects.get_or_create(
     name='GeoServer',
     client_type='confidential',
     authorization_grant_type='authorization-code',
-    skip_authorization=True
 )
+app.skip_authorization = True
 _host = os.getenv('HTTPS_HOST',"") if os.getenv('HTTPS_HOST',"") != "" else os.getenv('HTTP_HOST')
 _port = os.getenv('HTTPS_PORT') if os.getenv('HTTPS_HOST',"") != "" else os.getenv('HTTP_PORT')
 if _port and _port not in ("80", "443"):


### PR DESCRIPTION
This PR should avoid problems to users upgrading SPCGeoNode to newer GeoNode versions.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [X] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [X] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [X] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [X] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [X] The issue connected to the PR must have Labels and Milestone assigned
- [X] PR for bug fixes and small new features are presented as a single commit
- [X] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [X] New unit tests have been added covering the changes, unless there are explanation on why the tests are not necessary/implemented
- [X] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [X] This PR passes the QA checks: flake8 geonode
- [X] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**

flake8 fails, but not on the part of code being modifiied.