### PR TITLE
[Fixes #6025][Fixes #6040] Error on click 'Create Layer'

### DIFF
--- a/geonode/geoserver/createlayer/utils.py
+++ b/geonode/geoserver/createlayer/utils.py
@@ -234,8 +234,8 @@ def create_gs_layer(name, title, geometry_type, attributes=None):
            "<crs>EPSG:4326</crs></latLonBoundingBox>"
            "{attributes}"
            "</featureType>").format(
-        name=name.encode('UTF-8', 'strict'), native_name=native_name.encode('UTF-8', 'strict'),
-        title=title.encode('UTF-8', 'strict'),
+        name=name, native_name=native_name,
+        title=title,
         minx=BBOX[0], maxx=BBOX[1], miny=BBOX[2], maxy=BBOX[3],
         attributes=attributes_block)
 
@@ -247,6 +247,6 @@ def create_gs_layer(name, title, geometry_type, attributes=None):
     if req.status_code != 201:
         logger.error('Request status code was: %s' % req.status_code)
         logger.error('Response was: %s' % req.text)
-        raise GeoNodeException("Layer could not be created in GeoServer")
+        raise Exception("Layer could not be created in GeoServer {}".format(req.text))
 
     return workspace, datastore

--- a/geonode/geoserver/createlayer/views.py
+++ b/geonode/geoserver/createlayer/views.py
@@ -49,7 +49,7 @@ def layer_create(request, template='createlayer/layer_create.html'):
                 layer.set_permissions(json.loads(permissions))
                 return redirect(layer)
             except Exception as e:
-                error = '%s (%s)' % (e.message, type(e))
+                error = '%s (%s)' % (e, type(e))
     else:
         form = NewLayerForm()
 


### PR DESCRIPTION
<Include a few sentences describing the overall goals for this Pull Request>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
