### PR TITLE
[Fixes #5912] Extend resource search api with abstract and purpose fields

### DIFF
--- a/geonode/api/resourcebase_api.py
+++ b/geonode/api/resourcebase_api.py
@@ -89,6 +89,8 @@ class CommonMetaApi:
                  'group': ALL_WITH_RELATIONS,
                  'owner': ALL_WITH_RELATIONS,
                  'date': ALL,
+                 'purpose': ALL,
+                 'abstract': ALL
                  }
     ordering = ['date', 'title', 'popular_count']
     max_limit = None
@@ -161,22 +163,33 @@ class CommonModelApi(ModelResource):
             orm_filters.update({'type': filters.getlist('type__in')})
         if 'extent' in filters:
             orm_filters.update({'extent': filters['extent']})
-        # Nothing returned if +'s are used instead of spaces for text search,
-        # so swap them out. Must be a better way of doing this?
-        for filter in orm_filters:
-            if filter in ['title__contains', 'q']:
-                orm_filters[filter] = orm_filters[filter].replace("+", " ")
+        orm_filters['f_method'] = filters['f_method'] if 'f_method' in filters else 'and'
+        if not settings.SEARCH_RESOURCES_EXTENDED:
+            return self._remove_additional_filters(orm_filters)
+        return orm_filters
+
+    def _remove_additional_filters(self, orm_filters):
+        orm_filters.pop('abstract__icontains', None)
+        orm_filters.pop('purpose__icontains', None)
+        orm_filters.pop('f_method', None)
         return orm_filters
 
     def apply_filters(self, request, applicable_filters):
         types = applicable_filters.pop('type', None)
         extent = applicable_filters.pop('extent', None)
         keywords = applicable_filters.pop('keywords__slug__in', None)
-        semi_filtered = super(
-            CommonModelApi,
-            self).apply_filters(
-            request,
-            applicable_filters)
+        filtering_method = applicable_filters.pop('f_method', 'and')
+        if filtering_method == 'or':
+            filters = Q()
+            for f in applicable_filters.items():
+                filters |= Q(f)
+            semi_filtered = self.get_object_list(request).filter(filters)
+        else:
+            semi_filtered = super(
+                CommonModelApi,
+                self).apply_filters(
+                request,
+                applicable_filters)
         filtered = None
         if types:
             for the_type in types:

--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -1882,4 +1882,6 @@ USER_ANALYTICS_ENABLED = ast.literal_eval(os.getenv('USER_ANALYTICS_ENABLED', 'F
 USER_ANALYTICS_GZIP = ast.literal_eval(os.getenv('USER_ANALYTICS_GZIP', 'False'))
 
 GEOIP_PATH = os.getenv('GEOIP_PATH', os.path.join(PROJECT_ROOT, 'GeoIPCities.dat'))
+#This controls if tastypie search on resourches is performed only with titles
+SEARCH_RESOURCES_EXTENDED = strtobool(os.getenv('SEARCH_RESOURCES_EXTENDED', 'True'))
 # -- END Settings for MONITORING plugin

--- a/geonode/static/geonode/js/search/search.js
+++ b/geonode/static/geonode/js/search/search.js
@@ -628,7 +628,11 @@
               $scope.query[query_key] = $('#text_search_input').val().toLowerCase().replace(/ /g,"-");
             } else {
               $scope.query[query_key] = $('#text_search_input').val();
+
             }
+            $scope.query['abstract__icontains'] = $('#text_search_input').val();
+            $scope.query['purpose__icontains'] = $('#text_search_input').val();
+            $scope.query['f_method'] = 'or';
         query_api($scope.query);
         }
     });

--- a/geonode/templates/base.html
+++ b/geonode/templates/base.html
@@ -354,8 +354,14 @@
                   <div id="search-container" class="autocomplete-input">
                     {% if HAYSTACK_SEARCH %}
                     <input autocomplete="off" id="search_input" type="text" placeholder="{% trans 'Search' %}" name="q">
+                    <input type="hidden" name="abstract__icontains" id="search_abstract_input" placeholder="Search" >
+                    <input type="hidden" name="purpose__icontains" id="search_purpose_input" placeholder="Search" >
+                    <input type="hidden" name="f_method" id="filtering_type" value="or" >
                     {% else %}
                     <input autocomplete="off" type="text" name="title__icontains" id="search_input" placeholder="Search" >
+                    <input type="hidden" name="abstract__icontains" id="search_abstract_input" placeholder="Search" >
+                    <input type="hidden" name="purpose__icontains" id="search_purpose_input" placeholder="Search" >
+                    <input type="hidden" name="f_method" id="filtering_type" value="or" >
                     {% endif %}
                   </div>
                 </form>
@@ -639,6 +645,10 @@
               $('#search_input').val($(choice[0]).text());
               $('#search').submit();
           }
