### PR TITLE
[Fixes #7033] fix header tab classes

### DIFF
--- a/geonode/templates/metadata_form_js.html
+++ b/geonode/templates/metadata_form_js.html
@@ -93,8 +93,8 @@
           }
 
         {% if UI_REQUIRED_FIELDS %}
-         var advancedMissing = $('#ownership').find('.input-empty').length > 0;
-          if (advancedMissing) {
+         var metadataMissing = $('#ownership').find('.input-empty').length > 0;
+          if (metadataMissing) {
             var inputs = $('#ownership').find('.input-empty');
             var empty = inputs.length;
             for (var i=0; i<inputs.length; i++) {
@@ -102,12 +102,12 @@
                 empty--;
               }
             }
-            advancedMissing = empty > 0;
+            metadataMissing = empty > 0;
           }
           $('#completeness-hints .metadata-hint')
-            .toggleClass('progress-bar-danger', mandatoryMissing)
-            .toggleClass('progress-bar-success', !mandatoryMissing)
-            .attr('title', mandatoryMissing ? gettext("some schema mandatory fields are missing") : gettext("Metadata Schema mandatory fields completed") )
+            .toggleClass('progress-bar-danger', metadataMissing)
+            .toggleClass('progress-bar-success', !metadataMissing)
+            .attr('title', metadataMissing ? gettext("some schema mandatory fields are missing") : gettext("Metadata Schema mandatory fields completed") )
             .tooltip('fixTitle');
         {% endif %}
 


### PR DESCRIPTION
Small bugifix related to #7033 the class names were incorrect

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [ ] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
