### PR TITLE
[Fixes #5936] Backup/Restore with Read-Only mode

### DIFF
--- a/geonode/br/tests/__init__.py
+++ b/geonode/br/tests/__init__.py
@@ -20,3 +20,4 @@
 
 from geonode.br.tests.test_restore import *             # noqa aside
 from geonode.br.tests.test_restore_helpers import *     # noqa aside
+from geonode.br.tests.test_backup import *              # noqa aside

--- a/geonode/br/tests/test_backup.py
+++ b/geonode/br/tests/test_backup.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+#########################################################################
+#
+# Copyright (C) 2016 OSGeo
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#########################################################################
+
+import mock
+import tempfile
+
+from django.core.management import call_command
+
+from geonode.tests.base import GeoNodeBaseTestSupport
+from geonode.base.models import Configuration
+
+
+class BackupCommandTests(GeoNodeBaseTestSupport):
+
+    def setUp(self):
+        super().setUp()
+        # make sure Configuration exists in the database for Read Only mode tests
+        Configuration.load()
+
+    # force backup interruption before starting the procedure itself
+    @mock.patch('geonode.br.management.commands.utils.utils.confirm', return_value=False)
+    # mock geonode.base.models.Configuration save() method
+    @mock.patch('geonode.base.models.Configuration.save', return_value=None)
+    def test_with_read_only_mode(self, mock_configuration_save, fake_confirm):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            args = []
+            kwargs = {'backup_dir': tmp_dir}
+
+            call_command('backup', *args, **kwargs)
+
+            # make sure Configuration was saved twice (Read-Only set, and revert)
+            self.assertEqual(mock_configuration_save.call_count, 2)
+
+    # force backup interruption before starting the procedure itself
+    @mock.patch('geonode.br.management.commands.utils.utils.confirm', return_value=False)
+    # mock geonode.base.models.Configuration save() method
+    @mock.patch('geonode.base.models.Configuration.save', return_value=None)
+    def test_without_read_only_mode(self, mock_configuration_save, fake_confirm):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            args = ['--skip-read-only']
+            kwargs = {'backup_dir': tmp_dir}
+
+            call_command('backup', *args, **kwargs)
+
+            # make sure Configuration wasn't called at all
+            self.assertEqual(mock_configuration_save.call_count, 0)


### PR DESCRIPTION
By default backup and restore commands should set Gn into Read Only mode during the operations, and restore to previous state after that (if it was already in r/o mode it should remain as it was)

A new optional parameter should permit to switch this functionality off.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
