### PR TITLE
[Fixes  #7393] Geoapp filters return values from the first geostory only

### DIFF
--- a/geonode/api/api.py
+++ b/geonode/api/api.py
@@ -111,8 +111,8 @@ class CountJSONSerializer(Serializer):
         counts = list()
         if subtypes:
             for subtype in subtypes:
-                counts.append(
-                    subtype.values(options['count_type']).annotate(count=Count(options['count_type'])).first()
+                counts.extend(
+                    list(subtype.values(options['count_type']).annotate(count=Count(options['count_type'])))
                 )
         else:
             counts = list(resources.values(options['count_type']).annotate(count=Count(options['count_type'])))


### PR DESCRIPTION
References: #7393

Fixes json count for geoapps owners.

![geoapps](https://user-images.githubusercontent.com/20810749/116206816-df8cdf00-a747-11eb-9475-d30a2a76643c.png)


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
