### PR TITLE
[Backport 3.2.x][Fixes #7536] Migration to update existing services with metadata_only=True

### DIFF
--- a/geonode/services/migrations/0042_update_metadata_only.py
+++ b/geonode/services/migrations/0042_update_metadata_only.py
@@ -1,0 +1,19 @@
+from django.db import migrations
+from django.db.migrations.operations import RunPython
+
+from geonode.services.models import Service
+
+
+def update_services_metadata_only(apps, schema_editor):
+    Service.objects.filter(metadata_only=False).update(metadata_only=True)
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('services', '0031_service_probe'),
+        ('services', '0041_auto_20190404_0820'),
+    ]
+
+    operations = [
+        RunPython(update_services_metadata_only)
+    ]


### PR DESCRIPTION
Co-authored-by: Giovanni Allegri <giohappy@gmail.com>
(cherry picked from commit 4811e71e09572409e77baca71b1fb89a9ea7832d)

<Include a few sentences describing the overall goals for this Pull Request>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [ ] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [ ] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
