### PR TITLE
[Fixes #5993] Unexpected behavior of resource created under different RESOURCE_PUBLISHING setting

### DIFF
--- a/geonode/base/management/commands/migrate_baseurl.py
+++ b/geonode/base/management/commands/migrate_baseurl.py
@@ -28,8 +28,6 @@ from geonode.layers.models import Layer, Style
 from geonode.maps.models import Map, MapLayer
 from geonode.base.models import Link
 
-from geonode.utils import designals, resignals
-
 
 class Command(BaseCommand):
 
@@ -74,11 +72,6 @@ Styles and Links Base URLs from [%s] to [%s]." % (source_address, target_address
 
         if force_exec or helpers.confirm(prompt=message, resp=False):
             try:
-                # Deactivate GeoNode Signals
-                print("Deactivating GeoNode Signals...")
-                designals()
-                print("...done!")
-
                 _cnt = Map.objects.filter(thumbnail_url__icontains=source_address).update(
                     thumbnail_url=Func(
                         F('thumbnail_url'),Value(source_address),Value(target_address),function='replace'))
@@ -118,7 +111,4 @@ Styles and Links Base URLs from [%s] to [%s]." % (source_address, target_address
                         F('metadata_xml'), Value(source_address), Value(target_address), function='replace'))
                 print("Updated %s ResourceBases" % _cnt)
             finally:
-                # Reactivate GeoNode Signals
-                print("Reactivating GeoNode Signals...")
-                resignals()
                 print("...done!")

--- a/geonode/base/models.py
+++ b/geonode/base/models.py
@@ -476,7 +476,7 @@ class ThesaurusKeywordLabel(models.Model):
     lang = models.CharField(max_length=3)
     # read from the RDF file
     label = models.CharField(max_length=255)
-#    note  = models.CharField(max_length=511)
+    # note  = models.CharField(max_length=511)
 
     keyword = models.ForeignKey('ThesaurusKeyword', related_name='keyword', on_delete=models.CASCADE)
 
@@ -1393,9 +1393,10 @@ class ResourceBase(PolymorphicModel, PermissionLevelMixin, ItemBase):
         return the_ma
 
     def handle_moderated_uploads(self):
-        if settings.RESOURCE_PUBLISHING or settings.ADMIN_MODERATE_UPLOADS:
-            self.is_approved = False
+        if settings.RESOURCE_PUBLISHING:
             self.is_published = False
