### PR TITLE
[Issue #6414] File system operations do not adhere to Django file storage API

### DIFF
--- a/geonode/base/models.py
+++ b/geonode/base/models.py
@@ -1307,6 +1307,10 @@ class ResourceBase(PolymorphicModel, PermissionLevelMixin, ItemBase):
     # that indexing (or other listeners) are notified
     def save_thumbnail(self, filename, image):
         upload_path = os.path.join('thumbs/', filename)
+        local_thumbs = os.path.join(settings.MEDIA_ROOT, "thumbs")
+        if not os.path.exists(local_thumbs):
+            os.makedirs(local_thumbs)
+
         try:
             # Check that the image is valid
             from PIL import Image

--- a/geonode/base/models.py
+++ b/geonode/base/models.py
@@ -74,6 +74,9 @@ from geonode.notifications_helper import (
     send_notification,
     get_notification_recipients)
 from geonode.people.enumerations import ROLE_VALUES
+from geonode.base.thumb_utils import (
+    thumb_path,
+    remove_thumbs)
 
 from pyproj import transform, Proj
 
@@ -1306,10 +1309,7 @@ class ResourceBase(PolymorphicModel, PermissionLevelMixin, ItemBase):
     # Note - you should probably broadcast layer#post_save() events to ensure
     # that indexing (or other listeners) are notified
     def save_thumbnail(self, filename, image):
-        upload_path = os.path.join('thumbs/', filename)
-        local_thumbs = os.path.join(settings.MEDIA_ROOT, "thumbs")
-        if not os.path.exists(local_thumbs):
-            os.makedirs(local_thumbs)
+        upload_path = thumb_path(filename)
 
         try:
             # Check that the image is valid
@@ -1319,18 +1319,14 @@ class ResourceBase(PolymorphicModel, PermissionLevelMixin, ItemBase):
             im = Image.open(content_data)
             im.verify()  # verify that it is, in fact an image
 
-            thumbnail_name, ext = os.path.splitext(filename)
-            _, _thumbs = storage.listdir("thumbs")
-            for _thumb in _thumbs:
-                if _thumb.startswith(thumbnail_name):
-                    storage.delete(os.path.join("thumbs", _thumb))
-                    logger.debug("Deleted existing thumbnail: " + _thumb)
+            name, ext = os.path.splitext(filename)
+            remove_thumbs(name)
 
             if upload_path and image:
                 actual_name = storage.save(upload_path, ContentFile(image))
                 url = storage.url(actual_name)
                 _url = urlparse(url)
-                _upload_path = os.path.join('thumbs/', os.path.basename(_url.path))
+                _upload_path = thumb_path(os.path.basename(_url.path))
                 if upload_path != _upload_path:
                     if storage.exists(_upload_path):
                         storage.delete(_upload_path)

--- a/geonode/base/thumb_utils.py
+++ b/geonode/base/thumb_utils.py
@@ -33,4 +33,6 @@ def remove_thumb(filename):
 def remove_thumbs(name):
     """Removes all stored thumbnails that start with the same name as the
     file specified"""
-    map(remove_thumb, (thumb for thumb in get_thumbs() if thumb.startswith(name)))
+    for thumb in get_thumbs():
+        if thumb.startswith(name):
+            remove_thumb(thumb)

--- a/geonode/base/thumb_utils.py
+++ b/geonode/base/thumb_utils.py
@@ -1,0 +1,36 @@
+import os
+
+from django.conf import settings
+from django.core.files.storage import default_storage as storage
+
+
+def thumb_path(filename):
+    """Return the complete path of the provided thumbnail file accessible
+    via Django storage API"""
+    return os.path.join(settings.THUMBNAIL_LOCATION, filename)
+
+
+def thumb_exists(filename):
+    """Determine if a thumbnail file exists in storage"""
+    return storage.exists(thumb_path(filename))
+
+
+def get_thumbs():
+    """Fetches a list of all stored thumbnails"""
+    if not storage.exists(settings.THUMBNAIL_LOCATION):
+        return []
+
+    subdirs, thumbs = storage.listdir(settings.THUMBNAIL_LOCATION)
+
+    return thumbs
+
+
+def remove_thumb(filename):
+    """Delete a thumbnail from storage"""
+    storage.delete(thumb_path(filename))
+
+
+def remove_thumbs(name):
+    """Removes all stored thumbnails that start with the same name as the
+    file specified"""
+    map(remove_thumb, (thumb for thumb in get_thumbs() if thumb.startswith(name)))

--- a/geonode/base/utils.py
+++ b/geonode/base/utils.py
@@ -22,7 +22,6 @@
 """
 
 # Standard Modules
-import os
 import logging
 from dateutil.parser import isoparse
 from datetime import datetime, timedelta
@@ -30,7 +29,6 @@ from datetime import datetime, timedelta
 # Django functionality
 from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.core.files.storage import default_storage as storage
 
 # Geonode functionality
 from guardian.shortcuts import get_perms, remove_perm, assign_perm
@@ -41,6 +39,9 @@ from geonode.base.models import ResourceBase, Link, Configuration
 from geonode.geoserver.helpers import ogc_server_settings
 from geonode.maps.models import Map
 from geonode.services.models import Service
+from geonode.base.thumb_utils import (
+    get_thumbs,
+    remove_thumb)
 
 logger = logging.getLogger('geonode.base.utils')
 
@@ -55,7 +56,7 @@ def delete_orphaned_thumbs():
     Deletes orphaned thumbnails.
     """
     deleted = []
-    _, files = storage.listdir("thumbs")
+    files = get_thumbs()
 
     for filename in files:
         model = filename.split('-')[0]
@@ -63,7 +64,7 @@ def delete_orphaned_thumbs():
         if ResourceBase.objects.filter(uuid=uuid).count() == 0:
             logger.debug("Deleting orphaned thumbnail " + filename)
             try:
-                storage.delete(os.path.join("thumbs", filename))
+                remove_thumb(filename)
                 deleted.append(filename)
             except NotImplementedError as e:
                 logger.error(

--- a/geonode/documents/renderers.py
+++ b/geonode/documents/renderers.py
@@ -74,7 +74,7 @@ def render_document(document_path, extension="png"):
                     "-f", extension, "-o", output_path, document_path],
                 stdout=subprocess.PIPE, stderr=subprocess.PIPE
             )
