### PR TITLE
[Fixes #7194] Append data to an existing layer 

### DIFF
--- a/geonode/base/populate_test_data.py
+++ b/geonode/base/populate_test_data.py
@@ -316,6 +316,35 @@ def dump_models(path=None):
     with open(path, 'w') as f:
         f.write(result)
 
+def create_single_layer(name):
+    get_user_model().objects.create(
+                    username='admin',
+                    is_superuser=True,
+                    first_name='admin')
+    test_datetime = datetime.strptime('2020-01-01', '%Y-%m-%d')
+    user = get_user_model().objects.get(username='AnonymousUser')
+    ll = (name, 'lorem ipsum', name, f'geonode:{name}', [
+                    0, 22, 0, 22], test_datetime, ('populartag',), "farming")
+    title, abstract, name, alternate, (bbox_x0, bbox_x1, bbox_y0, bbox_y1), start, kws, category = ll
+    layer = Layer(
+        title=title,
+        abstract=abstract,
+        name=name,
+        alternate=alternate,
+        bbox_polygon=Polygon.from_bbox((bbox_x0, bbox_y0, bbox_x1, bbox_y1)),
+        ll_bbox_polygon=Polygon.from_bbox((bbox_x0, bbox_y0, bbox_x1, bbox_y1)),
+        srid='EPSG:4326',
+        uuid=str(uuid4()),
+        owner=user,
+        temporal_extent_start=test_datetime,
+        temporal_extent_end=test_datetime,
+        date=start,
+        storeType="dataStore",
+    )
+    layer.save()
+    layer.set_default_permissions()
+    return layer
+
 
 if __name__ == '__main__':
     create_models()

--- a/geonode/base/populate_test_data.py
+++ b/geonode/base/populate_test_data.py
@@ -316,6 +316,7 @@ def dump_models(path=None):
     with open(path, 'w') as f:
         f.write(result)
 
+
 def create_single_layer(name):
     get_user_model().objects.create(
                     username='admin',

--- a/geonode/layers/templates/layers/layer_append.html
+++ b/geonode/layers/templates/layers/layer_append.html
@@ -1,0 +1,133 @@
+{% extends "upload/layer_upload_base.html" %}
+{% load i18n %}
+{% load staticfiles %}
+{% load dialogos_tags %}
+{% load pinax_ratings_tags %}
+{% load bootstrap_tags %}
+{% load pagination_tags %}
+{% load base_tags %}
+{% load guardian_tags %}
+
+{% block title %} {% trans "Append to Layer"  %} - {{ block.super }}  {% endblock %}
+
+{% block body_class %}{% trans "layers append" %}{% endblock %}
+
+
+{% block head %}
+
+{{ block.super }}
+{% endblock %}
+
+{% block body_outer %}
+<div class="page-header">
+  <a href="{% url "layer_browse" %}?limit={{ CLIENT_RESULTS_LIMIT }}" class="btn btn-primary pull-right" style="margin-left: 3px;">{% trans "Explore Layers" %}</a>
+  <a href="{% url 'layer_detail' layername=resource.service_typename %}" class="btn btn-primary pull-right" style="margin-left: 3px;">{% trans "Return to Layer" %}</a>
+  <h2 class="page-title">{% trans "Append to Layer" %} <small><a href="{{ resource.get_absolute_url }}">{{ resource.title }}</a><small></h2>
+</div>
+<div class="row">
+  <div class="col-md-8">
+    {% if incomplete %}
+    <section class="widget" id="incomplete-download-list">
+      <h3>{% trans "Incomplete Uploads" %}</h3>
+      <p>{% trans "You have the following incomplete uploads" %}:</p>
+      {% for u in incomplete %}
+      <div class="clearfix uip" id="incomplete-{{ u.import_id }}">
+        <div class="pull-left">{{ u.name }}, {% trans "last updated on" %} {{ u.date }}</div>
+        <div class="upload_actions pull-right">
+          <a class="btn btn-mini" href="#" id="resume-{{ u.import_id }}">{% trans "Resume" %}</a>
+          <a class="btn btn-mini" href="#" id="delete-{{ u.import_id }}"><i class="icon-trash"></i> {% trans "Delete" %}</a>
+        </div>
+      </div>
+      {% endfor %}
+    </section>
+    <div id="confirm-delete" class="hidden alert alert-warning">
+      {% trans "Are you sure you want to delete this upload?" %}
+      <a href="#y" class="btn btn-danger">{% trans "Delete" %}</a>
+      <a href="#n" class="btn btn-default">{% trans "Cancel" %}</a>
+      <a href="#yy">{% trans "Delete, and don't ask me again." %}</a>
+    </div>
+    {% endif %}
+
+    {% block additional_info %}{% endblock %}
+
+    {% if errors %}
+    <div id="errors" class="alert alert-danger">
+      {% for error in errors %}
+      <p>{{ error }}</p>
+      {% endfor %}
+    </div>
+    {% endif %}
+
+    <div id="upload-status"></div>
+
+    <section id="drop-zone">
+      <h3><i class="fa fa-cloud-upload"></i><br />{% trans "Drop files here" %}</h3>
+    </section>
+
+    <p>{% trans " or select them one by one:" %}</p>
+
+    <form id="file-uploader" method="post" enctype="multipart/form-data">
+      <!-- UI change to hide the list of previously uploaded files from the user -->
+      <input type="file" id="file-input" style="display: none;" multiple>
+      <input class="btn btn-default" type="button" value="{% trans "Choose Files" %}" onclick="document.getElementById('file-input').click();">
+    </form>
+
+    <section class="widget">
+      <ul id="global-errors"></ul>
+      <h4>{% trans "Files to be uploaded" %}</h4>
+      <div id="file-queue"></div>
+      <div class="checkbox" style="display:none;" id="metadata_uploaded_preserve_check">
+          {% trans "Preserve Metadata XML" %} <input type="checkbox" name="metadata_uploaded_preserve" id="id_metadata_uploaded_preserve"/>
+      </div>
+    </section>
+
+    <section class="charset">
+      <p>{% trans "Select the charset or leave default" %}</p>
+      <select id="charset">
+        {% for charset in charsets %}
+        {% if charset.0 == 'UTF-8' %}
+        <option selected='selected' value={{ charset.0 }}>{{ charset.1 }}</option>
+        {% else %}
+        <option value={{ charset.0 }}>{{ charset.1 }}</option>
+        {% endif %}
+        {% endfor %}
+      </select>
+    </section>
+
+    <section>
+      <a href="#" id="clear-button" class="btn btn-default">{% trans "Clear" %}</a>
+      <a href="#" id="upload-button" class="btn btn-danger">{% trans "Append to Layer" %}</a>
+    </section>
+  </div>
+
+  {% if GEOSERVER_BASE_URL %}
+    {% get_obj_perms request.user for resource.layer as "layer_perms" %}
+  {% endif %}
+
+</div>
+{% endblock %}
+
+
+{% block extra_script %}
+{{ block.super }}
+<script data-main="{% static 'geonode/js/upload/main.js' %}"
+  src="{% static 'lib/js/require.js' %}">
+</script>
+<script type="text/javascript">
+{% autoescape off %}
+
+  csrf_token =  "{{ csrf_token }}",
+  form_target = "{% url "layer_append" resource.service_typename %}",
+  time_enabled = {{ TIME_ENABLED|lower  }},
+  mosaic_enabled = {{ MOSAIC_ENABLED|lower  }},
+  userLookup = "{% url "account_ajax_lookup" %}"
+
+{% endautoescape %}
+
+</script>
+{% if GEONODE_SECURITY_ENABLED %}
+{% with resource=layer %}
+{% include "_permissions_form_js.html" %}
+{% endwith %}
+{% endif %}
+{% endblock extra_script %}

--- a/geonode/layers/templates/layers/layer_detail.html
+++ b/geonode/layers/templates/layers/layer_detail.html
@@ -510,6 +510,9 @@
                   {% if "change_resourcebase" in perms_list and resource.storeType != "remoteStore" %}
                   <a class="btn btn-default btn-block btn-xs" href="{% url "layer_replace" resource.service_typename %}">{% trans "Replace" %}</a>
                   {% endif %}
+                  {% if "change_resourcebase" in perms_list and resource.storeType != "remoteStore" %}
+                  <a class="btn btn-default btn-block btn-xs" href="{% url "layer_append" resource.service_typename %}">{% trans "Append Data" %}</a>
+                  {% endif %}
                   {% if "change_layer_data" in layer_perms and OGC_SERVER.default.BACKEND == 'geonode.geoserver' %}
                     {% if layer_type != "raster" and resource.storeType != "remoteStore" %}
                     <a class="btn btn-default btn-block btn-xs" href="{% url "new_map" %}?layer={{resource.service_typename}}&storeType={{resource.storeType}}">{% trans "Edit data" %}</a>

--- a/geonode/layers/tests.py
+++ b/geonode/layers/tests.py
@@ -17,6 +17,8 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 #########################################################################
+from collections import namedtuple
+
 from geonode.tests.base import GeoNodeBaseTestSupport
 from django.test import TestCase
 import io
@@ -55,9 +57,9 @@ from geonode.layers.utils import (
     get_files,
     get_valid_name,
     get_valid_layer_name,
-    surrogate_escape_string)
+    surrogate_escape_string, validate_input_source)
 from geonode.people.utils import get_valid_user
-from geonode.base.populate_test_data import all_public
+from geonode.base.populate_test_data import all_public, create_single_layer
 from geonode.base.models import TopicCategory, License, Region, Link
 from geonode.layers.forms import JSONField, LayerUploadForm
 from geonode.utils import check_ogc_backend, set_resource_default_links
@@ -1701,3 +1703,109 @@ class TestCustomUUidHandler(TestCase):
         expected = "abc:abc-1234-abc"
         actual = Layer.objects.get(id=self.sut.id)
         self.assertEqual(expected, actual.uuid)
+
+
+class TestalidateInputSource(TestCase):
+
+    def setUp(self):
+        self.maxDiff = None
+        self.layer = create_single_layer('single_point')
+        self.r = namedtuple('GSCatalogRes', ['resource'])
+
+    def tearDown(self):
+        self.layer.delete()
+
+    def test_will_raise_exception_for_replace_vector_layer_with_raster(self):
+        layer = Layer.objects.filter(name="single_point")[0]
+        filename = "/tpm/filename.tif"
+        files = ["/opt/file1.shp", "/opt/file2.ccc"]
+        with self.assertRaises(Exception) as e:
+            validate_input_source(layer, filename, files, action_type="append")
+        expected = "You are attempting to append a vector layer with a raster."
+        self.assertEqual(expected, e.exception.args[0])
+
+    def test_will_raise_exception_for_replace_layer_with_unknown_format(self):
+        layer = Layer.objects.filter(name="single_point")[0]
+        filename = "/tpm/filename.ccc"
+        files = ["/opt/file1.shp", "/opt/file2.ccc"]
+        with self.assertRaises(Exception) as e:
+            validate_input_source(layer, filename, files, action_type="append")
+        expected = "You are attempting to append a vector layer with an unknown format."
+        self.assertEqual(expected, e.exception.args[0])
+
+    def test_will_raise_exception_for_replace_layer_with_different_file_name(self):
+        layer = Layer.objects.get(name="single_point")
+        file_path = gisdata.VECTOR_DATA
+        filename = os.path.join(file_path, "san_andres_y_providencia_highway.shp")
+        files = {
+            "shp": filename,
+            "dbf": f"{file_path}/san_andres_y_providencia_highway.sbf",
+            "prj": f"{file_path}/san_andres_y_providencia_highway.prj",
+            "shx": f"{file_path}/san_andres_y_providencia_highway.shx",
+        }
+        with self.assertRaises(Exception) as e:
+            validate_input_source(layer, filename, files, action_type="append")
+        expected = (
+            "Some error occurred while trying to access the uploaded schema: "
+            "Please ensure the name is consistent with the file you are trying to append."
+        )
+        self.assertEqual(expected, e.exception.args[0])
+
+    def test_will_raise_exception_for_not_existing_layer_in_the_catalog(self):
+        layer = Layer.objects.filter(name="single_point")[0]
+        file_path = gisdata.VECTOR_DATA
+        filename = os.path.join(file_path, "single_point.shp")
+        files = {
+            "shp": filename,
+            "dbf": f"{file_path}/single_point.sbf",
+            "prj": f"{file_path}/single_point.prj",
+            "shx": f"{file_path}/single_point.shx",
+        }
+        with self.assertRaises(Exception) as e:
+            validate_input_source(layer, filename, files, action_type="append")
+        expected = (
+            "Some error occurred while trying to access the uploaded schema: "
+            "The selected Layer does not exists in the catalog."
+        )
+        self.assertEqual(expected, e.exception.args[0])
+
+    @patch("geonode.layers.utils.gs_catalog")
+    def test_will_raise_exception_if_schema_is_not_equal_between_catalog_and_file(self, catalog):
+        attr = namedtuple('GSCatalogAttr', ['attributes'])
+        attr.attributes = []
+        self.r.resource = attr
+        catalog.get_layer.return_value = self.r
+        layer = Layer.objects.filter(name="single_point")[0]
+        file_path = gisdata.VECTOR_DATA
+        filename = os.path.join(file_path, "single_point.shp")
+        files = {
+            "shp": filename,
+            "dbf": f"{file_path}/single_point.sbf",
+            "prj": f"{file_path}/single_point.prj",
+            "shx": f"{file_path}/single_point.shx",
+        }
+        with self.assertRaises(Exception) as e:
+            validate_input_source(layer, filename, files, action_type="append")
+        expected = (
+            "Some error occurred while trying to access the uploaded schema: "
+            "Please ensure that the layer structure is consistent with the file you are trying to append."
+        )
+        self.assertEqual(expected, e.exception.args[0])
+
+    @patch("geonode.layers.utils.gs_catalog")
+    def test_validation_will_pass_for_valid_append(self, catalog):
+        attr = namedtuple('GSCatalogAttr', ['attributes'])
+        attr.attributes = ['label']
+        self.r.resource = attr
+        catalog.get_layer.return_value = self.r
+        layer = Layer.objects.filter(name="single_point")[0]
+        file_path = gisdata.VECTOR_DATA
+        filename = os.path.join(file_path, "single_point.shp")
+        files = {
+            "shp": filename,
+            "dbf": f"{file_path}/single_point.sbf",
+            "prj": f"{file_path}/single_point.prj",
+            "shx": f"{file_path}/single_point.shx",
+        }
+        actual = validate_input_source(layer, filename, files, action_type="append")
+        self.assertTrue(actual)

--- a/geonode/layers/urls.py
+++ b/geonode/layers/urls.py
@@ -54,6 +54,8 @@ urlpatterns = [
         name="layer_granule_remove"),
     url(r'^(?P<layername>[^/]*)/replace$',
         views.layer_replace, name="layer_replace"),
+    url(r'^(?P<layername>[^/]*)/append$',
+        views.layer_append, name="layer_append"),
     url(r'^(?P<layername>[^/]*)/thumbnail$',
         views.layer_thumbnail, name='layer_thumbnail'),
     url(r'^(?P<layername>[^/]*)/get$', views.get_layer, name='get_layer'),

--- a/geonode/layers/utils.py
+++ b/geonode/layers/utils.py
@@ -62,6 +62,7 @@ from geonode.upload.utils import _fixup_base_file
 from geonode.utils import (check_ogc_backend,
                            unzip_file,
                            extract_tarfile)
+from geonode.geoserver.helpers import gs_catalog, gs_uploader
 
 READ_PERMISSIONS = [
     'view_resourcebase'
@@ -459,52 +460,7 @@ def file_upload(filename,
 
     # We are going to replace an existing Layer...
     if layer and overwrite:
-        if layer.is_vector() and is_raster(filename):
-            raise Exception(_(
-                "You are attempting to replace a vector layer with a raster."))
-        elif (not layer.is_vector()) and is_vector(filename):
-            raise Exception(_(
-                "You are attempting to replace a raster layer with a vector."))
-
-        if layer.is_vector():
-            absolute_base_file = None
-            try:
-                if 'shp' in files and os.path.exists(files['shp']):
-                    absolute_base_file = _fixup_base_file(files['shp'])
-                elif 'zip' in files and os.path.exists(files['zip']):
-                    absolute_base_file = _fixup_base_file(files['zip'])
-            except Exception:
-                absolute_base_file = None
-
-            if not absolute_base_file or \
-            os.path.splitext(absolute_base_file)[1].lower() != '.shp':
-                raise Exception(
-                    _("You are attempting to replace a vector layer with an unknown format."))
-            else:
-                try:
-                    gtype = layer.gtype if not gtype else gtype
-                    inDataSource = ogr.Open(absolute_base_file)
-                    lyr = inDataSource.GetLayer(str(layer.name))
-                    if not lyr:
-                        raise Exception(
-                            _("Please ensure the name is consistent with the file you are trying to replace."))
-                    schema_is_compliant = False
-                    _ff = json.loads(lyr.GetFeature(0).ExportToJson())
-                    if gtype:
-                        logger.warning(
-                            _("Local GeoNode layer has no geometry type."))
-                        if _ff["geometry"]["type"] in gtype or gtype in _ff["geometry"]["type"]:
-                            schema_is_compliant = True
-                    elif "geometry" in _ff and _ff["geometry"]["type"]:
-                        schema_is_compliant = True
-
-                    if not schema_is_compliant:
-                        raise Exception(
-                            _("Please ensure there is at least one geometry type \
-                                that is consistent with the file you are trying to replace."))
-                except Exception as e:
-                    raise Exception(
-                        _(f"Some error occurred while trying to access the uploaded schema: {str(e)}"))
+        validate_input_source(layer, filename, files, gtype, action_type='replace')
 
     # Set a default title that looks nice ...
     if title is None:
@@ -1124,3 +1080,93 @@ def set_layers_permissions(permissions_name, resources_names=None,
 def get_uuid_handler():
     from django.utils.module_loading import import_string
     return import_string(settings.LAYER_UUID_HANDLER)
+
+
+def gs_append_data_to_layer(layer, base_files, user):
+    gs_layer = gs_catalog.get_layer(layer.name)
+    if gs_layer and gs_layer.type == 'VECTOR':
+        #  opening upload session for the selected layer
+        upload_session, created = UploadSession.objects.get_or_create(resource=layer, user=user)
+        upload_session.resource = layer
+        upload_session.processed = False
+        upload_session.save()
+
+        #  opening Import session for the selected layer
+        import_session = gs_uploader.start_import(
+            import_id=upload_session.id, name=layer.name, target_store=gs_layer.resource.store.name
+        )
+
+        import_session.upload_task(base_files)
+        task = import_session.tasks[0]
+        #  Changing layer name, mode and target
+        task.layer.set_target_layer_name(layer.name)
+        task.set_update_mode("APPEND")
+        task.set_target(store_name=gs_layer.resource.store.name, workspace=gs_layer.resource.workspace.name)
+        #  Starting import process
+        import_session.commit()
+        return upload_session
+
+
+def validate_input_source(layer, filename, files, gtype=None, action_type='replace'):
+    if layer.is_vector() and is_raster(filename):
+        raise Exception(_(
+            f"You are attempting to {action_type} a vector layer with a raster."))
+    elif (not layer.is_vector()) and is_vector(filename):
+        raise Exception(_(
+            f"You are attempting to {action_type} a raster layer with a vector."))
+
+    if layer.is_vector():
+        absolute_base_file = None
+        try:
+            if 'shp' in files and os.path.exists(files['shp']):
+                absolute_base_file = _fixup_base_file(files['shp'])
+            elif 'zip' in files and os.path.exists(files['zip']):
+                absolute_base_file = _fixup_base_file(files['zip'])
+        except Exception:
+            absolute_base_file = None
+
+        if not absolute_base_file or \
+        os.path.splitext(absolute_base_file)[1].lower() != '.shp':
+            raise Exception(
+                _(f"You are attempting to {action_type} a vector layer with an unknown format."))
+        else:
+            try:
+                gtype = layer.gtype if not gtype else gtype
+                inDataSource = ogr.Open(absolute_base_file)
+                lyr = inDataSource.GetLayer(str(layer.name))
+                if not lyr:
+                    raise Exception(
+                        _(f"Please ensure the name is consistent with the file you are trying to {action_type}."))
+                schema_is_compliant = False
+                _ff = json.loads(lyr.GetFeature(0).ExportToJson())
+                if gtype:
+                    logger.warning(
+                        _("Local GeoNode layer has no geometry type."))
+                    if _ff["geometry"]["type"] in gtype or gtype in _ff["geometry"]["type"]:
+                        schema_is_compliant = True
+                elif "geometry" in _ff and _ff["geometry"]["type"]:
+                    schema_is_compliant = True
+
+                if not schema_is_compliant:
+                    raise Exception(
+                        _(f"Please ensure there is at least one geometry type \
+                            that is consistent with the file you are trying to {action_type}."))
+
+                new_schema_fields = [field.name for field in lyr.schema]
+                gs_layer = gs_catalog.get_layer(layer.name)
+
+                if not gs_layer:
+                    raise Exception(
+                        _("The selected Layer does not exists in the catalog."))
+
+                gs_layer = gs_layer.resource.attributes
+                schema_is_compliant = all([x in gs_layer for x in new_schema_fields])
+
+                if not schema_is_compliant:
+                    raise Exception(
+                        _("Please ensure that the layer structure is consistent "
+                          f"with the file you are trying to {action_type}."))
+                return True
+            except Exception as e:
+                raise Exception(
+                    _(f"Some error occurred while trying to access the uploaded schema: {str(e)}"))


### PR DESCRIPTION
In order to resolve #7194 with this pr I want to:
- Creating new HTML for `layer_append` and his `view`
- New helper utility for the tests named `create_single_layer `for create only a single layer instead of the 10 created by `GeoNodeBaseTestSupport`
- New validation function for `layer_append `& `layer_replace` named `validate_input_source` which will check for the compatibility between the layer in upload and the information in the catalog. (with tests)
This will check the attributes of the uploaded file and the GS catalog:
```python
    new_schema_fields = [field.name for field in lyr.schema]
    gs_layer = gs_catalog.get_layer(layer.name)
    if not gs_layer:
        raise Exception(
            _("The selected Layer does not exists in the catalog."))
    gs_layer = gs_layer.resource.attributes
    schema_is_compliant = all([x in gs_layer for x in new_schema_fields])
    if not schema_is_compliant:
        raise Exception(
            _("Please ensure that the layer structure is consistent "
               f"with the file you are trying to {action_type}."))
```
- function named `gs_append_data_to_layer` which is responsible for the `APPEND `call to `geoserver`


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