+      });
+      $('#search').on('submit', (e) => {
+          $('#search_abstract_input')[0].value =$('#search_input')[0].value;
+          $('#search_purpose_input')[0].value = $('#search_input')[0].value;
       });
       $(".datepicker").datepicker({
           format: "yyyy-mm-dd"

--- a/geonode/templates/index.html
+++ b/geonode/templates/index.html
@@ -39,12 +39,18 @@
       	<div class="container">
       		<h1>{% trans "Search for Data." %}</h1>
       		<div class="search">
-      			<form id="search" action="{% url "search" %}" >
+      			<form id="main_search" action="{% url "search" %}" >
       				<span class="fa fa-search fa-3x"></span>
       				{% if HAYSTACK_SEARCH %}
-      				<input id="search_input" type="text" placeholder="{% trans 'Search' %}" class="form-control" name="q" autocomplete="off">
+      				<input id="main_search_input" type="text" placeholder="{% trans 'Search' %}" class="form-control" name="q" autocomplete="off">
+                    <input type="hidden" name="abstract__icontains" id="main_search_abstract_input" placeholder="Search" >
+                    <input type="hidden" name="purpose__icontains" id="main_search_purpose_input" placeholder="Search" >
+                    <input type="hidden" name="f_method" id="main_filtering_type" value="or" >
       				{% else %}
-      				<input id="search_input" type="text" placeholder="{% trans 'Search' %}" class="form-control" autocomplete="off" name="title__icontains">
+      				<input id="main_search_input" type="text" placeholder="{% trans 'Search' %}" class="form-control" autocomplete="off" name="title__icontains">
+                    <input type="hidden" name="abstract__icontains" id="main_search_abstract_input">
+                    <input type="hidden" name="purpose__icontains" id="main_search_purpose_input">
+                    <input type="hidden" name="f_method" id="main_filtering_type" value="or" >
       				{% endif %}
       			</form>
       		</div>
@@ -363,6 +369,12 @@
 {% endblock middle %}
 
 {% block extra_script %}
+    <script type="text/javascript">
+      $('#main_search').on('submit', (e) => {
+          $('#main_search_abstract_input')[0].value =$('#main_search_input')[0].value;
+          $('#main_search_purpose_input')[0].value = $('#main_search_input')[0].value;
+      });
+    </script>
 {{ block.super }}
 {% if DEBUG_STATIC %}
 <script src="{% static "lib/js/angular.js" %}"></script>

--- a/geonode/templates/search/_text_filter.html
+++ b/geonode/templates/search/_text_filter.html
@@ -8,7 +8,7 @@
           <form class="autocomplete-input input-group" id="text-search-autocomplete">
             {% csrf_token %}
             <div id="text-search-container">
-              <input autocomplete="off"  ng-model="text_query"  type="text" name="text_search_input" id="text_search_input" placeholder="Search by name" >
+              <input autocomplete="off"  ng-model="text_query"  type="text" name="text_search_input" id="text_search_input" placeholder="Search" >
             </div>
             <span class="input-group-btn">
               <button class="btn btn-primary" type="submit" id="text_search_btn"><i class="fa fa-search"></i></button>

--- a/geonode/tests/test_search.py
+++ b/geonode/tests/test_search.py
@@ -1,0 +1,60 @@
+#########################################################################
+#
+# Copyright (C) 2020 OSGeo
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#########################################################################
+
+from geonode.documents.models import Document
+from geonode.people.models import Profile
+from geonode.tests.base import GeoNodeBaseTestSupport
+from django.conf import settings
+
+
+class ResourceBaseSearchTest(GeoNodeBaseTestSupport):
+
+    def setUp(self):
+        self.p = Profile.objects.create(username='test')
+        self.d1 = Document.objects.create(title='word', purpose='this is a test', abstract='a brief document about...',
+                                          owner=self.p)
+        self.d1 = Document.objects.create(title='a word', purpose='this is a test',
+                                          abstract='a brief document about...',
+                                          owner=self.p)
+
+    def test_or_search(self):
+        url = f'{settings.SITEURL}api/base/?title__icontains=word&abstract__icontains=word&\
+        purpose__icontains=word&f_method=or'
+        self.client.force_login(self.p)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.json().get('objects')), 2)
+
+    def test_and_search(self):
+        url = f'{settings.SITEURL}api/base/?title__icontains=a&abstract__icontains=a&purpose__icontains=a'
+        self.client.force_login(self.p)
+        response = self.client.get(url)
+        self.assertEqual(len(response.json().get('objects')), 1)
+
+    def test_and_empty_search(self):
+        url = f'{settings.SITEURL}api/base/?title__icontains=test&abstract__icontains=test&purpose__icontains=test'
+        self.client.force_login(self.p)
+        response = self.client.get(url)
+        self.assertEqual(len(response.json().get('objects')), 0)
+
+    def test_bad_filter(self):
+        url = f'{settings.SITEURL}api/base/?edition__icontains=test&abstract__icontains=test&\
+        purpose__icontains=test&f_method=or'
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 400)


### PR DESCRIPTION
FIX #5912

It extends resourcebase api to perform OR queries on given lookups. By default tastypie is combinig queries with **and** operator, **or** has to be requested by sending **f_method** parameter. 

On frontend side purpose and abstract lookups are added

New configuration is described here:
https://github.com/GeoNode/documentation/pull/20

#5912
<Include a few sentences describing the overall goals for this Pull Request>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [x] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
