### PR TITLE
[Resolves #7441] Handle configuration for CSW pre-filtering

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,7 +128,7 @@ workflows:
           name: geonode_test_suite
           load_docker_cache: true
           save_docker_cache: false
-          test_suite: ./test.sh $(python -c "import sys;from geonode import settings;sys.stdout.write('\'' '\''.join([a+'\''.tests'\'' for a in settings.GEONODE_APPS]))") geonode.thumbs.tests
+          test_suite: ./test.sh $(python -c "import sys;from geonode import settings;sys.stdout.write('\'' '\''.join([a+'\''.tests'\'' for a in settings.GEONODE_APPS]))") geonode.catalogue.backends.tests geonode.thumbs.tests
           requires:
             - geonode_test_suite_smoke
       - build:

--- a/geonode/base/populate_test_data.py
+++ b/geonode/base/populate_test_data.py
@@ -335,11 +335,72 @@ def create_single_layer(name):
         temporal_extent_end=test_datetime,
         date=start,
         storeType="dataStore",
+        resource_type="layer"
     )
     layer.save()
     layer.set_default_permissions()
     layer.clear_dirty_state()
     return layer
+
+
+def create_single_map(name):
+    admin, created = get_user_model().objects.get_or_create(username='admin')
+    if created:
+        admin.is_superuser = True
+        admin.first_name = 'admin'
+        admin.set_password('admin')
+        admin.save()
+    test_datetime = datetime.strptime('2020-01-01', '%Y-%m-%d')
+    user = get_user_model().objects.get(username='AnonymousUser')
+    ll = (name, 'lorem ipsum', name, f'{name}', [
+        0, 22, 0, 22], test_datetime, ('populartag',))
+    title, abstract, name, alternate, (bbox_x0, bbox_x1, bbox_y0, bbox_y1), start, kws = ll
+    m = Map(
+        title=title,
+        abstract=abstract,
+        zoom=4,
+        projection='EPSG:4326',
+        center_x=42,
+        center_y=-73,
+        owner=user,
+        bbox_polygon=Polygon.from_bbox((bbox_x0, bbox_y0, bbox_x1, bbox_y1)),
+        ll_bbox_polygon=Polygon.from_bbox((bbox_x0, bbox_y0, bbox_x1, bbox_y1)),
+        srid='EPSG:4326',
+        resource_type="map"
+    )
+    m.save()
+    m.set_default_permissions()
+    m.clear_dirty_state()
+    return m
+
+
+def create_single_doc(name):
+    admin, created = get_user_model().objects.get_or_create(username='admin')
+    if created:
+        admin.is_superuser = True
+        admin.first_name = 'admin'
+        admin.set_password('admin')
+        admin.save()
+    test_datetime = datetime.strptime('2020-01-01', '%Y-%m-%d')
+    user = get_user_model().objects.get(username='AnonymousUser')
+    dd = (name, 'lorem ipsum', name, f'{name}', [
+        0, 22, 0, 22], test_datetime, ('populartag',))
+    title, abstract, name, alternate, (bbox_x0, bbox_x1, bbox_y0, bbox_y1), start, kws = dd
+    logger.debug(f"[SetUp] Add document {title}")
+    m = Document(
+        title=title,
+        abstract=abstract,
+        owner=user,
+        bbox_polygon=Polygon.from_bbox((bbox_x0, bbox_y0, bbox_x1, bbox_y1)),
+        ll_bbox_polygon=Polygon.from_bbox((bbox_x0, bbox_y0, bbox_x1, bbox_y1)),
+        srid='EPSG:4326',
+        doc_file=f,
+        resource_type="document"
+    )
+    m.save()
+    m.set_default_permissions()
+    m.clear_dirty_state()
+    return m
 
 
 if __name__ == '__main__':

--- a/geonode/catalogue/backends/pycsw_plugin.py
+++ b/geonode/catalogue/backends/pycsw_plugin.py
@@ -156,15 +156,17 @@ class GeoNodeRepository(Repository):
         # run the raw query and get total
         # we want to exclude layers which are not valid, as it is done in the
         # search engine
