### PR TITLE
[Fixes #6099] Move triggering of notifications out of notification_sender signals for ResourceBase

### DIFF
--- a/geonode/base/views.py
+++ b/geonode/base/views.py
@@ -79,7 +79,7 @@ def batch_modify(request, ids, model):
                     resource.keywords.clear()
                     for word in keywords.split(','):
                         resource.keywords.add(word.strip())
-                resource.save()
+                resource.save(notify=True)
             return HttpResponseRedirect(
                 '/admin/{model}s/{model}/'.format(model=model.lower())
             )
@@ -247,7 +247,6 @@ class OwnerRightsRequestView(LoginRequiredMixin, FormView):
         form = self.form_class(request.POST)
         if form.is_valid():
             reason = form.cleaned_data['reason']
-            # object.save()
             notice_type_label = 'request_resource_edit'
             recipients = OwnerRightsRequestViewUtils.get_message_recipients()
 

--- a/geonode/documents/tests.py
+++ b/geonode/documents/tests.py
@@ -574,7 +574,7 @@ class DocumentNotificationsTestCase(NotificationsTestsHelper):
             _d = Document.objects.create(title='test notifications', owner=self.u)
             self.assertTrue(self.check_notification_out('document_created', self.u))
             _d.title = 'test notifications 2'
-            _d.save()
+            _d.save(notify=True)
             self.assertTrue(self.check_notification_out('document_updated', self.u))
 
             from dialogos.models import Comment

--- a/geonode/documents/views.py
+++ b/geonode/documents/views.py
@@ -236,7 +236,7 @@ class DocumentUploadView(CreateView):
             self.object.is_approved = False
         if settings.RESOURCE_PUBLISHING:
             self.object.is_published = False
-        self.object.save()
+        self.object.save(notify=True)
         form.save_many2many()
         self.object.set_permissions(form.cleaned_data['permissions'])
 
@@ -482,7 +482,7 @@ def document_metadata(
             document.regions.clear()
             document.regions.add(*new_regions)
             document.category = new_category
-            document.save()
+            document.save(notify=True)
             document_form.save_many2many()
 
             register_event(request, EventType.EVENT_CHANGE_METADATA, document)

--- a/geonode/geoserver/helpers.py
+++ b/geonode/geoserver/helpers.py
@@ -696,7 +696,7 @@ def gs_slurp(
             # in some cases we need to explicitily save the resource to execute the signals
             # (for sure when running updatelayers)
             if execute_signals:
-                layer.save()
+                layer.save(notify=True)
 
             # Fix metadata links if the ip has changed
             if layer.link_set.metadata().count() > 0:

--- a/geonode/geoserver/views.py
+++ b/geonode/geoserver/views.py
@@ -128,7 +128,7 @@ def layer_style(request, layername):
     layer.default_style = new_style
     layer.styles = [
         s for s in layer.styles if s.name != style_name] + [old_default]
-    layer.save()
+    layer.save(notify=True)
 
     # Invalidate GeoWebCache for the updated resource
     try:

--- a/geonode/layers/tests.py
+++ b/geonode/layers/tests.py
@@ -1174,8 +1174,9 @@ class LayerNotificationsTestCase(NotificationsTestsHelper):
                 bbox_y0=-90,
                 bbox_y1=90,
                 srid='EPSG:4326')
+            self.assertTrue(self.check_notification_out('layer_created', self.u))
             _l.name = 'test notifications 2'
-            _l.save()
+            _l.save(notify=True)
             self.assertTrue(self.check_notification_out('layer_updated', self.u))
 
             from dialogos.models import Comment

--- a/geonode/layers/utils.py
+++ b/geonode/layers/utils.py
@@ -721,7 +721,6 @@ def file_upload(filename,
         # Blank out the store if overwrite is true.
         # geoserver_post_save_signal should upload the new file if needed
         layer.store = '' if overwrite else layer.store
-        layer.save()
 
         if upload_session:
             upload_session.resource = layer
@@ -758,7 +757,6 @@ def file_upload(filename,
     # Assign and save the charset using the Layer class' object (layer)
     if charset != 'UTF-8':
         layer.charset = charset
-        layer.save()
 
     to_update = {}
     if defaults.get('title', title) is not None:
@@ -789,7 +787,7 @@ def file_upload(filename,
             import traceback
             tb = traceback.format_exc()
             logger.error(tb)
-
+    layer.save(notify=True)
     return layer
 
 

--- a/geonode/layers/views.py
+++ b/geonode/layers/views.py
@@ -993,9 +993,7 @@ def layer_metadata(
                 except Exception:
                     tb = traceback.format_exc()
                     logger.error(tb)
-
         tkeywords_form = TKeywordForm(instance=layer)
-
     if request.method == "POST" and layer_form.is_valid() and attribute_form.is_valid(
     ) and category_form.is_valid():
         new_poc = layer_form.cleaned_data['poc']
@@ -1067,7 +1065,6 @@ def layer_metadata(
         if new_regions:
             layer.regions.add(*new_regions)
         layer.category = new_category
-        layer.save()
 
         up_sessions = UploadSession.objects.filter(layer=layer)
         if up_sessions.count() > 0 and up_sessions[0].user != layer.owner:
@@ -1100,6 +1097,7 @@ def layer_metadata(
             tb = traceback.format_exc()
             logger.error(tb)
 
+        layer.save(notify=True)
         return HttpResponse(json.dumps({'message': message}))
 
     if settings.ADMIN_MODERATE_UPLOADS:

--- a/geonode/maps/models.py
+++ b/geonode/maps/models.py
@@ -234,7 +234,7 @@ class Map(ResourceBase, GXPMapBase):
                     self.id, MapLayer, layer, source_for(layer), ordering
                 ))
 
-        self.save()
+        self.save(notify=True)
 
         if layer_names != set([l.alternate for l in self.local_layers]):
             map_changed_signal.send_robust(sender=self, what_changed='layers')
@@ -328,7 +328,7 @@ class Map(ResourceBase, GXPMapBase):
         # Save again to persist the zoom and bbox changes and
         # to generate the thumbnail.
         self.set_missing_info()
-        self.save()
+        self.save(notify=True)
 
     @property
     def sender(self):

--- a/geonode/maps/views.py
+++ b/geonode/maps/views.py
@@ -311,7 +311,7 @@ def map_metadata(
         map_obj.regions.clear()
         map_obj.regions.add(*new_regions)
         map_obj.category = new_category
-        map_obj.save()
+        map_obj.save(notify=True)
 
         register_event(request, EventType.EVENT_CHANGE_METADATA, map_obj)
         if not ajax:

--- a/geonode/services/serviceprocessors/arcgis.py
+++ b/geonode/services/serviceprocessors/arcgis.py
@@ -256,7 +256,7 @@ class ArcMapServiceHandler(base.ServiceHandlerBase):
             **resource_fields
         )
         geonode_layer.full_clean()
-        geonode_layer.save()
+        geonode_layer.save(notify=True)
         geonode_layer.keywords.add(*keywords)
         geonode_layer.set_default_permissions()
         return geonode_layer

--- a/geonode/services/serviceprocessors/wms.py
+++ b/geonode/services/serviceprocessors/wms.py
@@ -228,7 +228,7 @@ class WmsServiceHandler(base.ServiceHandlerBase,
             **resource_fields
         )
         geonode_layer.full_clean()
-        geonode_layer.save()
+        geonode_layer.save(notify=True)
         geonode_layer.keywords.add(*keywords)
         geonode_layer.set_default_permissions()
         return geonode_layer
@@ -604,7 +604,7 @@ class GeoNodeServiceHandler(WmsServiceHandler):
             except Exception:
                 traceback.print_exc()
             finally:
-                geonode_layer.save()
+                geonode_layer.save(notify=True)
 
 
 def _get_valid_name(proposed_name):

--- a/geonode/social/signals.py
+++ b/geonode/social/signals.py
@@ -62,7 +62,6 @@ def activity_post_modify_object(sender, instance, created=None, **kwargs):
     """
     Creates new activities after a Map, Layer, or Comment is  created/updated/deleted.
 
-
     action_settings:
     actor: the user who performed the activity
     action_object: the object that received the action
@@ -171,40 +170,6 @@ if activity:
     signals.post_delete.connect(activity_post_modify_object, sender=Document)
 
 
-def notification_post_save_resource(instance, sender, created, **kwargs):
-    """ Send a notification when a layer, map or document is created or
-    updated
-    """
-    notice_type_label = '%s_created' if created else '%s_updated'
-    notice_type_label = notice_type_label % instance.class_name.lower()
-    recipients = get_notification_recipients(notice_type_label)
-    send_notification(recipients, notice_type_label, {'resource': instance})
-
-    # Approval Notifications Here
-    if settings.ADMIN_MODERATE_UPLOADS:
-        if instance.is_approved and not instance.is_published:
-            notice_type_label = '%s_approved'
-            notice_type_label = notice_type_label % instance.class_name.lower()
-            recipients = get_notification_recipients(notice_type_label)
-            send_notification(recipients, notice_type_label, {'resource': instance})
-
-    # Publishing Notifications Here
-    if settings.RESOURCE_PUBLISHING:
-        if instance.is_approved and instance.is_published:
-            notice_type_label = '%s_published'
-            notice_type_label = notice_type_label % instance.class_name.lower()
-            recipients = get_notification_recipients(notice_type_label)
-            send_notification(recipients, notice_type_label, {'resource': instance})
-
-
-def notification_post_delete_resource(instance, sender, **kwargs):
-    """ Send a notification when a layer, map or document is deleted
-    """
-    notice_type_label = '%s_deleted' % instance.class_name.lower()
-    recipients = get_notification_recipients(notice_type_label)
-    send_notification(recipients, notice_type_label, {'resource': instance})
-
-
 def rating_post_save(instance, sender, created, **kwargs):
     """ Send a notification when rating a layer, map or document
     """
@@ -227,11 +192,7 @@ def comment_post_save(instance, sender, created, **kwargs):
 
 
 # signals
-# layer/map/document notifications
-for resource in (Layer, Map, Document):
-    signals.post_save.connect(notification_post_save_resource, sender=resource)
-    signals.post_delete.connect(notification_post_delete_resource, sender=resource)
-
+# comments notifications
 signals.post_save.connect(comment_post_save, sender=Comment)
 
 # rating notifications

--- a/geonode/tests/integration.py
+++ b/geonode/tests/integration.py
@@ -283,7 +283,7 @@ class GeoNodeMapTest(GeoNodeLiveTestSupport):
             self.assertTrue(math.isclose(bbox_x1, uploaded.bbox_x1))
             self.assertTrue(math.isclose(bbox_y0, uploaded.bbox_y0))
             self.assertTrue(math.isclose(bbox_y1, uploaded.bbox_y1))
-            self.assertEqual(srid, uploaded.srid)
+            self.assertTrue(uploaded.srid in srid)
 
             # bbox format: [xmin,xmax,ymin,ymax]
             expected_bbox = [

--- a/geonode/upload/upload.py
+++ b/geonode/upload/upload.py
@@ -933,6 +933,6 @@ def final_step(upload_session, user, charset="UTF-8"):
 
     signals.upload_complete.send(sender=final_step, layer=saved_layer)
     geonode_upload_session.save()
-    saved_layer.save()
+    saved_layer.save(notify=not created)
     cat._cache.clear()
     return saved_layer


### PR DESCRIPTION

 - Fixes #6099 : Move triggering of notifications out of notification_sender signals for ResourceBase

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
