### PR TITLE
[Fixes #7067] Totals of results inside the facets filters don't match the total value shown in the resource list when abstract and prupose filters are set

### DIFF
--- a/geonode/base/templatetags/base_tags.py
+++ b/geonode/base/templatetags/base_tags.py
@@ -71,6 +71,8 @@ def num_ratings(obj):
 def facets(context):
     request = context['request']
     title_filter = request.GET.get('title__icontains', '')
+    abstract_filter = request.GET.get('abstract__icontains', '')
+    purpose_filter = request.GET.get('purpose__icontains', '')
     extent_filter = request.GET.get('extent', None)
     keywords_filter = request.GET.getlist('keywords__slug__in', None)
     category_filter = request.GET.getlist('category__identifier__in', None)
@@ -181,7 +183,11 @@ def facets(context):
 
         return facets
     else:
-        layers = Layer.objects.filter(title__icontains=title_filter)
+        layers = Layer.objects.filter(
+            Q(title__icontains=title_filter) |
+            Q(abstract__icontains=abstract_filter) |
+            Q(purpose__icontains=purpose_filter)
+        )
         if category_filter:
             layers = layers.filter(category__identifier__in=category_filter)
         if regions_filter:

--- a/geonode/base/tests.py
+++ b/geonode/base/tests.py
@@ -19,8 +19,10 @@
 #########################################################################
 
 import os
-from unittest.mock import patch
+from unittest.mock import patch, Mock
 from urllib.parse import urlparse
+
+import requests
 from django.core.exceptions import ObjectDoesNotExist
 
 from guardian.shortcuts import assign_perm, get_perms
@@ -54,7 +56,7 @@ from django.shortcuts import reverse
 
 from geonode.base.middleware import ReadOnlyMiddleware, MaintenanceMiddleware
 from geonode.base.models import CuratedThumbnail
-from geonode.base.templatetags.base_tags import get_visibile_resources
+from geonode.base.templatetags.base_tags import get_visibile_resources, facets
 from geonode.base.templatetags.thesaurus import (
     get_name_translation, get_unique_thesaurus_set,
     get_thesaurus_title,
@@ -966,3 +968,51 @@ class TestThesaurusAvailableForm(TestCase):
     def test_form_is_valid_if_fileds_send_expected_values(self):
         actual = self.sut(data={"1": 1})
         self.assertTrue(actual.is_valid())
+
+
+class TestFacets(TestCase):
+    def setUp(self):
+        self.user = get_user_model().objects.create(username='test', email='test@test.com')
+        Layer.objects.create(
+            owner=self.user, title='test_boxes', abstract='nothing', storeType='dataStore', is_approved=True
+        )
+        Layer.objects.create(
+            owner=self.user, title='test_1', abstract='contains boxes', storeType='dataStore', is_approved=True
+        )
+        Layer.objects.create(
+            owner=self.user, title='test_2', purpose='contains boxes', storeType='dataStore', is_approved=True
+        )
+        Layer.objects.create(
+            owner=self.user, title='test_3', storeType='dataStore', is_approved=True
+        )
+
+        Layer.objects.create(
+            owner=self.user, title='test_boxes', abstract='nothing', storeType='coverageStore', is_approved=True
+        )
+        Layer.objects.create(
+            owner=self.user, title='test_1', abstract='contains boxes', storeType='coverageStore', is_approved=True
+        )
+        Layer.objects.create(
+            owner=self.user, title='test_2', purpose='contains boxes', storeType='coverageStore', is_approved=True
+        )
+        Layer.objects.create(
+            owner=self.user, title='test_boxes', storeType='coverageStore', is_approved=True
+        )
+
+        self.request_mock = Mock(spec=requests.Request, GET=Mock())
+
+    def test_facets_filter_layers_returns_correctly(self):
+        self.request_mock.GET.get.side_effect = lambda key, self: {
+            'title__icontains': 'boxes',
+            'abstract__icontains': 'boxes',
+            'purpose__icontains': 'boxes',
+            'date__gte': None,
+            'date__range': None,
+            'date__lte': None,
+            'extent': None
+        }.get(key)
+        self.request_mock.GET.getlist.return_value = None
+        self.request_mock.user = self.user
+        results = facets({'request': self.request_mock})
+        self.assertEqual(results['vector'], 3)
+        self.assertEqual(results['raster'], 4)


### PR DESCRIPTION
References: ISSUE #7087 #7067

Currently, the calculation of the numbers for the badges in the filter sidebar doesn't take into account the abstract__icontains and purpose__icontains URL parameter hence displaying wrong results count in facets.
This PR fixes the issue such that the total in facets match the total results returned
## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
