### PR TITLE
[Fixes #6955][REST API v2] Expose 'embed urls' of the concrete resources

### DIFF
--- a/geonode/base/api/serializers.py
+++ b/geonode/base/api/serializers.py
@@ -149,6 +149,19 @@ class AvatarUrlField(DynamicComputedField):
         return avatar_url(instance, self.avatar_size)
 
 
+class EmbedUrlField(DynamicComputedField):
+
+    def __init__(self, **kwargs):
+        super(EmbedUrlField, self).__init__(**kwargs)
+
+    def get_attribute(self, instance):
+        _instance = instance.get_real_instance()
+        if hasattr(_instance, 'embed_url') and _instance.embed_url != NotImplemented:
+            return _instance.embed_url
+        else:
+            return ""
+
+
 class ThumbnailUrlField(DynamicComputedField):
 
     def __init__(self, **kwargs):
@@ -237,6 +250,7 @@ class ResourceBaseSerializer(DynamicModelSerializer):
         self.fields['created'] = serializers.DateTimeField(read_only=True)
         self.fields['last_updated'] = serializers.DateTimeField(read_only=True)
 
+        self.fields['embed_url'] = EmbedUrlField()
         self.fields['thumbnail_url'] = ThumbnailUrlField()
         self.fields['keywords'] = DynamicRelationField(
             HierarchicalKeywordSerializer, embed=False, many=True)
@@ -264,7 +278,7 @@ class ResourceBaseSerializer(DynamicModelSerializer):
             'spatial_representation_type', 'temporal_extent_start', 'temporal_extent_end',
             'supplemental_information', 'data_quality_statement', 'group',
             'popular_count', 'share_count', 'rating', 'featured', 'is_published', 'is_approved',
-            'detail_url', 'created', 'last_updated'
+            'detail_url', 'embed_url', 'created', 'last_updated'
             # TODO
             # csw_typename, csw_schema, csw_mdsource, csw_insert_date, csw_type, csw_anytext, csw_wkt_geometry,
             # metadata_uploaded, metadata_uploaded_preserve, metadata_xml,

--- a/geonode/base/models.py
+++ b/geonode/base/models.py
@@ -1375,6 +1375,10 @@ class ResourceBase(PolymorphicModel, PermissionLevelMixin, ItemBase):
                      link.url))
         return links
 
+    @property
+    def embed_url(self):
+        return NotImplemented
+
     def get_tiles_url(self):
         """Return URL for Z/Y/X mapping clients or None if it does not exist.
         """

--- a/geonode/documents/api/tests.py
+++ b/geonode/documents/api/tests.py
@@ -17,6 +17,7 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 #########################################################################
+import django
 import logging
 
 from urllib.parse import urljoin
@@ -24,10 +25,15 @@ from urllib.parse import urljoin
 from django.urls import reverse
 from django.conf.urls import url, include
 from django.views.generic import TemplateView
+from django.views.i18n import JavaScriptCatalog
 from rest_framework.test import APITestCase, URLPatternsTestCase
 
 from geonode.api.urls import router
+from geonode.services.views import services
 from geonode.documents.models import Document
+from geonode.maps.views import map_embed
+from geonode.geoapps.views import geoapp_edit
+from geonode.layers.views import layer_upload, layer_embed
 from geonode.documents.views import document_download
 
 from geonode import geoserver
@@ -58,6 +64,33 @@ class DocumentsApiTests(APITestCase, URLPatternsTestCase):
         url(r'^api/v2/', include('geonode.api.urls')),
         url(r'^api/v2/api-auth/', include('rest_framework.urls', namespace='geonode_rest_framework')),
         url(r'^(?P<docid>\d+)/download/?$', document_download, name='document_download'),
+        url(r'^upload$', layer_upload, name='layer_upload'),
+        url(r'^$',
+            TemplateView.as_view(template_name='layers/layer_list.html'),
+            {'facet_type': 'layers', 'is_layer': True},
+            name='layer_browse'),
+        url(r'^$',
+            TemplateView.as_view(template_name='maps/map_list.html'),
+            {'facet_type': 'maps', 'is_map': True},
+            name='maps_browse'),
+        url(r'^$',
+            TemplateView.as_view(template_name='documents/document_list.html'),
+            {'facet_type': 'documents', 'is_document': True},
+            name='document_browse'),
+        url(r'^$',
+            TemplateView.as_view(template_name='groups/group_list.html'),
+            name='group_list'),
+        url(r'^search/$',
+            TemplateView.as_view(template_name='search/search.html'),
+            name='search'),
+        url(r'^$', services, name='services'),
+        url(r'^invitations/', include(
+            'geonode.invitations.urls', namespace='geonode.invitations')),
+        url(r'^i18n/', include(django.conf.urls.i18n), name="i18n"),
+        url(r'^jsi18n/$', JavaScriptCatalog.as_view(), {}, name='javascript-catalog'),
+        url(r'^(?P<mapid>[^/]+)/embed$', map_embed, name='map_embed'),
+        url(r'^(?P<layername>[^/]+)/embed$', layer_embed, name='layer_embed'),
+        url(r'^(?P<geoappid>[^/]+)/embed$', geoapp_edit, {'template': 'apps/app_embed.html'}, name='geoapp_embed'),
     ]
 
     if check_ogc_backend(geoserver.BACKEND_PACKAGE):

