### PR TITLE
[Fixes #7603] RemoteServices legend urls do not contain 'sld_service' param

### DIFF
--- a/geonode/services/serviceprocessors/wms.py
+++ b/geonode/services/serviceprocessors/wms.py
@@ -41,7 +41,10 @@ from django.db.models import Q
 from django.template.defaultfilters import slugify
 from django.utils.translation import ugettext as _
 
-from geonode.base.models import Link, TopicCategory
+from geonode.base.models import (
+    Link,
+    ResourceBase,
+    TopicCategory)
 from geonode.layers.models import Layer
 from geonode.layers.utils import resolve_regions
 from geonode.thumbs.thumbnails import create_thumbnail
@@ -332,18 +335,21 @@ class WmsServiceHandler(base.ServiceHandlerBase,
             params=_p_url.query
         )
         logger.debug(f"legend_url: {legend_url}")
-        Link.objects.get_or_create(
-            resource=geonode_layer.resourcebase_ptr,
-            url=legend_url,
-            name='Legend',
-            defaults={
-                "extension": 'png',
-                "name": 'Legend',
-                "url": legend_url,
-                "mime": 'image/png',
-                "link_type": 'image',
-            }
-        )
+        try:
+            Link.objects.get_or_create(
+                resource=geonode_layer.resourcebase_ptr,
+                url=legend_url,
+                name='Legend',
+                defaults={
+                    "extension": 'png',
+                    "name": 'Legend',
+                    "url": legend_url,
+                    "mime": 'image/png',
+                    "link_type": 'image',
+                }
+            )
+        except ResourceBase.DoesNotExist as e:
+            logger.exception(e)
         return legend_url
 
     def _create_layer_service_link(self, geonode_layer):

--- a/geonode/services/serviceprocessors/wms.py
+++ b/geonode/services/serviceprocessors/wms.py
@@ -46,7 +46,7 @@ from geonode.layers.models import Layer
 from geonode.layers.utils import resolve_regions
 from geonode.thumbs.thumbnails import create_thumbnail
 from geonode.geoserver.helpers import set_attributes_from_geoserver
-from geonode.utils import http_client
+from geonode.utils import http_client, get_legend_url
 from geonode.base.bbox_utils import BBOXHelper
 
 from owslib.map import wms111, wms130
@@ -322,21 +322,15 @@ class WmsServiceHandler(base.ServiceHandlerBase,
         creating the legend by making a request directly to the original
         service.
         """
+        cleaned_url, service, version, request = WmsServiceHandler.get_cleaned_url_params(self.url)
         _p_url = urlparse(self.url)
-        _q_separator = "&" if _p_url.query else "?"
-        params = {
-            "service": "WMS",
-            "version": self.parsed_service.version,
-            "request": "GetLegendGraphic",
-            "format": "image/png",
-            "width": 20,
-            "height": 20,
-            "layer": geonode_layer.name,
-            "legend_options": (
-                "fontAntiAliasing:true;fontSize:12;forceLabels:on")
-        }
-        kvp = "&".join("{}={}".format(*item) for item in params.items())
-        legend_url = f"{geonode_layer.remote_service.service_url}{_q_separator}{kvp}"
+        legend_url = get_legend_url(
+            geonode_layer, "",
+            service_url=f"{_p_url.scheme}://{_p_url.netloc}{_p_url.path}",
+            layer_name=geonode_layer.name,
+            version=version,
+            params=_p_url.query
+        )
         logger.debug(f"legend_url: {legend_url}")
         Link.objects.get_or_create(
             resource=geonode_layer.resourcebase_ptr,
@@ -350,6 +344,7 @@ class WmsServiceHandler(base.ServiceHandlerBase,
                 "link_type": 'image',
             }
         )
+        return legend_url
 
     def _create_layer_service_link(self, geonode_layer):
         ogc_wms_url = geonode_layer.ows_url

--- a/geonode/services/tests.py
+++ b/geonode/services/tests.py
@@ -682,7 +682,7 @@ class WmsServiceHandlerTestCase(GeoNodeBaseTestSupport):
             self.assertEqual(HarvestJob.objects.filter(service=geonode_service,
                                                        resource_id=geonode_layer.alternate).count(), 0)
             legend_url = handler._create_layer_legend_link(geonode_layer)
-            self.assertContains(legend_url, 'sld_version')
+            self.assertTrue('sld_version=1.1.0' in str(legend_url))
         except Service.DoesNotExist as e:
             # In the case the Service URL becomes inaccessible for some reason
             logger.error(e)

--- a/geonode/services/tests.py
+++ b/geonode/services/tests.py
@@ -681,6 +681,8 @@ class WmsServiceHandlerTestCase(GeoNodeBaseTestSupport):
             Layer.objects.filter(remote_service=geonode_service).delete()
             self.assertEqual(HarvestJob.objects.filter(service=geonode_service,
                                                        resource_id=geonode_layer.alternate).count(), 0)
+            legend_url = handler._create_layer_legend_link(geonode_layer)
+            self.assertContains(legend_url, 'sld_version')
         except Service.DoesNotExist as e:
             # In the case the Service URL becomes inaccessible for some reason
             logger.error(e)


### PR DESCRIPTION
References: #7603

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
