### PR TITLE
[Backport to 3.2.x][Fixes #7051] GeoServer will create three styles instead of one

### DIFF
--- a/geonode/security/tests.py
+++ b/geonode/security/tests.py
@@ -1508,14 +1508,13 @@ class GisBackendSignalsTests(ResourceTestCaseMixin, GeoNodeBaseTestSupport):
 
             # Layer Manipulation
             from geonode.geoserver.signals import gs_catalog
-            from geonode.geoserver.helpers import (check_geoserver_is_up,
-                                                   get_sld_for,
-                                                   fixup_style,
-                                                   set_layer_style,
-                                                   set_attributes_from_geoserver,
-                                                   set_styles,
-                                                   create_gs_thumbnail,
-                                                   cleanup)
+            from geonode.geoserver.helpers import (
+                check_geoserver_is_up,
+                set_layer_style,
+                set_attributes_from_geoserver,
+                set_styles,
+                create_gs_thumbnail,
+                cleanup)
             check_geoserver_is_up()
 
             admin_user = get_user_model().objects.get(username="admin")
@@ -1550,10 +1549,6 @@ class GisBackendSignalsTests(ResourceTestCaseMixin, GeoNodeBaseTestSupport):
                     sld = sld.decode().strip('\n')
                 _log("sld. ------------ %s " % sld)
                 set_layer_style(test_perm_layer, test_perm_layer.alternate, sld)
-
-                fixup_style(gs_catalog, test_perm_layer.alternate, None)
-                self.assertIsNotNone(get_sld_for(gs_catalog, test_perm_layer))
-                _log("fixup_sld. ------------ %s " % get_sld_for(gs_catalog, test_perm_layer))
 
             create_gs_thumbnail(test_perm_layer, overwrite=True)
             self.assertIsNotNone(test_perm_layer.get_thumbnail_url())

--- a/geonode/tests/integration.py
+++ b/geonode/tests/integration.py
@@ -164,12 +164,11 @@ class NormalUserTest(GeoNodeLiveTestSupport):
             o = json.loads(r.text)
             self.assertTrue('long-array-array' in o)
 
-            from geonode.geoserver.helpers import (get_sld_for,
-                                                   fixup_style,
-                                                   set_layer_style,
-                                                   set_attributes_from_geoserver,
-                                                   set_styles,
-                                                   create_gs_thumbnail)
+            from geonode.geoserver.helpers import (
+                set_layer_style,
+                set_attributes_from_geoserver,
+                set_styles,
+                create_gs_thumbnail)
 
             _log("0. ------------ %s " % saved_layer)
             self.assertIsNotNone(saved_layer)
@@ -192,10 +191,6 @@ class NormalUserTest(GeoNodeLiveTestSupport):
             self.assertIsNotNone(sld)
             _log("2. ------------ %s " % sld)
             set_layer_style(saved_layer, saved_layer.alternate, sld)
-
-            fixup_style(gs_catalog, saved_layer.alternate, None)
-            self.assertIsNotNone(get_sld_for(gs_catalog, saved_layer))
-            _log("3. ------------ %s " % get_sld_for(gs_catalog, saved_layer))
 
             create_gs_thumbnail(saved_layer, overwrite=True)
             _log(saved_layer.get_thumbnail_url())


### PR DESCRIPTION
(cherry picked from commit 4c86d15b0e1180513fc29fcd9297948eb623fef7)

<Include a few sentences describing the overall goals for this Pull Request>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [ ] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [ ] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
