### PR TITLE
[Backport 3.1.x][Fixes #7164] restore does not delete table in uppercase/camelcase

### DIFF
--- a/geonode/br/management/commands/utils/utils.py
+++ b/geonode/br/management/commands/utils/utils.py
@@ -31,6 +31,7 @@ from configparser import ConfigParser
 
 from django.core.management.base import CommandError
 
+import logging
 
 MEDIA_ROOT = 'uploaded'
 STATIC_ROOT = 'static_root'
@@ -39,6 +40,7 @@ TEMPLATE_DIRS = 'template_dirs'
 LOCALE_PATHS = 'locale_dirs'
 EXTERNAL_ROOT = 'external'
 
+logger = logging.getLogger(__name__)
 
 def option(parser):
 
@@ -329,7 +331,7 @@ def remove_existing_tables(db_name, db_user, db_port, db_host, db_passwd):
         pg_all_tables = [table[0] for table in curs.fetchall()]
         for pg_table in pg_all_tables:
             logger.info("Dropping existing GeoServer Vectorial Data : {}:{} ".format(db_name, pg_table))
-            curs.execute(f"DROP TABLE {pg_table} CASCADE")
+            curs.execute(f"DROP TABLE \"{pg_table}\" CASCADE")
 
         conn.commit()
     except Exception:


### PR DESCRIPTION
With this PR i want to:
- wrap table name in double-quotes to let postgres manage the table in uppercase/lowercase/camelcase without drop "missing table" error

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
