### PR TITLE
[Fixes  #7494] "set permissions" operations should be done inside an atomic transaction

### DIFF
--- a/geonode/security/models.py
+++ b/geonode/security/models.py
@@ -22,12 +22,13 @@ import traceback
 import operator
 
 from functools import reduce
-from django.conf import settings
-from django.contrib.auth.models import Group, Permission
-from django.contrib.auth import get_user_model
-from django.contrib.contenttypes.models import ContentType
-from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import Q
+from django.conf import settings
+from django.db import transaction
+from django.contrib.auth import get_user_model
+from django.core.exceptions import ObjectDoesNotExist
+from django.contrib.auth.models import Group, Permission
+from django.contrib.contenttypes.models import ContentType
 
 from geonode.groups.conf import settings as groups_settings
 
@@ -141,6 +142,7 @@ class PermissionLevelMixin(object):
             pass
         return self
 
+    @transaction.atomic
     def set_default_permissions(self, owner=None):
         """
         Remove all the permissions except for the owner and assign the
@@ -236,6 +238,7 @@ class PermissionLevelMixin(object):
                 if anonymous_can_download:
                     sync_geofence_with_guardian(self.layer, perms, user=None, group=None)
 
+    @transaction.atomic
     def set_permissions(self, perm_spec, created=False):
         """
         Sets an object's the permission levels based on the perm_spec JSON.
@@ -342,6 +345,7 @@ class PermissionLevelMixin(object):
                     if self.polymorphic_ctype.name == 'layer':
                         sync_geofence_with_guardian(self.layer, perms)
 
+    @transaction.atomic
     def set_workflow_perms(self, approved=False, published=False):
         """
                           |  N/PUBLISHED   | PUBLISHED


### PR DESCRIPTION
References: #7494

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
