### PR TITLE
[Fixes #6193] Geonode's "data_dt_filter" backup filter does not apply when a directory to be backed up contains files at it's root.

### DIFF
--- a/geonode/tests/test_utils.py
+++ b/geonode/tests/test_utils.py
@@ -1,0 +1,73 @@
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+from geonode.br.management.commands.utils.utils import ignore_time
+from geonode.tests.base import GeoNodeBaseTestSupport
+from geonode.utils import copy_tree
+
+
+class TestCopyTree(GeoNodeBaseTestSupport):
+    @patch('shutil.copy2')
+    @patch('os.path.getmtime', return_value=(datetime.now() - timedelta(days=1)).timestamp())
+    @patch('os.listdir', return_value=['Erling_Haaland.jpg'])
+    @patch('os.path.isdir', return_value=False)
+    def test_backup_of_root_files_with_modification_dates_meeting_less_than_filter_criteria(
+            self, patch_isdir, patch_listdir, patch_getmtime, patch_shutil_copy2):
+        """
+        Test that all root directories whose modification dates meet the 'data_dt_filter'
+        less-than iso timestamp are backed-up successfully
+        """
+        copy_tree('/src', '/dst', ignore=ignore_time('<', datetime.now().isoformat()))
+        self.assertTrue(patch_shutil_copy2.called)
+
+    @patch('shutil.copy2')
+    @patch('os.path.getmtime', return_value=(datetime.now() + timedelta(days=1)).timestamp())
+    @patch('os.listdir', return_value=['Sancho.jpg'])
+    @patch('os.path.isdir', return_value=False)
+    def test_skipped_backup_of_root_files_with_modification_dates_not_meeting_less_than_filter_criteria(
+            self, patch_isdir, patch_listdir, patch_getmtime, patch_shutil_copy2):
+        """
+        Test that all root directories whose modification dates do not meet the 'data_dt_filter'
+        less-than iso timestamp are not backed-up
+        """
+        copy_tree('/src', '/dst', ignore=ignore_time('<', datetime.now().isoformat()))
+        self.assertFalse(patch_shutil_copy2.called)
+
+    @patch('shutil.copy2')
+    @patch('os.path.getmtime', return_value=(datetime.now() - timedelta(days=1)).timestamp())
+    @patch('os.listdir', return_value=['Saala.jpg'])
+    @patch('os.path.isdir', return_value=False)
+    def test_backup_of_root_files_with_modification_dates_meeting_greater_than_filter_criteria(
+            self, patch_isdir, patch_listdir, patch_getmtime, patch_shutil_copy2):
+        """
+        Test that all root directories whose modification dates do not meet the 'data_dt_filter'
+        greater-than iso timestamp are backed-up successfully
+        """
+        copy_tree('/src', '/dst', ignore=ignore_time('>', datetime.now().isoformat()))
+        self.assertFalse(patch_shutil_copy2.called)
+
+    @patch('shutil.copy2')
+    @patch('os.path.getmtime', return_value=(datetime.now() + timedelta(days=1)).timestamp())
+    @patch('os.listdir', return_value=['Sadio.jpg'])
+    @patch('os.path.isdir', return_value=False)
+    def test_skipped_backup_of_root_files_with_modification_dates_not_meeting_greater_than_filter_criteria(
+            self, patch_isdir, patch_listdir, patch_getmtime, patch_shutil_copy2):
+        """
+        Test that all root directories whose modification dates do not meet the 'data_dt_filter'
+        less-than iso timestamp are not backed-up
+        """
+        copy_tree('/src', '/dst', ignore=ignore_time('>', datetime.now().isoformat()))
+        self.assertTrue(patch_shutil_copy2.called)
+
+    @patch('os.path.exists', return_value=True)
+    @patch('shutil.copytree')
+    @patch('os.path.getmtime', return_value=0)
+    @patch('os.listdir', return_value=['an_awesome_directory'])
+    @patch('os.path.isdir', return_value=True)
+    def test_backup_of_child_directories(
+            self, patch_isdir, patch_listdir, patch_getmtime, patch_shutil_copytree, path_os_exists):
+        """
+        Test that all directories which meet the 'ignore criteria are backed-up'
+        """
+        copy_tree('/src', '/dst', ignore=ignore_time('>=', datetime.now().isoformat()))
+        self.assertTrue(patch_shutil_copytree.called)

--- a/geonode/utils.py
+++ b/geonode/utils.py
@@ -1516,6 +1516,8 @@ def copy_tree(src, dst, symlinks=False, ignore=None):
                     pass
             else:
                 try:
+                    if ignore and s in ignore(dst, [s]):
+                        return
                     shutil.copy2(s, d)
                 except Exception:
                     pass


### PR DESCRIPTION
During Backup and Restore filters are used to include/exclude certain content from the backup. When the geonode upload directory/other directories (e.g the static root, templates dir, etc) that have to be backed up contain content (files) that are at their root. The content is backed up irrespective of date-time filters by configured by "data_dt_filter".

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
