### PR TITLE
[Fixes #5866] Restore errors

### DIFF
--- a/geonode/base/management/commands/helpers.py
+++ b/geonode/base/management/commands/helpers.py
@@ -246,7 +246,7 @@ def restore_db(config, db_name, db_user, db_port, db_host, db_passwd, source_fol
             print("Restoring GeoServer Vectorial Data : " + os.path.splitext(table)[0])
             pg_rstcmd = 'PGPASSWORD="' + db_passwd + '" ' + config.pg_restore_cmd + ' -c -h ' + db_host + \
                         ' -p ' + db_port + ' -U ' + db_user + ' -F c ' + \
-                        ' -t ' + table[0] + ' ' + \
+                        ' -t ' + os.path.splitext(table)[0] + ' ' + \
                         os.path.join(source_folder, table) + ' -d ' + db_name
             os.system(pg_rstcmd)
 


### PR DESCRIPTION
Restore error fix - restore procedure was not creating tables in Geoserver on PostGIS store.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
