### PR TITLE
[Fixes #7442] Missing information for remote layers

### DIFF
--- a/geonode/base/api/tests.py
+++ b/geonode/base/api/tests.py
@@ -526,7 +526,7 @@ class BaseApiTests(APITestCase, URLPatternsTestCase):
         self.assertTrue('layer' in response.data['resource_types'])
         self.assertTrue('map' in response.data['resource_types'])
         self.assertTrue('document' in response.data['resource_types'])
-        self.assertTrue('service' in response.data['resource_types'])
+        self.assertFalse('service' in response.data['resource_types'])
 
     @patch('PIL.Image.open', return_value=test_image)
     def test_thumbnail_urls(self, img):

--- a/geonode/base/api/views.py
+++ b/geonode/base/api/views.py
@@ -212,6 +212,8 @@ class ResourceBaseViewSet(DynamicModelViewSet):
                 resource_types = [_m.__name__.lower() for _m in _model.__subclasses__()]
         if "geoapp" in resource_types:
             resource_types.remove("geoapp")
+        if "service" in resource_types:
+            resource_types.remove("service")
         if settings.GEONODE_APPS_ENABLE:
             from geonode.geoapps.models import GeoApp
             for label, app in apps.app_configs.items():

--- a/geonode/services/serviceprocessors/arcgis.py
+++ b/geonode/services/serviceprocessors/arcgis.py
@@ -110,6 +110,7 @@ class ArcMapServiceHandler(base.ServiceHandlerBase):
             method=self.indexing_method,
             owner=owner,
             parent=parent,
+            metadata_only=True,
             version=self.parsed_service._json_struct.get("currentVersion", 0.0),
             name=self.name,
             title=self.title,
@@ -117,6 +118,7 @@ class ArcMapServiceHandler(base.ServiceHandlerBase):
                 "Not provided"),
             online_resource=self.parsed_service.url,
         )
+        instance.save()
         return instance
 
     def get_keywords(self):

--- a/geonode/services/serviceprocessors/wms.py
+++ b/geonode/services/serviceprocessors/wms.py
@@ -191,6 +191,7 @@ class WmsServiceHandler(base.ServiceHandlerBase,
             method=self.indexing_method,
             owner=owner,
             parent=parent,
+            metadata_only=True,
             version=self.parsed_service.identification.version,
             name=self.name,
             title=self.parsed_service.identification.title or self.name,
@@ -198,6 +199,7 @@ class WmsServiceHandler(base.ServiceHandlerBase,
                 "Not provided"),
             online_resource=self.parsed_service.provider.url,
         )
+        instance.save()
         return instance
 
     def get_keywords(self):

--- a/geonode/services/tests.py
+++ b/geonode/services/tests.py
@@ -520,14 +520,15 @@ class WmsServiceHandlerTestCase(GeoNodeBaseTestSupport):
         self.phony_url = ("http://a-really-long-and-fake-name-here-so-that-"
                           "we-use-it-in-tests")
         self.phony_title = "a generic title"
-        self.phony_version = "some.version"
+        self.phony_version = "s.version"
         self.phony_layer_name = "phony_name"
         self.phony_keywords = ["first", "second"]
         mock_parsed_wms = mock.MagicMock(OwsWebMapService).return_value
         (url, mock_parsed_wms) = mock.MagicMock(WebMapService,
                                                 return_value=(self.phony_url,
                                                               mock_parsed_wms)).return_value
-        mock_parsed_wms.url = self.phony_url
+        mock_parsed_wms.provider.url = self.phony_url
+        mock_parsed_wms.identification.abstract = None
         mock_parsed_wms.identification.title = self.phony_title
         mock_parsed_wms.identification.version = self.phony_version
         mock_parsed_wms.identification.keywords = self.phony_keywords
@@ -625,6 +626,8 @@ class WmsServiceHandlerTestCase(GeoNodeBaseTestSupport):
         self.assertEqual(result.version, self.phony_version)
         self.assertEqual(result.name, handler.name)
         self.assertEqual(result.title, self.phony_title)
+        # mata_data_only is set to Try
+        self.assertTrue(result.metadata_only)
 
     @mock.patch("geonode.services.serviceprocessors.wms.WebMapService",
                 autospec=True)


### PR DESCRIPTION
References: #7442

- Creates remote services with resource_type and metadata_only=True
- Removes service from resource_types api

vice should not be returned in list of services
## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
