### PR TITLE
Fix CI and improve pyproject.toml/setup.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -291,7 +291,8 @@ before_install:
     fi
 
 install:
-  - if [ "$TEST_RUN_INTEGRATION_BDD" = "True" ]; then
+  - set -ex;
+    if [ "$TEST_RUN_INTEGRATION_BDD" = "True" ]; then
       /usr/bin/Xvfb :99 -ac -screen 0 1024x768x8 & export DISPLAY=":99";
       GECKODRIVER_VERSION="v0.24.0";
       wget https://github.com/mozilla/geckodriver/releases/download/$GECKODRIVER_VERSION/geckodriver-$GECKODRIVER_VERSION-linux64.tar.gz -O geckodriver.tar.gz;
@@ -299,7 +300,8 @@ install:
       tar zxf geckodriver.tar.gz -C bin;
       export PATH=$PATH:$PWD/bin;
     fi
-  - if [ "$TEST_RUN_SELENIUM" = "True" ] && [ "$SPCGEONODE" == "True" ]; then
+  - set -ex;
+    if [ "$TEST_RUN_SELENIUM" = "True" ] && [ "$SPCGEONODE" == "True" ]; then
       :;
     elif [ "$TEST_RUN_SELENIUM" = "True" ]; then
       pip install -r geonode-selenium/requirements.txt --upgrade --no-cache;
@@ -327,7 +329,8 @@ install:
     fi
 
 before_script:
-  - if [ "$TEST_RUN_SELENIUM" = "True" ]; then
+  - set -ex;
+    if [ "$TEST_RUN_SELENIUM" = "True" ]; then
       sudo service nginx stop;
     else
       echo "Initialize DB";
@@ -346,7 +349,8 @@ before_script:
     fi
 
 script:
-  - if [ "$TEST_RUN_SELENIUM" = "True" ] && [ "$SPCGEONODE" = "True" ]; then
+  - set -ex;
+    if [ "$TEST_RUN_SELENIUM" = "True" ] && [ "$SPCGEONODE" = "True" ]; then
       geonode-selenium/test-docker.sh;
     elif [ "$TEST_RUN_SELENIUM" = "True" ]; then
       docker-compose -f docker-compose.yml -f docker-compose.override.localhost.yml up --build -d;
@@ -357,7 +361,8 @@ script:
     fi
 
 after_script:
-  - if [ "$TEST_RUN_SELENIUM" = "True" ]; then
+  - set -ex;
+    if [ "$TEST_RUN_SELENIUM" = "True" ]; then
       true;
     else
       echo "For GeoServer Server Travis steps";

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ jobs:
       name: "GeoServer-backend Core Modules Smoke Tests"
       python: "3.5"
       virtualenv:
-          system_site_packages: true
+          system_site_packages: false
       env:
           - BACKEND: 'geonode.geoserver'
           - DOCKER_COMPOSE_VERSION: 1.19.0
@@ -50,7 +50,7 @@ jobs:
       name: "GeoServer-backend Contrib Apps Smoke Tests"
       python: "3.5"
       virtualenv:
-          system_site_packages: true
+          system_site_packages: false
       env:
           - BACKEND: 'geonode.geoserver'
           - DOCKER_COMPOSE_VERSION: 1.19.0
@@ -66,7 +66,7 @@ jobs:
       name: "GeoServer-backend CSW-Catalogue Smoke Tests"
       python: "3.5"
       virtualenv:
-          system_site_packages: true
+          system_site_packages: false
       env:
           - BACKEND: 'geonode.geoserver'
           - DOCKER_COMPOSE_VERSION: 1.19.0
@@ -83,7 +83,7 @@ jobs:
       name: "QGis Server-backend Core Modules Smoke Tests"
       python: "3.5"
       virtualenv:
-          system_site_packages: true
+          system_site_packages: false
       env:
           - BACKEND: 'geonode.qgis_server'
           - DJANGO_SETTINGS_MODULE: 'geonode.local_settings'
@@ -104,7 +104,7 @@ jobs:
       name: "QGis Server-backend Contrib Apps Smoke Tests"
       python: "3.5"
       virtualenv:
-          system_site_packages: true
+          system_site_packages: false
       env:
           - BACKEND: 'geonode.qgis_server'
           - DJANGO_SETTINGS_MODULE: 'geonode.local_settings'
@@ -125,7 +125,7 @@ jobs:
       name: "GeoServer-backend Upload Tests"
       python: "3.5"
       virtualenv:
-          system_site_packages: true
+          system_site_packages: false
       env:
           - BACKEND: 'geonode.geoserver'
           - DOCKER_COMPOSE_VERSION: 1.19.0
@@ -149,7 +149,7 @@ jobs:
       name: "GeoServer-backend Monitoring Tests"
       python: "3.5"
       virtualenv:
-          system_site_packages: true
+          system_site_packages: false
       env:
           - BACKEND: 'geonode.geoserver'
           - DOCKER_COMPOSE_VERSION: 1.19.0
@@ -173,7 +173,7 @@ jobs:
       name: "BDD Tests"
       python: "3.5"
       virtualenv:
-          system_site_packages: true
+          system_site_packages: false
       env:
           - BACKEND: 'geonode.geoserver'
           - DOCKER_COMPOSE_VERSION: 1.19.0
@@ -205,7 +205,7 @@ jobs:
       name: "Backend Integration Tests"
       python: "3.5"
       virtualenv:
