### PR TITLE
[Fixes  #6929] Do not overwrite existing thumbnails if the image is b…

### DIFF
--- a/geonode/base/models.py
+++ b/geonode/base/models.py
@@ -1461,7 +1461,7 @@ class ResourceBase(PolymorphicModel, PermissionLevelMixin, ItemBase):
         try:
             # Check that the image is valid
             if is_monochromatic_image(None, image):
-                if not self.thumbnail_url:
+                if not self.thumbnail_url and not image:
                     raise Exception("Generated thumbnail image is blank")
                 else:
                     # Skip Image creation
@@ -1507,7 +1507,7 @@ class ResourceBase(PolymorphicModel, PermissionLevelMixin, ItemBase):
                     site_url = settings.SITEURL.rstrip('/') if settings.SITEURL.startswith('http') else settings.SITEURL
                     url = urljoin(site_url, url)
 
-                if thumb_size(name) == 0:
+                if thumb_size(filename) == 0:
                     raise Exception("Generated thumbnail image is zero size")
 
                 # should only have one 'Thumbnail' link

--- a/geonode/base/models.py
+++ b/geonode/base/models.py
@@ -1512,7 +1512,7 @@ class ResourceBase(PolymorphicModel, PermissionLevelMixin, ItemBase):
 
                 # should only have one 'Thumbnail' link
                 Link.objects.filter(resource=self, name='Thumbnail').delete()
-                obj = Link.objects.create(
+                obj, _created = Link.objects.get_or_create(
                     resource=self,
                     name='Thumbnail',
                     defaults=dict(
@@ -1536,7 +1536,7 @@ class ResourceBase(PolymorphicModel, PermissionLevelMixin, ItemBase):
             try:
                 Link.objects.filter(resource=self, name='Thumbnail').delete()
                 _thumbnail_url = staticfiles.static(settings.MISSING_THUMBNAIL)
-                obj = Link.objects.create(
+                obj, _created = Link.objects.get_or_create(
                     resource=self,
                     name='Thumbnail',
                     defaults=dict(

--- a/geonode/base/models.py
+++ b/geonode/base/models.py
@@ -1507,7 +1507,7 @@ class ResourceBase(PolymorphicModel, PermissionLevelMixin, ItemBase):
                     site_url = settings.SITEURL.rstrip('/') if settings.SITEURL.startswith('http') else settings.SITEURL
                     url = urljoin(site_url, url)
 
-                if thumb_size(filename) == 0:
+                if thumb_size(_upload_path) == 0:
                     raise Exception("Generated thumbnail image is zero size")
 
                 # should only have one 'Thumbnail' link

--- a/geonode/base/thumb_utils.py
+++ b/geonode/base/thumb_utils.py
@@ -15,6 +15,11 @@ def thumb_exists(filename):
     return storage.exists(thumb_path(filename))
 
 
+def thumb_size(filename):
+    """Determine if a thumbnail file exists in storage"""
+    return storage.size(thumb_path(filename))
+
+
 def get_thumbs():
     """Fetches a list of all stored thumbnails"""
     if not storage.exists(settings.THUMBNAIL_LOCATION):

--- a/geonode/base/thumb_utils.py
+++ b/geonode/base/thumb_utils.py
@@ -15,9 +15,13 @@ def thumb_exists(filename):
     return storage.exists(thumb_path(filename))
 
 
-def thumb_size(filename):
-    """Determine if a thumbnail file exists in storage"""
-    return storage.size(thumb_path(filename))
+def thumb_size(filepath):
+    """Determine if a thumbnail file size in storage"""
+    if storage.exists(filepath):
+        return storage.size(filepath)
+    elif os.path.exists(filepath):
+        return os.path.getsize(filepath)
+    return 0
 
 
 def get_thumbs():

--- a/geonode/documents/renderers.py
+++ b/geonode/documents/renderers.py
@@ -110,10 +110,10 @@ def generate_thumbnail_content(image_path, size=(200, 150)):
         if source_width != target_width or source_width != target_height:
             image = ImageOps.fit(image, size, Image.ANTIALIAS)
 
-        output = io.BytesIO()
-        image.save(output, format='PNG')
-        content = output.getvalue()
-        output.close()
+        with io.BytesIO() as output:
+            image.save(output, format='PNG')
+            content = output.getvalue()
+            output.close()
         return content
     except Exception as e:
         raise e

--- a/geonode/geoserver/helpers.py
+++ b/geonode/geoserver/helpers.py
@@ -22,12 +22,10 @@ import re
 import sys
 import time
 import uuid
-# import base64
 import json
 import errno
 import logging
 import datetime
-import requests
 import tempfile
 import traceback
 import mercantile
@@ -2034,33 +2032,6 @@ _esri_types = {
     "esriFieldTypeGUID": "xsd:string",
     "esriFieldTypeGlobalID": "xsd:string",
     "esriFieldTypeXML": "xsd:anyType"}
-
-
-def is_monochromatic_image(image_url):
-
-    def is_absolute(url):
-        return bool(urlparse(url).netloc)
-
-    try:
-        logger.debug(f"...Checking if '{image_url}' is a blank image")
-        url = image_url if is_absolute(image_url) else urljoin(settings.SITEURL, image_url)
-        response = requests.get(url, verify=False)
-        stream = BytesIO(response.content)
-        img = Image.open(stream).convert("L")
-        stream.close()
-        img.verify()  # verify that it is, in fact an image
-        extr = img.getextrema()
-        a = 0
-        for i in extr:
-            if isinstance(i, tuple):
-                a += abs(i[0] - i[1])
-            else:
-                a = abs(extr[0] - extr[1])
-                break
-        return a == 0
-    except Exception as e:
-        logger.exception(e)
-        return False
 
 
 def _render_thumbnail(req_body, width=240, height=200):

--- a/geonode/geoserver/helpers.py
+++ b/geonode/geoserver/helpers.py
@@ -2055,17 +2055,18 @@ def _render_thumbnail(req_body, width=240, height=200):
             raise Exception(content)
 
         # Optimize the Thumbnail size and resolution
-        content_data = BytesIO(content)
-        im = Image.open(content_data)
-        im.thumbnail(
-            (_default_thumb_size['width'], _default_thumb_size['height']),
-            resample=Image.ANTIALIAS)
-        cover = resizeimage.resize_cover(
-            im,
-            [_default_thumb_size['width'], _default_thumb_size['height']])
-        imgByteArr = BytesIO()
-        cover.save(imgByteArr, format='JPEG')
-        content = imgByteArr.getvalue()
+        with BytesIO(content) as content_data:
+            im = Image.open(content_data)
+            im.thumbnail(
+                (_default_thumb_size['width'], _default_thumb_size['height']),
+                resample=Image.ANTIALIAS)
+            cover = resizeimage.resize_cover(
+                im,
+                [_default_thumb_size['width'], _default_thumb_size['height']])
+            imgByteArr = BytesIO()
+            cover.save(imgByteArr, format='JPEG')
+            content = imgByteArr.getvalue()
+            imgByteArr.close()
     except Exception as e:
         logger.debug(f"Could not sucesfully send data to {url}")
         logger.debug(f" - user: [{_user}]")

--- a/geonode/geoserver/signals.py
+++ b/geonode/geoserver/signals.py
@@ -28,12 +28,13 @@ from django.forms.models import model_to_dict
 from django.contrib.staticfiles.templatetags import staticfiles
 
 # use different name to avoid module clash
-from geonode.utils import json_serializer_producer
+from geonode.utils import (
+    is_monochromatic_image,
+    json_serializer_producer)
 from geonode.decorators import on_ogc_backend
 from geonode.geoserver.helpers import (
     gs_catalog,
-    ogc_server_settings,
-    is_monochromatic_image)
+    ogc_server_settings)
 from geonode.geoserver.tasks import geoserver_create_thumbnail
 from geonode.layers.models import Layer
 from geonode.services.enumerations import CASCADED

--- a/geonode/geoserver/tasks.py
+++ b/geonode/geoserver/tasks.py
@@ -44,7 +44,9 @@ from geonode.base.models import (
     ResourceBase,
     TopicCategory,
     SpatialRepresentationType)
-from geonode.utils import set_resource_default_links
+from geonode.utils import (
+    is_monochromatic_image,
+    set_resource_default_links)
 from geonode.geoserver.upload import geoserver_upload
 from geonode.catalogue.models import catalogue_post_save
 
@@ -58,7 +60,6 @@ from .helpers import (
     cascading_delete,
     fetch_gs_resource,
     create_gs_thumbnail,
-    is_monochromatic_image,
     set_attributes_from_geoserver,
     _invalidate_geowebcache_layer,
     _stylefilterparams_geowebcache_layer)

--- a/geonode/proxy/views.py
+++ b/geonode/proxy/views.py
@@ -205,8 +205,9 @@ def proxy(request, url=None, response_callback=None,
     # if content and response and response.getheader('Content-Encoding') == 'gzip':
     if content and content_type and content_type == 'gzip':
         buf = io.BytesIO(content)
-        f = gzip.GzipFile(fileobj=buf)
-        content = f.read()
+        with gzip.GzipFile(fileobj=buf) as f:
+            content = f.read()
+        buf.close()
 
     PLAIN_CONTENT_TYPES = [
         'text',

--- a/geonode/utils.py
+++ b/geonode/utils.py
@@ -2013,26 +2013,27 @@ def is_monochromatic_image(image_url, image_data=None):
     try:
         if image_data:
             logger.debug("...Checking if image is a blank image")
-            stream = BytesIO(image_data)
+            stream_content = image_data
         elif image_url:
             logger.debug(f"...Checking if '{image_url}' is a blank image")
             url = image_url if is_absolute(image_url) else urljoin(settings.SITEURL, image_url)
             response = requests.get(url, verify=False)
-            stream = BytesIO(response.content)
+            stream_content = response.content
         else:
             return True
-        img = Image.open(stream).convert("L")
-        stream.close()
-        img.verify()  # verify that it is, in fact an image
-        extr = img.getextrema()
-        a = 0
-        for i in extr:
-            if isinstance(i, tuple):
-                a += abs(i[0] - i[1])
-            else:
-                a = abs(extr[0] - extr[1])
-                break
-        return a == 0
+        with BytesIO(stream_content) as stream:
+            img = Image.open(stream).convert("L")
+            stream.close()
+            img.verify()  # verify that it is, in fact an image
+            extr = img.getextrema()
+            a = 0
+            for i in extr:
+                if isinstance(i, tuple):
+                    a += abs(i[0] - i[1])
+                else:
+                    a = abs(extr[0] - extr[1])
+                    break
+            return a == 0
     except Exception as e:
         logger.exception(e)
         return False

--- a/geonode/utils.py
+++ b/geonode/utils.py
@@ -38,7 +38,8 @@ import traceback
 import subprocess
 
 from osgeo import ogr
-from io import StringIO
+from PIL import Image
+from io import BytesIO, StringIO
 from decimal import Decimal
 from slugify import slugify
 from contextlib import closing
@@ -2002,3 +2003,34 @@ def json_serializer_producer(dictionary):
                     y = model_to_dict(_obj)
             output[x] = to_json(y)
     return output
+
+
+def is_monochromatic_image(image_url, image_data=None):
+
+    def is_absolute(url):
+        return bool(urlparse(url).netloc)
+
+    try:
+        if image_data:
+            logger.debug("...Checking if image is a blank image")
+            stream = BytesIO(image_data)
+        else:
+            logger.debug(f"...Checking if '{image_url}' is a blank image")
+            url = image_url if is_absolute(image_url) else urljoin(settings.SITEURL, image_url)
+            response = requests.get(url, verify=False)
+            stream = BytesIO(response.content)
+        img = Image.open(stream).convert("L")
+        stream.close()
+        img.verify()  # verify that it is, in fact an image
+        extr = img.getextrema()
+        a = 0
+        for i in extr:
+            if isinstance(i, tuple):
+                a += abs(i[0] - i[1])
+            else:
+                a = abs(extr[0] - extr[1])
+                break
+        return a == 0
+    except Exception as e:
+        logger.exception(e)
+        return False

--- a/geonode/utils.py
+++ b/geonode/utils.py
@@ -2014,11 +2014,13 @@ def is_monochromatic_image(image_url, image_data=None):
         if image_data:
             logger.debug("...Checking if image is a blank image")
             stream = BytesIO(image_data)
-        else:
+        elif image_url:
             logger.debug(f"...Checking if '{image_url}' is a blank image")
             url = image_url if is_absolute(image_url) else urljoin(settings.SITEURL, image_url)
             response = requests.get(url, verify=False)
             stream = BytesIO(response.content)
+        else:
+            return True
         img = Image.open(stream).convert("L")
         stream.close()
         img.verify()  # verify that it is, in fact an image


### PR DESCRIPTION
…lank

<Include a few sentences describing the overall goals for this Pull Request>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
