### PR TITLE
[FIXES #6782] Approval notifications will not get send

### DIFF
--- a/geonode/notifications_helper.py
+++ b/geonode/notifications_helper.py
@@ -129,7 +129,7 @@ def get_notification_recipients(notice_type_label, exclude_user=None, resource=N
                 not user.has_perm('view_resourcebase', resource.get_self_resource()):
                     exclude_users_ids.append(user.id)
                 if user.pk == resource.owner.pk and \
-                not notice_type_label.split("_")[-1] in ("updated", "rated", "comment"):
+                not notice_type_label.split("_")[-1] in ("updated", "rated", "comment", "approved", "published"):
                     exclude_users_ids.append(user.id)
             except Exception:
                 # fallback which wont send mails


### PR DESCRIPTION
Sorry to spam with so many notifications related PRs. I just discover little regressions on my way to use the moderation workflow. Should have tested everything first and maybe merged some of the changes.

So, this will allow approved and published notification to get sent with pinax. Before this code changes the owner will get marked as an excluded user in the list.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