-            timeout = Timer(settings.UNOCONV_TIMEOUT, lambda p: p.kill(), [unoconv])
+            timeout = Timer(settings.UNOCONV_TIMEOUT, unoconv.kill)
             timeout.start()
             stdout, stderr = unoconv.communicate()
         except Exception as e:

--- a/geonode/documents/tasks.py
+++ b/geonode/documents/tasks.py
@@ -19,8 +19,6 @@
 #########################################################################
 
 import os
-from os import access, R_OK
-from os.path import isfile
 
 from geonode.celery_app import app
 from celery.utils.log import get_task_logger
@@ -29,7 +27,8 @@ from geonode.documents.models import Document
 from geonode.documents.renderers import render_document
 from geonode.documents.renderers import generate_thumbnail_content
 from geonode.documents.renderers import ConversionError
-from geonode.documents.renderers import MissingPILError
+
+from django.core.files.storage import default_storage as storage
 
 logger = get_task_logger(__name__)
 
@@ -47,38 +46,48 @@ def create_document_thumbnail(self, object_id):
         logger.error("Document #{} does not exist.".format(object_id))
         return
 
+    if not storage.exists(document.doc_file.name):
+        logger.error("Document #{} exists but its location could not be resolved.".format(object_id))
+        return
+
     image_path = None
+    image_file = None
 
     if document.is_image():
-        image_path = document.doc_file.path
+        image_file = storage.open(document.doc_file.name, 'rb')
     elif document.is_file():
         try:
-            image_file = render_document(document.doc_file.path)
-            image_path = image_file.name
+            document_location = storage.path(document.doc_file.name)
+        except NotImplementedError as e:
+            logger.debug(e)
+            document_location = storage.url(document.doc_file.name)
+
+        try:
+            image_path = render_document(document_location)
+            if image_path is not None:
+                image_file = open(image_path, 'rb')
+            else:
+                logger.debug("Failed to render document #{}".format(object_id))
         except ConversionError as e:
-            logger.debug("Could not convert document #{}: {}."
-                         .format(object_id, e))
-
-    try:
-        if image_path:
-            assert isfile(image_path) and access(image_path, R_OK) and os.stat(image_path).st_size > 0
-    except (AssertionError, TypeError):
-        image_path = None
-
-    if not image_path:
-        image_path = document.find_placeholder()
-
-    if not image_path or not os.path.exists(image_path):
-        logger.debug("Could not find placeholder for document #{}"
-                     .format(object_id))
-        return
+            logger.debug("Could not convert document #{}: {}.".format(object_id, e))
+        except NotImplementedError as e:
+            logger.debug("Failed to render document #{}: {}".format(object_id, e))
 
     thumbnail_content = None
     try:
-        thumbnail_content = generate_thumbnail_content(image_path)
-    except MissingPILError:
-        logger.error('Pillow not installed, could not generate thumbnail.')
+        try:
+            thumbnail_content = generate_thumbnail_content(image_file)
+        except Exception:
+            thumbnail_content = generate_thumbnail_content(document.find_placeholder())
+    except Exception as e:
+        logger.error("Could not generate thumbnail: {}".format(e))
         return
+    finally:
+        if image_file is not None:
+            image_file.close()
+
+        if image_path is not None:
+            os.remove(image_path)
 
     if not thumbnail_content:
         logger.warning("Thumbnail for document #{} empty.".format(object_id))

--- a/geonode/documents/tests.py
+++ b/geonode/documents/tests.py
@@ -48,6 +48,7 @@ from geonode.groups.models import (
 from geonode.maps.models import Map
 from geonode.layers.models import Layer
 from geonode.compat import ensure_string
+from geonode.base.thumb_utils import get_thumbs
 from geonode.base.models import License, Region
 from geonode.documents import DocumentsAppConfig
 from geonode.documents.forms import DocumentFormMixin
@@ -496,18 +497,17 @@ class DocumentModerationTestCase(GeoNodeBaseTestSupport):
             self.assertEqual(set(deleted), set(document_files_before) - set(document_files_after))
 
             from geonode.base.utils import delete_orphaned_thumbs
-            _, thumb_files_before = storage.listdir("thumbs")
+            thumb_files_before = get_thumbs()
             deleted = delete_orphaned_thumbs()
-            _, thumb_files_after = storage.listdir("thumbs")
+            thumb_files_after = get_thumbs()
             self.assertTrue(len(deleted) > 0)
             self.assertEqual(set(deleted), set(thumb_files_before) - set(thumb_files_after))
 
             fn = os.path.join("documents", os.path.basename(input_path))
             self.assertFalse(storage.exists(fn))
 
-            _, files = storage.listdir("thumbs")
-            _cnt = sum(1 for fn in files if uuid in fn)
-            self.assertEqual(_cnt, 0)
+            files = [thumb for thumb in get_thumbs() if uuid in thumb]
+            self.assertEqual(len(files), 0)
 
         with self.settings(ADMIN_MODERATE_UPLOADS=True):
             self.client.login(username=self.user, password=self.passwd)

--- a/geonode/documents/tests.py
+++ b/geonode/documents/tests.py
@@ -448,9 +448,6 @@ class DocumentModerationTestCase(GeoNodeBaseTestSupport):
 
     def setUp(self):
         super(DocumentModerationTestCase, self).setUp()
-        thumbs_dir = os.path.join(settings.MEDIA_ROOT, "thumbs")
-        if not os.path.exists(thumbs_dir):
-            os.mkdir(thumbs_dir)
         self.user = 'admin'
         self.passwd = 'admin'
         create_models(type=b'document')

--- a/geonode/layers/utils.py
+++ b/geonode/layers/utils.py
@@ -57,6 +57,7 @@ from geonode.base.auth import get_or_create_token
 from geonode import GeoNodeException, geoserver, qgis_server
 from geonode.people.utils import get_valid_user
 from geonode.layers.models import UploadSession, LayerFile
+from geonode.base.thumb_utils import thumb_exists
 from geonode.base.models import Link, SpatialRepresentationType,  \
     TopicCategory, Region, License, ResourceBase
 from geonode.layers.models import shp_exts, csv_exts, vec_exts, cov_exts, Layer
@@ -956,7 +957,7 @@ def create_thumbnail(instance, thumbnail_remote_url, thumbnail_create_url=None,
     elif isinstance(instance, Map):
         thumbnail_name = 'map-%s-thumb.png' % instance.uuid
 
-    _thumb_exists = storage.exists(os.path.join("thumbs", thumbnail_name))
+    _thumb_exists = thumb_exists(thumbnail_name)
     if overwrite or not _thumb_exists:
         BBOX_DIFFERENCE_THRESHOLD = 1e-5
 

--- a/geonode/qgis_server/tests/test_helpers.py
+++ b/geonode/qgis_server/tests/test_helpers.py
@@ -253,16 +253,18 @@ class HelperTest(GeoNodeBaseTestSupport):
         layer_path = settings.QGIS_SERVER_CONFIG['layer_directory']
         tiles_path = settings.QGIS_SERVER_CONFIG['tiles_directory']
 
+        # Use sets to perform difference operation later
         qgis_layers = set(os.listdir(layer_path))
         tile_caches = set(os.listdir(tiles_path))
-        _, geonode_layers = map(set, storage.listdir("layers"))
+        # storage.listdir returns a (directories, files) tuple
+        geonode_layers = set(storage.listdir("layers")[1])
 
         # run management command. should not change anything
         call_command('delete_orphaned_qgis_server_layers')
 
         actual_qgis_layers = set(os.listdir(layer_path))
         actual_tile_caches = set(os.listdir(tiles_path))
-        _, actual_geonode_layers = map(set, storage.listdir("layers"))
+        actual_geonode_layers = set(storage.listdir("layers")[1])
 
         self.assertEqual(qgis_layers, actual_qgis_layers)
         self.assertEqual(tile_caches, actual_tile_caches)
@@ -280,7 +282,7 @@ class HelperTest(GeoNodeBaseTestSupport):
 
         actual_qgis_layers = set(os.listdir(layer_path))
         actual_tile_caches = set(os.listdir(tiles_path))
-        _, actual_geonode_layers = map(set, storage.listdir("layers"))
+        actual_geonode_layers = set(storage.listdir("layers")[1])
 
         # run management command. This should clear the files. But preserve
         # registered files (the one that is saved in database)

--- a/geonode/qgis_server/tests/test_helpers.py
+++ b/geonode/qgis_server/tests/test_helpers.py
@@ -35,6 +35,7 @@ import shutil
 import requests
 from django.conf import settings
 from django.core.management import call_command
+from django.core.files.storage import default_storage as storage
 from django.urls import reverse
 
 from geonode import qgis_server
@@ -251,22 +252,21 @@ class HelperTest(GeoNodeBaseTestSupport):
         # register file list
         layer_path = settings.QGIS_SERVER_CONFIG['layer_directory']
         tiles_path = settings.QGIS_SERVER_CONFIG['tiles_directory']
-        geonode_layer_path = os.path.join(settings.MEDIA_ROOT, 'layers')
 
-        qgis_layer_list = set(os.listdir(layer_path))
-        tile_cache_list = set(os.listdir(tiles_path))
-        geonode_layer_list = set(os.listdir(geonode_layer_path))
+        qgis_layers = set(os.listdir(layer_path))
+        tile_caches = set(os.listdir(tiles_path))
+        _, geonode_layers = map(set, storage.listdir("layers"))
 
         # run management command. should not change anything
         call_command('delete_orphaned_qgis_server_layers')
 
-        actual_qgis_layer_list = set(os.listdir(layer_path))
-        actual_tile_cache_list = set(os.listdir(tiles_path))
-        actual_geonode_layer_list = set(os.listdir(geonode_layer_path))
+        actual_qgis_layers = set(os.listdir(layer_path))
+        actual_tile_caches = set(os.listdir(tiles_path))
+        _, actual_geonode_layers = map(set, storage.listdir("layers"))
 
-        self.assertEqual(qgis_layer_list, actual_qgis_layer_list)
-        self.assertEqual(tile_cache_list, actual_tile_cache_list)
-        self.assertEqual(geonode_layer_list, actual_geonode_layer_list)
+        self.assertEqual(qgis_layers, actual_qgis_layers)
+        self.assertEqual(tile_caches, actual_tile_caches)
+        self.assertEqual(geonode_layers, actual_geonode_layers)
 
         # now create random file without reference
         shutil.copy(
@@ -275,13 +275,12 @@ class HelperTest(GeoNodeBaseTestSupport):
         shutil.copytree(
             os.path.join(tiles_path, 'test_grid'),
             os.path.join(tiles_path, 'test_grid_copy'))
-        shutil.copy(
-            os.path.join(geonode_layer_path, 'test_grid.tif'),
-            os.path.join(geonode_layer_path, 'test_grid_copy.tif'))
+        with storage.open(os.path.join("layers", "test_grid.tif"), 'rb') as f:
+            storage.save(os.path.join("layers", "test_grid_copy.tif"), f)
 
-        actual_qgis_layer_list = set(os.listdir(layer_path))
-        actual_tile_cache_list = set(os.listdir(tiles_path))
-        actual_geonode_layer_list = set(os.listdir(geonode_layer_path))
+        actual_qgis_layers = set(os.listdir(layer_path))
+        actual_tile_caches = set(os.listdir(tiles_path))
+        _, actual_geonode_layers = map(set, storage.listdir("layers"))
 
         # run management command. This should clear the files. But preserve
         # registered files (the one that is saved in database)
@@ -289,13 +288,13 @@ class HelperTest(GeoNodeBaseTestSupport):
 
         self.assertEqual(
             {'test_grid_copy.tif'},
-            actual_qgis_layer_list - qgis_layer_list)
+            actual_qgis_layers - qgis_layers)
         self.assertEqual(
             {'test_grid_copy'},
-            actual_tile_cache_list - tile_cache_list)
+            actual_tile_caches - tile_caches)
         self.assertEqual(
             {'test_grid_copy.tif'},
-            actual_geonode_layer_list - geonode_layer_list)
+            actual_geonode_layers - geonode_layers)
 
         # cleanup
         uploaded.delete()

