### PR TITLE
[Issue #6925] Thesaurus admin pages

### DIFF
--- a/geonode/base/admin.py
+++ b/geonode/base/admin.py
@@ -45,6 +45,7 @@ from geonode.base.models import (
     MenuItem,
     CuratedThumbnail,
     Configuration,
+    Thesaurus, ThesaurusLabel, ThesaurusKeyword, ThesaurusKeywordLabel,
 )
 
 from geonode.base.forms import (
@@ -268,6 +269,62 @@ class ConfigurationAdmin(admin.ModelAdmin):
         return form
 
 
+class ThesaurusAdmin(admin.ModelAdmin):
+    model = Thesaurus
+    list_display = ('id', 'identifier')
+    list_display_links = ('id', 'identifier')
+    ordering = ('identifier',)
+
+
+class ThesaurusLabelAdmin(admin.ModelAdmin):
+    model = ThesaurusLabel
+    list_display = ('thesaurus_id', 'lang', 'label')
+    list_display_links = ('label',)
+    ordering = ('thesaurus__identifier', 'lang')
+
+    def thesaurus_id(self, obj):
+        return obj.thesaurus.identifier
+
+    thesaurus_id.short_description = 'Thesaurus'
+    thesaurus_id.admin_order_field = 'thesaurus__identifier'
+
+
+class ThesaurusKeywordAdmin(admin.ModelAdmin):
+    model = ThesaurusKeyword
+
+    list_display = ('thesaurus_id', 'about', 'alt_label',)
+    list_display_links = ('about', 'alt_label',)
+    ordering = ('thesaurus__identifier', 'alt_label',)
+    list_filter = ('thesaurus_id',)
+
+    def thesaurus_id(self, obj):
+        return obj.thesaurus.identifier
+
+    thesaurus_id.short_description = 'Thesaurus'
+    thesaurus_id.admin_order_field = 'thesaurus__identifier'
+
+
+class ThesaurusKeywordLabelAdmin(admin.ModelAdmin):
+    model = ThesaurusKeywordLabel
+
+    list_display = ('thesaurus_id', 'keyword_id', 'lang', 'label')
+    list_display_links = ('lang', 'label')
+    ordering = ('keyword__thesaurus__identifier', 'keyword__alt_label', 'lang')
+    list_filter = ('keyword__thesaurus__identifier', 'keyword_id', 'lang')
+
+    def thesaurus_id(self, obj):
+        return obj.keyword.thesaurus.identifier
+
+    thesaurus_id.short_description = 'Thesaurus'
+    thesaurus_id.admin_order_field = 'keyword__thesaurus__identifier'
+
+    def keyword_id(self, obj):
+        return obj.keyword.alt_label
+
+    keyword_id.short_description = 'Keyword'
+    keyword_id.admin_order_field = 'keyword__alt_label'
+
+
 admin.site.register(TopicCategory, TopicCategoryAdmin)
 admin.site.register(Region, RegionAdmin)
 admin.site.register(SpatialRepresentationType, SpatialRepresentationTypeAdmin)
@@ -281,6 +338,10 @@ admin.site.register(Menu, MenuAdmin)
 admin.site.register(MenuItem, MenuItemAdmin)
 admin.site.register(CuratedThumbnail, CuratedThumbnailAdmin)
 admin.site.register(Configuration, ConfigurationAdmin)
+admin.site.register(Thesaurus, ThesaurusAdmin)
+admin.site.register(ThesaurusLabel, ThesaurusLabelAdmin)
+admin.site.register(ThesaurusKeyword, ThesaurusKeywordAdmin)
+admin.site.register(ThesaurusKeywordLabel, ThesaurusKeywordLabelAdmin)
 
 
 class ResourceBaseAdminForm(autocomplete.FutureModelForm):

--- a/geonode/base/models.py
+++ b/geonode/base/models.py
@@ -509,7 +509,7 @@ class ThesaurusKeywordLabel(models.Model):
 
     class Meta:
         ordering = ("keyword", "lang")
-        verbose_name_plural = 'Labels'
+        verbose_name_plural = 'Thesaurus Keyword Labels'
         unique_together = (("keyword", "lang"),)
 
 

--- a/geonode/layers/admin.py
+++ b/geonode/layers/admin.py
@@ -29,7 +29,7 @@ from geonode.layers.models import Layer, Attribute, Style
 from geonode.layers.models import LayerFile, UploadSession
 
 from geonode.base.fields import MultiThesauriField
-from geonode.base.models import ThesaurusKeyword, ThesaurusKeywordLabel, Thesaurus
+from geonode.base.models import ThesaurusKeyword, ThesaurusKeywordLabel
 
 from dal import autocomplete
 
@@ -120,4 +120,3 @@ admin.site.register(Layer, LayerAdmin)
 admin.site.register(Attribute, AttributeAdmin)
 admin.site.register(Style, StyleAdmin)
 admin.site.register(UploadSession, UploadSessionAdmin)
-

--- a/geonode/layers/admin.py
+++ b/geonode/layers/admin.py
@@ -98,10 +98,6 @@ class AttributeAdmin(admin.ModelAdmin):
     search_fields = ('attribute', 'attribute_label',)
 
 
-class ThesaurusAdmin(admin.ModelAdmin):
-    model = Thesaurus
-
-
 class StyleAdmin(admin.ModelAdmin):
     model = Style
     list_display_links = ('sld_title',)
@@ -124,4 +120,4 @@ admin.site.register(Layer, LayerAdmin)
 admin.site.register(Attribute, AttributeAdmin)
 admin.site.register(Style, StyleAdmin)
 admin.site.register(UploadSession, UploadSessionAdmin)
-admin.site.register(Thesaurus, ThesaurusAdmin)
+


### PR DESCRIPTION
Add admin pages for Thesaurus, ThesaurusKeyword and related localized tables.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
