### PR TITLE
Fixes #5882 Mapstore fails with version 3.0.0

### DIFF
--- a/geonode/version.py
+++ b/geonode/version.py
@@ -36,8 +36,7 @@ def get_version(version=None):
     # sub = .devN - for pre-alpha releases
     #     | {a|b|c}N - for alpha, beta and rc releases
     git_changeset = get_git_changeset()
-    parts = 2 if version[2] == 0 else 3
-    main = '.'.join(str(x) for x in version[:parts])
+    main = '.'.join(str(x) for x in version[:3])
     sub = ''
     if version[3] not in ('unstable', 'final'):
         mapping = {'beta': 'b', 'rc': 'rc'}


### PR DESCRIPTION
This Pr fixes #5882

**Geonode populates the current version:**
https://github.com/GeoNode/geonode/blob/master/geonode/urls.py#L84

**and formats it to two or three decimals**
3.0 || 3.0.1 || ...

**Mapstore reads this enpoint to check the current version (in our case this is of no use!)**
https://github.com/geosolutions-it/MapStore2/blob/22bbfe82be2db71cd622d27bed457ccd41bb1332/web/client/actions/version.js#L42

**Mapstore will read the version as number in case it looks like f.e. `3`or `3.1` (which is the case when the patch number is zero). Further fail when using `indexOf` which is a string or array method.**

https://github.com/geosolutions-it/MapStore2/blob/22bbfe82be2db71cd622d27bed457ccd41bb1332/web/client/selectors/version.js#L10

---

**My fix removes the line which skips the patch number to read like:**
3.0.0 which will be interpreted as a string. (This is why it is working witch 2.10 **.3** )

Another option is to change mapstore to always typecast the version as string. However as this might be geonode specific I would solve it in our codebase.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
