### PR TITLE
[Fixes #6916] gsimporter.api.NotFound caused by missing trailing slash at the end of GEOSERVER_LOCATION

### DIFF
--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -951,6 +951,10 @@ GEOSERVER_LOCATION = os.getenv(
     'GEOSERVER_LOCATION', 'http://localhost:8080/geoserver/'
 )
 
+# add trailing slash to geoserver location url.
+if not GEOSERVER_LOCATION.endswith('/'):
+    GEOSERVER_LOCATION = '{}/'.format(GEOSERVER_LOCATION)
+    
 GEOSERVER_PUBLIC_SCHEMA = os.getenv(
     'GEOSERVER_PUBLIC_SCHEMA', SITE_HOST_SCHEMA
 )

--- a/geonode/tests/smoke.py
+++ b/geonode/tests/smoke.py
@@ -128,6 +128,12 @@ class GeoNodeSmokeTests(GeoNodeBaseTestSupport):
         response = self.client.get(reverse('opensearch_dispatch'))
         self.assertEqual(response.status_code, 200)
 
+    # Settings Tests #
+
+    def test_settings_geoserver_location(self):
+        '''Ensure GEOSERVER_LOCATION variable ends with /'''
+        self.assertTrue(settings.GEOSERVER_LOCATION.endswith('/'))
+
 
 class GeoNodeUtilsTests(GeoNodeBaseTestSupport):
 


### PR DESCRIPTION
GEOSERVER_LOCATION requires to end with trailing slash other wise it will raise an error which can't be explained.
```
gsimporter.api.NotFound
ERROR 2021-02-01 15:54:28,314 upload 1 139829203416832 Error creating import session
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/geonode/upload/upload.py", line 305, in save_step
    next_id = _get_next_id()
  File "/usr/local/lib/python3.8/site-packages/geonode/upload/upload.py", line 228, in _get_next_id
    importer_sessions = gs_uploader.get_sessions()
  File "/usr/local/lib/python3.8/site-packages/gsimporter/client.py", line 47, in get_sessions
    return self._call(self.client.get_imports)
  File "/usr/local/lib/python3.8/site-packages/gsimporter/client.py", line 34, in _call
    robj = fun(*args)
  File "/usr/local/lib/python3.8/site-packages/gsimporter/client.py", line 221, in get_imports
    return parse_response(self._request(self.url("imports")))
  File "/usr/local/lib/python3.8/site-packages/gsimporter/client.py", line 194, in _request
    raise NotFound()

```
## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
