### PR TITLE
[Fixes #7314] Wrong srid assigned to remote layer

### DIFF
--- a/geonode/layers/models.py
+++ b/geonode/layers/models.py
@@ -645,10 +645,12 @@ def pre_save_layer(instance, sender, **kwargs):
 
     if instance.bbox_polygon is None:
         instance.set_bbox_polygon((-180, -90, 180, 90), 'EPSG:4326')
-    instance.set_bounds_from_bbox(
-        instance.bbox_polygon,
-        instance.bbox_polygon.srid
-    )
+    if instance.ll_bbox_polygon is None or instance.srid is None:
+        instance.set_bounds_from_bbox(
+            instance.bbox_polygon,
+            instance.bbox_polygon.srid
+        )
+
     # Send a notification when a layer is created
     if instance.pk is None and instance.title:
         # Resource Created

--- a/geonode/services/models.py
+++ b/geonode/services/models.py
@@ -163,7 +163,7 @@ class Service(ResourceBase):
     @property
     def ptype(self):
         # Return the gxp ptype that should be used to display layers
-        return enumerations.GXP_PTYPES[self.type]
+        return enumerations.GXP_PTYPES[self.type] if self.type else None
 
     @property
     def service_type(self):

--- a/geonode/services/serviceprocessors/arcgis.py
+++ b/geonode/services/serviceprocessors/arcgis.py
@@ -20,6 +20,7 @@
 """Utilities for enabling ESRI:ArcGIS:MapServer and ESRI:ArcGIS:ImageServer remote services in geonode."""
 
 import os
+import re
 import logging
 import traceback
 
@@ -269,10 +270,26 @@ class ArcMapServiceHandler(base.ServiceHandlerBase):
             uuid=str(uuid4()),
             **resource_fields
         )
+        srid = geonode_layer.srid
+        bbox_polygon = geonode_layer.bbox_polygon
         geonode_layer.full_clean()
         geonode_layer.save(notify=True)
         geonode_layer.keywords.add(*keywords)
         geonode_layer.set_default_permissions()
+        if bbox_polygon and srid:
+            try:
+                # Dealing with the BBOX: this is a trick to let GeoDjango storing original coordinates
+                Layer.objects.filter(id=geonode_layer.id).update(
+                    bbox_polygon=bbox_polygon, srid='EPSG:4326')
+                match = re.match(r'^(EPSG:)?(?P<srid>\d{4,6})$', str(srid))
+                bbox_polygon.srid = int(match.group('srid')) if match else 4326
+                Layer.objects.filter(id=geonode_layer.id).update(
+                    ll_bbox_polygon=bbox_polygon, srid=srid)
+            except Exception as e:
+                logger.error(e)
+
+            # Refresh from DB
+            geonode_layer.refresh_from_db()
         return geonode_layer
 
     def _create_layer_thumbnail(self, geonode_layer):

--- a/geonode/services/serviceprocessors/wms.py
+++ b/geonode/services/serviceprocessors/wms.py
@@ -18,7 +18,7 @@
 #########################################################################
 
 """Utilities for enabling OGC WMS remote services in geonode."""
-
+import re
 import json
 import logging
 import requests
@@ -277,14 +277,30 @@ class WmsServiceHandler(base.ServiceHandlerBase,
             uuid=str(uuid4()),
             **resource_fields
         )
+        srid = geonode_layer.srid
+        bbox_polygon = geonode_layer.bbox_polygon
         geonode_layer.full_clean()
-        try:
-            geonode_layer.save(notify=True)
-        except Exception as e:
-            logger.error(e)
+        geonode_layer.save(notify=True)
         geonode_layer.keywords.add(*keywords)
         geonode_layer.set_default_permissions()
-        set_attributes_from_geoserver(geonode_layer)
+        try:
+            set_attributes_from_geoserver(geonode_layer)
+        except Exception as e:
+            logger.error(e)
+        if bbox_polygon and srid:
+            try:
+                # Dealing with the BBOX: this is a trick to let GeoDjango storing original coordinates
+                Layer.objects.filter(id=geonode_layer.id).update(
+                    bbox_polygon=bbox_polygon, srid='EPSG:4326')
+                match = re.match(r'^(EPSG:)?(?P<srid>\d{4,6})$', str(srid))
+                bbox_polygon.srid = int(match.group('srid')) if match else 4326
+                Layer.objects.filter(id=geonode_layer.id).update(
+                    ll_bbox_polygon=bbox_polygon, srid=srid)
+            except Exception as e:
+                logger.error(e)
+
+            # Refresh from DB
+            geonode_layer.refresh_from_db()
         return geonode_layer
 
     def _create_layer_thumbnail(self, geonode_layer):

--- a/test_dev.sh
+++ b/test_dev.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
-set -e
 set -a
 . ./.env_dev
 set +a
 
 # paver setup_data
-coverage run --branch --source=geonode manage.py test -v 3 --keepdb $@
+dropdb -U postgres test_geonode
+coverage run --branch --source=geonode manage.py test -v 3 $@


### PR DESCRIPTION
References: #7314

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
