### PR TITLE
geonode-updateip: Allow -s/--secure to be before other options

### DIFF
--- a/package/support/geonode.updateip
+++ b/package/support/geonode.updateip
@@ -30,11 +30,11 @@ if [[ $# -eq 0 ]] ; then
 fi
 
 POSITIONAL=()
+IS_HTTPS=0
 while [[ $# -gt 0 ]]
 do
 key="$1"
 
-IS_HTTPS=0
 case $key in
     -h|--help)
         usage 0


### PR DESCRIPTION
If you run `geonode-update -s -p 1.2.3.4`, the -s option is discarded.
This commit puts the IS_HTTPS flag outside of the arguments loop, to preserve its value.