### PR TITLE
[Fixes #5922] Send notification about restore procedure

### DIFF
--- a/geonode/br/tasks.py
+++ b/geonode/br/tasks.py
@@ -1,0 +1,44 @@
+#########################################################################
+#
+# Copyright (C) 2020 OSGeo
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#########################################################################
+
+from typing import List
+
+from django.conf import settings
+from django.core.mail import EmailMessage
+
+from geonode.celery_app import app
+
+
+@app.task(queue='email')
+def restore_notification(recipients: List, backup_file: str, backup_md5: str, exception: str = None):
+    """
+    Function sending a CC email report of the restore procedure to a provided emails.
+    """
+
+    if exception:
+        subject = 'Geonode restore procedure FAILED.'
+        message = f'Restoration of the backup file: "{backup_file}" (MD5 hash: {backup_md5}) on the ' \
+            f'GeoNode instance: {settings.SITEURL} FAILED with an exception: {exception}'
+    else:
+        subject = 'Geonode restore procedure finished with SUCCESS.'
+        message = f'Restoration of the backup file: "{backup_file}" (MD5 hash: {backup_md5}) on the ' \
+            f'GeoNode instance: {settings.SITEURL} was finished SUCCESSFULLY.'
+
+    msg = EmailMessage(subject=subject, body=message, to=recipients)
+    msg.send()


### PR DESCRIPTION
Add optional email notification for superusers about restore procedure outcome

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
