### PR TITLE
[Fixes #6728] SPCGeoNode Dockerfile build error - missing git

### DIFF
--- a/scripts/spcgeonode/django/Dockerfile
+++ b/scripts/spcgeonode/django/Dockerfile
@@ -8,7 +8,7 @@ FROM python:3.7-slim-stretch
 RUN echo "Updating apt-get" && \
     apt-get update && \
     echo "Installing build dependencies" && \
-    apt-get install -y gcc make libc-dev musl-dev libpcre3 libpcre3-dev g++ && \
+    apt-get install -y gcc make libc-dev musl-dev libpcre3 libpcre3-dev g++ git && \
     echo "Installing Pillow dependencies" && \
     # RUN apt-get install -y NOTHING ?? It was probably added in other packages... ALPINE needed jpeg-dev zlib-dev && \
     echo "Installing GDAL dependencies" && \


### PR DESCRIPTION
This PR modifies the spcgeonode `Dockerfile` for django to add `git` as an additional system dependency. This shall fix #6728

## Checklist

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] ~New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented~ - **does not apply**
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] ~This PR passes the QA checks: flake8 geonode~ - **does not apply**
- [ ] ~Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates~ - **does not apply**

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
