### PR TITLE
[Fixes: GeoNode#7618] Very slow upload on large instance

### DIFF
--- a/geonode/utils.py
+++ b/geonode/utils.py
@@ -1667,11 +1667,11 @@ def set_resource_default_links(instance, layer, prune=False, **kwargs):
             try:
                 gs_resource = gs_catalog.get_resource(
                     name=instance.name,
+                    store=instance.store,
                     workspace=instance.workspace)
                 if not gs_resource:
                     gs_resource = gs_catalog.get_resource(
                         name=instance.name,
-                        store=instance.store,
                         workspace=instance.workspace)
                 if not gs_resource:
                     gs_resource = gs_catalog.get_resource(name=instance.name)


### PR DESCRIPTION
This PR fixes a slow upload behaviour in case a geonode instance has a lot of raster datastores (several thousands) in geoserver. For a user this results in a bad experience as the upload bar is stuck at 80%. My fix favours first a search with all attributes and if nothing is found a general search without the store.

Further Background:

#7618 
https://lists.osgeo.org/pipermail/geonode-devel/2021-May/003254.html

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
