### PR TITLE
[Fixes #6888] Map and Layer thumbnail views do not correctly manage r…

### DIFF
--- a/geonode/layers/tests.py
+++ b/geonode/layers/tests.py
@@ -383,6 +383,27 @@ class LayersTest(GeoNodeBaseTestSupport):
             links = Link.objects.filter(resource=lyr.resourcebase_ptr, link_type="image")
             self.assertIsNotNone(links)
 
+    def test_layer_thumbnail_generation_managed_errors(self):
+        """
+        Test that 'layer_thumbnail' handles correctly thumbnail generation errors
+        """
+        layer = Layer.objects.all().first()
+        url = reverse('layer_thumbnail', args=(layer.alternate,))
+        # Now test with a valid user
+        self.client.login(username='admin', password='admin')
+
+        # test a method other than POST and GET
+        request_body = {'preview': '\
+"bbox":[1331513.3064995816,1333734.7576341194,5599619.355527631,5600574.818381195],\
+"srid":"EPSG:3857",\
+"center":{"x":11.971165359906351,"y":44.863749562810995,"crs":"EPSG:4326"},\
+"zoom":16,"width":930,"height":400,\
+"layers":"' + layer.alternate + '"}'}
+        response = self.client.post(url, data=request_body)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content.decode('utf-8'), 'Thumbnail saved')
+        self.assertNotEquals(layer.get_thumbnail_url(), settings.MISSING_THUMBNAIL)
+
     def test_get_valid_user(self):
         # Verify it accepts an admin user
         adminuser = get_user_model().objects.get(is_superuser=True)

--- a/geonode/layers/views.py
+++ b/geonode/layers/views.py
@@ -1497,7 +1497,11 @@ def layer_thumbnail(request, layername):
                     request.body, request=request)
             except Exception as e:
                 logger.debug(e)
-                image = _render_thumbnail(request.body)
+                try:
+                    image = _render_thumbnail(request.body)
+                except Exception as e:
+                    logger.debug(e)
+                    image = None
 
         is_image = False
         if image:

--- a/geonode/maps/tests.py
+++ b/geonode/maps/tests.py
@@ -298,6 +298,27 @@ community."
         response = self.client.get(reverse('map_detail', args=(map_obj.id,)))
         self.assertEqual(response.status_code, 200)
 
+    def test_map_thumbnail_generation_managed_errors(self):
+        """
+        Test that 'map_thumbnail' handles correctly thumbnail generation errors
+        """
+        map_obj = Map.objects.all().first()
+        url = reverse('map_thumbnail', args=(map_obj.id,))
+        # Now test with a valid user
+        self.client.login(username='admin', password='admin')
+
+        # test a method other than POST and GET
+        request_body = {'preview': '\
+"bbox":[1331513.3064995816,1333734.7576341194,5599619.355527631,5600574.818381195],\
+"srid":"EPSG:3857",\
+"center":{"x":11.971165359906351,"y":44.863749562810995,"crs":"EPSG:4326"},\
+"zoom":16,"width":930,"height":400,\
+"layers":"geonode:foo_bar"}'}
+        response = self.client.post(url, data=request_body)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content.decode('utf-8'), 'Thumbnail saved')
+        self.assertNotEquals(map_obj.get_thumbnail_url(), settings.MISSING_THUMBNAIL)
+
     def test_describe_map(self):
         map_obj = Map.objects.all().first()
         map_obj.set_default_permissions()

--- a/geonode/maps/views.py
+++ b/geonode/maps/views.py
@@ -1322,8 +1322,13 @@ def map_thumbnail(request, mapid):
         try:
             image = _prepare_thumbnail_body_from_opts(
                 request.body, request=request)
-        except Exception:
-            image = _render_thumbnail(request.body)
+        except Exception as e:
+            logger.debug(e)
+            try:
+                image = _render_thumbnail(request.body)
+            except Exception as e:
+                logger.debug(e)
+                image = None
 
         if not image:
             return HttpResponse(

--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -2037,10 +2037,15 @@ SOCIALACCOUNT_PROFILE_EXTRACTORS = {
 INVITATIONS_ADAPTER = ACCOUNT_ADAPTER
 
 # Choose thumbnail generator -- this is the default generator
-THUMBNAIL_GENERATOR = "geonode.layers.utils.create_gs_thumbnail_geonode"
-#THUMBNAIL_GENERATOR_DEFAULT_BG = r"http://a.tile.openstreetmap.org/{z}/{x}/{y}.png"
-THUMBNAIL_GENERATOR_DEFAULT_BG = r"https://maps.wikimedia.org/osm-intl/{z}/{x}/{y}.png"
-THUMBNAIL_GENERATOR_DEFAULT_SIZE = {'width': 240, 'height': 200}
+THUMBNAIL_GENERATOR = os.environ.get(
+    'THUMBNAIL_GENERATOR', 'geonode.layers.utils.create_gs_thumbnail_geonode')
+THUMBNAIL_GENERATOR_DEFAULT_BG = os.environ.get(
+    'THUMBNAIL_GENERATOR_DEFAULT_BG',
+    'https://maps.wikimedia.org/osm-intl/{z}/{x}/{y}.png')
+THUMBNAIL_GENERATOR_DEFAULT_SIZE = {
+    'width': int(os.environ.get('THUMBNAIL_GENERATOR_DEFAULT_SIZE_WIDTH', 240)),
+    'height': int(os.environ.get('THUMBNAIL_GENERATOR_DEFAULT_SIZE_HEIGHT', 200))
+}
 
 # define the urls after the settings are overridden
 if USE_GEOSERVER:

--- a/test.sh
+++ b/test.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 set -e
-. $HOME/.override_env
+set -a
+. ./.env_dev
+set +a
 
 coverage run --branch --source=geonode manage.py test -v 3 --keepdb  $@


### PR DESCRIPTION
…endering exceptions

<Include a few sentences describing the overall goals for this Pull Request>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
