### PR TITLE
[FIXES #5639] Group membership is ignored for layer permissions

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -86,8 +86,8 @@ John Jediny (nepanode)
 Guillermo Solano (gsolat)
 Jorge Martinez (JorgeMartinezG)
 Wayner Barrios (waybarrios)
+Steffen Berger (sjohn-atenekom)
 @gioscarda
-@sjohn-atenekom
 @LiliGuimaraes
 @kikislater
 @mtnorthcott

--- a/geonode/groups/models.py
+++ b/geonode/groups/models.py
@@ -199,9 +199,7 @@ class GroupProfile(models.Model):
         if user == user.get_anonymous():
             raise ValueError("The invited user cannot be anonymous")
         member, created = GroupMember.objects.get_or_create(group=self, user=user, defaults=kwargs)
-        if created:
-            user.groups.add(self.group)
-        else:
+        if not created:
             logger.warning("The invited user \"{0}\" is already a member".format(user.username))
 
     def leave(self, user, **kwargs):
@@ -245,6 +243,15 @@ class GroupMember(models.Model):
         (MEMBER, _("Member")),
     ])
     joined = models.DateTimeField(default=now)
+
+    def save(self, *args, **kwargs):
+        # add django.contrib.auth.group to user
+        self.user.groups.add(self.group.group)
+        super(GroupMember, self).save(*args, **kwargs)
+
+    def delete(self, *args, **kwargs):
+        self.user.groups.remove(self.group.group)
+        super(GroupMember, self).delete(*args, **kwargs)
 
 
 def group_pre_delete(instance, sender, **kwargs):

--- a/geonode/groups/views.py
+++ b/geonode/groups/views.py
@@ -199,7 +199,6 @@ def group_member_remove(request, slug, username):
         return HttpResponseForbidden()
     else:
         GroupMember.objects.get(group=group, user=user).delete()
-        user.groups.remove(group.group)
         return redirect("group_detail", slug=group.slug)
 
 


### PR DESCRIPTION
THe change in this Pull Request makes sure that the membership is properly synchronized between GroupProfile and django.contrib.auth-groups. The logic of automatically adding a user to the django auth group, when he was added to a groupprofile was moved from the GroupProfile.join() to GroupMember.save(). The removal has been moved from groups.views.group_member_remove() to GroupMember.delete().
Now, it doesn't matter anymore if a user has been added to a groupprofile through the frontend or the django admin panel.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there are explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
