### PR TITLE
[Fixes #5801] Check User permissions for private group

### DIFF
--- a/geonode/documents/views.py
+++ b/geonode/documents/views.py
@@ -519,11 +519,10 @@ def document_metadata(
         try:
             all_metadata_author_groups = chain(
                 request.user.group_list_all(),
-                GroupProfile.objects.exclude(
-                    access="private").exclude(access="public-invite"))
+                GroupProfile.objects.exclude(access="private"))
         except Exception:
             all_metadata_author_groups = GroupProfile.objects.exclude(
-                access="private").exclude(access="public-invite")
+                access="private")
         [metadata_author_groups.append(item) for item in all_metadata_author_groups
             if item not in metadata_author_groups]
 

--- a/geonode/groups/tests.py
+++ b/geonode/groups/tests.py
@@ -163,6 +163,18 @@ class SmokeTest(GeoNodeBaseTestSupport):
         logger.debug(f"Anonymous --> {content}")
         self.assertEqual(len(content["groups"]), 1)
         self.assertEqual(content["groups"][0]["name"], "public_group")
+        response = self.client.get(
+            reverse(
+                'group_detail',
+                args=['public_group', ])
+        )
+        self.assertEqual(response.status_code, 200)
+        response = self.client.get(
+            reverse(
+                'group_detail',
+                args=['private_group', ])
+        )
+        self.assertEqual(response.status_code, 404)
 
         # Admin
         """
@@ -186,6 +198,18 @@ class SmokeTest(GeoNodeBaseTestSupport):
         self.assertEqual(len(content["groups"]), 2)
         self.assertEqual(content["groups"][0]["name"], "public_group")
         self.assertEqual(content["groups"][1]["name"], "private_group")
+        response = self.client.get(
+            reverse(
+                'group_detail',
+                args=['public_group', ])
+        )
+        self.assertEqual(response.status_code, 200)
+        response = self.client.get(
+            reverse(
+                'group_detail',
+                args=['private_group', ])
+        )
+        self.assertEqual(response.status_code, 200)
 
         # Bobby
         """
@@ -209,6 +233,18 @@ class SmokeTest(GeoNodeBaseTestSupport):
         self.assertEqual(len(content["groups"]), 2)
         self.assertEqual(content["groups"][0]["name"], "public_group")
         self.assertEqual(content["groups"][1]["name"], "private_group")
