### PR TITLE
[Fixes #5795] utils get_object_or_404 raises exception if query retur…

### DIFF
--- a/geonode/layers/views.py
+++ b/geonode/layers/views.py
@@ -187,7 +187,11 @@ def _resolve_layer(request, alternate, permission='base.view_resourcebase',
         test_query = Layer.objects.filter(**query)
         if test_query.count() > 1 and test_query.exclude(storeType='remoteStore').count() == 1:
             query = {
-                'id': test_query.exclude(storeType='remoteStore').first().id
+                'id': test_query.exclude(storeType='remoteStore').last().id
+            }
+        elif test_query.count() > 1:
+            query = {
+                'id': test_query.last().id
             }
         return resolve_object(request,
                               Layer,


### PR DESCRIPTION
…n more than one object

<Include a few sentences describing the overall goals for this Pull Request>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there are explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
