### PR TITLE
[Fixes #7676] Search by thesauri items fails

### DIFF
--- a/geonode/base/views.py
+++ b/geonode/base/views.py
@@ -323,15 +323,19 @@ class ThesaurusAvailable(autocomplete.Select2QuerySetView):
     def get_queryset(self):
         tid = self.request.GET.get("sysid")
         lang = self.request.GET.get("lang")
-
         qs_local = []
         qs_non_local = []
         for key in ThesaurusKeyword.objects.filter(thesaurus_id=tid):
             label = ThesaurusKeywordLabel.objects.filter(keyword=key).filter(lang=lang)
+            if self.q:
+                label = label.filter(label__icontains=self.q)
             if label.exists():
                 qs_local.append(label.get())
             else:
-                qs_non_local.append(key)
+                if self.q in key.alt_label:
+                    qs_non_local.append(key)
+                elif not self.q:
+                    qs_non_local.append(key)
 
         return qs_non_local + qs_local
 


### PR DESCRIPTION
Add filters for searched value.
- If is a keyword label we use ORM in order to filter the results required
- if not (this means that the lable does not exists for the selected language), just check if the letters are contained in the keyword label
- In case of both are not true, the keyword will be excluded from the results


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
