### PR TITLE
[Resolves #7375][Backport 3.2.x] Export thesauri

### DIFF
--- a/geonode/base/management/commands/dump_thesaurus.py
+++ b/geonode/base/management/commands/dump_thesaurus.py
@@ -1,0 +1,137 @@
+# -*- coding: utf-8 -*-
+#########################################################################
+#
+# Copyright (C) 2021 OSGeo
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#########################################################################
+
+from lxml import etree
+
+from django.core.management.base import BaseCommand, CommandError
+
+from geonode.base.models import Thesaurus, ThesaurusKeyword, ThesaurusKeywordLabel, ThesaurusLabel
+
+RDF_URI = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#'
+XML_URI = 'http://www.w3.org/XML/1998/namespace'
+SKOS_URI = 'http://www.w3.org/2004/02/skos/core#'
+DC_URI = 'http://purl.org/dc/elements/1.1/'
+DCTERMS_URI = 'http://purl.org/dc/terms/'
+
+RDF_NS = f'{{{RDF_URI}}}'
+XML_NS = f'{{{XML_URI}}}'
+SKOS_NS = f'{{{SKOS_URI}}}'
+DC_NS = f'{{{DC_URI}}}'
+DCTERMS_NS = f'{{{DCTERMS_URI}}}'
+
+
+class Command(BaseCommand):
+
+    help = 'Dump a thesaurus in RDF format'
+
+    def add_arguments(self, parser):
+
+        # Named (optional) arguments
+        parser.add_argument(
+            '--name',
+            dest='name',
+            help='Dump the thesaurus with the given name')
+
+        # Named (optional) arguments
+        parser.add_argument(
+            '-l',
+            '--list',
+            action="store_true",
+            dest='list',
+            default=False,
+            help='List available thesauri')
+
+    def handle(self, **options):
+
+        name = options.get('name')
+        list = options.get('list')
+
+        if not name and not list:
+            raise CommandError("Missing identifier name for the thesaurus (--name)")
+
+        if list:
+            self.list_thesauri()
+            return
+
+        self.dump_thesaurus(name)
+
+    def list_thesauri(self):
+        print('LISTING THESAURI')
+        max_id_len = len(max(Thesaurus.objects.values_list('identifier', flat=True), key=len))
+
+        for t in Thesaurus.objects.order_by('order').all():
+            if t.card_max==0:
+                card = 'DISABLED'
+            else:
+                # DISABLED
+                # [0..n]
+                card = f'[{t.card_min}..{t.card_max if t.card_max!=-1 else "N"}]  '
+            print(f'id:{t.id:2} sort:{t.order:3} {card} name={t.identifier.ljust(max_id_len)} title="{t.title}" URI:{t.about}')
+
+    def dump_thesaurus(self, name):
+        thesaurus = Thesaurus.objects.filter(identifier=name).get()
+
+        ns = {
+            None: SKOS_URI,
+            'rdf': RDF_URI,
+            'xml': XML_URI,
+            'dc': DC_URI,
+            'dcterms': DCTERMS_URI
+        }
+
+        root = etree.Element(RDF_NS + 'RDF', nsmap=ns)
+        concept_scheme = etree.SubElement(root, SKOS_NS + 'ConceptScheme')
+        concept_scheme.set(RDF_NS + 'about', thesaurus.about)
+
+        # Default title
+        # <dc:title xmlns:dc="http://purl.org/dc/elements/1.1/">GEMET - INSPIRE themes, version 1.0</dc:title>
+        title = etree.SubElement(concept_scheme, DC_NS + 'title')
+        title.text = thesaurus.title
+
+        # Localized titles
+        # <dc:title xmlns:dc="http://purl.org/dc/elements/1.1/" xml:lang="en">Limitations on public access</dc:title>
+        for ltitle in ThesaurusLabel.objects.filter(thesaurus=thesaurus).all():
+            title = etree.SubElement(concept_scheme, DC_NS + 'title')
+            title.set(XML_NS + "lang", ltitle.lang)
+            title.text = ltitle.label
+
+        d = etree.SubElement(concept_scheme, DCTERMS_NS + 'issued')
+        d.text = thesaurus.date
+        d = etree.SubElement(concept_scheme, DCTERMS_NS + 'modified')
+        d.text = thesaurus.date
+
+        # Concepts
+        for keyword in ThesaurusKeyword.objects.filter(thesaurus=thesaurus).all():
+            concept = etree.SubElement(concept_scheme, SKOS_NS + 'Concept')
+            if keyword.about:
+                concept.set(RDF_NS + 'about', keyword.about)
+
+            if keyword.alt_label:
+                # <skos:altLabel>cp</skos:altLabel>
+                label = etree.SubElement(concept, SKOS_NS + 'altLabel')
+                label.text = keyword.alt_label
+
+            for label in ThesaurusKeywordLabel.objects.filter(keyword=keyword).all():
+                # <skos:prefLabel xml:lang="en">Geographical grid systems</skos:prefLabel>
+                pref_label = etree.SubElement(concept, SKOS_NS + 'prefLabel')
+                pref_label.set(XML_NS + 'lang', label.lang)
+                pref_label.text = label.label
+
+        etree.dump(root, pretty_print=True)


### PR DESCRIPTION
Add a command to export a thesaurus.

## Help
```
$ python manage.py dump_thesaurus --help

usage: manage.py dump_thesaurus [-h] [--name NAME] [-l] [--version]
                                [-v {0,1,2,3}] [--settings SETTINGS]
                                [--pythonpath PYTHONPATH] [--traceback]
                                [--no-color] [--force-color]

Dump a thesaurus in RDF format

optional arguments:
  -h, --help            show this help message and exit
  --name NAME           Dump the thesaurus with the given name
  -l, --list            List available thesauri

[...other standard options...]
```

## List 
```
$ python manage.py dump_thesaurus --list

LISTING THESAURI
id: 2 sort:  0 DISABLED name=ConditionsApplyingToAccessAndUse title="Conditions Applying To Access and Use" URI:http://inspire.ec.europa.eu/metadata-codelist/ConditionsApplyingToAccessAndUse
id: 1 sort:  0 DISABLED name=LimitationsOnPublicAccess        title="Limitations on public access" URI:http://inspire.ec.europa.eu/metadata-codelist/LimitationsOnPublicAccess
id: 3 sort: 10 [1..N]   name=3-2-4-1-gemet-inspire-themes-rdf title="GEMET - INSPIRE themes, version 1.0" URI:http://inspire.ec.europa.eu/theme
id: 4 sort: 20 [0..N]   name=3-2-4-2-prioritydataset-rdf      title="INSPIRE priority data set" URI:http://inspire.ec.europa.eu/metadata-codelist/PriorityDataset
id: 5 sort: 30 [0..N]   name=3-2-4-3-spatialscope-rdf         title="Spatial scope" URI:http://inspire.ec.europa.eu/metadata-codelist/SpatialScope
id: 6 sort: 40 [0..N]   name=3-2-4-5-rndt-all1-fixed-rdf      title="Registro dei dati di interesse generale per il RNDT" URI:https://registry.geodati.gov.it/rndt-all1
id: 8 sort: 50 [0..N]   name=adbpo_bacino                     title="Bacino di riferimento" URI:None
id: 9 sort: 60 [0..N]   name=adbpo_pgra                       title="Piano alluvioni (PGRA)" URI:https://pianoalluvioni.adbpo.it
id:10 sort: 70 [0..N]   name=adbpo_pdgpo                      title="Piano acque (PdGPo)" URI:https://pianoacque.adbpo.it
id:11 sort: 80 [0..N]   name=adbpo_pai                        title="Piano assetto idrogeologico (PAI)" URI:https://pai.adbpo.it
id:12 sort: 90 [0..N]   name=adbpo_pbi                        title="Piano bilancio idrico (PBI)" URI:https://pianobilancioidrico.adbpo.it
id: 7 sort:100 [0..N]   name=adbpo_thesaurus                  title="Parole chiave controllate" URI:https://adbpo.it/thesaurus
```

## dump

```
$ python manage.py dump_thesaurus --name 3-2-4-1-gemet-inspire-themes-rdf 

<rdf:RDF xmlns="http://www.w3.org/2004/02/skos/core#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/">
  <ConceptScheme rdf:about="http://inspire.ec.europa.eu/theme">
    <dc:title>GEMET - INSPIRE themes, version 1.0</dc:title>
    <dc:title xml:lang="it">Temi INSPIRE</dc:title>
    <dcterms:issued>2008-06-01</dcterms:issued>
    <dcterms:modified>2008-06-01</dcterms:modified>
    <Concept rdf:about="http://inspire.ec.europa.eu/theme/ac">
      <altLabel>ac</altLabel>
      <prefLabel xml:lang="en">Atmospheric conditions</prefLabel>
      <prefLabel xml:lang="it">Condizioni atmosferiche</prefLabel>
    </Concept>
[...]
```

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
