### PR TITLE
[Fixes #7644] Api - filter favorite in /resources endpoint doesn't return all favorites item

### DIFF
--- a/geonode/base/api/serializers.py
+++ b/geonode/base/api/serializers.py
@@ -340,7 +340,7 @@ class ResourceBaseSerializer(BaseDynamicModelSerializer):
             )
             if not request.user.is_anonymous:
                 favorite = Favorite.objects.filter(user=request.user, object_id=instance.pk).count()
-                data['favourite'] = favorite > 0
+                data['favorite'] = favorite > 0
         return data
 
 

--- a/geonode/base/api/views.py
+++ b/geonode/base/api/views.py
@@ -25,6 +25,7 @@ from django.db.models import Subquery
 from drf_spectacular.utils import extend_schema
 from dynamic_rest.viewsets import DynamicModelViewSet, WithDynamicViewSetMixin
 from dynamic_rest.filters import DynamicFilterBackend, DynamicSortingFilter
+from django.contrib.contenttypes.models import ContentType
 
 from rest_framework.mixins import ListModelMixin, RetrieveModelMixin
 from rest_framework.viewsets import GenericViewSet
@@ -283,7 +284,8 @@ class ResourceBaseViewSet(DynamicModelViewSet):
                 Favorite.objects.get(user=user, object_id=resource.pk)
                 return Response({"message": "Resource is already in favorites"}, status=400)
             except Favorite.DoesNotExist:
-                Favorite.objects.create_favorite(resource, user)
+                content_type = ContentType.objects.get(model=resource.resource_type)
+                Favorite.objects.create_favorite(resource, user, content_type)
                 return Response({"message": "Successfuly added resource to favorites"}, status=201)
 
         if request.method == 'DELETE':

--- a/geonode/base/api/views.py
+++ b/geonode/base/api/views.py
@@ -25,7 +25,6 @@ from django.db.models import Subquery
 from drf_spectacular.utils import extend_schema
 from dynamic_rest.viewsets import DynamicModelViewSet, WithDynamicViewSetMixin
 from dynamic_rest.filters import DynamicFilterBackend, DynamicSortingFilter
-from django.contrib.contenttypes.models import ContentType
 
 from rest_framework.mixins import ListModelMixin, RetrieveModelMixin
 from rest_framework.viewsets import GenericViewSet
@@ -284,8 +283,7 @@ class ResourceBaseViewSet(DynamicModelViewSet):
                 Favorite.objects.get(user=user, object_id=resource.pk)
                 return Response({"message": "Resource is already in favorites"}, status=400)
             except Favorite.DoesNotExist:
-                content_type = ContentType.objects.get(model=resource.resource_type)
-                Favorite.objects.create_favorite(resource, user, content_type)
+                Favorite.objects.create_favorite(resource, user)
                 return Response({"message": "Successfuly added resource to favorites"}, status=201)
 
         if request.method == 'DELETE':

--- a/geonode/favorite/models.py
+++ b/geonode/favorite/models.py
@@ -18,6 +18,7 @@
 #
 #########################################################################
 
+from geonode.base.models import ResourceBase
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
@@ -78,8 +79,12 @@ class FavoriteManager(models.Manager):
             favs[ct.name] = m.objects.filter(id__in=f.values('object_id'))
         return favs
 
-    def create_favorite(self, content_object, user, resource_type = None):
-        content_type = ContentType.objects.get_for_model(type(content_object)) if not resource_type else resource_type
+    def create_favorite(self, content_object, user):
+        if type(content_object) == ResourceBase:
+            content_type = ContentType.objects.get(model=content_object.resource_type)
+        else:
+            content_type = ContentType.objects.get_for_model(type(content_object))
+
         favorite, _ = self.get_or_create(
             user=user,
             content_type=content_type,

--- a/geonode/favorite/models.py
+++ b/geonode/favorite/models.py
@@ -78,8 +78,8 @@ class FavoriteManager(models.Manager):
             favs[ct.name] = m.objects.filter(id__in=f.values('object_id'))
         return favs
 
-    def create_favorite(self, content_object, user):
-        content_type = ContentType.objects.get_for_model(type(content_object))
+    def create_favorite(self, content_object, user, resource_type = None):
+        content_type = ContentType.objects.get_for_model(type(content_object)) if not resource_type else resource_type
         favorite, _ = self.get_or_create(
             user=user,
             content_type=content_type,

--- a/geonode/favorite/tests.py
+++ b/geonode/favorite/tests.py
@@ -18,6 +18,8 @@
 #
 #########################################################################
 
+from geonode.base.models import ResourceBase
+from geonode.base.populate_test_data import create_single_layer
 from geonode.tests.base import GeoNodeBaseTestSupport
 
 import json
@@ -89,6 +91,27 @@ class FavoriteTest(GeoNodeBaseTestSupport):
         self.assertEqual(len(bulk_favorites["layer"]), 0)
         self.assertEqual(len(bulk_favorites["map"]), 0)
         self.assertEqual(len(bulk_favorites["user"]), 0)
+
+    def test_given_resource_base_object_will_assign_subtype_as_content_type(self):
+        test_user = get_user_model().objects.first()
+
+        '''
+        If the input object is a ResourceBase, in favorite content type, should be saved he
+        subtype content type (Doc, Layer, Map or GeoApp)
+        '''
+        create_single_layer('foo_layer')
+        resource = ResourceBase.objects.get(title='foo_layer')
+        created_fav = Favorite.objects.create_favorite(resource, test_user)
+        self.assertEqual('layer', created_fav.content_type.model)
+
+        '''
+        If the input object is a subtype, should save the relative content type
+        '''
+        test_document_1 = Document.objects.first()
+        Favorite.objects.create_favorite(test_document_1, test_user)
+        fav = Favorite.objects.last()
+        ct = ContentType.objects.get_for_model(test_document_1)
+        self.assertEqual(fav.content_type, ct)
 
     # tests of view methods.
     def test_create_favorite_view(self):


### PR DESCRIPTION
References: #7644

From the `api/v2/resources/{id}/favorite` endpoint, the `content_type` of the resource is set as `resourcebase` in the favorite table, while from the Layer/Document/app table, is correctly assigned -> `['document', 'geostory', 'map', 'layer']`

So this means that the `FavoriteFilter` when is called, filter for the `resource_type` available in the queryset (for reducing the weight of the query)

With this PR I want to assign the correct subtype of the resource even if a `resourcebase` is sent to the favorite creation

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
