### PR TITLE
[Backport Fixes #7150] Thesaurus from web

### DIFF
--- a/geonode/base/forms.py
+++ b/geonode/base/forms.py
@@ -683,3 +683,7 @@ class OwnerRightsRequestForm(forms.Form):
 
     class Meta:
         fields = ['reason', 'resource']
+
+
+class ThesaurusImportForm(forms.Form):
+    rdf_file = forms.FileField()

--- a/geonode/base/templates/admin/thesauri/change_list.html
+++ b/geonode/base/templates/admin/thesauri/change_list.html
@@ -1,0 +1,10 @@
+{% extends 'admin/change_list.html' %}
+
+<br>
+<ul class="grp-object-tools">
+    {% block object-tools-items %}
+        <li><a href="add/" class="grp-add-link grp-state-focus">Add thesaurus</a></li>
+        <li><a href="importrdf/" class="grp-add-link grp-state-focus">Upload thesaurus</a></li>
+    {% endblock %}
+</ul>
+{{ block.super }}

--- a/geonode/base/templates/admin/thesauri/upload_form.html
+++ b/geonode/base/templates/admin/thesauri/upload_form.html
@@ -5,7 +5,7 @@
         <form action="." method="POST" enctype="multipart/form-data">
             {{ form.as_p }}
             {% csrf_token %}
-            <button style="width:auto;margin-top:10px" class="grp-button" type="submit">Upload CSV</button>
+            <button style="width:auto;margin-top:10px" class="grp-button" type="submit">Upload RDF</button>
         </form>
     </div>
     <br />

--- a/geonode/base/templates/admin/thesauri/upload_form.html
+++ b/geonode/base/templates/admin/thesauri/upload_form.html
@@ -1,0 +1,13 @@
+{% extends 'admin/base.html' %}
+
+{% block content %}
+    <div>
+        <form action="." method="POST" enctype="multipart/form-data">
+            {{ form.as_p }}
+            {% csrf_token %}
+            <button style="width:auto;margin-top:10px" class="grp-button" type="submit">Upload CSV</button>
+        </form>
+    </div>
+    <br />
+
+{% endblock %}{{ block.super }}


### PR DESCRIPTION
In order to change the way to upload the thesaurus, with this PR i want to:
- Change `ThesaurusAdmin` in order to add a custom URL with the `upload` feature
- Custom template for upload (extended from `admin/base.html`)
- `import_rdf` function in `ThesaurusAdmin` which call the management command `upload_thesaurus` to perform the upload via web

PR Documentantion -> https://github.com/GeoNode/documentation/pull/88

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
