### PR TITLE
[Fixes #7429] Null references in thesauri items

### DIFF
--- a/geonode/api/tests.py
+++ b/geonode/api/tests.py
@@ -590,7 +590,7 @@ class ThesaurusKeywordResourceTests(ResourceTestCaseMixin, GeoNodeBaseTestSuppor
         url = f"{self.list_url}?thesaurus=inspire-theme"
         resp = self.api_client.get(url)
         self.assertValidJSONResponse(resp)
-        self.assertEqual(resp.json()["meta"]["total_count"], 34)
+        self.assertEqual(resp.json()["meta"]["total_count"], 36)
 
     def test_will_return_empty_if_the_alt_label_does_not_exists(self):
         url = f"{self.list_url}?alt_label=invalid-alt_label"
@@ -618,8 +618,8 @@ class ThesaurusKeywordResourceTests(ResourceTestCaseMixin, GeoNodeBaseTestSuppor
         resp = self.api_client.get(url)
         # the german translations exists, for the other labels, the alt_label will be used
         expected_labels = [
-            "ac", "Adressen", "af", "am", "au", "br", "bu",
-            "cp", "ef", "el", "er", "ge", "gg", "gn", "hb", "hh",
+            "", "ac", "Adressen", "af", "am", "au", "br", "bu",
+            "cp", "ef", "el", "er", "foo_keyword", "ge", "gg", "gn", "hb", "hh",
             "hy", "lc", "lu", "mf", "mr", "nz", "of", "oi", "pd",
             "pf", "ps", "rs", "sd", "so", "sr", "su", "tn", "us"
         ]
@@ -634,10 +634,10 @@ class ThesaurusKeywordResourceTests(ResourceTestCaseMixin, GeoNodeBaseTestSuppor
         resp = self.api_client.get(url)
         # no translations exists, the alt_label will be used for all keywords
         expected_labels = [
-            "ac", "ad", "af", "am", "au", "br", "bu",
-            "cp", "ef", "el", "er", "ge", "gg", "gn", "hb", "hh",
+            "", "ac", "ad", "af", "am", "au", "br", "bu",
+            "cp", "ef", "el", "er", "foo_keyword", "ge", "gg", "gn", "hb", "hh",
             "hy", "lc", "lu", "mf", "mr", "nz", "of", "oi", "pd",
-            "pf", "ps", "rs", "sd", "so", "sr", "su", "tn", "us"
+            "pf", "ps", "rs", "sd", "so", "sr", "su", "tn", "us",
         ]
         actual_labels = [x["alt_label"] for x in self.deserialize(resp)["objects"]]
         self.assertValidJSONResponse(resp)

--- a/geonode/base/fixtures/test_thesaurus.json
+++ b/geonode/base/fixtures/test_thesaurus.json
@@ -29,6 +29,21 @@
             "facet": true,
             "order": 0
         }
+      },{
+        "model": "base.thesaurus",
+        "pk": 3,
+        "fields": {
+            "identifier": "no-about-thesauro",
+            "title": "Thesauro without the about",
+            "date": "2021-05-23T10:25:56",
+            "description": "Thesauro without the about",
+            "slug": "",
+            "about": "",
+            "card_min": 0,
+            "card_max": -1,
+            "facet": true,
+            "order": 2
+        }
       },
       {
         "model": "base.thesauruskeyword",
@@ -334,6 +349,42 @@
             "about": "http://inspire.ec.europa.eu/theme/mf",
             "alt_label": "mf",
             "thesaurus": 1
+        }
+    },
+    {
+        "model": "base.thesauruskeyword",
+        "pk": 36,
+        "fields": {
+            "about": "",
+            "alt_label": "foo_keyword",
+            "thesaurus": 1
+        }
+    },
+    {
+        "model": "base.thesauruskeyword",
+        "pk": 37,
+        "fields": {
+            "about": "",
+            "alt_label": "",
+            "thesaurus": 1
+        }
+    },
+    {
+        "model": "base.thesauruskeyword",
+        "pk": 38,
+        "fields": {
+            "about": "",
+            "alt_label": "",
+            "thesaurus": 3
+        }
+    },
+    {
+        "model": "base.thesauruskeyword",
+        "pk": 39,
+        "fields": {
+            "about": "",
+            "alt_label": "bar_keyword",
+            "thesaurus": 3
         }
     },
     {

--- a/geonode/base/models.py
+++ b/geonode/base/models.py
@@ -542,6 +542,25 @@ class ThesaurusKeyword(models.Model):
         unique_together = (("thesaurus", "alt_label"),)
 
 
+def generate_thesaurus_reference(instance, *args, **kwargs):
+    if instance.about:
+        return instance.about
+
+    if instance.thesaurus.about and instance.alt_label:
+        instance.about = f'{instance.thesaurus.about}#{instance.alt_label}'
+    elif instance.thesaurus.about and not instance.alt_label:
+        instance.about = f'{instance.thesaurus.about}#{instance.id}'
+    elif not instance.thesaurus.about and instance.alt_label:
+        instance.about = f'{settings.SITEURL}/thesaurus/{instance.thesaurus.identifier}#{instance.alt_label}'
+    else:
+        instance.about = f'{settings.SITEURL}/thesaurus/{instance.thesaurus.identifier}#{instance.id}'
+
+    instance.save()
+    return instance.about
+
+signals.post_save.connect(generate_thesaurus_reference, sender=ThesaurusKeyword)
+
+
 class ThesaurusLabel(models.Model):
     """
     Contains localized version of the thesaurus title

--- a/geonode/base/models.py
+++ b/geonode/base/models.py
@@ -558,6 +558,7 @@ def generate_thesaurus_reference(instance, *args, **kwargs):
     instance.save()
     return instance.about
 
+
 signals.post_save.connect(generate_thesaurus_reference, sender=ThesaurusKeyword)
 
 

--- a/geonode/base/models.py
+++ b/geonode/base/models.py
@@ -546,14 +546,9 @@ def generate_thesaurus_reference(instance, *args, **kwargs):
     if instance.about:
         return instance.about
 
-    if instance.thesaurus.about and instance.alt_label:
-        instance.about = f'{instance.thesaurus.about}#{instance.alt_label}'
-    elif instance.thesaurus.about and not instance.alt_label:
-        instance.about = f'{instance.thesaurus.about}#{instance.id}'
-    elif not instance.thesaurus.about and instance.alt_label:
-        instance.about = f'{settings.SITEURL}/thesaurus/{instance.thesaurus.identifier}#{instance.alt_label}'
-    else:
-        instance.about = f'{settings.SITEURL}/thesaurus/{instance.thesaurus.identifier}#{instance.id}'
+    prefix = instance.thesaurus.about or f'{settings.SITEURL}/thesaurus/{instance.thesaurus.identifier}'
+    suffix = instance.alt_label or instance.id
+    instance.about = f'{prefix}#{suffix}'
 
     instance.save()
     return instance.about


### PR DESCRIPTION
References: #7429

- Add function `generate_thesaurus_reference` as `post_save` in order to generate the `about`  based on the specification provided into the issue #7429 
- Add new items in the test thesaurus json
- Test coverage for the new function

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
