### PR TITLE
[Fixes #6910] meaningful filename for document download

### DIFF
--- a/geonode/documents/views.py
+++ b/geonode/documents/views.py
@@ -17,7 +17,7 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 #########################################################################
-
+import os
 import json
 import logging
 import traceback
@@ -194,8 +194,8 @@ def document_download(request, docid):
                 '401.html', context={
                     'error_message': _("You are not allowed to view this document.")}, request=request), status=401)
     register_event(request, EventType.EVENT_DOWNLOAD, document)
-    filename = slugify(document.title) + "." + document.extension
-    return DownloadResponse(document.doc_file, basename=filename)
+    filename = slugify(os.path.splitext(os.path.basename(document.title))[0])
+    return DownloadResponse(document.doc_file, basename=f"{filename}.{document.extension}")
 
 
 class DocumentUploadView(CreateView):

--- a/geonode/documents/views.py
+++ b/geonode/documents/views.py
@@ -29,6 +29,7 @@ from django.shortcuts import render, get_object_or_404
 from django.http import HttpResponse, HttpResponseRedirect, Http404
 from django.template import loader
 from django.utils.translation import ugettext as _
+from django.utils.text import slugify
 from django.contrib.auth.decorators import login_required
 from django.conf import settings
 from django.urls import reverse
@@ -193,7 +194,8 @@ def document_download(request, docid):
                 '401.html', context={
                     'error_message': _("You are not allowed to view this document.")}, request=request), status=401)
     register_event(request, EventType.EVENT_DOWNLOAD, document)
-    return DownloadResponse(document.doc_file)
+    filename = slugify(document.title) + "." + document.extension
+    return DownloadResponse(document.doc_file, basename=filename)
 
 
 class DocumentUploadView(CreateView):


### PR DESCRIPTION
This PR will use the slugified document title to create the filename for downloads.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