-          system_site_packages: true
+          system_site_packages: false
       env:
           - BACKEND: 'geonode.geoserver'
           - DOCKER_COMPOSE_VERSION: 1.19.0
@@ -229,7 +229,7 @@ jobs:
       name: "GeoServer Integration Tests"
       python: "3.5"
       virtualenv:
-          system_site_packages: true
+          system_site_packages: false
       env:
           - BACKEND: 'geonode.geoserver'
           - DOCKER_COMPOSE_VERSION: 1.19.0
@@ -253,7 +253,7 @@ jobs:
       name: "QGis Server Integration Tests"
       python: "3.5"
       virtualenv:
-          system_site_packages: true
+          system_site_packages: false
       env:
           - BACKEND: 'geonode.qgis_server'
           - DJANGO_SETTINGS_MODULE: 'geonode.local_settings'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,5 +15,5 @@ exclude = '''
 '''
 
 [build-system]
-requires = ["setuptools", "wheel", "pip"]
+requires = ["setuptools >= 40.8", "pip >= 19.1"]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,3 +13,7 @@ exclude = '''
   | node_modules
 )/
 '''
+
+[build-system]
+requires = ["setuptools", "wheel", "pip"]
+build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 120
-target-version = 'py35'
+target-version = ['py35']
 exclude = '''
 /(
     geonode/.*/migrations/.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -134,4 +134,5 @@ splinter==0.13.0
 pytest-splinter==2.0.1
 pytest-django==3.8.0
 setuptools==45.2.0
+pip==20.0.2
 Twisted==19.10.0

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,12 @@ from distutils.core import setup
 
 from setuptools import find_packages
 
+import os
+import sys
+
+current_directory = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(current_directory)
+
 # Parse requirements.txt to get the list of dependencies
 inst_req = parse_requirements("requirements.txt", session=PipSession())
 REQUIREMENTS = [str(r.req) for r in inst_req]

--- a/setup.py
+++ b/setup.py
@@ -18,52 +18,49 @@
 #
 #########################################################################
 
-try:  # for pip >= 10
+try:
+    # pip >=20
+    from pip._internal.network.session import PipSession
     from pip._internal.req import parse_requirements
+except ImportError:
     try:
+        # 10.0.0 <= pip <= 19.3.1
         from pip._internal.download import PipSession
-        pip_session = PipSession()
-    except ImportError:  # for pip >= 20
-        from pip._internal.network.session import PipSession
-        pip_session = PipSession()
-except ImportError:  # for pip <= 9.0.3
-    try:
-        from pip.req import parse_requirements
+        from pip._internal.req import parse_requirements
+    except ImportError:
+        # pip <= 9.0.3
         from pip.download import PipSession
-        pip_session = PipSession()
-    except ImportError:  # backup in case of further pip changes
-        pip_session = 'hack'
+        from pip.req import parse_requirements
 
 from distutils.core import setup
 
 from setuptools import find_packages
 
 # Parse requirements.txt to get the list of dependencies
-inst_req = parse_requirements('requirements.txt',
-                              session=pip_session)
+inst_req = parse_requirements("requirements.txt", session=PipSession())
 REQUIREMENTS = [str(r.req) for r in inst_req]
 
-setup(name='GeoNode',
-      version=__import__('geonode').get_version(),
-      description="Application for serving and sharing geospatial data",
-      long_description=open('README.md').read(),
-      classifiers=[
-          "Development Status :: 5 - Production/Stable"],
-      python_requires='>=3',
-      keywords='',
-      author='GeoNode Developers',
-      author_email='dev@geonode.org',
-      url='http://geonode.org',
-      license='GPL',
-      packages=find_packages(),
-      package_data={
-          '': ['*.*'], # noqa
-          '': ['static/*.*'], # noqa
-          'static': ['*.*'],
-          '': ['templates/*.*'], # noqa
-          'templates': ['*.*'],
-      },
-      include_package_data=True,
-      install_requires=REQUIREMENTS,
-      zip_safe=False
-      )
+setup(
+    name="GeoNode",
+    version=__import__("geonode").get_version(),
+    description="Application for serving and sharing geospatial data",
+    long_description=open("README.md").read(),
+    classifiers=["Development Status :: 5 - Production/Stable"],
+    python_requires=">=3",
+    keywords="",
+    author="GeoNode Developers",
+    author_email="dev@geonode.org",
+    url="http://geonode.org",
+    license="GPL",
+    packages=find_packages(),
+    package_data={
+        "": ["*.*"],  # noqa
+        "": ["static/*.*"],  # noqa
+        "static": ["*.*"],
+        "": ["templates/*.*"],  # noqa
+        "templates": ["*.*"],
+    },
+    include_package_data=True,
+    install_requires=REQUIREMENTS,
+    zip_safe=False,
+)


### PR DESCRIPTION
Fixes #5735

- pyproject.toml refers to setup.py
- add pip as dependency
- support for pip 20 is added in setup.py
- installing geonode from another directory is now possible
- Travis early fail + print commands (set -ex)
- Travis do not use system wide packages
- minor fix for black


This should allow GeoNode tu use pyproject.toml without having to switch to Poetry, which it would be nice but it would be better to do it later.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [X] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [X] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [X] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [X] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [X] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [X] New unit tests have been added covering the changes, unless there are explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: flake8 geonode
- [X] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates