### PR TITLE
[Fixes #5779] Data edition permissions set in GeoNode for a layer are…

### DIFF
--- a/geonode/proxy/views.py
+++ b/geonode/proxy/views.py
@@ -183,12 +183,13 @@ def proxy(request, url=None, response_callback=None,
             '%s%s' % (settings.SITEURL, 'geoserver'),
             ogc_server_settings.LOCATION.rstrip('/'))
 
-    response, content = http_client.request(_url,
-                                            method=request.method,
-                                            data=_data,
-                                            headers=headers,
-                                            timeout=timeout,
-                                            user=request.user)
+    response, content = http_client.request(
+        _url,
+        method=request.method,
+        data=_data,
+        headers=headers,
+        timeout=timeout,
+        user=request.user)
     content = response.content or response.reason
     status = response.status_code
     content_type = response.headers.get('Content-Type')

--- a/geonode/security/models.py
+++ b/geonode/security/models.py
@@ -300,7 +300,10 @@ class PermissionLevelMixin(object):
                     # Set the GeoFence Rules
                     if settings.OGC_SERVER['default'].get("GEOFENCE_SECURITY_ENABLED", False):
                         if self.polymorphic_ctype.name == 'layer':
-                            sync_geofence_with_guardian(self.layer, perms, user=user)
+                            group_perms = None
+                            if 'groups' in perm_spec and len(perm_spec['groups']) > 0:
+                                group_perms = perm_spec['groups']
+                            sync_geofence_with_guardian(self.layer, perms, user=_user, group_perms=group_perms)
 
         # All the other groups
         if 'groups' in perm_spec and len(perm_spec['groups']) > 0:

--- a/geonode/security/utils.py
+++ b/geonode/security/utils.py
@@ -532,7 +532,7 @@ def set_geofence_all(instance):
 
 
 @on_ogc_backend(geoserver.BACKEND_PACKAGE)
-def sync_geofence_with_guardian(layer, perms, user=None, group=None):
+def sync_geofence_with_guardian(layer, perms, user=None, group=None, group_perms=None):
     """
     Sync Guardian permissions to GeoFence.
     """
@@ -540,8 +540,6 @@ def sync_geofence_with_guardian(layer, perms, user=None, group=None):
     _layer_workspace = get_layer_workspace(layer)
     # Create new rule-set
     gf_services = {}
-    gf_services["*"] = 'download_resourcebase' in perms and \
-        ('view_resourcebase' in perms or 'change_layer_style' in perms)
     gf_services["WMS"] = 'view_resourcebase' in perms or 'change_layer_style' in perms
     gf_services["GWC"] = 'view_resourcebase' in perms or 'change_layer_style' in perms
     gf_services["WFS"] = ('download_resourcebase' in perms or 'change_layer_data' in perms) \
@@ -549,7 +547,26 @@ def sync_geofence_with_guardian(layer, perms, user=None, group=None):
     gf_services["WCS"] = ('download_resourcebase' in perms or 'change_layer_data' in perms) \
         and not layer.is_vector()
     gf_services["WPS"] = 'download_resourcebase' in perms or 'change_layer_data' in perms
+    gf_services["*"] = 'download_resourcebase' in perms and \
+        ('view_resourcebase' in perms or 'change_layer_style' in perms)
 
+    gf_requests = {}
+    if 'change_layer_data' not in perms:
+        _skip_perm = False
+        if user and group_perms:
+            if isinstance(user, string_types):
+                user = get_user_model().objects.get(username=user)
+            user_groups = list(user.groups.all().values_list('name', flat=True))
+            for _group, _perm in group_perms.items():
+                if 'change_layer_data' in _perm and _group in user_groups:
+                    _skip_perm = True
+                    break
+        if not _skip_perm:
+            gf_requests["WFS"] = {
+                "TRANSACTION": False,
+                "LOCKFEATURE": False,
+                "GETFEATUREWITHLOCK": False
+            }
     _user = None
     _group = None
     _disable_layer_cache = False
@@ -579,6 +596,11 @@ def sync_geofence_with_guardian(layer, perms, user=None, group=None):
         # delete_layer_cache('{}:{}'.format(_layer_workspace, _layer_name))
         filters = None
         formats = None
+        # Re-order dictionary
+        # - if geo-limits have been defined for this user/group, the "*" rule must be the first one
+        gf_services_limits_first = {"*": gf_services.pop('*')}
+        gf_services_limits_first.update(gf_services)
+        gf_services = gf_services_limits_first
     else:
         filters = [{
             "styleParameterFilter": {
@@ -602,18 +624,30 @@ def sync_geofence_with_guardian(layer, perms, user=None, group=None):
                 _wkt = None
                 if users_geolimits and users_geolimits.count():
                     _wkt = users_geolimits.last().wkt
+                if service in gf_requests:
+                    for request, enabled in gf_requests[service].items():
+                        _update_geofence_rule(layer, _layer_name, _layer_workspace,
+                                              service, request=request, user=_user, allow=enabled)
                 _update_geofence_rule(layer, _layer_name, _layer_workspace, service, user=_user, geo_limit=_wkt)
             elif not _group:
                 logger.debug("Adding to geofence the rule: %s %s *" % (layer, service))
                 _wkt = None
                 if anonymous_geolimits and anonymous_geolimits.count():
                     _wkt = anonymous_geolimits.last().wkt
+                if service in gf_requests:
+                    for request, enabled in gf_requests[service].items():
+                        _update_geofence_rule(layer, _layer_name, _layer_workspace,
+                                              service, request=request, user=_user, allow=enabled)
                 _update_geofence_rule(layer, _layer_name, _layer_workspace, service, geo_limit=_wkt)
             if _group:
                 logger.debug("Adding 'group' to geofence the rule: %s %s %s" % (layer, service, _group))
                 _wkt = None
                 if groups_geolimits and groups_geolimits.count():
                     _wkt = groups_geolimits.last().wkt
+                if service in gf_requests:
+                    for request, enabled in gf_requests[service].items():
+                        _update_geofence_rule(layer, _layer_name, _layer_workspace,
+                                              service, request=request, group=_group, allow=enabled)
                 _update_geofence_rule(layer, _layer_name, _layer_workspace, service, group=_group, geo_limit=_wkt)
     if not getattr(settings, 'DELAYED_SECURITY_SIGNALS', False):
         set_geofence_invalidate_cache()
@@ -682,7 +716,7 @@ def remove_object_permissions(instance):
 
 
 def _get_geofence_payload(layer, layer_name, workspace, access, user=None, group=None,
-                          service=None, geo_limit=None):
+                          service=None, request=None, geo_limit=None):
     highest_priority = get_highest_priority()
     root_el = etree.Element("Rule")
     username_el = etree.SubElement(root_el, "userName")
@@ -702,6 +736,9 @@ def _get_geofence_payload(layer, layer_name, workspace, access, user=None, group
     if service is not None and service != "*":
         service_el = etree.SubElement(root_el, "service")
         service_el.text = service
+    if request is not None and request != "*":
+        service_el = etree.SubElement(root_el, "request")
+        service_el.text = request
     if service and service == "*" and geo_limit is not None and geo_limit != "":
         access_el = etree.SubElement(root_el, "access")
         access_el.text = "LIMIT"
@@ -716,15 +753,19 @@ def _get_geofence_payload(layer, layer_name, workspace, access, user=None, group
     return etree.tostring(root_el)
 
 
-def _update_geofence_rule(layer, layer_name, workspace, service, user=None, group=None, geo_limit=None):
+def _update_geofence_rule(layer, layer_name, workspace,
+                          service, request=None,
+                          user=None, group=None,
+                          geo_limit=None, allow=True):
     payload = _get_geofence_payload(
         layer=layer,
         layer_name=layer_name,
         workspace=workspace,
-        access="ALLOW",
+        access="ALLOW" if allow else "DENY",
         user=user,
         group=group,
         service=service,
+        request=request,
         geo_limit=geo_limit
     )
     logger.debug("request data: {}".format(payload))


### PR DESCRIPTION
… not applied on the WFS

<Include a few sentences describing the overall goals for this Pull Request>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
