### PR TITLE
[Fixes #7292] Thumbnail failure when data bbox extends beyond the are a of use of EPSG:3857

### DIFF
--- a/geonode/thumbs/tests/test_unit.py
+++ b/geonode/thumbs/tests/test_unit.py
@@ -193,7 +193,7 @@ class ThumbnailsUnitTest(GeoNodeBaseTestSupport):
         self.assertEqual(locations, [[settings.OGC_SERVER["default"]["LOCATION"], [layer.alternate]]])
 
     def test_layers_locations_composition_map_default_bbox(self):
-        expected_bbox = [-18415954.05583559, 1414810.0631394347, -24064384.914356533, 16333507.057976719, "EPSG:3857"]
+        expected_bbox = [-18411664.521739896, 1414810.0631394347, -20040289.599925745, 16329038.485056704, 'EPSG:3857']
         expected_locations = [
             [
                 settings.GEOSERVER_LOCATION,


### PR DESCRIPTION
Refers: ISSUE #7292

Implemented solution
- for generating a default thumbnail (thumbnail generated in `EPSG:3857`; BBOX retrieved from `layer.bbox` of an instance), cropping the BBOX to the `EPSG:3857`'s area of use was introduced to ensure correct CRS transformations
- for the default thumbnail's CRS (`EPSG:3857`), the flow for BBOXes provided in `EPSG:3857` was preserved
- for the default thumbnail's CRS (`EPSG:3857`), for BBOXes provided in CRSs different from `EPSG:3857` an additional check was introduced, forcing the crop of the overflowing coordinates to `EPSG:3857`'s area of use
- for forced thumbnail's CRS (different from `EPSG:3857`; by default used in layers from external services), and additional check was introduced, turning off thumbnail's ratio preservation, in case of receiving a BBOX in CRS different from `EPSG:3857`
## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
