### PR TITLE
[Fixes #6261] Limit "maps using this layer" to maps the user has permission to see

### DIFF
--- a/geonode/layers/templates/layers/layer_detail.html
+++ b/geonode/layers/templates/layers/layer_detail.html
@@ -613,11 +613,11 @@
     {% endif %}
     <li class="list-group-item">
       <h4>{% trans "Maps using this layer" %}</h4>
-      {% if resource.maps %}
+      {% if map_layers %}
         <p>{% trans "List of maps using this layer:" %}</p>
         {% endif %}
         <ul class="list-unstyled">
-          {% for maplayer in resource.maps %}
+          {% for maplayer in map_layers %}
             <li><a href="{{ maplayer.map.get_absolute_url }}">{{ maplayer.map.title }}</a></li>
           {% empty %}
             <li>{% trans "This layer is not currently used in any maps." %}</li>

--- a/geonode/layers/tests.py
+++ b/geonode/layers/tests.py
@@ -63,6 +63,10 @@ from geonode.tests.utils import NotificationsTestsHelper
 from geonode.layers.populate_layers_data import create_layer_data
 from geonode.layers import utils
 from geonode.layers.views import _resolve_layer
+from geonode.maps.models import Map, MapLayer
+from geonode.utils import DisableDjangoSignals
+from geonode.maps.tests_populate_maplayers import maplayers as ml
+from geonode.security.utils import remove_object_permissions
 
 logger = logging.getLogger(__name__)
 
@@ -1351,3 +1355,62 @@ class LayersUploaderTests(GeoNodeBaseTestSupport):
                 _l.delete()
         finally:
             Layer.objects.all().delete()
+
+
+class TestLayerDetailMapViewRights(GeoNodeBaseTestSupport):
+    def setUp(self):
+        super(TestLayerDetailMapViewRights, self).setUp()
+        create_layer_data()
+        self.user = get_user_model().objects.create(username='dybala', email='dybala@gmail.com')
+        self.user.set_password('very-secret')
+        admin = get_user_model().objects.get(username='admin')
+        self.map = Map.objects.create(owner=admin, title='test', is_approved=True, zoom=0, center_x=0.0, center_y=0.0)
+
+        self.layer = Layer.objects.all().first()
+        with DisableDjangoSignals():
+            self.map_layer = MapLayer.objects.create(
+                fixed=ml[0]['fixed'],
+                group=ml[0]['group'],
+                name=self.layer.alternate,
+                layer_params=ml[0]['layer_params'],
+                map=self.map,
+                source_params=ml[0]['source_params'],
+                stack_order=ml[0]['stack_order'],
+                opacity=ml[0]['opacity'],
+                transparent=True,
+                visibility=True
+            )
+
+    def test_that_authenticated_user_without_permissions_cannot_view_map_in_layer_detail(self):
+        """
+        Test that an authenticated user without permissions to view a map does not see the map under
+        'Maps using this layer' in layer_detail when map is not viewable by 'anyone'
+        """
+        remove_object_permissions(self.map.get_self_resource())
+        self.client.login(username='dybala', password='very-secret')
+        response = self.client.get(reverse('layer_detail', args=(self.layer.alternate,)))
+        self.assertEqual(response.context['map_layers'], [])
+
+    def test_that_anonymous_user_can_view_map_available_to_anyone(self):
+        """
+        Test that anonymous user can view map that has view permissions to 'anyone'
+        """
+        response = self.client.get(reverse('layer_detail', args=(self.layer.alternate,)))
+        self.assertEqual(response.context['map_layers'], [self.map_layer])
+
+    def test_that_anonymous_user_cannot_view_map_with_restricted_view(self):
+        """
+        Test that anonymous user cannot view map that are not viewable by 'anyone'
+        """
+        remove_object_permissions(self.map.get_self_resource())
+        response = self.client.get(reverse('layer_detail', args=(self.layer.alternate,)))
+        self.assertEqual(response.context['map_layers'], [])
+
+    def test_that_only_users_with_permissions_can_view_maps_in_layer_view(self):
+        """
+        Test only users with view permissions to a map can view them in layer detail view
+        """
+        remove_object_permissions(self.map.get_self_resource())
+        self.client.login(username='admin', password='admin')
+        response = self.client.get(reverse('layer_detail', args=(self.layer.alternate,)))
+        self.assertEqual(response.context['map_layers'], [self.map_layer])

--- a/geonode/layers/views.py
+++ b/geonode/layers/views.py
@@ -750,6 +750,8 @@ def layer_detail(request, layername, template='layers/layer_detail.html'):
             context_dict['groups'] = [group for group in request.user.group_list_all()]
 
     register_event(request, 'view', layer)
+    context_dict['map_layers'] = [map_layer for map_layer in layer.maps() if
+                                  request.user.has_perm('view_resourcebase', map_layer.map.get_self_resource())]
     return TemplateResponse(
         request, template, context=context_dict)
 


### PR DESCRIPTION
Limite "maps using this layer" to maps the user has permission to see

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [x] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
