### PR TITLE
Modify default source type for layer configuration for geoext

### DIFF
--- a/geonode/maps/tests.py
+++ b/geonode/maps/tests.py
@@ -287,7 +287,7 @@ community."
         if isinstance(content, bytes):
             content = content.decode('UTF-8')
         cfg = json.loads(content)
-        self.assertEqual(cfg['defaultSourceType'], "gxp_wmscsource")
+        self.assertEqual(cfg['defaultSourceType'], "gxp_osmsource")
 
     def test_map_details(self):
         """/maps/1 -> Test accessing the map browse view function"""

--- a/geonode/utils.py
+++ b/geonode/utils.py
@@ -646,7 +646,7 @@ class GXPMapBase(object):
                 'abstract': self.abstract
             },
             'aboutUrl': '../about',
-            'defaultSourceType': "gxp_wmscsource",
+            'defaultSourceType': "gxp_osmsource",
             'sources': sources,
             'map': {
                 'layers': [layer_config(l, user=user) for l in layers],


### PR DESCRIPTION
This PR modifies the **defaultSourceType** value for layer configuration used by geoext. Actual value causes an error within the javascript client, making the map not to be rendered within the layer_detail page

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [ ] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
