### PR TITLE
[Fixes #7312] Replace EPSG:900913 with EPSG:3857 inside metadata wizard's thumbnail widget

### DIFF
--- a/geonode/client/templates/ol/layers/layer_ol2_map.html
+++ b/geonode/client/templates/ol/layers/layer_ol2_map.html
@@ -64,17 +64,17 @@
         // olMap is used by thumbnail.js to POST to the thumbnail update view
     	var map = window.olMap = new OpenLayers.Map({
             div: 'preview_map',
-            projection: new OpenLayers.Projection('EPSG:900913'),
+            projection: new OpenLayers.Projection('EPSG:3857'),
             layers: layers,
             center: [0, 0],
             zoom: 2
     	});
 
     	if (bbox != null) {
-    	  if (crs != 'EPSG:900913') {
+    	  if (crs != 'EPSG:3857') {
           bbox = new OpenLayers.Bounds(bbox).transform(
             new OpenLayers.Projection(crs),
-            new OpenLayers.Projection("EPSG:900913"));
+            new OpenLayers.Projection("EPSG:3857"));
         }
     		map.zoomToExtent(bbox);
     	}

--- a/geonode/client/templates/ol/maps/map_ol2.html
+++ b/geonode/client/templates/ol/maps/map_ol2.html
@@ -20,7 +20,7 @@
     var center = [center_x, center_y];
     var settings_crs = '{{ crs }}';
     if (settings_crs != 'EPSG:4326') {
-        settings_crs = 'EPSG:900913';
+        settings_crs = 'EPSG:3857';
     }
     if ('EPSG:4326' != model_crs) {
         // if the two crs are not the same, user must have switched default crs for project after map was created
@@ -49,7 +49,7 @@
     // olMap is used by thumbnail.js to POST to the thumbnail update view
     window.olMap = new OpenLayers.Map({
         div: 'preview_map',
-        projection: new OpenLayers.Projection('EPSG:900913'),
+        projection: new OpenLayers.Projection('EPSG:3857'),
         layers: layers,
         center: center,
         zoom: zoom


### PR DESCRIPTION
References: #7312

The widget still uses the deprecated 900913, which most part of external services don't support anymore. This PR replaces it with EPSG:3857

<Include a few sentences describing the overall goals for this Pull Request>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [x] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
