### PR TITLE
[FIX #6001] Limit comment notifications

### DIFF
--- a/geonode/notifications_helper.py
+++ b/geonode/notifications_helper.py
@@ -23,7 +23,7 @@ from importlib import import_module
 
 from django.apps import AppConfig
 from django.conf import settings
-from django.db.models import signals
+from django.db.models import signals, Q
 
 from geonode.tasks.tasks import send_queued_notifications
 
@@ -68,6 +68,7 @@ def call_celery(func):
         if settings.PINAX_NOTIFICATIONS_QUEUE_ALL:
             send_queued_notifications.delay()
         return ret
+
     return wrap
 
 
@@ -114,4 +115,11 @@ def get_notification_recipients(notice_type_label, exclude_user=None):
     profiles = get_user_model().objects.filter(id__in=recipients_ids)
     if exclude_user:
         profiles.exclude(username=exclude_user.username)
+
+    return profiles
+
+
+def get_comment_notification_recipients(notice_type_label, instance_owner, exclude_user=None):
+    profiles = get_notification_recipients(notice_type_label, exclude_user)
+    profiles = profiles.filter(Q(pk=instance_owner.pk) | Q(is_superuser=True))
     return profiles

--- a/geonode/social/signals.py
+++ b/geonode/social/signals.py
@@ -28,6 +28,7 @@ from dialogos.models import Comment
 
 from django.conf import settings
 from django.db.models import signals
+from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
 
 # from actstream.exceptions import ModelNotActionable
@@ -36,7 +37,8 @@ from geonode.layers.models import Layer
 from geonode.maps.models import Map
 from geonode.documents.models import Document
 from geonode.notifications_helper import (send_notification, queue_notification,
-                                          has_notifications, get_notification_recipients)
+                                          has_notifications, get_notification_recipients,
+                                          get_comment_notification_recipients)
 
 logger = logging.getLogger(__name__)
 
@@ -216,8 +218,12 @@ def comment_post_save(instance, sender, created, **kwargs):
     been submitted
     """
     notice_type_label = '%s_comment' % instance.content_type.model.lower()
-    recipients = get_notification_recipients(notice_type_label, instance.author)
-    send_notification(recipients, notice_type_label, {"instance": instance})
+    recipients = get_comment_notification_recipients(notice_type_label, instance.content_object.owner)
+    send_notification(recipients,
+                      notice_type_label,
+                      extra_context={
+                          "instance": instance, 'notice_settings_url': reverse('pinax_notifications:notice_settings')
+                      })
 
 
 # signals

--- a/geonode/templates/pinax/notifications/email_body.txt
+++ b/geonode/templates/pinax/notifications/email_body.txt
@@ -5,6 +5,6 @@
 {{ message }}
 </p>
 <p>
-{% blocktrans %}To change how you receive notifications, please go to{% endblocktrans %} {{ default_http_protocol }}://{{ current_site }}{{ notices_url }}
+{% blocktrans %}To change how you receive notifications, please go to {% endblocktrans %} {{ default_http_protocol }}://{{ current_site }}{{ notice_settings_url }}
 </p>
 </body>


### PR DESCRIPTION
FIX #6001
Restrict recipients of comment notification just to resource owner and aministrator

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
