### PR TITLE
[Fixes #5893] delete_resources management command

### DIFF
--- a/geonode/base/management/commands/delete_resources.py
+++ b/geonode/base/management/commands/delete_resources.py
@@ -1,0 +1,152 @@
+# -*- coding: utf-8 -*-
+#########################################################################
+#
+# Copyright (C) 2018 OSGeo
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#########################################################################
+
+import os
+import json
+
+# import needed to resolve model filters:
+from django.db.models import Q
+from django.db import transaction
+from django.core.management.base import BaseCommand, CommandError
+
+from geonode.maps.models import Map
+from geonode.layers.models import Layer
+from geonode.documents.models import Document
+
+
+class Command(BaseCommand):
+
+    help = 'Delete resources meeting a certain condition'
+
+    def add_arguments(self, parser):
+
+        parser.add_argument(
+            '-c',
+            '--config',
+            dest='config_path',
+            help='Configuration file path. Default is: delete_resources.json')
+
+        parser.add_argument(
+            '-l',
+            '--layer_filters',
+            dest='layer_filters',
+            nargs='+',
+            required=False,
+        )
+
+        parser.add_argument(
+            '-m',
+            '--map_filters',
+            dest='map_filters',
+            nargs='+',
+            required=False,
+        )
+
+        parser.add_argument(
+            '-d',
+            '--document_filters',
+            dest='document_filters',
+            nargs='+',
+            required=False,
+        )
+
+    def handle(self, **options):
+        layer_filters = options.get('layer_filters')
+        map_filters = options.get('map_filters')
+        document_filters = options.get('document_filters')
+
+        config_path = options.get('config_path')
+
+        # check argument set
+        if all(config is None for config in [layer_filters, map_filters, document_filters, config_path]):
+            raise CommandError("No configuration provided. Please specify any of the following arguments: '-l', '-m', '-d', '-c'.")
+
+        if any([layer_filters, map_filters, document_filters]) and config_path:
+            raise CommandError("Too many configuration options provided. Please use either '-c' or '-l', '-m', '-d' arguments.")
+
+        # check config_file, if it exists
+        if config_path:
+
+            if not os.path.exists(config_path):
+                raise CommandError(f'Specified configuration file does not exist: "{config_path}"')
+
+            if os.path.getsize(config_path) == 0:
+                raise CommandError(f'Specified configuration file is empty: "{config_path}"')
+
+            with open(config_path) as file:
+                try:
+                    config = json.load(file)
+                except json.decoder.JSONDecodeError as e:
+                    raise CommandError(f'Parsing configuration file failed with an exception: {e}')
+
+                if (
+                        # if config is an empty JSON object
+                        not config
+                        # or 'filters' is not set in config OR it is not an JSON object
+                        or not isinstance(config.get('filters'), dict)
+                        # or all filters are empty
+                        or not any([config.get('filters').get('layer'), config.get('filters').get('map'), config.get('filters').get('document')])
+                ):
+                    print('Nothing to be done... exiting delete_resources command.')
+                    return
+
+            # override filters variables with configuration file data
+            layer_filters = config.get('filters').get('layer')
+            map_filters = config.get('filters').get('map')
+            document_filters = config.get('filters').get('document')
+
+        # remove layers
+        if layer_filters:
+
+            if '*' in layer_filters:
+                layers_to_delete = Layer.objects.all()
+            else:
+                layers_q_expressions = [eval(expr) for expr in layer_filters]
+                layers_to_delete = Layer.objects.filter(*layers_q_expressions)
+
+            for layer in layers_to_delete:
+                print(f'Deleting layer "{layer.name}" with ID: {layer.id}')
+                with transaction.atomic():
+                    layer.delete()
+
+        if map_filters:
+
+            if '*' in map_filters:
+                maps_to_delete = Map.objects.all()
+            else:
+                maps_q_expressions = [eval(expr) for expr in map_filters]
+                maps_to_delete = Map.objects.filter(*maps_q_expressions)
+
+            for map in maps_to_delete:
+                print(f'Deleting map "{map.title}" with ID: {map.id}')
+                map.layer_set.all().delete()
+                map.delete()
+
+        if document_filters:
+
+            if '*' in document_filters:
+                documents_to_delete = Document.objects.all()
+            else:
+                documents_q_expressions = [eval(expr) for expr in document_filters]
+                documents_to_delete = Document.objects.filter(*documents_q_expressions)
+
+            for document in documents_to_delete:
+                print(f'Deleting document "{document.title}" with ID: {document.id}')
+                document.delete()


### PR DESCRIPTION
Management command removing certain resources (layers, maps, documents), based on django's Q() expressions.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [x] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
