### PR TITLE
[Fixes #6895] Correcly catching thumbnail async task errors

### DIFF
--- a/geonode/geoserver/tests/test_server.py
+++ b/geonode/geoserver/tests/test_server.py
@@ -1121,11 +1121,14 @@ class UtilsTests(GeoNodeBaseTestSupport):
             self.assertTrue(identifier in _link[3])
 
         # Thumbnails Generation Default
-        create_gs_thumbnail(instance, overwrite=True)
+        with self.assertRaises(Exception):
+            create_gs_thumbnail(instance, overwrite=True)
         self.assertIsNotNone(instance.get_thumbnail_url())
 
         # Thumbnails Generation Through "remote url"
-        create_gs_thumbnail_geonode(instance, overwrite=True, check_bbox=True)
+        with self.assertRaises(Exception):
+            create_gs_thumbnail_geonode(instance, overwrite=True, check_bbox=True)
+        self.assertIsNotNone(instance.get_thumbnail_url())
 
         # Thumbnails Generation Through "image"
         time.sleep(10)

--- a/geonode/layers/utils.py
+++ b/geonode/layers/utils.py
@@ -1087,6 +1087,7 @@ def create_thumbnail(instance, thumbnail_remote_url, thumbnail_create_url=None,
                     msg = 'Unable to obtain thumbnail for: %s' % instance
                     logger.debug(msg)
                     instance.save_thumbnail(thumbnail_name, image=None)
+                    raise Exception(msg)
 
 
 # this is the original implementation of create_gs_thumbnail()


### PR DESCRIPTION
This is also related to https://github.com/GeoNode/django-mapstore-adapter/commit/bd0250b6588b843f33a1da8aafd3b0504bb14f0b

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
