### PR TITLE
[Fixes #5965] B/R: restoration in Docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ services:
       - data-dir-conf
     volumes:
       - geoserver-data-dir:/geoserver_data/data
+      - backup-restore:/backup_restore
     env_file:
       - ./scripts/docker/env/${SET_DOCKER_ENV}/geoserver.env
 
@@ -50,6 +51,7 @@ services:
     volumes:
       - statics:/mnt/volumes/statics
       - geoserver-data-dir:/geoserver_data/data
+      - backup-restore:/backup_restore
     env_file:
       - ./scripts/docker/env/${SET_DOCKER_ENV}/django.env
 
@@ -92,3 +94,5 @@ volumes:
     name: ${COMPOSE_PROJECT_NAME}-dbbackups
   rabbitmq:
     name: ${COMPOSE_PROJECT_NAME}-rabbitmq
+  backup-restore:
+    name: ${COMPOSE_PROJECT_NAME}-backup-restore

--- a/geonode/br/management/commands/restore.py
+++ b/geonode/br/management/commands/restore.py
@@ -148,8 +148,6 @@ class Command(BaseCommand):
         # choose backup_file from backup_files_dir, if --backup-files-dir was provided
         if backup_files_dir:
             backup_file = self.parse_backup_files_dir(backup_files_dir)
-        else:
-            backup_files_dir = os.path.dirname(backup_file)
 
         # calculate and validate backup archive hash
         backup_md5 = self.validate_backup_file_hash(backup_file)

--- a/geonode/br/management/commands/restore.py
+++ b/geonode/br/management/commands/restore.py
@@ -182,7 +182,7 @@ class Command(BaseCommand):
             # not be Geoserver data dir)
             # for dockerized project-template GeoNode projects, it should be located in /backup-restore,
             # otherwise default tmp directory is chosen
-            temp_dir_path = '/backup-restore' if os.path.exists('/backup-restore') else None
+            temp_dir_path = '/backup_restore' if os.path.exists('/backup_restore') else None
 
             with tempfile.TemporaryDirectory(dir=temp_dir_path) as restore_folder:
 

--- a/geonode/br/management/commands/restore.py
+++ b/geonode/br/management/commands/restore.py
@@ -178,9 +178,13 @@ class Command(BaseCommand):
         if force_exec or utils.confirm(prompt=message, resp=False):
 
             # Create Target Folder
-            # target_folder must be located in the directory Geoserver has access to, for dockerized
-            # project-template GeoNode projects, it has to be located in /geoserver_data/data directory
-            with tempfile.TemporaryDirectory(dir=backup_files_dir) as restore_folder:
+            # restore_folder must be located in the directory Geoserver has access to (and it should
+            # not be Geoserver data dir)
+            # for dockerized project-template GeoNode projects, it should be located in /backup-restore,
+            # otherwise default tmp directory is chosen
+            temp_dir_path = '/backup-restore' if os.path.exists('/backup-restore') else None
+
+            with tempfile.TemporaryDirectory(dir=temp_dir_path) as restore_folder:
 
                 # Extract ZIP Archive to Target Folder
                 target_folder = extract_archive(backup_file, restore_folder)


### PR DESCRIPTION
Restore: extracting backup archive in the directory accessible by `Geoserver` docker image.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [x] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
