### PR TITLE
[Backport #7101] Error in preview

### DIFF
--- a/geonode/base/fixtures/test_thesaurus.json
+++ b/geonode/base/fixtures/test_thesaurus.json
@@ -13,6 +13,20 @@
             "card_max": 1,
             "facet": true
         }
+      },{
+        "model": "base.thesaurus",
+        "pk": 2,
+        "fields": {
+            "identifier": "optional-theme",
+            "title": "Optional thesaurus Fields",
+            "date": "2021-05-23T10:25:56",
+            "description": "Optional thesaurus Fields",
+            "slug": "",
+            "about": "http://optional/theme2",
+            "card_min": 0,
+            "card_max": -1,
+            "facet": true
+        }
       },
       {
         "model": "base.thesauruskeyword",

--- a/geonode/base/forms.py
+++ b/geonode/base/forms.py
@@ -344,21 +344,25 @@ class ThesaurusAvailableForm(forms.Form):
     def _define_multifield(self, item, required, tname, lang):
         return MultipleChoiceField(
             choices=self._get_thesauro_keyword_label(item, lang),
-            widget=autocomplete.Select2Multiple(url=f"/base/thesaurus_available/?sysid={item.id}&lang={lang}"),
+            widget=autocomplete.Select2Multiple(
+                url=f"/base/thesaurus_available/?sysid={item.id}&lang={lang}",
+                attrs={"class": "treq" if required else ""},
+            ),
             label=f"{tname}",
-            required=required,
+            required=False,
         )
 
     def _define_choicefield(self, item, required, tname, lang):
         return models.ChoiceField(
             label=f"{tname}",
             required=required,
+            widget=forms.Select(attrs={"class": "treq" if required else ""}),
             choices=self._get_thesauro_keyword_label(item, lang))
 
     @staticmethod
     def _get_thesauro_keyword_label(item, lang):
         qs_local = []
-        qs_non_local = []
+        qs_non_local = [("", "------")]
         for key in ThesaurusKeyword.objects.filter(thesaurus_id=item.id):
             label = ThesaurusKeywordLabel.objects.filter(keyword=key).filter(lang=lang)
             if label.exists():

--- a/geonode/base/forms.py
+++ b/geonode/base/forms.py
@@ -355,7 +355,7 @@ class ThesaurusAvailableForm(forms.Form):
     def _define_choicefield(self, item, required, tname, lang):
         return models.ChoiceField(
             label=f"{tname}",
-            required=required,
+            required=False,
             widget=forms.Select(attrs={"class": "treq" if required else ""}),
             choices=self._get_thesauro_keyword_label(item, lang))
 

--- a/geonode/base/tests.py
+++ b/geonode/base/tests.py
@@ -892,7 +892,7 @@ class TestTagThesaurus(TestCase):
 
     @staticmethod
     def __get_last_thesaurus():
-        return Thesaurus.objects.all().order_by("-id")[0]
+        return Thesaurus.objects.all().order_by("id")[0]
 
 
 @override_settings(THESAURUS_DEFAULT_LANG="en")
@@ -905,9 +905,11 @@ class TestThesaurusAvailableForm(TestCase):
     def setUp(self):
         self.sut = ThesaurusAvailableForm
 
-    def test_form_is_invalid_if_required_fields_are_missing(self):
+    def test_form_is_valid_if_all_fields_are_missing(self):
+        #  is now always true since the required is moved to the UI
+        #  (like the other fields)
         actual = self.sut(data={})
-        self.assertFalse(actual.is_valid())
+        self.assertTrue(actual.is_valid())
 
     def test_form_is_invalid_if_fileds_send_unexpected_values(self):
         actual = self.sut(data={"1": [1, 2]})
@@ -916,6 +918,18 @@ class TestThesaurusAvailableForm(TestCase):
     def test_form_is_valid_if_fileds_send_expected_values(self):
         actual = self.sut(data={"1": 1})
         self.assertTrue(actual.is_valid())
+
+    def test_field_class_treq_is_correctly_set_when_field_is_required(self):
+        actual = self.sut(data={"1": 1})
+        required = actual.fields.get('1')
+        obj_class = required.widget.attrs.get('class')
+        self.assertTrue(obj_class == 'treq')
+
+    def test_field_class_treq_is_not_set_when_field_is_optional(self):
+        actual = self.sut(data={"1": 1})
+        required = actual.fields.get('2')
+        obj_class = required.widget.attrs.get('class')
+        self.assertTrue(obj_class == '')
 
 
 class TestFacets(TestCase):

--- a/geonode/context_processors.py
+++ b/geonode/context_processors.py
@@ -193,6 +193,11 @@ def resource_urls(request):
         GEONODE_APPS_NAME=getattr(settings, 'GEONODE_APPS_NAME', 'Apps'),
         GEONODE_APPS_NAV_MENU_ENABLE=getattr(settings, 'GEONODE_APPS_NAV_MENU_ENABLE', False),
         CATALOG_METADATA_TEMPLATE=getattr(settings, "CATALOG_METADATA_TEMPLATE", "catalogue/full_metadata.xml"),
-        UI_REQUIRED_FIELDS=getattr(settings, "UI_REQUIRED_FIELDS", [])
+        UI_REQUIRED_FIELDS=getattr(settings, "UI_REQUIRED_FIELDS", []),
+        REQ_THESAURI=[
+            f"tkeywords-{x.id}"
+            for x in Thesaurus.objects.all()
+            if (x.card_max == -1 and x.card_min == 1) or (x.card_max == 1 and x.card_min == 1)
+        ],
     )
     return defaults

