### PR TITLE
[Fixes #7109] Disable edit permissions globally when read-only mode is active

### DIFF
--- a/geonode/geoserver/tests/test_server.py
+++ b/geonode/geoserver/tests/test_server.py
@@ -37,6 +37,7 @@ from django.test.utils import override_settings
 from guardian.shortcuts import assign_perm, remove_perm
 
 from geonode import geoserver
+from geonode.base.models import Configuration
 from geonode.decorators import on_ogc_backend
 
 from geonode.layers.models import Layer, Style
@@ -551,6 +552,7 @@ class LayerTests(GeoNodeBaseTestSupport):
         self.user = 'admin'
         self.passwd = 'admin'
         create_layer_data()
+        self.config = Configuration.load()
 
     @on_ogc_backend(geoserver.BACKEND_PACKAGE)
     def test_style_manager(self):
@@ -697,7 +699,13 @@ class LayerTests(GeoNodeBaseTestSupport):
         if isinstance(content, bytes):
             content = content.decode('UTF-8')
         response_json = json.loads(content)
-        self.assertEqual(response_json['authorized'], True)
+        # TODO Needs discussion of it's validity
+        # This will only be true for storeType dataStore
+        # self.assertEqual(response_json['authorized'], True)
+        if layer.storeType == 'dataStore':
+            self.assertEqual(response_json['authorized'], True)
+        else:
+            self.assertEqual(response_json['authorized'], False)
 
         # Let's change layer permissions and try again with non-owner
         norman = get_user_model().objects.get(username='norman')
@@ -731,7 +739,13 @@ class LayerTests(GeoNodeBaseTestSupport):
         if isinstance(content, bytes):
             content = content.decode('UTF-8')
         response_json = json.loads(content)
-        self.assertEqual(response_json['authorized'], True)
+        # TODO Needs discussion of it's validity
+        # This will only be true for storeType dataStore
+        # self.assertEqual(response_json['authorized'], True)
+        if layer.storeType == 'dataStore':
+            self.assertEqual(response_json['authorized'], True)
+        else:
+            self.assertEqual(response_json['authorized'], False)
 
         # Login as a user with the proper permission and test the endpoint
         logged_in = self.client.login(username='admin', password='admin')
@@ -746,7 +760,13 @@ class LayerTests(GeoNodeBaseTestSupport):
         if isinstance(content, bytes):
             content = content.decode('UTF-8')
         response_json = json.loads(content)
-        self.assertEqual(response_json['authorized'], True)
+        # TODO Needs discussion of it's validity
+        # This will only be true for storeType dataStore
+        # self.assertEqual(response_json['authorized'], True)
+        if layer.storeType == 'dataStore':
+            self.assertEqual(response_json['authorized'], True)
+        else:
+            self.assertEqual(response_json['authorized'], False)
 
         layer = Layer.objects.all()[0]
         layer.storeType = "dataStore"
@@ -759,13 +779,28 @@ class LayerTests(GeoNodeBaseTestSupport):
                 reverse(
                     'feature_edit_check',
                     args=(
-                        valid_layer_typename,
+                        layer.alternate,
                     )))
             content = response.content
             if isinstance(content, bytes):
                 content = content.decode('UTF-8')
             response_json = json.loads(content)
             self.assertEqual(response_json['authorized'], True)
+
+        # Test when the system is in readonly mode
+        self.config.read_only = True
+        self.config.save()
+        response = self.client.post(
+            reverse(
+                'feature_edit_check',
+                args=(
+                    valid_layer_typename,
+                )))
+        content = response.content
+        if isinstance(content, bytes):
+            content = content.decode('UTF-8')
+        response_json = json.loads(content)
+        self.assertEqual(response_json['authorized'], False)
 
     @on_ogc_backend(geoserver.BACKEND_PACKAGE)
     def test_layer_acls(self):

--- a/geonode/geoserver/tests/test_server.py
+++ b/geonode/geoserver/tests/test_server.py
@@ -699,9 +699,7 @@ class LayerTests(GeoNodeBaseTestSupport):
         if isinstance(content, bytes):
             content = content.decode('UTF-8')
         response_json = json.loads(content)
-        # TODO Needs discussion of it's validity
         # This will only be true for storeType dataStore
