### PR TITLE
[Fixes #6867] HTML mode for GetFeatureInfo results template missing i…

### DIFF
--- a/geonode/layers/templates/layers/layer_metadata_advanced.html
+++ b/geonode/layers/templates/layers/layer_metadata_advanced.html
@@ -89,7 +89,15 @@
              Unfortunately this needs to appear at the bottom of the form since tkeywords_form is a complete other django form. 
              There might be a better way to solve this. -->
         <div class="col-md-6 form-controls">
-          {{ layer_form|as_bootstrap }}
+          {% for field in layer_form %}
+            {% if field.name != 'use_featureinfo_custom_template' and field.name != 'featureinfo_custom_template' %}
+            <div>
+              <span><label for="{{ field.id }}">{{ field.label }}</label></span>
+              {{ field }}
+            </div>
+            {% endif %}
+          {% endfor %}
+          {# layer_form|as_bootstrap #}
           {% if THESAURI_FILTERS %}
             {{ tkeywords_form }}
           {% endif %}
@@ -120,29 +128,43 @@
 
           <div class="col-md-12 grid-spacer">
             <h5>{% trans "Attributes" %}</h5>
-            {{ attribute_form.management_form }}
-            <table class="table table-striped table-bordered table-condensed">
-              <tr>
-                <th>{% trans "Attribute" %}</th>
-                <th>{% trans "Label" %}</th>
-                <th>{% trans "Description" %}</th>
-                <th>{% trans "Display Order" %}</th>
-                <th>{% trans "Display Type" %}</th>
-                <th>{% trans "Visible" %}</th>
-              </tr>
-              {% for form in attribute_form.forms %}
-              {% if form.attribute %}
-              <tr>
-                <td><div style="display:none">{{form.id}}</div>{{form.attribute}}</td>
-                <td>{{form.attribute_label}}</td>
-                <td>{{form.description}}</td>
-                <td>{{form.display_order}}</td>
-                <td>{{form.featureinfo_type}}</td>
-                <td>{{form.visible}}</td>
-              </tr>
-              {% endif %}
-              {% endfor %}
-            </table>
+            <label>{% trans "Use a custom template?" %}</label>
+            <input type="checkbox" name="resource-use_featureinfo_custom_template" class="has-external-popover"
+                data-content="specifies wether or not use a custom GetFeatureInfo template." data-placement="right"
+                data-container="body" data-html="true" data-toggle="toggle"
+                placeholder="specifies wether or not use a custom GetFeatureInfo template."
+                id="id_resource-use_featureinfo_custom_template"
+                {% if resource.use_featureinfo_custom_template %}checked{% endif %}>
+            <div id="layer-attributes-panel"
+                {% if resource.use_featureinfo_custom_template %}style="visibility: collapse;" {% endif %}>
+                {{ attribute_form.management_form }}
+                <table class="table table-striped table-bordered table-condensed">
+                <tr>
+                    <th>{% trans "Attribute" %}</th>
+                    <th>{% trans "Label" %}</th>
+                    <th>{% trans "Description" %}</th>
+                    <th>{% trans "Display Order" %}</th>
+                    <th>{% trans "Display Type" %}</th>
+                    <th>{% trans "Visible" %}</th>
+                </tr>
+                {% for form in attribute_form.forms %}
+                {% if form.attribute %}
+                <tr>
+                    <td><div style="display:none">{{form.id}}</div>{{form.attribute}}</td>
+                    <td>{{form.attribute_label}}</td>
+                    <td>{{form.description}}</td>
+                    <td>{{form.display_order}}</td>
+                    <td>{{form.featureinfo_type}}</td>
+                    <td>{{form.visible}}</td>
+                </tr>
+                {% endif %}
+                {% endfor %}
+                </table>
+            </div>
+            <div id="layer-attributes-custom_template"
+                  {% if not resource.use_featureinfo_custom_template %}style="visibility: collapse;" {% endif %}>
+                {{layer_form.featureinfo_custom_template}}
+            </div>
 
             <fieldset class="form-controls modal-forms modal hide fade" id="poc_form" >
               <h2>{% trans "Point of Contact" %}</h2>
@@ -166,4 +188,19 @@
       </form>
   </div>
 </div>
+{% endblock %}
+
+{% block extra_script %}
+    {{ block.super }}
+    <script type="text/javascript">
+        $(document.body).on("change", "#id_resource-use_featureinfo_custom_template", function (event) {
+            if (this.checked) {
+                $('#layer-attributes-panel').css("visibility", "collapse");
+                $('#layer-attributes-custom_template').css("visibility", "visible");
+            } else {
+                $('#layer-attributes-panel').css("visibility", "visible");
+                $('#layer-attributes-custom_template').css("visibility", "collapse");
+            }
+        });
+    </script>
 {% endblock %}


### PR DESCRIPTION
…nside the Advanced Edit page

<Include a few sentences describing the overall goals for this Pull Request>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
