### PR TITLE
Assorted minor performance issues

### DIFF
--- a/geonode/base/models.py
+++ b/geonode/base/models.py
@@ -1056,7 +1056,7 @@ class ResourceBase(PolymorphicModel, PermissionLevelMixin, ItemBase):
         if self.bbox_polygon:
             bbox = self.bbox_polygon
             match = re.match(r'^(EPSG:)?(?P<srid>\d{4,6})$', self.srid)
-            srid = int(match.group('srid'))
+            srid = int(match.group('srid')) if match else 4326
             if bbox.srid is not None and bbox.srid != srid:
                 try:
                     bbox = bbox.transform(srid, clone=True)
@@ -1276,8 +1276,8 @@ class ResourceBase(PolymorphicModel, PermissionLevelMixin, ItemBase):
         bbox_polygon = Polygon.from_bbox(bbox)
 
         try:
-            match = re.match(r'^(EPSG:)?(?P<srid>\d{4,5})$', str(srid))
-            bbox_polygon.srid = int(match.group('srid'))
+            match = re.match(r'^(EPSG:)?(?P<srid>\d{4,6})$', str(srid))
+            bbox_polygon.srid = int(match.group('srid')) if match else 4326
         except AttributeError:
             logger.warning("No srid found for layer %s bounding box", self)
 

--- a/geonode/base/thumb_utils.py
+++ b/geonode/base/thumb_utils.py
@@ -24,6 +24,11 @@ def thumb_size(filepath):
     return 0
 
 
+def thumb_open(filename):
+    """Returns file handler of a thumbnail on the storage"""
+    return storage.open(thumb_path(filename))
+
+
 def get_thumbs():
     """Fetches a list of all stored thumbnails"""
     if not storage.exists(settings.THUMBNAIL_LOCATION):

--- a/geonode/geoserver/tasks.py
+++ b/geonode/geoserver/tasks.py
@@ -653,7 +653,7 @@ def geoserver_post_save_layers(
                 # Creating Layer Thumbnail by sending a signal
                 from geonode.geoserver.signals import geoserver_post_save_complete
                 geoserver_post_save_complete.send(
-                    sender=instance.__class__, instance=instance)
+                    sender=instance.__class__, instance=instance, update_fields=['thumbnail_url'])
             try:
                 geonode_upload_sessions = UploadSession.objects.filter(resource=instance)
                 geonode_upload_sessions.update(processed=True)

--- a/geonode/layers/forms.py
+++ b/geonode/layers/forms.py
@@ -24,6 +24,7 @@ import tempfile
 import zipfile
 
 from django import forms
+from django.conf import settings
 
 from geonode import geoserver
 from geonode.utils import check_ogc_backend
@@ -194,7 +195,7 @@ class LayerUploadForm(forms.Form):
 
     def write_files(self):
         absolute_base_file = None
-        tempdir = tempfile.mkdtemp()
+        tempdir = tempfile.mkdtemp(dir=settings.STATIC_ROOT)
         if zipfile.is_zipfile(self.cleaned_data['base_file']):
             absolute_base_file = unzip_file(self.cleaned_data['base_file'],
                                             '.shp', tempdir=tempdir)

--- a/geonode/layers/utils.py
+++ b/geonode/layers/utils.py
@@ -152,7 +152,7 @@ def get_files(filename):
     import tempfile
     from geonode.utils import unzip_file
     if is_zipfile(filename):
-        tempdir = tempfile.mkdtemp()
+        tempdir = tempfile.mkdtemp(dir=settings.STATIC_ROOT)
         _filename = unzip_file(filename,
                                '.shp', tempdir=tempdir)
         if not _filename:

--- a/geonode/proxy/views.py
+++ b/geonode/proxy/views.py
@@ -275,7 +275,7 @@ def download(request, resourceid, sender=Layer):
 
     if isinstance(instance, Layer):
         # Create Target Folder
-        dirpath = tempfile.mkdtemp()
+        dirpath = tempfile.mkdtemp(dir=settings.STATIC_ROOT)
         dir_time_suffix = get_dir_time_suffix()
         target_folder = os.path.join(dirpath, dir_time_suffix)
         if not os.path.exists(target_folder):

