### PR TITLE
[Fixes #6957] Duplicated registered attributes in GeoNode - and Update sttributes can't fix it

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,7 +123,7 @@ workflows:
           name: geonode_test_suite_smoke
           load_docker_cache: true
           save_docker_cache: true
-          test_suite: coverage run --branch --source=geonode manage.py test -v 3 --keepdb geonode.tests.smoke
+          test_suite: coverage run --branch --source=geonode manage.py test -v 3 --keepdb geonode.tests.smoke geonode.tests.test_message_notifications geonode.tests.test_rest_api geonode.tests.test_search geonode.tests.test_utils
       - build:
           name: geonode_test_suite
           load_docker_cache: true

--- a/geonode/geoserver/helpers.py
+++ b/geonode/geoserver/helpers.py
@@ -904,7 +904,8 @@ def set_attributes(
         'display_order': 4,
     }
     for attribute in attribute_map:
-        attribute.extend((None, None, 0))
+        if len(attribute) == 2:
+            attribute.extend((None, None, 0))
 
     attributes = layer.attribute_set.all()
     # Delete existing attributes if they no longer exist in an updated layer
@@ -934,7 +935,9 @@ def set_attributes(
                 _gs_attrs = Attribute.objects.filter(layer=layer, attribute=field)
                 if _gs_attrs.count() == 1:
                     la = _gs_attrs.get()
-                elif _gs_attrs.count() == 0:
+                else:
+                    if _gs_attrs.count() > 0:
+                        _gs_attrs.delete()
                     la = Attribute.objects.create(layer=layer, attribute=field)
                     la.visible = ftype.find("gml:") != 0
                     la.attribute_type = ftype
@@ -942,8 +945,6 @@ def set_attributes(
                     la.attribute_label = label
                     la.display_order = iter
                     iter += 1
-                else:
-                    la = _gs_attrs.last()
                 if (not attribute_stats or layer.name not in attribute_stats or
                         field not in attribute_stats[layer.name]):
                     result = None

--- a/geonode/messaging/notifications.py
+++ b/geonode/messaging/notifications.py
@@ -16,12 +16,15 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 #########################################################################
+import logging
 
 from django.conf import settings
 from user_messages.models import Message
 from user_messages.signals import message_sent
 
 from geonode.notifications_helper import send_notification
+
+logger = logging.getLogger(__name__)
 
 
 def message_received_notification(**kwargs):
@@ -41,6 +44,7 @@ def message_received_notification(**kwargs):
         'thread_url': settings.SITEURL + thread.get_absolute_url()[1:],
         'site_url': settings.SITEURL
     }
+    logger.debug(f"message_received_notification to: {recipients}")
     send_notification(recipients, notice_type_label, ctx)
 
 

--- a/geonode/notifications_helper.py
+++ b/geonode/notifications_helper.py
@@ -91,8 +91,7 @@ def send_notification(*args, **kwargs):
     Simple wrapper around notifications.model send().
     This can be called safely if notifications are not installed.
     """
-    resource = args[2]['resource'] if len(args) > 1 and 'resource' in args[2] else None
-    if has_notifications and resource and resource.title:
+    if has_notifications:
         # queue for further processing if required
         if settings.PINAX_NOTIFICATIONS_QUEUE_ALL:
             return queue_notification(*args, **kwargs)

--- a/geonode/tests/test_message_notifications.py
+++ b/geonode/tests/test_message_notifications.py
@@ -16,13 +16,13 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 #########################################################################
-
-from user_messages.models import Thread, Message, GroupMemberThread
-from geonode.messaging.notifications import message_received_notification
-from geonode.people.models import Profile
-from geonode.tests.base import GeoNodeBaseTestSupport
 from unittest.mock import patch
 from django.contrib.auth.models import Group
+
+from user_messages.models import Thread, Message, GroupMemberThread
+from geonode.people.models import Profile
+from geonode.tests.base import GeoNodeBaseTestSupport
+from geonode.messaging.notifications import message_received_notification
 
 
 class TestSendEmail(GeoNodeBaseTestSupport):
@@ -48,24 +48,40 @@ class TestSendEmail(GeoNodeBaseTestSupport):
 
     @patch('geonode.notifications_backend.EmailBackend.deliver')
     def test_email_sent(self, email_message):
-        message_received_notification(message=self.m)
-        email_message.assert_called_once()
+        with self.settings(ASYNC_SIGNALS=False,
+                           NOTIFICATION_ENABLED=True,
+                           NOTIFICATIONS_MODULE='pinax.notifications',
+                           PINAX_NOTIFICATIONS_QUEUE_ALL=False):
+            message_received_notification(message=self.m)
+            email_message.assert_called_once()
 
     @patch('geonode.notifications_backend.EmailBackend.deliver')
     def test_email_sent_many(self, email_message):
-        self.p1.email = 'test@test.test'
-        self.p1.save()
-        message_received_notification(message=self.m)
-        self.assertEqual(email_message.call_count, 2)
+        with self.settings(ASYNC_SIGNALS=False,
+                           NOTIFICATION_ENABLED=True,
+                           NOTIFICATIONS_MODULE='pinax.notifications',
+                           PINAX_NOTIFICATIONS_QUEUE_ALL=False):
+            self.p1.email = 'test@test.test'
+            self.p1.save()
+            message_received_notification(message=self.m)
+            self.assertEqual(email_message.call_count, 2)
 
     @patch('geonode.notifications_backend.EmailBackend.deliver')
     def test_email_sent_to_group(self, email_message):
-        self.p1.email = 'test@test.test'
-        self.p1.save()
-        message_received_notification(message=self.m2)
-        self.assertEqual(email_message.call_count, 2)
+        with self.settings(ASYNC_SIGNALS=False,
+                           NOTIFICATION_ENABLED=True,
+                           NOTIFICATIONS_MODULE='pinax.notifications',
+                           PINAX_NOTIFICATIONS_QUEUE_ALL=False):
+            self.p1.email = 'test@test.test'
+            self.p1.save()
+            message_received_notification(message=self.m2)
+            self.assertEqual(email_message.call_count, 2)
 
     @patch('geonode.notifications_backend.EmailBackend.deliver')
     def test_email_sent_to_group_single(self, email_message):
-        message_received_notification(message=self.m2)
-        self.assertEqual(email_message.call_count, 1)
+        with self.settings(ASYNC_SIGNALS=False,
+                           NOTIFICATION_ENABLED=True,
+                           NOTIFICATIONS_MODULE='pinax.notifications',
+                           PINAX_NOTIFICATIONS_QUEUE_ALL=False):
+            message_received_notification(message=self.m2)
+            self.assertEqual(email_message.call_count, 1)

--- a/geonode/tests/test_search.py
+++ b/geonode/tests/test_search.py
@@ -16,7 +16,6 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 #########################################################################
-
 from geonode.documents.models import Document
 from geonode.people.models import Profile
 from geonode.tests.base import GeoNodeBaseTestSupport

--- a/geonode/tests/utils.py
+++ b/geonode/tests/utils.py
@@ -17,11 +17,9 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 #########################################################################
-
 from geonode.tests.base import GeoNodeBaseTestSupport
 
 import os
-import copy
 import time
 import base64
 import pickle
@@ -46,17 +44,12 @@ from requests.packages.urllib3.util.retry import Retry
 from requests_toolbelt.multipart.encoder import MultipartEncoder
 
 from django.core import mail
-from django.conf import settings
-from django.db.models import signals
 from django.urls import reverse
-from django.core.management import call_command
+from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.contrib.gis.geos import Polygon
 from django.test.client import Client as DjangoTestClient
 
 from geonode.maps.models import Layer
-from geonode.geoserver.helpers import set_attributes
-from geonode.geoserver.signals import geoserver_post_save
 from geonode.notifications_helper import has_notifications, notifications
 
 logger = logging.getLogger(__name__)
@@ -324,56 +317,6 @@ def check_layer(uploaded):
     assert isinstance(uploaded, Layer), msg
     msg = ('The layer does not have a valid name: %s' % uploaded.name)
     assert len(uploaded.name) > 0, msg
-
-
-class TestSetAttributes(GeoNodeBaseTestSupport):
-
-    def setUp(self):
-        super(TestSetAttributes, self).setUp()
-        # Load users to log in as
-        call_command('loaddata', 'people_data', verbosity=0)
-
-    def test_set_attributes_creates_attributes(self):
-        """ Test utility function set_attributes() which creates Attribute instances attached
-            to a Layer instance.
-        """
-        # Creating a layer requires being logged in
-        self.client.login(username='norman', password='norman')
-
-        # Disconnect the geoserver-specific post_save signal attached to Layer creation.
-        # The geoserver signal handler assumes things about the store where the Layer is placed.
-        # this is a workaround.
-        disconnected_post_save = signals.post_save.disconnect(geoserver_post_save, sender=Layer)
-
-        # Create dummy layer to attach attributes to
-        _l = Layer.objects.create(
-            name='dummy_layer',
-            bbox_polygon=Polygon.from_bbox((-180, -90, 180, 90)),
-            srid='EPSG:4326')
-
-        # Reconnect the signal if it was disconnected
-        if disconnected_post_save:
-            signals.post_save.connect(geoserver_post_save, sender=Layer)
-
-        attribute_map = [
-            ['id', 'Integer'],
-            ['date', 'IntegerList'],
-            ['enddate', 'Real'],
-            ['date_as_date', 'xsd:dateTime'],
-        ]
-
-        # attribute_map gets modified as a side-effect of the call to set_attributes()
-        expected_results = copy.deepcopy(attribute_map)
-
-        # set attributes for resource
-        set_attributes(_l, attribute_map)
-
-        # 2 items in attribute_map should translate into 2 Attribute instances
-        self.assertEqual(_l.attributes.count(), len(expected_results))
-
-        # The name and type should be set as provided by attribute map
-        for a in _l.attributes:
-            self.assertIn([a.attribute, a.attribute_type], expected_results)
 
 
 if has_notifications:


### PR DESCRIPTION
Related to: #6957

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
