### PR TITLE
[Fixes #7075] LOCKDOWN mode with custom login view

### DIFF
--- a/geonode/security/middleware.py
+++ b/geonode/security/middleware.py
@@ -32,6 +32,12 @@ from geonode.base.auth import get_token_object_from_session, basic_auth_authenti
 
 from guardian.shortcuts import get_anonymous_user
 
+
+# make sure login_url can be mapped to redirection URL and will match request.path
+login_url = settings.LOGIN_URL.replace(settings.SITEURL.rstrip('/'), '')
+if not login_url.startswith('/'):
+    login_url = '/' + login_url
+
 if check_ogc_backend(geoserver.BACKEND_PACKAGE):
     white_list_paths = (
         reverse('account_login'),
@@ -44,6 +50,7 @@ if check_ogc_backend(geoserver.BACKEND_PACKAGE):
         '/account/(?!.*(?:signup))',
         # block unauthenticated users from creating new accounts.
         '/static/*',
+        login_url,
     )
 else:
     white_list_paths = (
@@ -53,6 +60,7 @@ else:
         '/account/(?!.*(?:signup))',
         # block unauthenticated users from creating new accounts.
         '/static/*',
+        login_url,
     )
 
 white_list = [compile(x) for x in white_list_paths + getattr(settings, "AUTH_EXEMPT_URLS", ())]
@@ -72,7 +80,7 @@ class LoginRequiredMiddleware(MiddlewareMixin):
     authentication_classes).
     """
 
-    redirect_to = getattr(settings, "LOGIN_URL", reverse("account_login"))
+    redirect_to = login_url
 
     def __init__(self, get_response):
         self.get_response = get_response

--- a/geonode/security/tests.py
+++ b/geonode/security/tests.py
@@ -24,6 +24,7 @@ import json
 import base64
 import logging
 import gisdata
+import importlib
 import contextlib
 
 from urllib.request import urlopen, Request
@@ -33,6 +34,7 @@ from django.conf import settings
 from django.http import HttpRequest
 from django.urls import reverse
 from django.contrib.auth import get_user_model
+from django.test.utils import override_settings
 
 from guardian.shortcuts import (
     get_anonymous_user,
@@ -203,6 +205,40 @@ class SecurityTest(GeoNodeBaseTestSupport):
         self.assertIsNone(
             response,
             msg="Middleware activated for white listed path: {0}".format(black_listed_url))
+
+    @on_ogc_backend(geoserver.BACKEND_PACKAGE)
+    @dump_func_name
+    def test_login_middleware_with_custom_login_url(self):
+        """
+        Tests the Geonode login required authentication middleware with Basic authenticated queries
+        """
+
+        site_url_settings = [settings.SITEURL + "login/custom", "/login/custom", "login/custom"]
+        black_listed_url = reverse("maps_browse")
+
+        for setting in site_url_settings:
+            with override_settings(LOGIN_URL=setting):
+
+                from geonode.security import middleware as mw
+
+                # reload the middleware module to fetch overridden settings
+                importlib.reload(mw)
+                middleware = mw.LoginRequiredMiddleware(None)
+
+                # unauthorized request to black listed URL should be redirected to `redirect_to` URL
+                request = HttpRequest()
+                request.user = get_anonymous_user()
+                request.path = black_listed_url
+
+                response = middleware.process_request(request)
+
+                self.assertIsNotNone(response, "Middleware didn't activate for blacklisted URL.")
+                self.assertEqual(response.status_code, 302)
+                self.assertTrue(
+                    response.get("Location").startswith("/"),
+                    msg=f"Returned redirection should be a valid path starting '/'. "
+                        f"Instead got: {response.get('Location')}",
+                )
 
     @on_ogc_backend(geoserver.BACKEND_PACKAGE)
     @dump_func_name


### PR DESCRIPTION
Enable to set `LOCKDOWN_GEONODE` with a custom login view. `LoginRequiredMiddleware` did not include `LOGIN_URL` in whitelisted URLs, causing infinite redirection loop, in case where `LOGIN_URL` didn't point at `account_login` view. Additionally, made sure, that following `LOGIN_URL` formats are supported by `LoginRequiredMiddleware`:
- `/path/to/login`
- `path/to/login`
- `<full site URL>/path/to/login`

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [x] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
