### PR TITLE
fixed: attribute type stored as string tuple

### DIFF
--- a/geonode/geoserver/helpers.py
+++ b/geonode/geoserver/helpers.py
@@ -925,7 +925,7 @@ def set_attributes(
                 la, created = Attribute.objects.get_or_create(layer=layer, attribute=field)
                 if created:
                     la.visible = ftype.find("gml:") != 0
-                    la.attribute_type = ftype,
+                    la.attribute_type = ftype
                     la.description = description
                     la.attribute_label = label
                     la.display_order = iter


### PR DESCRIPTION
issue:
Attribute typed stored as stringified python tuple
Ex (Actual behavior):
layer.attirbute.attribute_type = '('xsd:string',)'

Expected behavior:
layer.attirbute.attribute_type = 'xsd:string'