### PR TITLE
[Issue #6414] Delete thumbnails using Django file storage API 

### DIFF
--- a/geonode/base/models.py
+++ b/geonode/base/models.py
@@ -20,7 +20,6 @@
 
 import os
 import re
-import glob
 import math
 import uuid
 import logging
@@ -1316,11 +1315,12 @@ class ResourceBase(PolymorphicModel, PermissionLevelMixin, ItemBase):
             im = Image.open(content_data)
             im.verify()  # verify that it is, in fact an image
 
-            for _thumb in glob.glob(storage.path('thumbs/%s*' % os.path.splitext(filename)[0])):
-                try:
-                    os.remove(_thumb)
-                except Exception:
-                    pass
+            thumbnail_name, ext = os.path.splitext(filename)
+            _, _thumbs = storage.listdir("thumbs")
+            for _thumb in _thumbs:
+                if _thumb.startswith(thumbnail_name):
+                    storage.delete(os.path.join("thumbs", _thumb))
+                    logger.debug("Deleted existing thumbnail: " + _thumb)
 
             if upload_path and image:
                 actual_name = storage.save(upload_path, ContentFile(image))


### PR DESCRIPTION
PR to perform thumbnail deletions using the Django file storage API.

Previously, `os.remove` was used to delete files from Django storage, which did not function correctly for remote storage as this is not implemented. This fix uses Django's `storage.delete` method instead which will work if the chosen storage plug-in implements it.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [x] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
