### PR TITLE
[6037] Fix double click to remove message

### DIFF
--- a/geonode/base/templatetags/user_messages.py
+++ b/geonode/base/templatetags/user_messages.py
@@ -9,7 +9,8 @@ register = template.Library()
 
 @register.simple_tag
 def is_unread(thread, user):
-    if thread.userthread_set.filter(user=user, unread=True).count() > 0:
+    if thread.userthread_set.filter(user=user, unread=True).count() > 0 or \
+            thread.groupmemberthread_set.filter(user=user, unread=True).count() > 0:
         return True
     return False
 

--- a/geonode/groups/templates/groups/group_members.html
+++ b/geonode/groups/templates/groups/group_members.html
@@ -135,7 +135,7 @@
         <h3>{% trans "Add new members" %}</h3>
         <form method="POST" action="{% url "group_members_add" group.slug %}">
             {% csrf_token %}
-            <div id="member_form_container"
+            <div id="member_form_container">
                 {{ member_form|as_bootstrap }}<br/><br/>
             </div>
             <input type="submit" value="{% trans "Add Group Members" %}" class="btn btn-primary"/>

--- a/geonode/messaging/views.py
+++ b/geonode/messaging/views.py
@@ -2,24 +2,27 @@ from django.shortcuts import redirect
 from django.urls import reverse
 from django.views import View
 
-from user_messages.models import UserThread
+from user_messages.models import UserThread, GroupMemberThread
 
 
 class MarkReadUnread(View):
 
     def post(self, request, **kwargs):
         status_action = request.POST.get('action_type', '').lower()
-        thread_ids = self._get_thread_ids(request.POST.keys())
-        query_set = UserThread.objects.filter(user=request.user, thread__in=thread_ids)
+        thread_ids = self._get_thread_ids()
+        user_threads = UserThread.objects.filter(user=request.user, thread__in=thread_ids)
+        group_member_threads = GroupMemberThread.objects.filter(user=request.user, thread__in=thread_ids)
         if status_action == 'read':
-            query_set.update(unread=False)
+            group_member_threads.update(unread=False)
+            user_threads.update(unread=False)
         elif status_action == 'unread':
-            query_set.update(unread=True)
+            group_member_threads.update(unread=True)
+            user_threads.update(unread=True)
         return redirect(reverse('messages_inbox'))
 
-    def _get_thread_ids(self, post_keys):
+    def _get_thread_ids(self):
         ids = []
-        for key in post_keys:
-            if 'thread' in key:
+        for key in self.request.POST.keys():
+            if 'thread' in key and self.request.POST.get(key).lower() == 'true':
                 ids.append(int(key.split('_')[1]))
         return ids

--- a/geonode/templates/user_messages/_message_snippet.html
+++ b/geonode/templates/user_messages/_message_snippet.html
@@ -13,7 +13,7 @@
         <tr>
             <td class="col-sm-1">
                 <div class="inbox-checkbox">
-                    <input name="thread_{{ thread.pk }}" id={{ input_id }} type="checkbox">
+                    <input name=thread_{{ thread.pk }} id={{ input_id }} type="checkbox">
                     <label for={{ input_id }} class="inbox-marker-checkmark"></label>
                 </div>
             </td>
@@ -28,8 +28,7 @@
                 {{ thread.latest_message.sent_at}}
             </td>
             <td class="col-md-1">
-                <form id="thread_delete_{{ thread.pk }}" method="post"
-                      action="{% url "messages_thread_delete" thread.pk %}">
+                <form method="post" action="{% url "messages_thread_delete" thread.pk %}">
                     {% csrf_token %}
                     <button class="btn btn-danger message_delete_btn">{% trans "Delete" %}</button>
                 </form>

--- a/geonode/templates/user_messages/inbox.html
+++ b/geonode/templates/user_messages/inbox.html
@@ -35,10 +35,14 @@
                 $("#id-inbox-form").submit();
             });
         </script>
-
-        <form method="POST" id="id-inbox-form" action={% url "msg_status" %}>
+        <form method="POST" id="id-inbox-form" action={% url "msg_status" %} >
             {% csrf_token %}
             <input id="id-action-type" name="action_type" type="hidden" value="">
+            {% for thread in  threads_all%}
+                <input name=thread_{{ thread.pk }} id=read_unread_{{ thread.pk }} type="hidden" value="">
+            {% endfor %}
+        </form>
+
             <div class="tab-content">
               <article id="inbox" class="tab-pane active">
                 {% with threads_unread as threads %}
@@ -51,7 +55,6 @@
                 {% endwith %}
               </article>
             </div>
-        </form>
       </div>
     </div>
   </div>
@@ -68,8 +71,17 @@
 {% block extra_script %}
 {{ block.super }}
 <script type="text/javascript">
+
+function prepare_read_unread_form(objectClicked) {
+    if (objectClicked.type === 'checkbox') {
+        $("#read_unread_" + objectClicked.name.split("_")[1])[0].value = objectClicked.checked;
+    }
+}
+
 $('.tab-content').click(function(event) {
-  objectClicked = event.target;
+  const objectClicked = event.target;
+  prepare_read_unread_form(objectClicked)
+
   // If we clicked the delete button
   if ($(objectClicked)[0].className.indexOf('message_delete_btn') >= 0) {
     // Grab the correct form


### PR DESCRIPTION
FIX [#6037 ]
Bug was caused by nested forms
Messages table is no longer part of rad/unread form . Now it contains hidden input for each tread in inbox, that input is processed on backed side 

Minor improvement in text bolding for unread messages 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
