### PR TITLE
[Fixes #5682] Thumbnails broken for RemoteServices using a invalid WMS GetCapabilities request

### DIFF
--- a/geonode/base/models.py
+++ b/geonode/base/models.py
@@ -1207,6 +1207,13 @@ class ResourceBase(PolymorphicModel, PermissionLevelMixin, ItemBase):
     def save_thumbnail(self, filename, image):
         upload_path = os.path.join('thumbs/', filename)
         try:
+            # Check that the image is valid
+            from PIL import Image
+            from io import BytesIO
+            content_data = BytesIO(image)
+            im = Image.open(content_data)
+            im.verify()  # verify that it is, in fact an image
+
             for _thumb in glob.glob(storage.path('thumbs/%s*' % os.path.splitext(filename)[0])):
                 try:
                     os.remove(_thumb)

--- a/geonode/layers/utils.py
+++ b/geonode/layers/utils.py
@@ -1005,6 +1005,21 @@ def create_thumbnail(instance, thumbnail_remote_url, thumbnail_create_url=None,
 
             if ogc_client:
                 if check_ogc_backend(geoserver.BACKEND_PACKAGE):
+                    headers = {}
+                    if thumbnail_remote_url:
+                        try:
+                            resp, image = ogc_client.request(
+                                thumbnail_remote_url,
+                                headers=headers,
+                                timeout=600)
+                            if 'ServiceException' in image or \
+                                    resp.status_code < 200 or resp.status_code > 299:
+                                msg = 'Unable to obtain thumbnail: %s' % image
+                                logger.error(msg)
+                                # Replace error message with None.
+                                image = None
+                        except BaseException:
+                            image = None
                     if image is None:
                         request_body = {
                             'width': width,
@@ -1063,7 +1078,6 @@ def create_thumbnail(instance, thumbnail_remote_url, thumbnail_create_url=None,
                         for _p in params.keys():
                             if _p.lower() not in thumbnail_create_url.lower():
                                 thumbnail_create_url = thumbnail_create_url + '&%s=%s' % (str(_p), str(params[_p]))
-                        headers = {}
                         if check_ogc_backend(geoserver.BACKEND_PACKAGE):
                             _ogc_server_settings = settings.OGC_SERVER['default']
                             _user = _ogc_server_settings['USER'] if 'USER' in _ogc_server_settings else 'admin'
@@ -1081,7 +1095,6 @@ def create_thumbnail(instance, thumbnail_remote_url, thumbnail_create_url=None,
 
                             # Replace error message with None.
                             image = None
-
                     except BaseException as e:
                         logger.exception(e)
                         # Replace error message with None.
@@ -1092,6 +1105,7 @@ def create_thumbnail(instance, thumbnail_remote_url, thumbnail_create_url=None,
                 else:
                     msg = 'Unable to obtain thumbnail for: %s' % instance
                     logger.debug(msg)
+                    instance.save_thumbnail(thumbnail_name, image=None)
 
 
 # this is the original implementation of create_gs_thumbnail()

--- a/geonode/layers/utils.py
+++ b/geonode/layers/utils.py
@@ -965,8 +965,10 @@ def create_thumbnail(instance, thumbnail_remote_url, thumbnail_create_url=None,
     if overwrite or not _thumb_exists:
         BBOX_DIFFERENCE_THRESHOLD = 1e-5
 
+        is_remote = False
         if not thumbnail_create_url:
             thumbnail_create_url = thumbnail_remote_url
+            is_remote = True
 
         if check_bbox:
             # Check if the bbox is invalid
@@ -1006,7 +1008,7 @@ def create_thumbnail(instance, thumbnail_remote_url, thumbnail_create_url=None,
             if ogc_client:
                 if check_ogc_backend(geoserver.BACKEND_PACKAGE):
                     headers = {}
-                    if thumbnail_remote_url:
+                    if is_remote and thumbnail_remote_url:
                         try:
                             resp, image = ogc_client.request(
                                 thumbnail_remote_url,

--- a/geonode/services/serviceprocessors/arcgis.py
+++ b/geonode/services/serviceprocessors/arcgis.py
@@ -273,6 +273,7 @@ class ArcMapServiceHandler(base.ServiceHandlerBase):
             "width": "200",
             "height": "150",
             "format": "image/png",
+            "styles": ""
         }
         kvp = "&".join("{}={}".format(*item) for item in params.items())
         thumbnail_remote_url = "{}?{}".format(

--- a/geonode/services/serviceprocessors/wms.py
+++ b/geonode/services/serviceprocessors/wms.py
@@ -250,6 +250,7 @@ class WmsServiceHandler(base.ServiceHandlerBase,
             "width": "200",
             "height": "150",
             "format": "image/png",
+            "styles": ""
         }
         kvp = "&".join("{}={}".format(*item) for item in params.items())
         thumbnail_remote_url = "{}?{}".format(


### PR DESCRIPTION
 - Fixes #5682 : Thumbnails broken for RemoteServices using a invalid WMS GetCapabilities request

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there are explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