+        if settings.ADMIN_MODERATE_UPLOADS:
+            self.is_approved = False
 
     def add_missing_metadata_author_or_poc(self):
         """

--- a/geonode/documents/forms.py
+++ b/geonode/documents/forms.py
@@ -19,9 +19,10 @@
 #########################################################################
 
 from geonode.base.forms import ResourceBaseForm
-import json
 import os
 import re
+import json
+import logging
 
 from django import forms
 from django.utils.translation import ugettext as _
@@ -37,6 +38,8 @@ from geonode.documents.models import (
 )
 from geonode.maps.models import Map
 from geonode.layers.models import Layer
+
+logger = logging.getLogger(__name__)
 
 
 class DocumentFormMixin(object):
@@ -199,9 +202,11 @@ class DocumentCreateForm(TranslationModelForm, DocumentFormMixin):
         doc_url = self.cleaned_data.get('doc_url')
 
         if not doc_file and not doc_url:
+            logger.debug("Document must be a file or url.")
             raise forms.ValidationError(_("Document must be a file or url."))
 
         if doc_file and doc_url:
+            logger.debug("A document cannot have both a file and a url.")
             raise forms.ValidationError(
                 _("A document cannot have both a file and a url."))
 
@@ -216,6 +221,7 @@ class DocumentCreateForm(TranslationModelForm, DocumentFormMixin):
         if doc_file and not os.path.splitext(
                 doc_file.name)[1].lower()[
                 1:] in settings.ALLOWED_DOCUMENT_TYPES:
+            logger.debug("This file type is not allowed")
             raise forms.ValidationError(_("This file type is not allowed"))
 
         return doc_file

--- a/geonode/documents/models.py
+++ b/geonode/documents/models.py
@@ -18,9 +18,9 @@
 #
 #########################################################################
 
-import logging
 import os
 import uuid
+import logging
 from urllib.parse import urlparse
 
 from django.db import models

--- a/geonode/documents/templates/documents/document_detail.html
+++ b/geonode/documents/templates/documents/document_detail.html
@@ -120,59 +120,59 @@
         {%  endif %}
       {%  endif %}
       </li>
-      {% if "change_resourcebase_metadata" in perms_list or "change_resourcebase" in perms_list or "delete_resourcebase" in perms_list %}
-        {% if not READ_ONLY_MODE %}
+      {% if not READ_ONLY_MODE %}
+        {% if "change_resourcebase_metadata" in perms_list or "change_resourcebase" in perms_list or "delete_resourcebase" in perms_list %}
           <li class="list-group-item">
             <button class="btn btn-primary btn-md btn-block" data-toggle="modal" data-target="#edit-document">{% trans "Edit Document" %}</button>
           </li>
         {% endif %}
-      {% endif %}
 
-      <div class="modal fade" id="edit-document" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
-        <div class="modal-dialog">
-          <div class="modal-content">
-            <div class="modal-header">
-              <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-              <h4 class="modal-title" id="myModalLabel">{% trans "Edit Document" %}</h4>
-            </div>
-            <div class="modal-body">
-
-              <div class="row edit-modal">
-                {% if "change_resourcebase_metadata" in perms_list %}
-                <div class="col-sm-3">
-                  <i class="fa fa-list-alt fa-3x"></i>
-                  <h4>{% trans "Metadata" %}</h4>
-                  <a class="btn btn-default btn-block btn-xs" href="{% url "document_metadata" resource.id %}">{% trans "Wizard" %}</a>
-                  <a class="btn btn-default btn-block btn-xs" href="{% url "document_metadata_advanced" resource.id %}">{% trans "Advanced Edit" %}</a>
-                </div>
-                {% endif %}
-                {% if "change_resourcebase" in perms_list %}
-                <div class="col-sm-3">
-                  <i class="fa fa-photo fa-3x"></i>
-                  <h4>{% trans "Thumbnail" %}</h4>
-                  <a class="btn btn-default btn-block btn-xs" href="{% url "thumbnail_upload" resource.resourcebase_ptr.id %}">{% trans "Upload" %}</a>
-                </div>
-                {% endif %}
-                {% if "change_resourcebase" in perms_list or "delete_resourcebase" in perms_list %}
-                <div class="col-sm-3">
-                  <i class="fa fa-file-text-o fa-3x"></i>
-                  <h4>{% trans "Document" %}</h4>
-                  {% if "change_resourcebase" in perms_list %}
-                  <a class="btn btn-default btn-block btn-xs" href="{% url "document_replace" resource.id %}">{% trans "Replace" %}</a>
-                  {% endif %}
-                  {% if "delete_resourcebase" in perms_list %}
-                  <a class="btn btn-danger btn-block btn-xs" href="{% url "document_remove" resource.id %}">{% trans "Remove" %}</a>
-                  {% endif %}
-                </div>
-                {% endif %}
+        <div class="modal fade" id="edit-document" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+          <div class="modal-dialog">
+            <div class="modal-content">
+              <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                <h4 class="modal-title" id="myModalLabel">{% trans "Edit Document" %}</h4>
               </div>
-            </div>
-            <div class="modal-footer">
-              <button type="button" class="btn btn-default" data-dismiss="modal">{% trans "Close" %}</button>
+              <div class="modal-body">
+
+                <div class="row edit-modal">
+                  {% if "change_resourcebase_metadata" in perms_list %}
+                  <div class="col-sm-3">
+                    <i class="fa fa-list-alt fa-3x"></i>
+                    <h4>{% trans "Metadata" %}</h4>
+                    <a class="btn btn-default btn-block btn-xs" href="{% url "document_metadata" resource.id %}">{% trans "Wizard" %}</a>
+                    <a class="btn btn-default btn-block btn-xs" href="{% url "document_metadata_advanced" resource.id %}">{% trans "Advanced Edit" %}</a>
+                  </div>
+                  {% endif %}
+                  {% if "change_resourcebase" in perms_list %}
+                  <div class="col-sm-3">
+                    <i class="fa fa-photo fa-3x"></i>
+                    <h4>{% trans "Thumbnail" %}</h4>
+                    <a class="btn btn-default btn-block btn-xs" href="{% url "thumbnail_upload" resource.resourcebase_ptr.id %}">{% trans "Upload" %}</a>
+                  </div>
+                  {% endif %}
+                  {% if "change_resourcebase" in perms_list or "delete_resourcebase" in perms_list %}
+                  <div class="col-sm-3">
+                    <i class="fa fa-file-text-o fa-3x"></i>
+                    <h4>{% trans "Document" %}</h4>
+                    {% if "change_resourcebase" in perms_list %}
+                    <a class="btn btn-default btn-block btn-xs" href="{% url "document_replace" resource.id %}">{% trans "Replace" %}</a>
+                    {% endif %}
+                    {% if "delete_resourcebase" in perms_list %}
+                    <a class="btn btn-danger btn-block btn-xs" href="{% url "document_remove" resource.id %}">{% trans "Remove" %}</a>
+                    {% endif %}
+                  </div>
+                  {% endif %}
+                </div>
+              </div>
+              <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal">{% trans "Close" %}</button>
+              </div>
             </div>
           </div>
         </div>
-      </div>
+      {% endif %}
 
       <li class="list-group-item">
         <button class="btn btn-default btn-md btn-block" data-toggle="modal" data-target="#download-metadata">{% trans "Download Metadata" %}</button>
@@ -224,14 +224,16 @@
         </ul>
       </li>
 
-      {% if "change_resourcebase_permissions" in perms_list %}
-        {% if not READ_ONLY_MODE %}
-          <li class="list-group-item">
-            <h4>{% trans "Permissions" %}</h4>
-            <p>{% trans "Click the button below to change the permissions of this document." %}</p>
-            <p><a href="#modal_perms" data-toggle="modal" class="btn btn-primary btn-block" data-target="#_permissions">{% trans "Change Document Permissions" %}</a></p>
-          </li>
-          {% include "_permissions_form.html" %}
+      {% if GEONODE_SECURITY_ENABLED %}
+        {% if "change_resourcebase_permissions" in perms_list %}
+          {% if not READ_ONLY_MODE %}
+            <li class="list-group-item">
+              <h4>{% trans "Permissions" %}</h4>
+              <p>{% trans "Click the button below to change the permissions of this document." %}</p>
+              <p><a href="#modal_perms" data-toggle="modal" class="btn btn-primary btn-block" data-target="#_permissions">{% trans "Change Document Permissions" %}</a></p>
+            </li>
+            {% include "_permissions_form.html" %}
+          {% endif %}
         {% endif %}
       {% endif %}
 

--- a/geonode/documents/tests.py
+++ b/geonode/documents/tests.py
@@ -31,16 +31,19 @@ import json
 
 import gisdata
 from datetime import datetime
-from django.core.files.uploadedfile import SimpleUploadedFile
-from django.contrib.auth import get_user_model
-from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
 from django.contrib.auth.models import Group
+from django.contrib.auth import get_user_model
+from django.contrib.contenttypes.models import ContentType
+from django.core.files.uploadedfile import SimpleUploadedFile
 
-from guardian.shortcuts import get_anonymous_user
+from guardian.shortcuts import get_perms, get_anonymous_user
 
 from .forms import DocumentCreateForm
 
+from geonode.groups.models import (
+    GroupProfile,
+    GroupMember)
 from geonode.maps.models import Map
 from geonode.layers.models import Layer
 from geonode.compat import ensure_string
@@ -448,6 +451,8 @@ class DocumentModerationTestCase(GeoNodeBaseTestSupport):
         self.passwd = 'admin'
         create_models(type=b'document')
         create_models(type=b'map')
+        self.document_upload_url = "{}?no__redirect=true".format(
+            reverse('document_upload'))
         self.u = get_user_model().objects.get(username=self.user)
         self.u.email = 'test@email.com'
         self.u.is_active = True
@@ -462,7 +467,6 @@ class DocumentModerationTestCase(GeoNodeBaseTestSupport):
         Test if moderation flag works
         """
         with self.settings(ADMIN_MODERATE_UPLOADS=False):
-            document_upload_url = reverse('document_upload')
             self.client.login(username=self.user, password=self.passwd)
 
             input_path = self._get_input_path()
@@ -470,12 +474,12 @@ class DocumentModerationTestCase(GeoNodeBaseTestSupport):
             with open(input_path, 'rb') as f:
                 data = {'title': 'document title',
                         'doc_file': f,
-                        'doc_url': '',
                         'resource': '',
+                        'extension': 'txt',
                         'permissions': '{}',
                         }
-                resp = self.client.post(document_upload_url, data=data)
-            self.assertEqual(resp.status_code, 302)
+                resp = self.client.post(self.document_upload_url, data=data)
+                self.assertEqual(resp.status_code, 200)
             dname = 'document title'
             _d = Document.objects.get(title=dname)
 
@@ -503,24 +507,52 @@ class DocumentModerationTestCase(GeoNodeBaseTestSupport):
             self.assertTrue(_cnt == 0)
 
         with self.settings(ADMIN_MODERATE_UPLOADS=True):
-            document_upload_url = reverse('document_upload')
             self.client.login(username=self.user, password=self.passwd)
 
+            norman = get_user_model().objects.get(username="norman")
+            group = GroupProfile.objects.get(slug="bar")
             input_path = self._get_input_path()
-
             with open(input_path, 'rb') as f:
                 data = {'title': 'document title',
                         'doc_file': f,
-                        'doc_url': '',
                         'resource': '',
+                        'extension': 'txt',
                         'permissions': '{}',
                         }
-                resp = self.client.post(document_upload_url, data=data)
-            self.assertEqual(resp.status_code, 302)
+                resp = self.client.post(self.document_upload_url, data=data)
+                self.assertEqual(resp.status_code, 200)
             dname = 'document title'
             _d = Document.objects.get(title=dname)
+            self.assertFalse(_d.is_approved)
+            self.assertTrue(_d.is_published)
 
-            self.assertFalse(_d.is_published)
+            group.join(norman)
+            self.assertFalse(group.user_is_role(norman, "manager"))
+            GroupMember.objects.get(group=group, user=norman).promote()
+            self.assertTrue(group.user_is_role(norman, "manager"))
+
+            self.client.login(username="norman", password="norman")
+            resp = self.client.get(
+                reverse('document_detail', args=(_d.id,)))
+            # Forbidden
+            self.assertEqual(resp.status_code, 403)
+            _d.group = group.group
+            _d.save()
+            resp = self.client.get(
+                reverse('document_detail', args=(_d.id,)))
+            # Allowed - edit permissions
+            self.assertEqual(resp.status_code, 200)
+            perms_list = get_perms(norman, _d.get_self_resource()) + get_perms(norman, _d)
+            self.assertTrue('change_resourcebase_metadata' in perms_list)
+            GroupMember.objects.get(group=group, user=norman).demote()
+            self.assertFalse(group.user_is_role(norman, "manager"))
+            resp = self.client.get(
+                reverse('document_detail', args=(_d.id,)))
+            # Allowed - no edit
+            self.assertEqual(resp.status_code, 200)
+            perms_list = get_perms(norman, _d.get_self_resource()) + get_perms(norman, _d)
+            self.assertFalse('change_resourcebase_metadata' in perms_list)
+            group.leave(norman)
 
 
 class DocumentNotificationsTestCase(NotificationsTestsHelper):

--- a/geonode/geoserver/helpers.py
+++ b/geonode/geoserver/helpers.py
@@ -17,30 +17,28 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 #########################################################################
-
-from collections import namedtuple, defaultdict
-import datetime
-from decimal import Decimal
+import os
+import re
+import sys
+import time
+import uuid
+# import base64
+import json
 import errno
-from itertools import cycle
+import logging
+import datetime
+import traceback
+
 from six import (
     string_types,
     reraise as raise_
 )
-import json
-import logging
-import traceback
-import os
+from itertools import cycle
+from decimal import Decimal
+from collections import namedtuple, defaultdict
 from os.path import basename, splitext, isfile
-import re
-import sys
 from threading import local
-import time
-import uuid
-# import base64
-
 from urllib.parse import urlencode, urlsplit, urljoin
-
 from pinax.ratings.models import OverallRating
 from bs4 import BeautifulSoup
 from dialogos.models import Comment

--- a/geonode/geoserver/signals.py
+++ b/geonode/geoserver/signals.py
@@ -17,10 +17,13 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 #########################################################################
-
 import errno
 import logging
+import geoserver
+
 from time import sleep
+from geoserver.layer import Layer as GsLayer
+
 from django.conf import settings
 from django.forms.models import model_to_dict
 from django.contrib.auth import get_user_model
@@ -28,25 +31,24 @@ from django.contrib.auth import get_user_model
 # use different name to avoid module clash
 from . import BACKEND_PACKAGE
 from geonode import GeoNodeException
-from geonode.utils import set_resource_default_links
+from geonode.utils import (
+    set_resource_default_links,
+    json_serializer_producer)
 from geonode.decorators import on_ogc_backend
 from geonode.geoserver.upload import geoserver_upload
-from geonode.geoserver.helpers import (cascading_delete,
-                                       set_attributes_from_geoserver,
-                                       set_styles,
-                                       gs_catalog,
-                                       ogc_server_settings,
-                                       create_gs_thumbnail,
-                                       _stylefilterparams_geowebcache_layer,
-                                       _invalidate_geowebcache_layer)
+from geonode.geoserver.helpers import (
+    cascading_delete,
+    set_attributes_from_geoserver,
+    set_styles,
+    gs_catalog,
+    ogc_server_settings,
+    create_gs_thumbnail,
+    _stylefilterparams_geowebcache_layer,
+    _invalidate_geowebcache_layer)
 from geonode.catalogue.models import catalogue_post_save
 from geonode.base.models import ResourceBase
 from geonode.layers.models import Layer
-from geonode.social.signals import json_serializer_producer
 from geonode.services.enumerations import CASCADED
-
-import geoserver
-from geoserver.layer import Layer as GsLayer
 
 logger = logging.getLogger("geonode.geoserver.signals")
 

--- a/geonode/layers/forms.py
+++ b/geonode/layers/forms.py
@@ -194,14 +194,11 @@ class LayerUploadForm(forms.Form):
                         # overwrite as file.shp
                         if cleaned.get("sld_file"):
                             cleaned["sld_file"].name = '%s.sld' % base_name
-
         return cleaned
 
     def write_files(self):
-
         absolute_base_file = None
         tempdir = tempfile.mkdtemp()
-
         if zipfile.is_zipfile(self.cleaned_data['base_file']):
             absolute_base_file = unzip_file(self.cleaned_data['base_file'],
                                             '.shp', tempdir=tempdir)

--- a/geonode/layers/utils.py
+++ b/geonode/layers/utils.py
@@ -599,9 +599,10 @@ def file_upload(filename,
     # by default, if RESOURCE_PUBLISHING=True then layer.is_published
     # must be set to False
     if not overwrite:
-        if settings.RESOURCE_PUBLISHING or settings.ADMIN_MODERATE_UPLOADS:
-            is_approved = False
+        if settings.RESOURCE_PUBLISHING:
             is_published = False
+        if settings.ADMIN_MODERATE_UPLOADS:
+            is_approved = False
 
     defaults = {
         'upload_session': upload_session,

--- a/geonode/maps/models.py
+++ b/geonode/maps/models.py
@@ -176,11 +176,11 @@ class Map(ResourceBase, GXPMapBase):
                 pass
 
         conf = context.get("config", {})
-        if not isinstance(conf, dict):
+        if not isinstance(conf, dict) or isinstance(conf, bytes):
             try:
                 conf = json.loads(ensure_string(conf))
             except Exception:
-                pass
+                conf = {}
 
         about = conf.get("about", {})
         self.title = conf.get("title", about.get("title", ""))

--- a/geonode/maps/templates/maps/map_detail.html
+++ b/geonode/maps/templates/maps/map_detail.html
@@ -136,6 +136,7 @@
             </div>
           </div>
         </div>
+
         {% if not READ_ONLY_MODE %}
           {% if "change_resourcebase" in perms_list  or "change_resourcebase_metadata" in perms_list %}
           <li class="list-group-item">
@@ -184,6 +185,7 @@
           </div>
           {% endif %}
         {% endif %}
+
         <li class="list-group-item">
         {% if "change_resourcebase" not in perms_list and "change_resourcebase_metadata" not in perms_list %}
           <a href="{% url "map_view" resource.id %}" class="btn btn-default btn-md btn-block">{% trans "View Map" %}</a>
@@ -225,15 +227,17 @@
         </li>
         {% endif %}
 
-        {% if "change_resourcebase_permissions" in perms_list %}
-          {% if not READ_ONLY_MODE %}
-            <li class="list-group-item">
-              <h4>{% trans "Permissions" %}</h4>
-              <p>{% trans "Specify which users can view or modify this map" %}</p>
-              <button class="btn btn-primary btn-md btn-block" data-toggle="modal" data-target="#_permissions">{% trans "Change Permissions of this Map" %}</button>
-            </li>
+        {% if GEONODE_SECURITY_ENABLED %}
+          {% if "change_resourcebase_permissions" in perms_list %}
+            {% if not READ_ONLY_MODE %}
+              <li class="list-group-item">
+                <h4>{% trans "Permissions" %}</h4>
+                <p>{% trans "Specify which users can view or modify this map" %}</p>
+                <button class="btn btn-primary btn-md btn-block" data-toggle="modal" data-target="#_permissions">{% trans "Change Permissions of this Map" %}</button>
+              </li>
+            {% endif %}
+          {% include "_permissions_form.html" %}
           {% endif %}
-        {% include "_permissions_form.html" %}
         {% endif %}
 
         {% if not READ_ONLY_MODE %}

--- a/geonode/maps/tests.py
+++ b/geonode/maps/tests.py
@@ -220,8 +220,6 @@ community."
         except Exception:
             pass
 
-        self.client.logout()
-
     @on_ogc_backend(geoserver.BACKEND_PACKAGE)
     def test_map_fetch(self):
         """/maps/[id]/data -> Test fetching a map in JSON"""
@@ -932,7 +930,7 @@ class MapModerationTestCase(GeoNodeBaseTestSupport):
                 content = content.decode('UTF-8')
             map_id = int(json.loads(content)['id'])
             _l = Map.objects.get(id=map_id)
-
+            self.assertTrue(_l.is_approved)
             self.assertTrue(_l.is_published)
 
         with self.settings(ADMIN_MODERATE_UPLOADS=True):
@@ -947,8 +945,8 @@ class MapModerationTestCase(GeoNodeBaseTestSupport):
                 content = content.decode('UTF-8')
             map_id = int(json.loads(content)['id'])
             _l = Map.objects.get(id=map_id)
-
-            self.assertFalse(_l.is_published)
+            self.assertFalse(_l.is_approved)
+            self.assertTrue(_l.is_published)
 
 
 class MapsNotificationsTestCase(NotificationsTestsHelper):

--- a/geonode/messaging/producer.py
+++ b/geonode/messaging/producer.py
@@ -75,11 +75,11 @@ def sync_if_local_memory(func, *args, **kwargs):
                 tb = traceback.format_exc()
                 msg = "Exception while publishing message: {}".format(tb)
                 logger.error(msg)
-                raise
+                raise Exception(msg)
         elif not getattr(connection.connection, 'driver_name', None):
             msg = "Exception while getting connection to {}".format(url)
             logger.error(msg)
-            raise
+            raise Exception(msg)
 
 
 @sync_if_local_memory
@@ -89,7 +89,6 @@ def send_email_producer(layer_uuid, user_id):
         payload = {
             "layer_uuid": layer_uuid,
             "user_id": user_id
-
         }
         producer.publish(
             payload,

--- a/geonode/monitoring/tests/integration.py
+++ b/geonode/monitoring/tests/integration.py
@@ -54,7 +54,6 @@ from geonode.monitoring.models import do_autoconfigure
 from geonode.compat import ensure_string
 from geonode.monitoring.collector import CollectorAPI
 from geonode.monitoring.utils import generate_periods, align_period_start
-from geonode.utils import designals
 from geonode.maps.models import Map
 from geonode.layers.models import Layer
 from geonode.documents.models import Document
@@ -181,9 +180,6 @@ class MonitoringTestBase(GeoNodeLiveTestSupport):
             os.unlink('integration_settings.py')
 
     def setUp(self):
-
-        designals()
-
         # await startup
         cl = Client(
             GEONODE_URL, GEONODE_USER, GEONODE_PASSWD

--- a/geonode/security/utils.py
+++ b/geonode/security/utils.py
@@ -144,7 +144,7 @@ def get_users_with_perms(obj):
     """
     ctype = ContentType.objects.get_for_model(obj)
     permissions = {}
-    PERMISSIONS_TO_FETCH = models.ADMIN_PERMISSIONS + models.LAYER_ADMIN_PERMISSIONS
+    PERMISSIONS_TO_FETCH = models.VIEW_PERMISSIONS + models.ADMIN_PERMISSIONS + models.LAYER_ADMIN_PERMISSIONS
 
     for perm in Permission.objects.filter(codename__in=PERMISSIONS_TO_FETCH, content_type_id=ctype.id):
         permissions[perm.id] = perm.codename
@@ -639,10 +639,11 @@ def set_owner_permissions(resource):
     """assign all admin permissions to the owner"""
     if resource.polymorphic_ctype:
         # Set the GeoFence Owner Rule
+        admin_perms = models.VIEW_PERMISSIONS + models.ADMIN_PERMISSIONS
         if resource.polymorphic_ctype.name == 'layer':
             for perm in models.LAYER_ADMIN_PERMISSIONS:
                 assign_perm(perm, resource.owner, resource.layer)
-        for perm in models.ADMIN_PERMISSIONS:
+        for perm in admin_perms:
             assign_perm(perm, resource.owner, resource.get_self_resource())
 
 

--- a/geonode/security/views.py
+++ b/geonode/security/views.py
@@ -43,7 +43,6 @@ if "notification" in settings.INSTALLED_APPS:
 
 def _perms_info(obj):
     info = obj.get_all_level_info()
-
     return info
 
 
@@ -51,7 +50,6 @@ def _perms_info_json(obj):
     info = _perms_info(obj)
     info['users'] = {u.username: perms for u, perms in info['users'].items()}
     info['groups'] = {g.name: perms for g, perms in info['groups'].items()}
-
     return json.dumps(info)
 
 

--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -509,7 +509,7 @@ if UNOCONV_ENABLE:
 
 LOGGING = {
     'version': 1,
-    'disable_existing_loggers': True,
+    'disable_existing_loggers': False,
     'formatters': {
         'verbose': {
             'format': '%(levelname)s %(asctime)s %(module)s %(process)d '
@@ -526,7 +526,7 @@ LOGGING = {
     },
     'handlers': {
         'console': {
-            'level': 'INFO',
+            'level': 'ERROR',
             'class': 'logging.StreamHandler',
             'formatter': 'simple'
         },
@@ -540,7 +540,7 @@ LOGGING = {
         "django": {
             "handlers": ["console"], "level": "ERROR", },
         "geonode": {
-            "handlers": ["console"], "level": "INFO", },
+            "handlers": ["console"], "level": "ERROR", },
         "geonode.qgis_server": {
             "handlers": ["console"], "level": "ERROR", },
         "geoserver-restconfig.catalog": {
@@ -550,7 +550,7 @@ LOGGING = {
         "pycsw": {
             "handlers": ["console"], "level": "ERROR", },
         "celery": {
-            "handlers": ["console"], "level": "ERROR", },
+            'handlers': ["console"], 'level': 'ERROR', },
     },
 }
 
@@ -1228,9 +1228,6 @@ API_LIMIT_PER_PAGE = int(os.getenv('API_LIMIT_PER_PAGE', '200'))
 API_INCLUDE_REGIONS_COUNT = ast.literal_eval(
     os.getenv('API_INCLUDE_REGIONS_COUNT', 'False'))
 
-# option to enable/disable resource unpublishing for administrators
-RESOURCE_PUBLISHING = ast.literal_eval(os.getenv('RESOURCE_PUBLISHING', 'False'))
-
 # Settings for EXIF plugin
 EXIF_ENABLED = ast.literal_eval(os.getenv('EXIF_ENABLED', 'True'))
 
@@ -1717,6 +1714,33 @@ if os.name == 'nt':
 # Filter: (boolean, optional, default false) a filter option on that thesaurus will appear in the main search page
 # THESAURUS = {'name': 'inspire_themes', 'required': True, 'filter': True}
 
+# ######################################################## #
+# Advanced Resource Publishing Worklow Settings - START    #
+# ######################################################## #
+"""
+    - if [ RESOURCE_PUBLISHING == True ]
+      By default the uploaded resources will be "unpublished".
+      The owner will be able to change them to "published" **UNLESS** the ADMIN_MODERATE_UPLOADS is activated.
+      If the owner assigns unpublished resources to a Group, both from Metadata and Permissions, in any case
+       the Group "Managers" will be able to edit the Resource.
+
+    - if [ ADMIN_MODERATE_UPLOADS == True ]
+      1. The owner won't be able to change to neither "approved" nor "published" state (unless he is a superuser)
+      2. If the Resource belongs to a Group somehow, the Managers will be able to change the state to "approved"
+         but **NOT** to "published". Only a superuser can publish a resource.
+      3. Superusers can do enything.
+
+    - if [ GROUP_PRIVATE_RESOURCES == True ]
+      The "unapproved" and "unpublished" Resources will be accessible **ONLY** by owners, superusers and member of 
+       the belonging groups.
+
+    - if [ GROUP_MANDATORY_RESOURCES == True ]
+      Editor will be **FORCED** to select a Group when editing the resource metadata.
+"""
+
+# option to enable/disable resource unpublishing for administrators
+RESOURCE_PUBLISHING = ast.literal_eval(os.getenv('RESOURCE_PUBLISHING', 'False'))
+
 # Each uploaded Layer must be approved by an Admin before becoming visible
 ADMIN_MODERATE_UPLOADS = ast.literal_eval(os.environ.get('ADMIN_MODERATE_UPLOADS', 'False'))
 
@@ -1727,6 +1751,9 @@ GROUP_PRIVATE_RESOURCES = ast.literal_eval(os.environ.get('GROUP_PRIVATE_RESOURC
 # If this option is enabled, Groups will become strictly Mandatory on
 # Metadata Wizard
 GROUP_MANDATORY_RESOURCES = ast.literal_eval(os.environ.get('GROUP_MANDATORY_RESOURCES', 'False'))
+# ######################################################## #
+# Advanced Resource Publishing Worklow Settings - END      #
+# ######################################################## #
 
 # A boolean which specifies wether to display the email in user's profile
 SHOW_PROFILE_EMAIL = ast.literal_eval(os.environ.get('SHOW_PROFILE_EMAIL', 'False'))
@@ -1875,7 +1902,7 @@ if MONITORING_ENABLED:
 
     CELERY_BEAT_SCHEDULE['collect_metrics'] = {
         'task': 'geonode.monitoring.tasks.collect_metrics',
-        'schedule': 60.0,
+        'schedule': 300.0,
     }
 
 USER_ANALYTICS_ENABLED = ast.literal_eval(os.getenv('USER_ANALYTICS_ENABLED', 'False'))

--- a/geonode/social/signals.py
+++ b/geonode/social/signals.py
@@ -23,7 +23,6 @@
     relationships, actstream user_messages and potentially others
 """
 import logging
-import datetime
 from collections import defaultdict
 from dialogos.models import Comment
 
@@ -237,42 +236,3 @@ if relationships and activity:
     signals.pre_delete.connect(relationship_pre_delete_actstream, sender=Relationship)
 if relationships and has_notifications:
     signals.post_save.connect(relationship_post_save, sender=Relationship)
-
-
-def json_serializer_producer(dictionary):
-    output = {}
-    # pop no useful information for others services which wants to connect to geonode
-    if 'supplemental_information_en' in dictionary.keys():
-        dictionary.pop('supplemental_information_en', None)
-    if 'supplemental_information' in dictionary.keys():
-        dictionary.pop('supplemental_information', None)
-    if 'doc_file' in dictionary.keys():
-        file_object = dictionary['doc_file']
-        dictionary['doc_file'] = str(file_object)
-    if 'regions' in dictionary.keys():
-        keys = dictionary['regions']
-        dictionary['regions'] = str(keys)
-    if 'keywords' in dictionary.keys():
-        keys = dictionary['keywords']
-        dictionary['keywords'] = str(keys)
-    if 'tkeywords' in dictionary.keys():
-        keys = dictionary['tkeywords']
-        dictionary['tkeywords'] = str(keys)
-    if 'styles' in dictionary.keys():
-        keys = dictionary['styles']
-        dictionary['styles'] = str(keys)
-    if 'contacts' in dictionary.keys():
-        keys = dictionary['contacts']
-        dictionary['contacts'] = str(keys)
-    for (x, y) in dictionary.items():
-        if not y:
-            # this is used to solve
-            # TypeError: [] is not JSON serializable when it is null
-            y = str(y)
-        # check datetime object
-        # TODO: Use instanceof
-        if isinstance(y, datetime.datetime):
-            y = str(y)
-
-        output[x] = y
-    return output


### PR DESCRIPTION
 - Fixes #5993 : Unexpected behavior of resource created under different RESOURCE_PUBLISHING setting

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
