### PR TITLE
[Fixes #6922][REST API v2] Expose the curated thumbnail URL if it has…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,6 +132,13 @@ workflows:
           requires:
             - geonode_test_suite_smoke
       - build:
+          name: geonode_test_rest_apis
+          load_docker_cache: true
+          save_docker_cache: false
+          test_suite: coverage run --branch --source=geonode manage.py test -v 3 --keepdb geonode.base.api.tests geonode.layers.api.tests geonode.maps.api.tests geonode.documents.api.tests geonode.geoapps.api.tests
+          requires:
+            - geonode_test_suite_smoke
+      - build:
           name: geonode_test_integration_csw
           load_docker_cache: true
           save_docker_cache: false

--- a/geonode/base/api/serializers.py
+++ b/geonode/base/api/serializers.py
@@ -17,6 +17,7 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 #########################################################################
+from django.conf import settings
 from django.contrib.auth.models import Group
 from django.contrib.auth import get_user_model
 
@@ -25,6 +26,7 @@ from rest_framework_gis import fields
 from dynamic_rest.serializers import DynamicEphemeralSerializer, DynamicModelSerializer
 from dynamic_rest.fields.fields import DynamicRelationField, DynamicComputedField
 
+from urllib.parse import urljoin
 from avatar.templatetags.avatar_tags import avatar_url
 
 from geonode.base.models import (
@@ -147,6 +149,22 @@ class AvatarUrlField(DynamicComputedField):
         return avatar_url(instance, self.avatar_size)
 
 
+class ThumbnailUrlField(DynamicComputedField):
+
+    def __init__(self, **kwargs):
+        super(ThumbnailUrlField, self).__init__(**kwargs)
+
+    def get_attribute(self, instance):
+        thumbnail_url = instance.thumbnail_url
+        if hasattr(instance, 'curatedthumbnail'):
+            if hasattr(instance.curatedthumbnail.img_thumbnail, 'url'):
+                thumbnail_url = instance.curatedthumbnail.thumbnail_url
+
+        if thumbnail_url and 'http' not in thumbnail_url:
+            thumbnail_url = urljoin(settings.SITEURL, thumbnail_url)
+        return thumbnail_url
+
+
 class UserSerializer(DynamicModelSerializer):
 
     class Meta:
@@ -215,11 +233,11 @@ class ResourceBaseSerializer(DynamicModelSerializer):
         self.fields['featured'] = serializers.BooleanField()
         self.fields['is_published'] = serializers.BooleanField()
         self.fields['is_approved'] = serializers.BooleanField()
-        self.fields['thumbnail_url'] = serializers.CharField()
         self.fields['detail_url'] = serializers.CharField(read_only=True)
         self.fields['created'] = serializers.DateTimeField(read_only=True)
         self.fields['last_updated'] = serializers.DateTimeField(read_only=True)
 
+        self.fields['thumbnail_url'] = ThumbnailUrlField()
         self.fields['keywords'] = DynamicRelationField(
             HierarchicalKeywordSerializer, embed=False, many=True)
         self.fields['regions'] = DynamicRelationField(
@@ -246,7 +264,7 @@ class ResourceBaseSerializer(DynamicModelSerializer):
             'spatial_representation_type', 'temporal_extent_start', 'temporal_extent_end',
             'supplemental_information', 'data_quality_statement', 'group',
             'popular_count', 'share_count', 'rating', 'featured', 'is_published', 'is_approved',
-            'thumbnail_url', 'detail_url', 'created', 'last_updated'
+            'detail_url', 'created', 'last_updated'
             # TODO
             # csw_typename, csw_schema, csw_mdsource, csw_insert_date, csw_type, csw_anytext, csw_wkt_geometry,
             # metadata_uploaded, metadata_uploaded_preserve, metadata_xml,


### PR DESCRIPTION
… been uploaded

<Include a few sentences describing the overall goals for this Pull Request>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