+        response = self.client.get(
+            reverse(
+                'group_detail',
+                args=['public_group', ])
+        )
+        self.assertEqual(response.status_code, 200)
+        response = self.client.get(
+            reverse(
+                'group_detail',
+                args=['private_group', ])
+        )
+        self.assertEqual(response.status_code, 200)
 
         # Norman
         """
@@ -230,6 +266,18 @@ class SmokeTest(GeoNodeBaseTestSupport):
         logger.debug(f"norman --> {content}")
         self.assertEqual(len(content["groups"]), 1)
         self.assertEqual(content["groups"][0]["name"], "public_group")
+        response = self.client.get(
+            reverse(
+                'group_detail',
+                args=['public_group', ])
+        )
+        self.assertEqual(response.status_code, 200)
+        response = self.client.get(
+            reverse(
+                'group_detail',
+                args=['private_group', ])
+        )
+        self.assertEqual(response.status_code, 404)
 
         if _public_created:
             public_group.delete()

--- a/geonode/groups/tests.py
+++ b/geonode/groups/tests.py
@@ -118,6 +118,126 @@ class SmokeTest(GeoNodeBaseTestSupport):
         self.assertTrue(groupprofile.user_is_role(admin, 'manager'))
         self.assertFalse(admin in groupprofile.get_managers())
 
+    def test_users_group_list_view(self):
+        """
+        1. Ensures that a superuser can see the whole group list.
+
+        2. Ensures that a user can see only public/public-invite groups.
+
+        3. Ensures that a user belonging to a private group, can see it.
+        """
+        bobby = get_user_model().objects.get(username="bobby")
+
+        public_group, _public_created = GroupProfile.objects.get_or_create(
+            slug='public_group',
+            title='public_group',
+            access='public')
+        private_group, _private_created = GroupProfile.objects.get_or_create(
+            slug='private_group',
+            title='private_group',
+            access='private')
+
+        private_group.join(bobby)
+        data = {
+            "query": "p",
+            "page": 1,
+            "pageSize": 9
+        }
+
+        # Anonymous
+        """
+            '{
+                "users": [], "count": 0,
+                "groups": [
+                    {"name": "public_group", "title": "public_group"}]
+            }'
+        """
+        response = self.client.post(
+            reverse(
+                'account_ajax_lookup'
+            ),
+            data
+        )
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        logger.debug(f"Anonymous --> {content}")
+        self.assertEqual(len(content["groups"]), 1)
+        self.assertEqual(content["groups"][0]["name"], "public_group")
+
+        # Admin
+        """
+            '{
+                "users": [], "count": 0,
+                "groups": [
+                    {"name": "public_group", "title": "public_group"},
+                    {"name": "private_group", "title": "private_group"}]
+            }'
+        """
+        self.assertTrue(self.client.login(username="admin", password="admin"))
+        response = self.client.post(
+            reverse(
+                'account_ajax_lookup'
+            ),
+            data
+        )
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        logger.debug(f"admin --> {content}")
+        self.assertEqual(len(content["groups"]), 2)
+        self.assertEqual(content["groups"][0]["name"], "public_group")
+        self.assertEqual(content["groups"][1]["name"], "private_group")
+
+        # Bobby
+        """
+            '{
+                "users": [], "count": 0,
+                "groups": [
+                    {"name": "public_group", "title": "public_group"},
+                    {"name": "private_group", "title": "private_group"}]
+            }'
+        """
+        self.assertTrue(self.client.login(username="bobby", password="bob"))
+        response = self.client.post(
+            reverse(
+                'account_ajax_lookup'
+            ),
+            data
+        )
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        logger.debug(f"bobby --> {content}")
+        self.assertEqual(len(content["groups"]), 2)
+        self.assertEqual(content["groups"][0]["name"], "public_group")
+        self.assertEqual(content["groups"][1]["name"], "private_group")
+
+        # Norman
+        """
+            '{
+                "users": [], "count": 0,
+                "groups": [
+                    {"name": "public_group", "title": "public_group"}]
+            }'
+        """
+        self.assertTrue(self.client.login(username="norman", password="norman"))
+        response = self.client.post(
+            reverse(
+                'account_ajax_lookup'
+            ),
+            data
+        )
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        logger.debug(f"norman --> {content}")
+        self.assertEqual(len(content["groups"]), 1)
+        self.assertEqual(content["groups"][0]["name"], "public_group")
+
+        if _public_created:
+            public_group.delete()
+            self.assertFalse(GroupProfile.objects.filter(slug='public_group').exists())
+        if _private_created:
+            private_group.delete()
+            self.assertFalse(GroupProfile.objects.filter(slug='private_group').exists())
+
     def test_group_permissions_extend_to_user(self):
         """
         Ensures that when a user is in a group, the group permissions
@@ -661,7 +781,7 @@ class GroupCategoriesTestCase(GeoNodeBaseTestSupport):
         super(GroupCategoriesTestCase, self).setUp()
 
         c1 = GroupCategory.objects.create(name='test #1 category')
-        g = GroupProfile.objects.create(title='test')
+        g = GroupProfile.objects.create(slug='test', title='test')
         g.categories.add(c1)
         g.save()
         User = get_user_model()

--- a/geonode/groups/views.py
+++ b/geonode/groups/views.py
@@ -146,6 +146,9 @@ class GroupDetailView(ListView):
     def get(self, request, *args, **kwargs):
         self.group = get_object_or_404(
             models.GroupProfile, slug=kwargs.get('slug'))
+        if self.group.access == 'private' and \
+        not self.group.user_is_member(request.user):
+            raise Http404
         return super(GroupDetailView, self).get(request, *args, **kwargs)
 
     def get_context_data(self, **kwargs):

--- a/geonode/layers/views.py
+++ b/geonode/layers/views.py
@@ -1185,11 +1185,10 @@ def layer_metadata(
         try:
             all_metadata_author_groups = chain(
                 request.user.group_list_all().distinct(),
-                GroupProfile.objects.exclude(
-                    access="private").exclude(access="public-invite"))
+                GroupProfile.objects.exclude(access="private"))
         except Exception:
             all_metadata_author_groups = GroupProfile.objects.exclude(
-                access="private").exclude(access="public-invite")
+                access="private")
         [metadata_author_groups.append(item) for item in all_metadata_author_groups
             if item not in metadata_author_groups]
 

--- a/geonode/maps/views.py
+++ b/geonode/maps/views.py
@@ -387,11 +387,10 @@ def map_metadata(
         try:
             all_metadata_author_groups = chain(
                 request.user.group_list_all(),
-                GroupProfile.objects.exclude(
-                    access="private").exclude(access="public-invite"))
+                GroupProfile.objects.exclude(access="private"))
         except Exception:
             all_metadata_author_groups = GroupProfile.objects.exclude(
-                access="private").exclude(access="public-invite")
+                access="private")
         [metadata_author_groups.append(item) for item in all_metadata_author_groups
             if item not in metadata_author_groups]
 