--- a/geonode/qgis_server/tests/test_views.py
+++ b/geonode/qgis_server/tests/test_views.py
@@ -33,6 +33,7 @@ from defusedxml import lxml as dlxml
 import gisdata
 from django.conf import settings
 from django.contrib.staticfiles.templatetags import staticfiles
+from django.core.files.storage import default_storage as storage
 from django.urls import reverse
 
 from geonode import qgis_server
@@ -572,13 +573,12 @@ class ThumbnailGenerationTest(GeoNodeBaseTestSupport):
 
         response = self.client.get(remote_thumbnail_url)
 
-        thumbnail_dir = os.path.join(settings.MEDIA_ROOT, 'thumbs')
-        thumbnail_path = os.path.join(thumbnail_dir, 'layer-thumb.png')
+        thumbnail_path = os.path.join("thumbs", "layer-thumb.png")
 
         layer.save_thumbnail(thumbnail_path, ensure_string(response.content))
 
         # Check thumbnail created
-        self.assertTrue(os.path.exists(thumbnail_path))
+        self.assertTrue(storage.exists(thumbnail_path))
         self.assertEqual(what(thumbnail_path), 'png')
 
         # Check that now we have thumbnail
@@ -646,13 +646,12 @@ class ThumbnailGenerationTest(GeoNodeBaseTestSupport):
 
         response = self.client.get(remote_thumbnail_url)
 
