### PR TITLE
[Backport to 3.2.x][Fixes #7557] Permissions set during the upload are lost (#7563)

### DIFF
--- a/geonode/geoapps/api/tests.py
+++ b/geonode/geoapps/api/tests.py
@@ -150,7 +150,7 @@ class BaseApiTests(APITestCase, URLPatternsTestCase):
         self.assertEqual(len(response.data['geoapps']), 1)
         self.assertTrue('data' in response.data['geoapps'][0])
         self.assertEqual(
-            response.data['geoapps'][0]['data'],
+            json.loads(response.data['geoapps'][0]['data']),
             {
                 "test_data": {
                     "test": [

--- a/geonode/geoserver/tasks.py
+++ b/geonode/geoserver/tasks.py
@@ -44,7 +44,6 @@ from geonode.utils import (
     is_monochromatic_image,
     set_resource_default_links)
 from geonode.geoserver.upload import geoserver_upload
-from geonode.security.utils import spec_perms_is_empty
 from geonode.catalogue.models import catalogue_post_save
 
 from .helpers import (
@@ -292,7 +291,7 @@ def geoserver_finalize_upload(
             logger.debug(f'Finalizing (permissions and notifications) Layer {instance}')
             instance.handle_moderated_uploads()
 
-            if permissions is not None and not spec_perms_is_empty(permissions):
+            if permissions is not None:
                 logger.debug(f'Setting permissions {permissions} for {instance.name}')
                 instance.set_permissions(permissions, created=created)
 

--- a/geonode/layers/tests.py
+++ b/geonode/layers/tests.py
@@ -314,7 +314,7 @@ class LayersTest(GeoNodeBaseTestSupport):
 
         self.assertEqual(
             set(lyr.keyword_list()), {
-                '&lt;IMG SRC=&#39;javascript:true;&#39;&gt;Science', 'Europe&lt;script&gt;true;&lt;/script&gt;',
+                '&lt;IMG SRC=&#x27;javascript:true;&#x27;&gt;Science', 'Europe&lt;script&gt;true;&lt;/script&gt;',
                 'here', 'keywords', 'land_&lt;script&gt;true;&lt;/script&gt;covering', 'populartag', 'saving',
                 'ß', 'ä', 'ö', 'ü', '論語'})
 

--- a/geonode/security/utils.py
+++ b/geonode/security/utils.py
@@ -843,22 +843,6 @@ def sync_resources_with_guardian(resource=None):
                     logger.warn(f"!WARNING! - Failure Synching-up Security Rules for Resource [{r}]")
 
 
-def spec_perms_is_empty(perm_spec):
-    _user_empty = True
-    if 'users' in perm_spec and len(perm_spec['users']) > 0:
-        for user, perms in perm_spec['users'].items():
-            if perms and len(perms) > 0:
-                _user_empty = False
-
-    _group_empty = True
-    if 'groups' in perm_spec and len(perm_spec['groups']) > 0:
-        for group, perms in perm_spec['groups'].items():
-            if perms and len(perms) > 0:
-                _group_empty = False
-
-    return (_user_empty and _group_empty)
-
-
 def get_resources_with_perms(user, filter_options={}, shortcut_kwargs={}):
     """
     Returns resources a user has access to.

--- a/geonode/tests/utils.py
+++ b/geonode/tests/utils.py
@@ -205,7 +205,7 @@ class Client(DjangoTestClient):
         self.csrf_token = self.get_csrf_token()
         self.response_cookies = response.headers.get('Set-Cookie')
 
-    def upload_file(self, _file):
+    def upload_file(self, _file, perms=None):
         """ function that uploads a file, or a collection of files, to
         the GeoNode"""
         if not self.csrf_token:
@@ -213,8 +213,8 @@ class Client(DjangoTestClient):
         spatial_files = ("dbf_file", "shx_file", "prj_file")
         base, ext = os.path.splitext(_file)
         params = {
-            # make public since wms client doesn't do authentication
-            'permissions': '{ "users": {"AnonymousUser": ["view_resourcebase"]} , "groups":{}}',
+            # make public if perms not provided since wms client doesn't do authentication
+            'permissions': perms or '{ "users": {"AnonymousUser": ["view_resourcebase"]} , "groups":{}}',
             'csrfmiddlewaretoken': self.csrf_token,
             'time': 'true',
             'charset': 'UTF-8'

--- a/geonode/upload/tests/integration.py
+++ b/geonode/upload/tests/integration.py
@@ -723,7 +723,13 @@ class TestUploadDBDataStore(UploaderBase):
         thefile = os.path.join(
             GOOD_DATA, 'time', f'{layer_name}.shp'
         )
-        resp, data = self.client.upload_file(thefile)
+        # Test upload with custom permissions
+        resp, data = self.client.upload_file(
+            thefile, perms='{"users": {"AnonymousUser": []}, "groups":{}}'
+            )
+        _layer = Layer.objects.get(name=layer_name)
+        _user = get_user_model().objects.get(username='AnonymousUser')
+        self.assertEqual(_layer.get_user_perms(_user).count(), 0)
 
         # initial state is no positions or info
         self.assertTrue(get_wms_timepositions() is None)


### PR DESCRIPTION
* update layer with perms set on upload

* - Add unit tests

* fix lgtm

* - fix failing tests

* remove unused function

(cherry picked from commit 6ee01f8f889bdb29e0dbe0d6f9f0f6a28ff4981c)

<Include a few sentences describing the overall goals for this Pull Request>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [ ] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [ ] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
