### PR TITLE
[Fixes #5975] Geoserver backup sometime fails when running in Docker

### DIFF
--- a/geonode/br/management/__init__.py
+++ b/geonode/br/management/__init__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+#########################################################################
+#
+# Copyright (C) 2016 OSGeo
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#########################################################################

--- a/geonode/br/management/commands/__init__.py
+++ b/geonode/br/management/commands/__init__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+#########################################################################
+#
+# Copyright (C) 2016 OSGeo
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#########################################################################

--- a/geonode/br/management/commands/backup.py
+++ b/geonode/br/management/commands/backup.py
@@ -296,7 +296,7 @@ class Command(BaseCommand):
 
         _status_code = None
         _status_text = None
-        # Sometime It happens the, when Geoserver runs in a Docker container
+        # Sometime It happens tht, with Geoserver running in a Docker container
         # first call to the GS B/R plugin isn't able to dump correctly the catalog.
         # From our experience the second time it works. We retry three times for safety
         for _r in range(retries):

--- a/geonode/br/management/commands/backup.py
+++ b/geonode/br/management/commands/backup.py
@@ -296,6 +296,9 @@ class Command(BaseCommand):
 
         _status_code = None
         _status_text = None
+        # Sometime It happens the, when Geoserver runs in a Docker container
+        # first call to the GS B/R plugin isn't able to dump correctly the catalog.
+        # From our experience the second time it works. We retry three times for safety
         for _r in range(retries):
             print("... GeoServer Backup tries {} of {}".format(_r + 1, retries))
             data = {'backup': {'archiveFile': geoserver_bk_file, 'overwrite': 'true',

--- a/geonode/br/management/commands/restore.py
+++ b/geonode/br/management/commands/restore.py
@@ -148,6 +148,8 @@ class Command(BaseCommand):
         # choose backup_file from backup_files_dir, if --backup-files-dir was provided
         if backup_files_dir:
             backup_file = self.parse_backup_files_dir(backup_files_dir)
+        else:
+            backup_files_dir = os.path.dirname(backup_file)
 
         # calculate and validate backup archive hash
         backup_md5 = self.validate_backup_file_hash(backup_file)
@@ -180,7 +182,7 @@ class Command(BaseCommand):
             # not be Geoserver data dir)
             # for dockerized project-template GeoNode projects, it should be located in /backup-restore,
             # otherwise default tmp directory is chosen
-            temp_dir_path = '/backup_restore' if os.path.exists('/backup_restore') else None
+            temp_dir_path = backup_files_dir if os.path.exists(backup_files_dir) else None
 
             with tempfile.TemporaryDirectory(dir=temp_dir_path) as restore_folder:
 
@@ -553,7 +555,7 @@ class Command(BaseCommand):
                   'file "{}" not found.'.format(geoserver_bk_file)))
             return
 
-        print("Restoring 'GeoServer Catalog ["+url+"]' into '"+geoserver_bk_file+"'.")
+        print("Restoring 'GeoServer Catalog ["+url+"]' from '"+geoserver_bk_file+"'.")
 
         # Best Effort Restore: 'options': {'option': ['BK_BEST_EFFORT=true']}
         data = {'restore': {'archiveFile': geoserver_bk_file, 'options': {}}}
@@ -630,14 +632,14 @@ class Command(BaseCommand):
         if (config.gs_data_dir):
             if (config.gs_dump_raster_data):
 
-                gs_data_folder = os.path.join(target_folder, 'gs_data_dir', 'data', 'geonode')
+                gs_data_folder = os.path.join(target_folder, 'gs_data_dir', 'geonode')
                 if not os.path.exists(gs_data_folder):
                     print(('Skipping geoserver raster data restore: ' +
                           'directory "{}" not found.'.format(gs_data_folder)))
                     return
 
                 # Restore '$config.gs_data_dir/data/geonode'
-                gs_data_root = os.path.join(config.gs_data_dir, 'data', 'geonode')
+                gs_data_root = os.path.join(config.gs_data_dir, 'geonode')
                 if not os.path.isabs(gs_data_root):
                     gs_data_root = os.path.join(settings.PROJECT_ROOT, '..', gs_data_root)
 
@@ -679,7 +681,7 @@ class Command(BaseCommand):
         """Restore Vectorial Data from DB"""
         if (config.gs_dump_vector_data):
 
-            gs_data_folder = os.path.join(target_folder, 'gs_data_dir', 'data', 'geonode')
+            gs_data_folder = os.path.join(target_folder, 'gs_data_dir', 'geonode')
             if not os.path.exists(gs_data_folder):
                 print(('Skipping geoserver vector data restore: ' +
                       'directory "{}" not found.'.format(gs_data_folder)))

--- a/geonode/br/management/commands/settings.ini
+++ b/geonode/br/management/commands/settings.ini
@@ -3,7 +3,7 @@ pgdump = pg_dump
 pgrestore = pg_restore
 
 [geoserver]
-datadir = geoserver/data
+datadir = /geoserver_data/data/
 dumpvectordata = yes
 dumprasterdata = yes
 

--- a/geonode/br/migrations/__init__.py
+++ b/geonode/br/migrations/__init__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+#########################################################################
+#
+# Copyright (C) 2016 OSGeo
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#########################################################################


### PR DESCRIPTION
 - Fixes #5975 : Geoserver backup sometime fails when running in Docker

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