--- a/geonode/geoapps/api/tests.py
+++ b/geonode/geoapps/api/tests.py
@@ -18,9 +18,9 @@
 #
 #########################################################################
 import json
+import django
 import logging
 
-import django
 from django.urls import reverse
 from django.conf.urls import url, include
 from django.views.generic import TemplateView
@@ -30,6 +30,9 @@ from rest_framework.test import APITestCase, URLPatternsTestCase
 
 from geonode.api.urls import router
 from geonode.services.views import services
+from geonode.maps.views import map_embed
+from geonode.geoapps.views import geoapp_edit
+from geonode.layers.views import layer_upload, layer_embed
 from geonode.geoapps.models import GeoApp, GeoAppData
 
 from geonode import geoserver
@@ -69,6 +72,7 @@ class BaseApiTests(APITestCase, URLPatternsTestCase):
         url(r'^api/v2/', include(router.urls)),
         url(r'^api/v2/', include('geonode.api.urls')),
         url(r'^api/v2/api-auth/', include('rest_framework.urls', namespace='geonode_rest_framework')),
+        url(r'^upload$', layer_upload, name='layer_upload'),
         url(r'^$',
             TemplateView.as_view(template_name='layers/layer_list.html'),
             {'facet_type': 'layers', 'is_layer': True},
@@ -91,7 +95,10 @@ class BaseApiTests(APITestCase, URLPatternsTestCase):
         url(r'^invitations/', include(
             'geonode.invitations.urls', namespace='geonode.invitations')),
         url(r'^i18n/', include(django.conf.urls.i18n), name="i18n"),
-        url(r'^jsi18n/$', JavaScriptCatalog.as_view(), {}, name='javascript-catalog')
+        url(r'^jsi18n/$', JavaScriptCatalog.as_view(), {}, name='javascript-catalog'),
+        url(r'^(?P<mapid>[^/]+)/embed$', map_embed, name='map_embed'),
+        url(r'^(?P<layername>[^/]+)/embed$', layer_embed, name='layer_embed'),
+        url(r'^(?P<geoappid>[^/]+)/embed$', geoapp_edit, {'template': 'apps/app_embed.html'}, name='geoapp_embed'),
     ]
 
     if check_ogc_backend(geoserver.BACKEND_PACKAGE):

--- a/geonode/geoapps/models.py
+++ b/geonode/geoapps/models.py
@@ -129,6 +129,10 @@ class GeoApp(ResourceBase):
     def get_absolute_url(self):
         return reverse('geoapp_detail', None, [str(self.id)])
 
+    @property
+    def embed_url(self):
+        return reverse('geoapp_embed', kwargs={'geoappid': self.pk})
+
     class Meta(ResourceBase.Meta):
         pass
 

--- a/geonode/layers/api/tests.py
+++ b/geonode/layers/api/tests.py
@@ -17,14 +17,20 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 #########################################################################
+import django
 import logging
 
 from django.urls import reverse
 from django.conf.urls import url, include
 from django.views.generic import TemplateView
+from django.views.i18n import JavaScriptCatalog
 from rest_framework.test import APITestCase, URLPatternsTestCase
 
 from geonode.api.urls import router
+from geonode.services.views import services
+from geonode.maps.views import map_embed
+from geonode.geoapps.views import geoapp_edit
+from geonode.layers.views import layer_upload, layer_embed
 
 from geonode import geoserver
 from geonode.utils import check_ogc_backend
@@ -53,6 +59,33 @@ class LayersApiTests(APITestCase, URLPatternsTestCase):
         url(r'^api/v2/', include(router.urls)),
         url(r'^api/v2/', include('geonode.api.urls')),
         url(r'^api/v2/api-auth/', include('rest_framework.urls', namespace='geonode_rest_framework')),
+        url(r'^upload$', layer_upload, name='layer_upload'),
+        url(r'^$',
+            TemplateView.as_view(template_name='layers/layer_list.html'),
+            {'facet_type': 'layers', 'is_layer': True},
+            name='layer_browse'),
+        url(r'^$',
+            TemplateView.as_view(template_name='maps/map_list.html'),
+            {'facet_type': 'maps', 'is_map': True},
+            name='maps_browse'),
+        url(r'^$',
+            TemplateView.as_view(template_name='documents/document_list.html'),
+            {'facet_type': 'documents', 'is_document': True},
+            name='document_browse'),
+        url(r'^$',
+            TemplateView.as_view(template_name='groups/group_list.html'),
+            name='group_list'),
+        url(r'^search/$',
+            TemplateView.as_view(template_name='search/search.html'),
+            name='search'),
+        url(r'^$', services, name='services'),
+        url(r'^invitations/', include(
+            'geonode.invitations.urls', namespace='geonode.invitations')),
+        url(r'^i18n/', include(django.conf.urls.i18n), name="i18n"),
+        url(r'^jsi18n/$', JavaScriptCatalog.as_view(), {}, name='javascript-catalog'),
+        url(r'^(?P<mapid>[^/]+)/embed$', map_embed, name='map_embed'),
+        url(r'^(?P<layername>[^/]+)/embed$', layer_embed, name='layer_embed'),
+        url(r'^(?P<geoappid>[^/]+)/embed$', geoapp_edit, {'template': 'apps/app_embed.html'}, name='geoapp_embed'),
     ]
 
     if check_ogc_backend(geoserver.BACKEND_PACKAGE):

