### PR TITLE
[Backport to 3.2.x][Fixes #7367] Error when Map Legend tries to read the name of the default style for a layer

### DIFF
--- a/geonode/maps/models.py
+++ b/geonode/maps/models.py
@@ -584,19 +584,13 @@ class MapLayer(models.Model, GXPLayerBase):
             layer_params = json.loads(self.layer_params)
 
             capability = layer_params.get('capability', {})
-            style_name = capability.get('style')
-            if style_name:
-                if ':' in style_name:
-                    style_name = style_name.split(':')[1]
-                href = Layer.objects.filter(title=self.layer_title).first().get_legend_url(style_name=style_name)
-                return {style_name: href}
-            else:
-                # use the default style on layer
-                layer_obj = Layer.objects.filter(alternate=self.name).first()
-                if layer_obj:
-                    default_style_name = layer_obj.default_style.name
-                    legend_url = layer_obj.get_legend_url(style_name=default_style_name)
-                    return {default_style_name: legend_url}
+            # Use '' to represent default layer style
+            style_name = capability.get('style', '')
+            layer_obj = Layer.objects.filter(alternate=self.name).first()
+            if ':' in style_name:
+                style_name = style_name.split(':')[1]
+            href = layer_obj.get_legend_url(style_name=style_name)
+            return {style_name: href}
         except Exception as e:
             logger.exception(e)
             return None


### PR DESCRIPTION
cherry-picked from https://github.com/GeoNode/geonode/commit/190e5f0939c3e89eca1d2dcd16f79cd867fba3a9

<Include a few sentences describing the overall goals for this Pull Request>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
