### PR TITLE
[Backport to 3.1.x][Fixes #7236] Issues with layer style legends displayed when more tha…

### DIFF
--- a/geonode/geoserver/helpers.py
+++ b/geonode/geoserver/helpers.py
@@ -1162,7 +1162,7 @@ def save_style(gs_style, layer):
     try:
         style, created = Style.objects.get_or_create(name=style_name)
         style.workspace = gs_style.workspace
-        style.sld_title = gs_style.sld_title if gs_style.style_format != 'css' else sld_name
+        style.sld_title = gs_style.sld_title if gs_style.style_format != 'css' and gs_style.sld_title else sld_name
         style.sld_body = gs_style.sld_body
         style.sld_url = gs_style.body_href
         style.save()

--- a/geonode/geoserver/views.py
+++ b/geonode/geoserver/views.py
@@ -533,13 +533,13 @@ def geoserver_proxy(request,
                     "[geoserver_proxy] Updating Style ---> url %s" %
                     url.geturl())
                 _style_name, _style_ext = os.path.splitext(os.path.basename(urlsplit(url.geturl()).path))
+                _parsed_get_args = dict(parse_qsl(urlsplit(url.geturl()).query))
                 if _style_name == 'styles.json' and request.method == "PUT":
-                    _parsed_get_args = dict(parse_qsl(urlsplit(url.geturl()).query))
-                    if 'name' in _parsed_get_args:
-                        _style_name, _style_ext = os.path.splitext(_parsed_get_args['name'])
+                    if _parsed_get_args.get('name'):
+                        _style_name, _style_ext = os.path.splitext(_parsed_get_args.get('name'))
                 else:
                     _style_name, _style_ext = os.path.splitext(_style_name)
-                if _style_name != 'style-check' and _style_ext == '.json' and \
+                if _style_name != 'style-check' and (_style_ext == '.json' or _parsed_get_args.get('raw')) and \
                 not re.match(temp_style_name_regex, _style_name):
                     affected_layers = style_update(request, raw_url)
             elif downstream_path == 'rest/layers':

--- a/geonode/layers/templates/layers/layer_detail.html
+++ b/geonode/layers/templates/layers/layer_detail.html
@@ -602,7 +602,8 @@
       {% if resource.default_style %}
       {% get_all_resource_styles resource as resource_styles_all%}
       {% for style in resource_styles_all %}
-          {% if resource.default_style == style or resource.default_style.name == style.name or resource.default_style.sld_title == style.sld_title %}
+        {% if style.name or style.sld_title %}
+          {% if resource.default_style == style or resource.default_style.name == style.name or style.sld_title and resource.default_style.sld_title == style.sld_title %}
               {% for legend in resource.get_legend %}
                   {% get_sld_name_from_url style.sld_url as sld_name %}
                   {% with "STYLE="|add:sld_name as style_name %}
@@ -619,6 +620,7 @@
                   {% endwith %}
               {% endfor %}
           {% endif %}
+        {% endif %}
       {% endfor %}
       {% else %}
         {% for legend in resource.get_legend %}


### PR DESCRIPTION
…n one style is selected (#7253)

(cherry picked from commit 8b0d62949bea0befa644d26776dcca3d831ac3c2)

# Conflicts:
#	geonode/geoserver/views.py

<Include a few sentences describing the overall goals for this Pull Request>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [ ] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [ ] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
