### PR TITLE
[Fixes #6048][SPCGeoNode] HTTPS_PORT not considered by envsubst

### DIFF
--- a/scripts/spcgeonode/docker-compose.yml
+++ b/scripts/spcgeonode/docker-compose.yml
@@ -93,6 +93,8 @@ services:
     environment:
       - HTTPS_HOST=${HTTPS_HOST}
       - HTTP_HOST=${HTTP_HOST}
+      - HTTPS_PORT=${HTTPS_PORT}
+      - HTTP_PORT=${HTTP_PORT}
       - LETSENCRYPT_MODE=${LETSENCRYPT_MODE}
       - RESOLVER=127.0.0.11
     ports:

--- a/scripts/spcgeonode/nginx/docker-entrypoint.sh
+++ b/scripts/spcgeonode/nginx/docker-entrypoint.sh
@@ -33,8 +33,8 @@ else
 fi
 
 echo "Replacing environement variables"
-envsubst '\$HTTP_HOST \$HTTPS_HOST \$RESOLVER' < /etc/nginx/nginx.conf.envsubst > /etc/nginx/nginx.conf
-envsubst '\$HTTP_HOST \$HTTPS_HOST \$RESOLVER' < /etc/nginx/nginx.https.available.conf.envsubst > /etc/nginx/nginx.https.available.conf
+envsubst '\$HTTP_PORT \$HTTPS_PORT \$HTTP_HOST \$HTTPS_HOST \$RESOLVER' < /etc/nginx/nginx.conf.envsubst > /etc/nginx/nginx.conf
+envsubst '\$HTTP_PORT \$HTTPS_PORT \$HTTP_HOST \$HTTPS_HOST \$RESOLVER' < /etc/nginx/nginx.https.available.conf.envsubst > /etc/nginx/nginx.https.available.conf
 
 echo "Enabling or not https configuration"
 if [ -z "${HTTPS_HOST}" ]; then 

--- a/scripts/spcgeonode/nginx/nginx.conf.envsubst
+++ b/scripts/spcgeonode/nginx/nginx.conf.envsubst
@@ -1,11 +1,14 @@
 # NOTE : $VARIABLES are env variables replaced by entrypoint.sh using envsubst
 # not to be mistaken for nginx variables (also starting with $, but usually lowercase)
 
+worker_processes auto;
+
 events {
 
 }
 
-http{
+http {
+    server_names_hash_bucket_size  64;
 
     # Allow Nginx to resolve Docker host names (see https://sandro-keil.de/blog/2017/07/24/let-nginx-start-if-upstream-host-is-unavailable-or-down/)
     resolver $RESOLVER; # it seems rancher uses 169.254.169.250 instead of 127.0.0.11 which works well in docker-compose (see /etc/resolv.conf)
@@ -19,7 +22,7 @@ http{
     # even if not used (HTTP_HOST empty), we must keep it as it's used for internal API calls between django and geoserver
     # TODO : do not use unencrypted connection even on LAN, but is it possible to have browser not complaining about unknown authority ?
     server {
-        listen              80;
+        listen              $HTTP_PORT;
         server_name         $HTTP_HOST 127.0.0.1 nginx;
 
         include spcgeonode.conf;
@@ -27,8 +30,8 @@ http{
 
     # Default server closes the connection (we can connect only using HTTP_HOST and HTTPS HOST)
     server {
-        listen          80 default_server;
-        listen          443;
+        listen          $HTTP_PORT default_server;
+        listen          $HTTPS_PORT;
         server_name     _;
         return          444;
     }

--- a/scripts/spcgeonode/nginx/nginx.https.available.conf.envsubst
+++ b/scripts/spcgeonode/nginx/nginx.https.available.conf.envsubst
@@ -2,14 +2,19 @@
 # not to be mistaken for nginx variables (also starting with $, but usually lowercase)
 
 # This file is to be included in the main nginx.conf configuration if HTTPS_HOST is set
+ssl_session_cache   shared:SSL:10m;
+ssl_session_timeout 10m;
 
 # this is the actual HTTPS host
 server {
-    listen              443 ssl;
+    listen              $HTTPS_PORT ssl;
     server_name         $HTTPS_HOST;
+    keepalive_timeout   70;
 
     ssl_certificate     /certificate_symlink/fullchain.pem;
     ssl_certificate_key /certificate_symlink/privkey.pem;
+    ssl_protocols       TLSv1 TLSv1.1 TLSv1.2;
+    ssl_ciphers         HIGH:!aNULL:!MD5;
 
     include spcgeonode.conf;
 }
@@ -27,6 +32,6 @@ server {
 
     # Redirect to https
     location / {
-        return 302 https://$HTTPS_HOST$request_uri; # TODO : we should use 301 (permanent redirect, but not practical for debug)
+       return 302 https://$HTTPS_HOST$request_uri; # TODO : we should use 301 (permanent redirect, but not practical for debug)
     }
 }


### PR DESCRIPTION
<Include a few sentences describing the overall goals for this Pull Request>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
