### PR TITLE
[Fixes #7369] Thumbnail error for arcgis layers

### DIFF
--- a/geonode/services/serviceprocessors/arcgis.py
+++ b/geonode/services/serviceprocessors/arcgis.py
@@ -32,7 +32,6 @@ from django.utils.translation import ugettext as _
 
 from geonode.base.models import Link
 from geonode.layers.models import Layer
-from geonode.thumbs.thumbnails import create_thumbnail
 from geonode.base.bbox_utils import BBOXHelper
 
 from arcrest import MapService as ArcMapService, ImageService as ArcImageService
@@ -294,13 +293,10 @@ class ArcMapServiceHandler(base.ServiceHandlerBase):
 
     def _create_layer_thumbnail(self, geonode_layer):
         """Create a thumbnail with a WMS request."""
-        create_thumbnail(
-            instance=geonode_layer,
-            wms_version=self.parsed_service.version,
-            bbox=geonode_layer.bbox,
-            forced_crs=geonode_layer.srid if 'EPSG:' in str(geonode_layer.srid) else f'EPSG:{geonode_layer.srid}',
-            overwrite=True,
-        )
+        # The thumbnail generation implementation relies on WMS image retrieval, which fails for layers from ESRI
+        # services (not all of them support GetCapabilities or GetCapabilities path is different from the service's
+        # URL); in order to create a thumbnail for ESRI layer, a user must upload one.
+        logger.debug("Skipping thumbnail execution for layer from ESRI service.")
 
     def _create_layer_service_link(self, geonode_layer):
         Link.objects.get_or_create(


### PR DESCRIPTION
References: #7369

Unsupported thumbnail creation removal for ESRI layers (fix for code clarity).

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
