### PR TITLE
Fix startup JVM options for SPC Docker GeoServer

### DIFF
--- a/scripts/spcgeonode/.env
+++ b/scripts/spcgeonode/.env
@@ -63,3 +63,13 @@ S3_ACCESS_KEY=
 S3_SECRET_KEY=
 S3_REGION=
 S3_BUCKET=
+
+# Geoserver settings
+INITIAL_MEMORY=2G
+# Startup memory for the JVM
+MAXIMUM_MEMORY=4G
+# maximum allowed memory for the JVM
+GEOSERVER_CSRF_DISABLED=true
+EXISTING_DATA_DIR=true
+# Flag to indicate you have a data directory populated and do not need to reinitialise it
+

--- a/scripts/spcgeonode/docker-compose.yml
+++ b/scripts/spcgeonode/docker-compose.yml
@@ -105,6 +105,8 @@ services:
       retries: 1
       start_period: 60s
     environment:
+      - INITIAL_MEMORY=${INITIAL_MEMORY}
+      - MAXIMUM_MEMORY=${MAXIMUM_MEMORY}
       - HTTPS_HOST=${HTTPS_HOST}
       - HTTPS_PORT=${HTTPS_PORT}
       - HTTP_HOST=${HTTP_HOST}

--- a/scripts/spcgeonode/geoserver/Dockerfile
+++ b/scripts/spcgeonode/geoserver/Dockerfile
@@ -36,9 +36,9 @@ RUN for plugin in $plugins; do \
     done
 
 # Download initial data dir
-RUN wget https://www.dropbox.com/s/43vw52s99w6w0rb/data-$branch.zip?dl=1 -O data-$branch.zip --no-check-certificate
-RUN unzip /data-$branch.zip
-RUN ls /data
+RUN wget https://www.dropbox.com/s/43vw52s99w6w0rb/data-$branch.zip?dl=1 -O data-$branch.zip --no-check-certificate && \
+unzip /data-$branch.zip
+
 
 WORKDIR /geoserver/
 
@@ -51,9 +51,13 @@ ENTRYPOINT ["/docker-entrypoint.sh"]
 EXPOSE 8080
 
 # Set environnment variables
-ENV GEOSERVER_HOME=/geoserver
-ENV GEOSERVER_DATA_DIR=/spcgeonode-geodatadir
-ENV GEOSERVER_CSRF_DISABLED=true
+ENV \
+    GEOSERVER_HOME=/geoserver \
+    GEOSERVER_DATA_DIR=/spcgeonode-geodatadir \
+    GEOWEBCACHE_CACHE_DIR=/spcgeonode-geodatadir/gwc \
+    GEOSERVER_CSRF_DISABLED=true \
+    INITIAL_MEMORY=2G \
+    MAXIMUM_MEMORY=4G
 
 # Run geoserver
 CMD ["bin/startup.sh"]

--- a/scripts/spcgeonode/geoserver/docker-entrypoint.sh
+++ b/scripts/spcgeonode/geoserver/docker-entrypoint.sh
@@ -169,7 +169,15 @@ if [ ! -z "$HTTPS_HOST" ]; then
     fi
     rm server.crt
 
-    JAVA_OPTS="$JAVA_OPTS -Djavax.net.ssl.keyStore=/keystore.jks -Djavax.net.ssl.keyStorePassword=$PASSWORD"
+    export GEOSERVER_JAVA_OPTS="-Djava.awt.headless=true -Xms${INITIAL_MEMORY} -Xmx${MAXIMUM_MEMORY} \
+    -XX:PerfDataSamplingInterval=500 -XX:SoftRefLRUPolicyMSPerMB=36000 \
+    -XX:-UseGCOverheadLimit -XX:+UseConcMarkSweepGC -XX:+UseParNewGC -XX:ParallelGCThreads=4 \
+    -Dfile.encoding=UTF8 -Djavax.servlet.request.encoding=UTF-8 \
+    -Djavax.servlet.response.encoding=UTF-8 -Duser.timezone=GMT \
+    -Dorg.geotools.shapefile.datetime=false -DGEOSERVER_CSRF_DISABLED=${GEOSERVER_CSRF_DISABLED} \
+    -Djavax.net.ssl.keyStore=/keystore.jks -Djavax.net.ssl.keyStorePassword=$PASSWORD"
+
+    export JAVA_OPTS="$JAVA_OPTS ${GEOSERVER_JAVA_OPTS}"
 fi
 
 echo "-----------------------------------------------------"


### PR DESCRIPTION
Fixes and issue with SPC GeoServer running out of Memory because it was using default JVM startup options 
```
org.springframework.beans.BeanInstantiationException: Failed to instantiate [org.springframework.security.oauth2.client.OAuth2RestTemplate]: Factory method 'geoServerOauth2RestTemplate' threw exception; nested exception is java.lang.OutOfMemoryError: Java heap space
````
