### PR TITLE
[Fixes #6995] Extending Geonode Template

### DIFF
--- a/geonode/layers/templates/layers/layer_metadata_advanced.html
+++ b/geonode/layers/templates/layers/layer_metadata_advanced.html
@@ -36,8 +36,10 @@
         Editing details for {{ layer_title }}
       {% endblocktrans %}
     </p>
-
+    {% block advanced_edit_form %}
     <form id="metadata_update" class="form-horizontal" action="{% url "layer_metadata" layer.service_typename %}" method="POST">
+
+      {% block metadata_uploaded_check %}
       {% if layer.metadata_uploaded_preserve %}
         <p class="bg-warning">{% blocktrans %}Note: this layer's orginal metadata was populated and preserved by importing a metadata XML file.
           This metadata cannot be edited.{% endblocktrans %}</p>
@@ -46,9 +48,11 @@
           GeoNode's metadata import supports a subset of ISO, FGDC, and Dublin Core metadata elements.
           Some of your original metadata may have been lost.{% endblocktrans %}</p>
       {% endif %}
+      {% endblock metadata_uploaded_check %}
 
+      {% block layer_form_errors %}
       {% if layer_form.errors or attribute_form.errors or category_form.errors or author_form.errors or poc.errors %}
-    	  <p class="bg-danger">{% blocktrans %}Error updating metadata.  Please check the following fields: {% endblocktrans %}</p>
+    	    <p class="bg-danger">{% blocktrans %}Error updating metadata.  Please check the following fields: {% endblocktrans %}</p>
           <ul class="bg-danger">
           {% if author_form.errors %}
             <li>{% trans "Metadata Author" %}</li>
@@ -76,6 +80,7 @@
           {% endif %}
           </ul>
         {% endif %}
+      {% endblock layer_form_errors %}
 
         {% if not layer.metadata_uploaded_preserve %}
         <div class="form-actions">
@@ -89,6 +94,7 @@
              Unfortunately this needs to appear at the bottom of the form since tkeywords_form is a complete other django form. 
              There might be a better way to solve this. -->
         <div class="col-md-6 form-controls">
+          {% block layer_fields %}
           {% for field in layer_form %}
             {% if field.name != 'use_featureinfo_custom_template' and field.name != 'featureinfo_custom_template' %}
             <div>
@@ -97,11 +103,18 @@
             </div>
             {% endif %}
           {% endfor %}
+          {% endblock layer_fields %}
+
+          {% block thesauri %}
           {# layer_form|as_bootstrap #}
           {% if THESAURI_FILTERS %}
             {{ tkeywords_form }}
           {% endif %}
+
+          {% endblock thesauri %}
         </div>
+
+        {% block category %}
         <div class="row">
           <div class="col-md-12">
             <label class="control-label required-field">{% trans "Category" %}</label>
@@ -125,7 +138,11 @@
               {% endautoescape %}
             </fieldset>
           </div>
+          {% endblock category %}
 
+          {% block other_tab %}{% endblock %}
+
+          {% block attributes %}
           <div class="col-md-12 grid-spacer">
             <h5>{% trans "Attributes" %}</h5>
             <label>{% trans "Use a custom template?" %}</label>
@@ -161,31 +178,42 @@
                 {% endfor %}
                 </table>
             </div>
+            {% endblock attributes %}
+
+            {% block layer_custom_template %}
             <div id="layer-attributes-custom_template"
                   {% if not resource.use_featureinfo_custom_template %}style="visibility: collapse;" {% endif %}>
                 {{layer_form.featureinfo_custom_template}}
             </div>
+            {% endblock layer_custom_template %}
 
+            {% block point_of_contact %}
             <fieldset class="form-controls modal-forms modal hide fade" id="poc_form" >
               <h2>{% trans "Point of Contact" %}</h2>
               {{ poc_form|as_bootstrap }}
               <button type='button' class="modal-cloose-btn btn btn-primary">{% trans "Done" %}</button>
             </fieldset>
+            {% endblock point_of_contact %}
+            {% block metadata_provider %}
             <fieldset class="form-controls modal-forms modal hide fade" id="metadata_form">
               <h2>{% trans "Metadata Provider" %}</h2>
                 {{ author_form|as_bootstrap }}
               <button type='button' class="modal-cloose-btn btn btn-primary">{% trans "Done" %}</button>
             </fieldset>
+            {% endblock metadata_provider %}
 
             {% if not layer.metadata_uploaded_preserve %}
+            {% block form_actions %}
             <div class="form-actions">
               <a href="{% url 'layer_detail' layername=resource.alternate %}" class="btn btn-primary">{% trans "Return to Layer" %}</a>
               <input type="submit" id="btn_upd_md_dwn" class="btn btn-primary" value="{% trans "Update" %}"/>
             </div>
+            {% endblock form_actions %}
             {% endif %}
           </div>
         </div>
       </form>
+      {% endblock advanced_edit_form %}
   </div>
 </div>
 

--- a/geonode/layers/templates/layers/layer_metadata_advanced.html
+++ b/geonode/layers/templates/layers/layer_metadata_advanced.html
@@ -140,7 +140,7 @@
           </div>
           {% endblock category %}
 
-          {% block other_tab %}{% endblock %}
+          {% block other_tab %}{% endblock other_tab %}
 
           {% block attributes %}
           <div class="col-md-12 grid-spacer">


### PR DESCRIPTION
References: ISSUE #6995

With this PR i want to continue the work related to the addition of the `block` tags in geonode template.
In this PR i add the blocks to `layer_metadata_advanced.html`

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
