### PR TITLE
[Fixes #6856] Inconsistent behavior between document and layer upload…

### DIFF
--- a/geonode/documents/tests.py
+++ b/geonode/documents/tests.py
@@ -469,6 +469,23 @@ class DocumentModerationTestCase(GeoNodeBaseTestSupport):
         base_path = gisdata.GOOD_DATA
         return os.path.join(base_path, 'vector', 'readme.txt')
 
+    def test_document_upload_redirect(self):
+        with self.settings(ADMIN_MODERATE_UPLOADS=False):
+            self.client.login(username=self.user, password=self.passwd)
+            input_path = self._get_input_path()
+            document_upload_url = "{}".format(reverse('document_upload'))
+            with open(input_path, 'rb') as f:
+                data = {'title': 'document title',
+                        'doc_file': f,
+                        'resource': '',
+                        'extension': 'txt',
+                        'permissions': '{}',
+                        }
+                resp = self.client.post(document_upload_url, data=data)
+                self.assertEqual(resp.status_code, 200)
+                content = resp.content.decode('utf-8')
+                self.asserTrue("document title" in content)
+
     def test_moderated_upload(self):
         """
         Test if moderation flag works

--- a/geonode/documents/views.py
+++ b/geonode/documents/views.py
@@ -303,7 +303,7 @@ class DocumentUploadView(CreateView):
         else:
             return HttpResponseRedirect(
                 reverse(
-                    'document_metadata',
+                    'document_detail',
                     args=(
                         self.object.id,
                     )))
@@ -329,7 +329,7 @@ class DocumentUpdateView(UpdateView):
         register_event(self.request, EventType.EVENT_CHANGE, self.object)
         return HttpResponseRedirect(
             reverse(
-                'document_metadata',
+                'document_detail',
                 args=(
                     self.object.id,
                 )))


### PR DESCRIPTION
… flow

<Include a few sentences describing the overall goals for this Pull Request>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