--- a/geonode/upload/utils.py
+++ b/geonode/upload/utils.py
@@ -506,7 +506,7 @@ def _get_time_dimensions(layer, upload_session):
 
 def _fixup_base_file(absolute_base_file, tempdir=None):
     if not tempdir:
-        tempdir = tempfile.mkdtemp()
+        tempdir = tempfile.mkdtemp(dir=settings.STATIC_ROOT)
     if not os.path.isfile(absolute_base_file):
         tmp_files = [f for f in os.listdir(tempdir) if os.path.isfile(os.path.join(tempdir, f))]
         for f in tmp_files:

--- a/geonode/upload/views.py
+++ b/geonode/upload/views.py
@@ -163,7 +163,7 @@ def save_step_view(req, session):
         )
     form = LayerUploadForm(req.POST, req.FILES)
     if form.is_valid():
-        tempdir = tempfile.mkdtemp(dir=settings.FILE_UPLOAD_TEMP_DIR)
+        tempdir = tempfile.mkdtemp(dir=settings.STATIC_ROOT)
         logger.debug("valid_extensions: {}".format(form.cleaned_data["valid_extensions"]))
         relevant_files = _select_relevant_files(
             form.cleaned_data["valid_extensions"],

--- a/geonode/utils.py
+++ b/geonode/utils.py
@@ -59,6 +59,7 @@ from django.contrib.auth import get_user_model
 from django.shortcuts import get_object_or_404
 from django.core.exceptions import PermissionDenied
 from django.core.serializers.json import DjangoJSONEncoder
+from django.core.files.storage import default_storage as storage
 from django.db import models, connection, transaction
 from django.utils.translation import ugettext_lazy as _
 
@@ -1424,7 +1425,8 @@ class HttpClient(object):
             self.username = ogc_server_settings.get('USER', 'admin')
             self.password = ogc_server_settings.get('PASSWORD', 'geoserver')
 
-    def request(self, url, method='GET', data=None, headers={}, stream=False, timeout=None, retries=None, user=None):
+    def request(self, url, method='GET', data=None, headers={}, stream=False,
+                timeout=None, retries=None, user=None, verify=False):
         if (user or self.username != 'admin') and \
         check_ogc_backend(geoserver.BACKEND_PACKAGE) and 'Authorization' not in headers:
             if connection.cursor().db.vendor not in ('sqlite', 'sqlite3', 'spatialite'):
@@ -1469,7 +1471,8 @@ class HttpClient(object):
                     data=data,
                     headers=headers,
                     timeout=_req_tout,
-                    stream=stream)
+                    stream=stream,
+                    verify=verify)
             except (requests.exceptions.RequestException, ValueError) as e:
                 msg = f"Request exception [{e}] - TOUT [{_req_tout}] to URL: {url} - headers: {headers}"
                 logger.exception(Exception(msg))
@@ -1484,23 +1487,25 @@ class HttpClient(object):
 
         return (response, content)
 
-    def get(self, url, data=None, headers={}, stream=False, timeout=None, user=None):
+    def get(self, url, data=None, headers={}, stream=False, timeout=None, user=None, verify=False):
         return self.request(url,
                             method='GET',
                             data=data,
                             headers=headers,
                             timeout=timeout or self.timeout,
                             stream=stream,
-                            user=user)
+                            user=user,
+                            verify=verify)
 
-    def post(self, url, data=None, headers={}, stream=False, timeout=None, user=None):
+    def post(self, url, data=None, headers={}, stream=False, timeout=None, user=None, verify=False):
         return self.request(url,
                             method='POST',
                             data=data,
                             headers=headers,
                             timeout=timeout or self.timeout,
                             stream=stream,
-                            user=user)
+                            user=user,
+                            verify=verify)
 
 
 http_client = HttpClient()
@@ -2006,23 +2011,25 @@ def json_serializer_producer(dictionary):
 
 def is_monochromatic_image(image_url, image_data=None):
 
+    def is_local_static(url):
+        if url.startswith(settings.STATIC_URL) or \
+        (url.startswith(settings.SITEURL) and settings.STATIC_URL in url):
+            return True
+        return False
+
     def is_absolute(url):
         return bool(urlparse(url).netloc)
 