+        pycsw_filters = settings.PYCSW.get('FILTER', {'resource_type__in': ['layer']})
+
         if 'where' in constraint:  # GetRecords with constraint
             query = self._get_repo_filter(
-                ResourceBase.objects).extra(
+                ResourceBase.objects.filter(**pycsw_filters)).extra(
                 where=[
                     constraint['where']],
                 params=constraint['values'])
         else:  # GetRecords sans constraint
             query = self._get_repo_filter(
-                ResourceBase.objects)
+                ResourceBase.objects.filter(**pycsw_filters))
 
         total = query.count()
 

--- a/geonode/catalogue/backends/tests.py
+++ b/geonode/catalogue/backends/tests.py
@@ -1,0 +1,58 @@
+import ast
+from django.test.utils import override_settings
+from owslib.etree import etree
+from geonode.base.populate_test_data import create_single_doc, create_single_layer, create_single_map
+from django.contrib.auth.models import AnonymousUser
+from django.test.client import RequestFactory
+from geonode.catalogue.views import csw_global_dispatch
+from django.test import TestCase
+from django.conf import settings
+
+pycsw_settings = settings.PYCSW.copy()
+pycsw_settings_all = settings.PYCSW.copy()
+pycsw_settings['FILTER'] = {'resource_type__in': ['layer', 'map']}
+pycsw_settings_all['FILTER'] = {'resource_type__in': ['layer', 'map', 'document']}
+
+
+class TestGeoNodeRepository(TestCase):
+    # to simplify the tests we pass throught csw_global_dispatch
+    # since call the GeoNodeRepository.query
+    def setUp(self):
+        self.layer = create_single_layer("layer_name")
+        self.map = create_single_map("map_name")
+        self.doc = create_single_doc("doc_name")
+        self.request = self.__request_factory()
+
+    def test_if_pycsw_filter_is_not_set_should_return_only_the_layer_by_default(self):
+        response = csw_global_dispatch(self.request)
+        root = etree.fromstring(response.content)
+        child = [x.attrib for x in root.getchildren() if 'numberOfRecordsMatched' in x.attrib]
+        returned_results = ast.literal_eval(child[0].get('numberOfRecordsMatched', '0')) if child else 0
+        self.assertEqual(1, returned_results)
+
+    @override_settings(PYCSW=pycsw_settings)
+    def test_if_pycsw_filter_is_set_should_return_only_layers_and_map(self):
+        response = csw_global_dispatch(self.request)
+        root = etree.fromstring(response.content)
+        child = [x.attrib for x in root.getchildren() if 'numberOfRecordsMatched' in x.attrib]
+        returned_results = ast.literal_eval(child[0].get('numberOfRecordsMatched', '0')) if child else 0
+        self.assertEqual(2, returned_results)
+
+    @override_settings(PYCSW=pycsw_settings_all)
+    def test_if_pycsw_filter_is_set_should_return_all_layers_map_doc(self):
+        response = csw_global_dispatch(self.request)
+        root = etree.fromstring(response.content)
+        child = [x.attrib for x in root.getchildren() if 'numberOfRecordsMatched' in x.attrib]
+        returned_results = ast.literal_eval(child[0].get('numberOfRecordsMatched', '0')) if child else 0
+        self.assertEqual(3, returned_results)
+
+    @staticmethod
+    def __request_factory():
+        factory = RequestFactory()
+        url = "http://localhost:8000/catalogue/csw?request=GetRecords"
+        url += "&service=CSW&version=2.0.2&outputschema=http%3A%2F%2Fwww.isotc211.org%2F2005%2Fgmd"
+        url += "&elementsetname=brief&typenames=csw:Record&resultType=results"
+        request = factory.get(url)
+
+        request.user = AnonymousUser()
+        return request


### PR DESCRIPTION
References: #7441

With this PR i want to:
- Add test helper utility in order to create a single `Map` or `Document`
- Set new `pycsw_filters` in `GeoNodeRepository` with default value as `{'resource_type__in': ['layer']}`
- Tests in order to validate the method

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
