### PR TITLE
[Fixes: #6925] Thesauri improvements

### DIFF
--- a/geonode/api/tests.py
+++ b/geonode/api/tests.py
@@ -17,6 +17,8 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 #########################################################################
+from unittest.case import TestCase
+from unittest.mock import patch
 from django.conf import settings
 
 from datetime import datetime, timedelta
@@ -526,3 +528,80 @@ class LockdownApiTests(ResourceTestCaseMixin, GeoNodeBaseTestSupport):
         resp = self.api_client.get(filter_url)
         self.assertValidJSONResponse(resp)
         self.assertEqual(len(self.deserialize(resp)['objects']), 5)
+
+
+class ThesaurusKeywordResourceTests(ResourceTestCaseMixin, TestCase):
+    #  loading test thesausurs
+    fixtures = ["test_thesaurus.json"]
+
+    def setUp(self):
+        super(ThesaurusKeywordResourceTests, self).setUp()
+
+        self.list_url = reverse("api_dispatch_list", kwargs={"api_name": "api", "resource_name": "thesaurus/keywords"})
+
+    def test_api_will_return_a_valid_json_response(self):
+        resp = self.api_client.get(self.list_url)
+        self.assertValidJSONResponse(resp)
+
+    def test_will_return_empty_if_the_thesaurus_does_not_exists(self):
+        url = f"{self.list_url}?thesaurus=invalid-identifier"
+        resp = self.api_client.get(url)
+        self.assertValidJSONResponse(resp)
+        self.assertEqual(resp.json()["meta"]["total_count"], 0)
+
+    def test_will_return_keywords_for_the_selected_thesaurus_if_exists(self):
+        url = f"{self.list_url}?thesaurus=inspire-theme"
+        resp = self.api_client.get(url)
+        self.assertValidJSONResponse(resp)
+        self.assertEqual(resp.json()["meta"]["total_count"], 34)
+
+    def test_will_return_empty_if_the_alt_label_does_not_exists(self):
+        url = f"{self.list_url}?alt_label=invalid-alt_label"
+        resp = self.api_client.get(url)
+        self.assertValidJSONResponse(resp)
+        self.assertEqual(resp.json()["meta"]["total_count"], 0)
+
+    def test_will_return_keywords_for_the_selected_alt_label_if_exists(self):
+        url = f"{self.list_url}?alt_label=ac"
+        resp = self.api_client.get(url)
+        self.assertValidJSONResponse(resp)
+        self.assertEqual(resp.json()["meta"]["total_count"], 1)
+
+    def test_will_return_empty_if_the_kaywordId_does_not_exists(self):
+        url = f"{self.list_url}?id=12365478954862"
+        resp = self.api_client.get(url)
+        print(self.deserialize(resp))
+        self.assertValidJSONResponse(resp)
+        self.assertEqual(resp.json()["meta"]["total_count"], 0)
+
+    @patch("geonode.api.api.get_language")
+    def test_will_return_expected_keyword_label_for_existing_lang(self, lang):
+        lang.return_value = "de"
+        url = f"{self.list_url}?thesaurus=inspire-theme"
+        resp = self.api_client.get(url)
+        # the german translations exists, for the other labels, the alt_label will be used
+        expected_labels = [
+            "ac", "Adressen", "af", "am", "au", "br", "bu",
+            "cp", "ef", "el", "er", "ge", "gg", "gn", "hb", "hh",
+            "hy", "lc", "lu", "mf", "mr", "nz", "of", "oi", "pd",
+            "pf", "ps", "rs", "sd", "so", "sr", "su", "tn", "us"
+        ]
+        actual_labels = [x["alt_label"] for x in self.deserialize(resp)["objects"]]
+        self.assertValidJSONResponse(resp)
+        self.assertListEqual(expected_labels, actual_labels)
+
+    @patch("geonode.api.api.get_language")
+    def test_will_return_default_keyword_label_for_not_existing_lang(self, lang):
+        lang.return_value = "ke"
+        url = f"{self.list_url}?thesaurus=inspire-theme"
+        resp = self.api_client.get(url)
+        # no translations exists, the alt_label will be used for all keywords
+        expected_labels = [
+            "ac", "ad", "af", "am", "au", "br", "bu",
+            "cp", "ef", "el", "er", "ge", "gg", "gn", "hb", "hh",
+            "hy", "lc", "lu", "mf", "mr", "nz", "of", "oi", "pd",
+            "pf", "ps", "rs", "sd", "so", "sr", "su", "tn", "us"
+        ]
+        actual_labels = [x["alt_label"] for x in self.deserialize(resp)["objects"]]
+        self.assertValidJSONResponse(resp)
+        self.assertListEqual(expected_labels, actual_labels)

--- a/geonode/templates/search/_t_keywords_filter.html
+++ b/geonode/templates/search/_t_keywords_filter.html
@@ -5,7 +5,7 @@
 {% for tname in THESAURI_FILTERS %}
 
 <nav class="filter">
-  <h4><a href="#" class="toggle toggle-nav"><i class="fa fa-chevron-right"></i> {% trans "Thesaurus" %}: {{ tname|get_name_translation }}</a></h4>
+  <h4><a href="#" class="toggle toggle-nav"><i class="fa fa-chevron-right"></i>{{ tname|get_name_translation }}</a></h4>
   <ul class="nav closed" id="tkeywords_{{ tname }}">
       <li ng-repeat="tk in tkeywords" ng-if="tk.count > 0 && tk.thesaurus_identifier == '{{ tname }}'">
     {% verbatim %}


### PR DESCRIPTION
With this PR I want to:
- Fix facets for Thesauri in order to return the translated keywords label (if exists) otherwise return the alt_label of the keyword. (At the moment if the translation does not exist, the keyword is not shown)
- Add tests coverage for resource `thesaurus/keywords`
- Remove the label `Thesaurus:` from the facet to make it lighter than before

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
