### PR TITLE
[Fixes #6874] Search filter string is not reset per search box is cle…

### DIFF
--- a/geonode/static/geonode/js/search/search.js
+++ b/geonode/static/geonode/js/search/search.js
@@ -642,11 +642,26 @@
                 } else {
                     var query_key = $('#text_search_input').data('query-key') || 'title__icontains';
                 }
-                $scope.query[query_key] = $('#text_search_input').val();
+                if ($('#text_search_input').val()) {
+                    $scope.query[query_key] = $('#text_search_input').val();
+                } else {
+                    // Reset query context
+                    var limit = $scope.query['limit'];
+                    var offset = $scope.query['offset'];
+                    var order_by = $scope.query['order_by'];
+                    $scope.query = {};
+                    $scope.query['limit'] = limit;
+                    $scope.query['offset'] = offset;
+                    if (order_by) {
+                        $scope.query['order_by'] = order_by;
+                    }
+                }
             }
-            $scope.query['abstract__icontains'] = $('#text_search_input').val();
-            $scope.query['purpose__icontains'] = $('#text_search_input').val();
-            $scope.query['f_method'] = 'or';
+            if ($('#text_search_input').val() || $('#text_search_input').val()) {
+                $scope.query['abstract__icontains'] = $('#text_search_input').val();
+                $scope.query['purpose__icontains'] = $('#text_search_input').val();
+                $scope.query['f_method'] = 'or';
+            }
             query_api($scope.query);
         });
 


### PR DESCRIPTION
…ared

<Include a few sentences describing the overall goals for this Pull Request>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