--- a/geonode/locale/it/LC_MESSAGES/django.po
+++ b/geonode/locale/it/LC_MESSAGES/django.po
@@ -6296,3 +6296,6 @@ msgstr "Permesso negato"
 
 msgid "If true, will be excluded from search"
 msgstr "Se Vero, l'elemento verrà escluso dalla ricerca"
+
+msgid "Please, fill the following items before clicking on preview:"
+msgstr "Perfavore, completa i seguenti campi prima di andare su Anteprima:"

--- a/geonode/templates/metadata_base.html
+++ b/geonode/templates/metadata_base.html
@@ -199,7 +199,6 @@
         <h4 class="modal-title">{% trans "ERROR" %}</h4>
       </div>
       <div class="modal-body general_errors">
-        {% trans "Following items are required:" %}
         <p id="general_errors"></p>
       </div>
       <div class="modal-footer">

--- a/geonode/templates/metadata_form_js.html
+++ b/geonode/templates/metadata_form_js.html
@@ -240,6 +240,9 @@
           } else if( !$(target).hasClass('autocomplete') ){
             // display error status for token fields if not completed
             $(target).toggleClass("input-empty", empty);
+            if (target.id.startsWith('id_tkeywords')) {
+                $("#" + target.id).closest("p").toggleClass("has-error", empty);   
+            }
           }
           var imgMissing = $('img#image').attr('src');
           console.log(target.id + ": " + imgMissing)
@@ -326,6 +329,12 @@
             return false;
           }
 
+          if (el.id.startsWith('id_tkeywords') && $(el).hasClass('treq')) {
+              return true;
+          } else if (el.id.startsWith('id_tkeywords') && !$(el).hasClass('treq')) {
+              return false;
+          }
+
           var is_mandatory = (el.id.indexOf("autocomplete") < 0 &&
                         (typeof $(el).attr("class") !== 'undefined' && $(el).attr("class").indexOf("select2") < 0) &&
                         !$(el).hasClass('value-select') &&
@@ -384,13 +393,12 @@
         {{UI_REQUIRED_FIELDS}}.forEach(element => $('#' + element).change(onInputChange).change());
         $('#category_form').change(onInputChange).change();
         $('#id_resource-group').change(onInputChange).change();
-        $('#id_resource-group').change(onInputChange).change();
 
         $('#id_resource-date').change(onInputChange).change();
         $('#id_resource-links').change(onInputChange).change();
 
-        document.querySelector('select[name="resource-keywords"]').onchange=onInputChange
-
+        document.querySelector('select[name="resource-keywords"]').onchange=onInputChange;
+        {{REQ_THESAURI}}.forEach(element => document.querySelector('select[name="'+ element + '"]').onchange=onInputChange);
         $( ':input[id*="id_tkeywords"][required]:visible').each( function () {
             $('#' + this.id).change(onInputChange).change();
         });
@@ -526,13 +534,13 @@
         });
         
         function validateRequiredInput() {
-            var errors = []
+            var errors = ['{% trans "Following items are required:" %}']
             $( ':input[required]').each( function () {
                 if ( this.value.trim() == '' ) {
                     errors.push(this.id)
                 }
             });
-            if (errors.length > 0) {
+            if (errors.length > 1) {
                 console.error("Following items are required: " + errors)
                 $(".general_errors").find("p").html(errors.join('<br>'));
                 $('#error_mandatoryDialog').modal();
@@ -565,8 +573,19 @@
             }
         });
 
-        $('#preview_tab').on('show.bs.tab', function(){
-            if
+        $('#preview_tab').on('show.bs.tab', function(e){
+            var errors = ['{% trans "Please, fill the following items before clicking on preview:" %}<br>']
+                $( ':input[required]').each( function () {
+                    if ( this.value.trim() == '' ) {
+                        errors.push(this.id)
+                    }
+                });
+            if (errors.length > 1) {
+                e.preventDefault();
+                console.error("Please, fill the following items before clicking on preview: " + errors)
+                $(".general_errors").find("p").html(errors.join('<br>'));
+                $('#error_mandatoryDialog').modal();
+            } else if
             ( is_category_mandatory &&
                 (
                     (!is_advanced && $('#category_form').hasClass("input-empty")) ||


### PR DESCRIPTION
In order to fix the issue #7101 :
- now the `$('#preview_tab').on('show.bs.tab')` event, will block the user with a warning modal by warning him that  some required field is missing by using `preventDefault();`
A field is considered required if match with this code;
```javascript
  $( ':input[required]').each( function () {
      if ( this.value.trim() == '' ) {
          errors.push(this.id)
      }
  });
```
- Change the behavior of the Thesaurus item from `required` in Django-form to `required` from a UI point of view (like the other fields as commented [here](https://github.com/GeoNode/geonode/issues/7095#issuecomment-802010017)) 
-  Re-add `.vscode` to gitignore
- Add `REQ_THESAURI` to context processor in order to dynamically assign required classes in UI for the thesaurus
- Fix thesaurus tests with the new form specification
- Italian translation for the new modal

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [x] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
