### PR TITLE
[Fixes #7525] Remove Geoserver keywords at layer creation time

### DIFF
--- a/geonode/geoserver/tasks.py
+++ b/geonode/geoserver/tasks.py
@@ -431,16 +431,9 @@ def geoserver_post_save_layers(
                         if instance.is_published != gs_resource.advertised:
                             gs_resource.advertised = 'true'
 
-                    if not settings.FREETEXT_KEYWORDS_READONLY:
-                        # AF: Warning - this won't allow people to have empty keywords on GeoNode
-                        if len(instance.keyword_list()) == 0 and gs_resource.keywords:
-                            for keyword in gs_resource.keywords:
-                                if keyword not in instance.keyword_list():
-                                    instance.keywords.add(keyword)
-
                     if any(instance.keyword_list()):
-                        keywords = instance.keyword_list()
-                        gs_resource.keywords = [kw for kw in list(set(keywords))]
+                        keywords = gs_resource.keywords + instance.keyword_list()
+                        gs_resource.keywords = list(set(keywords))
 
                     # gs_resource should only be called if
                     # ogc_server_settings.BACKEND_WRITE_ENABLED == True

--- a/geonode/tests/integration.py
+++ b/geonode/tests/integration.py
@@ -408,14 +408,14 @@ class GeoNodeMapTest(GeoNodeLiveTestSupport):
 
                 if check_ogc_backend(geoserver.BACKEND_PACKAGE):
                     self.assertEqual(
-                        len(uploaded.keyword_list()), 5,
+                        len(uploaded.keyword_list()), 0,
                         'Expected specific number of keywords from uploaded layer XML metadata')
 
                 self.assertTrue(
                     'Airport,Airports,Landing Strips,Runway,Runways' in uploaded.keyword_csv,
                     'Expected CSV of keywords from uploaded layer XML metadata')
 
-                self.assertTrue(
+                self.assertFalse(
                     'Landing Strips' in uploaded.keyword_list(),
                     'Expected specific keyword from uploaded layer XML metadata')
 
@@ -499,14 +499,14 @@ class GeoNodeMapTest(GeoNodeLiveTestSupport):
 
                     if check_ogc_backend(geoserver.BACKEND_PACKAGE):
                         self.assertEqual(
-                            len(uploaded.keyword_list()), 5,
+                            len(uploaded.keyword_list()), 0,
                             'Expected specific number of keywords from uploaded layer XML metadata')
 
                     self.assertTrue(
                         'Airport,Airports,Landing Strips,Runway,Runways' in uploaded.keyword_csv,
                         'Expected CSV of keywords from uploaded layer XML metadata')
 
-                    self.assertTrue(
+                    self.assertFalse(
                         'Landing Strips' in uploaded.keyword_list(),
                         'Expected specific keyword from uploaded layer XML metadata')
 
@@ -614,7 +614,7 @@ class GeoNodeMapTest(GeoNodeLiveTestSupport):
                 if os.path.exists(thelayer_zip):
                     uploaded = file_upload(thelayer_zip, overwrite=True, charset='UTF-8')
                     self.assertEqual(uploaded.title, 'Unesco Global Geoparks')
-                    self.assertEqual(len(uploaded.keyword_list()), 2)
+                    self.assertEqual(len(uploaded.keyword_list()), 0)
                     self.assertEqual(uploaded.constraints_other, None)
         finally:
             # Clean up and completely delete the layer


### PR DESCRIPTION
<Include a few sentences describing the overall goals for this Pull Request>
References #7525

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
