### PR TITLE
[Fixes #6877] Notification settings for monitoring must be hidden to …

### DIFF
--- a/geonode/base/templatetags/user_messages.py
+++ b/geonode/base/templatetags/user_messages.py
@@ -1,7 +1,27 @@
-from django import template
+# -*- coding: utf-8 -*-
+#########################################################################
+#
+# Copyright (C) 2016 OSGeo
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#########################################################################
 from uuid import uuid4
-from django.contrib.auth import get_user_model
+from django import template
+from django.conf import settings
 from django.db.models import Sum
+from django.contrib.auth import get_user_model
 from django.utils.translation import ugettext as _
 
 register = template.Library()
@@ -52,3 +72,12 @@ def format_senders(thread, current_user):
 @register.simple_tag
 def get_item(dictionary, key):
     return dictionary.get(key, [])
+
+
+@register.simple_tag
+def show_notification(notice_type_label, current_user):
+    adms_notice_types = getattr(settings, 'ADMINS_ONLY_NOTICE_TYPES', [])
+    if not current_user.is_superuser and adms_notice_types and \
+    notice_type_label in adms_notice_types:
+        return False
+    return True

--- a/geonode/base/tests.py
+++ b/geonode/base/tests.py
@@ -42,7 +42,8 @@ from django.shortcuts import reverse
 
 from geonode.base.middleware import ReadOnlyMiddleware, MaintenanceMiddleware
 from geonode.base.models import CuratedThumbnail
-from geonode.base.templatetags.base_tags import get_visibile_resources, show_notification
+from geonode.base.templatetags.base_tags import get_visibile_resources
+from geonode.base.templatetags.user_messages import show_notification
 from geonode import geoserver
 from geonode.decorators import on_ogc_backend
 

--- a/geonode/base/tests.py
+++ b/geonode/base/tests.py
@@ -42,7 +42,7 @@ from django.shortcuts import reverse
 
 from geonode.base.middleware import ReadOnlyMiddleware, MaintenanceMiddleware
 from geonode.base.models import CuratedThumbnail
-from geonode.base.templatetags.base_tags import get_visibile_resources
+from geonode.base.templatetags.base_tags import get_visibile_resources, show_notification
 from geonode import geoserver
 from geonode.decorators import on_ogc_backend
 
@@ -804,6 +804,13 @@ class TestGetVisibleResource(TestCase):
         assign_perm('view_resourcebase', self.user, self.rb)
         categories = get_visibile_resources(self.user)
         self.assertEqual(categories['iso_formats'].count(), 1)
+
+    def test_visible_notifications(self):
+        """
+        Test that a standard user won't be able to show ADMINS_ONLY_NOTICE_TYPES
+        """
+        self.assertFalse(show_notification('monitoring_alert', self.user))
+        self.assertTrue(show_notification('request_download_resourcebase', self.user))
 
 
 class TestHtmlTagRemoval(SimpleTestCase):

--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -1876,6 +1876,7 @@ PINAX_NOTIFICATIONS_LOCK_WAIT_TIMEOUT = os.environ.get('NOTIFICATIONS_LOCK_WAIT_
 # pinax.notifications
 # or notification
 NOTIFICATIONS_MODULE = 'pinax.notifications'
+ADMINS_ONLY_NOTICE_TYPES = ast.literal_eval(os.getenv('ADMINS_ONLY_NOTICE_TYPES', "['monitoring_alert',]"))
 
 # set to true to have multiple recipients in /message/create/
 USER_MESSAGES_ALLOW_MULTIPLE_RECIPIENTS = ast.literal_eval(

--- a/geonode/templates/pinax/notifications/notice_settings.html
+++ b/geonode/templates/pinax/notifications/notice_settings.html
@@ -1,6 +1,7 @@
 {% extends "pinax/notifications/base.html" %}
 
 {% load i18n %}
+{% load user_messages %}
 
 {% block body_id %}notification-settings{% endblock %}
 
@@ -31,7 +32,8 @@
                 {% endfor %}
             </tr>
             {% for row in notice_settings.rows %}
-                <tr class="notice-row">
+                {% show_notification row.notice_type.label request.user as notice_enabled %}
+                <tr class="notice-row" {% if not notice_enabled %}style="visibility:collapse"{% endif %}>
                     <td>
                         <strong>{% trans row.notice_type.display %}</strong><br/>
                         <span class="notice_type_description">
@@ -40,7 +42,7 @@
                     </td>
                     {% for cell in row.cells %}
                         <td>
-                            <input type="checkbox" name="{{ cell.0 }}" {% if cell.1 %}checked="yes"{% endif %} />
+                            <input type="checkbox" name="{{ cell.0 }}" {% if not notice_enabled %}disabled="true"{% else %}{% if cell.1 %}checked="yes"{% endif %}{% endif %} />
                         </td>
                     {% endfor %}
                 </tr>


### PR DESCRIPTION
…non admin users

<Include a few sentences describing the overall goals for this Pull Request>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [x] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
