### PR TITLE
[Fixes #6866] What is the effect of assigning permissions to styles?

### DIFF
--- a/geonode/layers/templates/layers/layer_style_upload.html
+++ b/geonode/layers/templates/layers/layer_style_upload.html
@@ -107,15 +107,6 @@
   {% endif %}
   {% endif %}
 
-  {% if GEONODE_SECURITY_ENABLED %}
-  <div class="col-md-4">
-    <h3>{% trans "Permissions"  %}</h3>
-    <form id="permission_form">
-      {% include "_permissions.html" %}
-    </form>
-  </div>
-  {% endif %}
-
 </div>
 {% endblock %}
 
@@ -137,9 +128,4 @@
     {% endautoescape %}
 
     </script>
-    {% if GEONODE_SECURITY_ENABLED %}
-        {% with resource=layer %}
-            {% include "_permissions_form_js.html" %}
-        {% endwith %}
-    {% endif %}
 {% endblock extra_script %}

--- a/geonode/layers/tests.py
+++ b/geonode/layers/tests.py
@@ -768,7 +768,7 @@ class LayersTest(GeoNodeBaseTestSupport):
 
         # test a method other than POST and GET
         response = self.client.put(url)
-        content = response.content
+        content = response.content.decode('utf-8')
         self.assertEqual(response.status_code, 200)
         self.assertFalse("#modal_perms" in content)
 

--- a/geonode/layers/tests.py
+++ b/geonode/layers/tests.py
@@ -758,6 +758,20 @@ class LayersTest(GeoNodeBaseTestSupport):
         rating = OverallRating.objects.all()
         self.assertEqual(rating.count(), 0)
 
+    def test_sld_upload(self):
+        """Test layer remove functionality
+        """
+        layer = Layer.objects.all().first()
+        url = reverse('layer_sld_upload', args=(layer.alternate,))
+        # Now test with a valid user
+        self.client.login(username='admin', password='admin')
+
+        # test a method other than POST and GET
+        response = self.client.put(url)
+        content = response.content
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse("#modal_perms" in content)
+
     def test_layer_remove(self):
         """Test layer remove functionality
         """


### PR DESCRIPTION
<Include a few sentences describing the overall goals for this Pull Request>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