-        # self.assertEqual(response_json['authorized'], True)
         if layer.storeType == 'dataStore':
             self.assertEqual(response_json['authorized'], True)
         else:
@@ -739,13 +737,7 @@ class LayerTests(GeoNodeBaseTestSupport):
         if isinstance(content, bytes):
             content = content.decode('UTF-8')
         response_json = json.loads(content)
-        # TODO Needs discussion of it's validity
-        # This will only be true for storeType dataStore
-        # self.assertEqual(response_json['authorized'], True)
-        if layer.storeType == 'dataStore':
-            self.assertEqual(response_json['authorized'], True)
-        else:
-            self.assertEqual(response_json['authorized'], False)
+        self.assertEqual(response_json['authorized'], True)
 
         # Login as a user with the proper permission and test the endpoint
         logged_in = self.client.login(username='admin', password='admin')
@@ -760,9 +752,7 @@ class LayerTests(GeoNodeBaseTestSupport):
         if isinstance(content, bytes):
             content = content.decode('UTF-8')
         response_json = json.loads(content)
-        # TODO Needs discussion of it's validity
         # This will only be true for storeType dataStore
-        # self.assertEqual(response_json['authorized'], True)
         if layer.storeType == 'dataStore':
             self.assertEqual(response_json['authorized'], True)
         else:
@@ -793,6 +783,18 @@ class LayerTests(GeoNodeBaseTestSupport):
         response = self.client.post(
             reverse(
                 'feature_edit_check',
+                args=(
+                    valid_layer_typename,
+                )))
+        content = response.content
+        if isinstance(content, bytes):
+            content = content.decode('UTF-8')
+        response_json = json.loads(content)
+        self.assertEqual(response_json['authorized'], False)
+
+        response = self.client.post(
+            reverse(
+                'style_edit_check',
                 args=(
                     valid_layer_typename,
                 )))

--- a/geonode/geoserver/views.py
+++ b/geonode/geoserver/views.py
@@ -355,13 +355,14 @@ def feature_edit_check(request, layername, permission='change_layer_data'):
         return HttpResponse(
             json.dumps({'authorized': False}), content_type="application/json")
     datastore = ogc_server_settings.DATASTORE
-    feature_edit = datastore
-    if layer.user_can(request.user, permission) and layer.storeType == 'dataStore' and feature_edit:
-        return HttpResponse(
-            json.dumps({'authorized': True}), content_type="application/json")
-    else:
-        return HttpResponse(
-            json.dumps({'authorized': False}), content_type="application/json")
+    authorized = False
+    if layer.user_can(request.user, permission):
+        authorized = True
+        if permission == 'change_layer_data':
+            if not layer.storeType == 'dataStore' and datastore:
+                authorized = False
+    return HttpResponse(
+        json.dumps({'authorized': authorized}), content_type="application/json")
 
 
 def style_edit_check(request, layername):

--- a/geonode/geoserver/views.py
+++ b/geonode/geoserver/views.py
@@ -356,23 +356,7 @@ def feature_edit_check(request, layername, permission='change_layer_data'):
             json.dumps({'authorized': False}), content_type="application/json")
     datastore = ogc_server_settings.DATASTORE
     feature_edit = datastore
-    is_admin = False
-    is_staff = False
-    is_owner = False
-    is_manager = False
-    if request.user:
-        is_admin = request.user.is_superuser if request.user else False
-        is_staff = request.user.is_staff if request.user else False
-        is_owner = (str(request.user) == str(layer.owner))
-        try:
-            is_manager = request.user.groupmember_set.all().filter(
-                role='manager').exists()
-        except Exception:
-            is_manager = False
-    if is_admin or is_staff or is_owner or is_manager or request.user.has_perm(
-            permission,
-            obj=layer) and \
-            layer.storeType == 'dataStore' and feature_edit:
+    if layer.user_can(request.user, permission) and layer.storeType == 'dataStore' and feature_edit:
         return HttpResponse(
             json.dumps({'authorized': True}), content_type="application/json")
     else:


### PR DESCRIPTION
<Include a few sentences describing the overall goals for this Pull Request>
References #7109
Adds a check for the read-only mode to edit-features
## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