--- a/geonode/people/adapters.py
+++ b/geonode/people/adapters.py
@@ -139,7 +139,7 @@ class LocalAccountAdapter(DefaultAccountAdapter, BaseInvitationsAdapter):
         user = context.get("inviter") if context.get("inviter") else context.get("user")
         full_name = " ".join((user.first_name, user.last_name)) if user.first_name or user.last_name else None
         user_groups = GroupProfile.objects.filter(
-            slug__in=user.groupmember_set.filter().values_list("group__slug", flat=True))
+            slug__in=user.groupmember_set.all().values_list("group__slug", flat=True))
         enhanced_context = context.copy()
         enhanced_context.update({
             "username": user.username,

--- a/geonode/tests/test_rest_api.py
+++ b/geonode/tests/test_rest_api.py
@@ -49,7 +49,7 @@ class TestGroupResAuthorization(GeoNodeBaseTestSupport):
     @patch('geonode.api.authorization.ApiLockdownAuthorization.read_list',
            return_value=Group.objects.exclude(name='anonymous'))
     @patch('geonode.people.models.Profile.group_list_all', return_value=[2])
-    def test_regular_user_hide_private(self, super_mock, mocke_profile):
+    def test_regular_user_hide_private(self, super_mock, mocked_profile):
         mock_bundle = MagicMock()
         request_mock = MagicMock()
         r_attr = {
@@ -67,7 +67,7 @@ class TestGroupResAuthorization(GeoNodeBaseTestSupport):
     @patch('geonode.api.authorization.ApiLockdownAuthorization.read_list',
            return_value=Group.objects.exclude(name='anonymous'))
     @patch('geonode.people.models.Profile.group_list_all', return_value=[1])
-    def test_regular_user(self, super_mock, mocke_profile):
+    def test_regular_user(self, super_mock, mocked_profile):
         mock_bundle = MagicMock()
         request_mock = MagicMock()
         r_attr = {
@@ -85,7 +85,7 @@ class TestGroupResAuthorization(GeoNodeBaseTestSupport):
     @patch('geonode.api.authorization.ApiLockdownAuthorization.read_list',
            return_value=Group.objects.exclude(name='anonymous'))
     @patch('geonode.people.models.Profile.group_list_all', return_value=[1])
-    def test_anonymous_user(self, super_mock, mocke_profile):
+    def test_anonymous_user(self, super_mock, mocked_profile):
         mock_bundle = MagicMock()
         request_mock = MagicMock()
         r_attr = {
@@ -122,7 +122,7 @@ class TestGroupProfileResAuthorization(GeoNodeBaseTestSupport):
 
     @patch('geonode.api.authorization.ApiLockdownAuthorization.read_list', return_value=GroupProfile.objects.all())
     @patch('geonode.people.models.Profile.group_list_all', return_value=[2])
-    def test_regular_user_hide_private(self, super_mock, mocke_profile):
+    def test_regular_user_hide_private(self, super_mock, mocked_profile):
         mock_bundle = MagicMock()
         request_mock = MagicMock()
         r_attr = {
@@ -139,7 +139,7 @@ class TestGroupProfileResAuthorization(GeoNodeBaseTestSupport):
 
     @patch('geonode.api.authorization.ApiLockdownAuthorization.read_list', return_value=GroupProfile.objects.all())
     @patch('geonode.people.models.Profile.group_list_all', return_value=[1])
-    def test_regular_user(self, super_mock, mocke_profile):
+    def test_regular_user(self, super_mock, mocked_profile):
         mock_bundle = MagicMock()
         request_mock = MagicMock()
         r_attr = {
@@ -156,7 +156,7 @@ class TestGroupProfileResAuthorization(GeoNodeBaseTestSupport):
 
     @patch('geonode.api.authorization.ApiLockdownAuthorization.read_list', return_value=GroupProfile.objects.all())
     @patch('geonode.people.models.Profile.group_list_all', return_value=[1])
-    def test_anonymous_user(self, super_mock, mocke_profile):
+    def test_anonymous_user(self, super_mock, mocked_profile):
         mock_bundle = MagicMock()
         request_mock = MagicMock()
         r_attr = {


### PR DESCRIPTION
<Include a few sentences describing the overall goals for this Pull Request>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