-    try:
-        if image_data:
-            logger.debug("...Checking if image is a blank image")
-            stream_content = image_data
-        elif image_url:
-            logger.debug(f"...Checking if '{image_url}' is a blank image")
-            url = image_url if is_absolute(image_url) else urljoin(settings.SITEURL, image_url)
-            response = requests.get(url, verify=False)
-            stream_content = response.content
-        else:
-            return True
-        with BytesIO(stream_content) as stream:
-            img = Image.open(stream).convert("L")
-            stream.close()
+    def get_thumb_handler(url):
+        _index = url.find(settings.STATIC_URL)
+        _thumb_path = urlparse(url[_index + len(settings.STATIC_URL):]).path
+        if storage.exists(_thumb_path):
+            return storage.open(_thumb_path)
+        return None
+
+    def verify_image(stream):
+        with Image.open(stream) as _stream:
+            img = _stream.convert("L")
             img.verify()  # verify that it is, in fact an image
             extr = img.getextrema()
             a = 0
@@ -2033,6 +2040,23 @@ def is_monochromatic_image(image_url, image_data=None):
                     a = abs(extr[0] - extr[1])
                     break
             return a == 0
+
+    try:
+        if image_data:
+            logger.debug("...Checking if image is a blank image")
+            with BytesIO(image_data) as stream:
+                return verify_image(stream)
+        elif image_url:
+            logger.debug(f"...Checking if '{image_url}' is a blank image")
+            url = image_url if is_absolute(image_url) else urljoin(settings.SITEURL, image_url)
+            if not is_local_static(url):
+                req, stream_content = http_client.get(url, timeout=5)
+                with BytesIO(stream_content) as stream:
+                    return verify_image(stream)
+            else:
+                with get_thumb_handler(url) as stream:
+                    return verify_image(stream)
+        return True
     except Exception as e:
         logger.exception(e)
         return False

--- a/geonode/utils.py
+++ b/geonode/utils.py
@@ -123,7 +123,7 @@ def unzip_file(upload_file, extension='.shp', tempdir=None):
     """
     absolute_base_file = None
     if tempdir is None:
-        tempdir = tempfile.mkdtemp()
+        tempdir = tempfile.mkdtemp(dir=settings.STATIC_ROOT)
     if not os.path.isdir(tempdir):
         os.makedirs(tempdir)
 
@@ -142,7 +142,7 @@ def extract_tarfile(upload_file, extension='.shp', tempdir=None):
     """
     absolute_base_file = None
     if tempdir is None:
-        tempdir = tempfile.mkdtemp()
+        tempdir = tempfile.mkdtemp(dir=settings.STATIC_ROOT)
 
     the_tar = tarfile.open(upload_file)
     the_tar.extractall(tempdir)
@@ -1159,7 +1159,7 @@ def fixup_shp_columnnames(inShapefile, charset, tempdir=None):
     charset = charset if charset and 'undefined' not in charset else 'UTF-8'
 
     if not tempdir:
-        tempdir = tempfile.mkdtemp()
+        tempdir = tempfile.mkdtemp(dir=settings.STATIC_ROOT)
 
     if is_zipfile(inShapefile):
         inShapefile = unzip_file(inShapefile, '.shp', tempdir=tempdir)


### PR DESCRIPTION
This PR includes a small series of minor improvements and fixes as described here below:

 - Make `is_monochromatic_image` able to fetch local thumbs instead of querying URL anytime: this is a performance improvement; if the method recognizes that the thumbnail url is pointing to a local file, it will fetch it from the local storage instead of getting the stream from the URL. This also resolves a potential issue with NATted instances.
- Create "tempdirs" under "settings.STATIC_ROOT" in order to make sure containers share the same folder: when running docker containers in `ASYNC` mode, if the `/tmp` folder is not shared between `django` and `celery` containers, the latter won't be able to retrieve the uploaded auxiliary files. By creating the `/tmp` folder under the `STATIC_FOLDER` fixes the problem, since this is shared by default.
- Make sure the SRID is always set also in the case it could not be found into the SRID string: this is a minor potential issue whenever the regex on the `base.models` is not able to fetch the SRID correctly.