### PR TITLE
Fixes issue #5839: Featured thumbnails on home too wide

### DIFF
--- a/geonode/templates/index.html
+++ b/geonode/templates/index.html
@@ -300,7 +300,7 @@
 			 		<div class="row">
 			 			{% verbatim %}
 			 			<div ng-repeat="item in featured" class="col-xs-6 col-sm-6 col-md-3">
-			 				<a href="{{ item.detail_url }}"><img ng-src="{{ item.thumbnail_url }}" style="width: 240px;" /></a>
+			 				<a href="{{ item.detail_url }}"><img ng-src="{{ item.thumbnail_url }}" style="width: 100%" /></a>
 			 				<h4>{{ item.title | limitTo: 20 }}{{item.title.length > 20 ? '...' : ''}}</h4>
 			 			</div>
 			 			{% endverbatim %}


### PR DESCRIPTION
Excess width (240px) caused page to scroll horizontally and obscure the nav menu icon on mobile devices. Set to 100%.

Tested on Geonode 2.10.3 with chrome DevTools ("Samsung S5" setting).