-        thumbnail_dir = os.path.join(settings.MEDIA_ROOT, 'thumbs')
-        thumbnail_path = os.path.join(thumbnail_dir, 'map-thumb.png')
+        thumbnail_path = os.path.join("thumbs", "map-thumb.png")
 
         map.save_thumbnail(thumbnail_path, ensure_string(response.content))
 
         # Check thumbnail created
-        self.assertTrue(os.path.exists(thumbnail_path))
+        self.assertTrue(storage.exists(thumbnail_path))
         self.assertEqual(what(thumbnail_path), 'png')
 
         # Check that now we have thumbnail

--- a/geonode/qgis_server/tests/test_views.py
+++ b/geonode/qgis_server/tests/test_views.py
@@ -38,6 +38,7 @@ from django.urls import reverse
 
 from geonode import qgis_server
 from geonode.compat import ensure_string
+from geonode.base.thumb_utils import thumb_path
 from geonode.decorators import on_ogc_backend
 from geonode.layers.utils import file_upload
 from geonode.maps.models import Map
@@ -573,7 +574,7 @@ class ThumbnailGenerationTest(GeoNodeBaseTestSupport):
 
         response = self.client.get(remote_thumbnail_url)
 
-        thumbnail_path = os.path.join("thumbs", "layer-thumb.png")
+        thumbnail_path = thumb_path("layer-thumb.png")
 
         layer.save_thumbnail(thumbnail_path, ensure_string(response.content))
 
@@ -646,7 +647,7 @@ class ThumbnailGenerationTest(GeoNodeBaseTestSupport):
 
         response = self.client.get(remote_thumbnail_url)
 
-        thumbnail_path = os.path.join("thumbs", "map-thumb.png")
+        thumbnail_path = thumb_path("map-thumb.png")
 
         map.save_thumbnail(thumbnail_path, ensure_string(response.content))
 

--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -266,6 +266,7 @@ ROOT_URLCONF = os.getenv('ROOT_URLCONF', 'geonode.urls')
 
 STATICFILES_LOCATION = 'static'
 MEDIAFILES_LOCATION = 'uploaded'
+THUMBNAIL_LOCATION = 'thumbs'
 
 # Absolute path to the directory that holds media.
 # Example: "/home/media/media.lawrence.com/"


### PR DESCRIPTION
Fixes #6414 

PR to replace file system operations performed using Python's `os`, `shutil` etc. library functions with the more generic [Django file storage API](https://docs.djangoproject.com/en/2.2/ref/files/storage/) function calls with the goal of supporting Django storage plugins such as [django-storage-swift](https://github.com/dennisv/django-storage-swift).

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [x] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
