### PR TITLE
[Fixes #6914] Remove "add to basket" tool for documents and maps

### DIFF
--- a/geonode/base/templates/base/_resourcebase_snippet.html
+++ b/geonode/base/templates/base/_resourcebase_snippet.html
@@ -37,37 +37,36 @@
                   <a href="{{ item.detail_url }}">{{ item.title }}</a>
               </h4>
             </div>
+            {% endverbatim %}
+
+            {% if facet_type == 'layers' %}
             <div class="col-xs-2">
-              <h4>{% endverbatim %}
+              <h4>
                 <button
                   class="btn btn-default btn-xs pull-right"
                   ng-if="cart"
                   ng-click="cart.toggleItem(item)"
                   data-toggle="tooltip"
                   data-placement="bottom"
-                  title="{% trans "Select" %}"><i ng-class="cart.getFaClass(item.id)" class="fa fa-lg"></i></button>{% verbatim %}
+                  title="{% trans "Select" %}"><i ng-class="cart.getFaClass(item.id)" class="fa fa-lg"></i></button>
               </h4>
             </div>
+            {% endif %}
           </div>
           <em ng-if="item.store_type == 'remoteStore'">
-            {% endverbatim %}
             <span ng-if="item.online == true"><i class="fa fa-power-off text-success"></i> {% trans "Service is" %} {% trans "online" %}</span>
             <span ng-if="item.online == false"><i class="fa fa-power-off text-danger"></i> {% trans "Service is" %} {% trans "offline" %}</span>
-            {% verbatim %}
           </em>
           <em ng-if="item.processed == false">
-            {% endverbatim %}
             <i class="fa fa-cog fa-spin fa-fw"></i>{% trans "Layer not ready yet. Still finalizing layer ingestion..." %}
-            {% verbatim %}
           </em>
-		      {% endverbatim %}
           <div class="alert alert-danger" ng-if="item.dirty_state == true">{% trans "SECURITY NOT YET SYNCHRONIZED" %}
               {% verbatim %}<a href="{{ item.detail_url }}" class="btn btn-primary btn-block" data-dismiss="modal" ng-click="securityRefreshButton($event)">{% endverbatim %}{% trans "Sync permissions immediately" %}</a>
           </div>
           <div class="alert alert-warning" ng-if="item.dirty_state == false && item.is_approved == false">{% trans "PENDING APPROVAL" %}</div>
           <div class="alert alert-danger" ng-if="item.dirty_state == false && item.is_approved == true && item.is_published == false">{% trans "UNPUBLISHED" %}</div>
-          {% verbatim %}
 
+          {% verbatim %}
           <div class="abstract" ng-bind-html="item.abstract | limitTo: 300"></div>
           <p class="abstract">{{ item.abstract.length  > 300 ? '...' : ''}}</p>
           <div class="row">

--- a/geonode/templates/search/_search_content.html
+++ b/geonode/templates/search/_search_content.html
@@ -1,18 +1,23 @@
 {% load i18n %}
 <div class="row" ng-controller="CartList">
   <div class="col-md-3">
-    <resource-cart data-facet-type="{{ facet_type }}" selectedString='{% trans "Selection" %}' emptyString="{% trans "No list items selected. Use the selection fields to add." %}" ></resource-cart>
+
+    {% if facet_type == 'layers' %}
+    <resource-cart data-facet-type="{{ facet_type }}" selectedString='{% trans "Selection" %}' emptyString="{% trans "No list items selected. Use the selection fields to add." %}" >
+    </resource-cart>
+    {% endif %}
     <div class="row">
       <div class="col-xs-12">
-        {% block bulk_perms_button %}
-        <div class="btn-group btn-group-justified" role="group" aria-label="tools">
-          {% if facet_type == 'layers' %}
-          <div class="btn-group" role="group">
-            <button type="button" class="btn btn-default" ng-disabled="!cart.getCart().items.length" ng-click="newMap()">{% trans "Create a Map" %}</button>
+
+        {% if facet_type == 'layers' %}
+          {% block bulk_perms_button %}
+          <div class="btn-group btn-group-justified" role="group" aria-label="tools">
+            <div class="btn-group" role="group">
+              <button type="button" class="btn btn-default" ng-disabled="!cart.getCart().items.length" ng-click="newMap()">{% trans "Create a Map" %}</button>
+            </div>
           </div>
-          {% endif %}
-        </div>
-        {% endblock %}
+          {% endblock %}
+        {% endif %}
 
         <div class="selections">
             {% trans "Filters" %}


### PR DESCRIPTION
<Include a few sentences describing the overall goals for this Pull Request>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