--- a/geonode/layers/models.py
+++ b/geonode/layers/models.py
@@ -336,7 +336,7 @@ class Layer(ResourceBase):
 
     @property
     def embed_url(self):
-        return reverse('layer_embed', kwargs={'layername': self.name})
+        return reverse('layer_embed', kwargs={'layername': self.service_typename})
 
     def attribute_config(self):
         # Get custom attribute sort order and labels if any

--- a/geonode/layers/models.py
+++ b/geonode/layers/models.py
@@ -334,6 +334,10 @@ class Layer(ResourceBase):
             args=("%s:%s" % (self.store, self.alternate),)
         )
 
+    @property
+    def embed_url(self):
+        return reverse('layer_embed', kwargs={'layername': self.name})
+
     def attribute_config(self):
         # Get custom attribute sort order and labels if any
         cfg = {}

--- a/geonode/maps/api/tests.py
+++ b/geonode/maps/api/tests.py
@@ -17,6 +17,7 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 #########################################################################
+import django
 import logging
 
 from urllib.parse import urljoin
@@ -25,11 +26,15 @@ from django.conf import settings
 from django.urls import reverse
 from django.conf.urls import url, include
 from django.views.generic import TemplateView
+from django.views.i18n import JavaScriptCatalog
 from rest_framework.test import APITestCase, URLPatternsTestCase
 
 from geonode.api.urls import router
+from geonode.services.views import services
 from geonode.maps.models import Map
-from geonode.layers.views import layer_upload
+from geonode.maps.views import map_embed
+from geonode.geoapps.views import geoapp_edit
+from geonode.layers.views import layer_upload, layer_embed
 
 from geonode import geoserver
 from geonode.utils import check_ogc_backend
@@ -59,6 +64,32 @@ class MapsApiTests(APITestCase, URLPatternsTestCase):
         url(r'^api/v2/', include('geonode.api.urls')),
         url(r'^api/v2/api-auth/', include('rest_framework.urls', namespace='geonode_rest_framework')),
         url(r'^upload$', layer_upload, name='layer_upload'),
+        url(r'^$',
+            TemplateView.as_view(template_name='layers/layer_list.html'),
+            {'facet_type': 'layers', 'is_layer': True},
+            name='layer_browse'),
+        url(r'^$',
+            TemplateView.as_view(template_name='maps/map_list.html'),
+            {'facet_type': 'maps', 'is_map': True},
+            name='maps_browse'),
+        url(r'^$',
+            TemplateView.as_view(template_name='documents/document_list.html'),
+            {'facet_type': 'documents', 'is_document': True},
+            name='document_browse'),
+        url(r'^$',
+            TemplateView.as_view(template_name='groups/group_list.html'),
+            name='group_list'),
+        url(r'^search/$',
+            TemplateView.as_view(template_name='search/search.html'),
+            name='search'),
+        url(r'^$', services, name='services'),
+        url(r'^invitations/', include(
+            'geonode.invitations.urls', namespace='geonode.invitations')),
+        url(r'^i18n/', include(django.conf.urls.i18n), name="i18n"),
+        url(r'^jsi18n/$', JavaScriptCatalog.as_view(), {}, name='javascript-catalog'),
+        url(r'^(?P<mapid>[^/]+)/embed$', map_embed, name='map_embed'),
+        url(r'^(?P<layername>[^/]+)/embed$', layer_embed, name='layer_embed'),
+        url(r'^(?P<geoappid>[^/]+)/embed$', geoapp_edit, {'template': 'apps/app_embed.html'}, name='geoapp_embed'),
     ]
 
     if check_ogc_backend(geoserver.BACKEND_PACKAGE):

--- a/geonode/maps/models.py
+++ b/geonode/maps/models.py
@@ -250,6 +250,10 @@ class Map(ResourceBase, GXPMapBase):
     def get_absolute_url(self):
         return reverse('map_detail', None, [str(self.id)])
 
+    @property
+    def embed_url(self):
+        return reverse('map_embed', kwargs={'mapid': self.pk})
+
     def get_bbox_from_layers(self, layers):
         """
         Calculate the bbox from a given list of Layer objects


### PR DESCRIPTION
<Include a few sentences describing the overall goals for this Pull Request>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
