### PR TITLE
[Fixes #7675] Problem creating thumbnail

### DIFF
--- a/geonode/thumbs/thumbnails.py
+++ b/geonode/thumbs/thumbnails.py
@@ -255,6 +255,8 @@ def _layers_locations(
              and a list optionally consisting of 5 elements containing west, east, south, north
              instance's boundaries and CRS
     """
+    ogc_server_settings = OGC_Servers_Handler(settings.OGC_SERVER)["default"]
+
     locations = []
     bbox = []
 
@@ -262,7 +264,7 @@ def _layers_locations(
 
         # for local layers
         if instance.remote_service is None:
-            locations.append([settings.OGC_SERVER["default"]["LOCATION"], [instance.alternate]])
+            locations.append([ogc_server_settings.LOCATION, [instance.alternate]])
         # for remote layers
         else:
             locations.append([instance.remote_service.service_url, [instance.alternate]])

--- a/geonode/thumbs/utils.py
+++ b/geonode/thumbs/utils.py
@@ -184,6 +184,9 @@ def get_map(
     else:
         thumbnail_url = ogc_server_settings.LOCATION
 
+    if thumbnail_url.startswith(ogc_server_settings.PUBLIC_LOCATION):
+        thumbnail_url = thumbnail_url.replace(ogc_server_settings.PUBLIC_LOCATION, ogc_server_settings.LOCATION)
+
     wms_endpoint = ""
     additional_kwargs = {}
     if thumbnail_url == ogc_server_settings.LOCATION:
@@ -201,7 +204,7 @@ def get_map(
     # prepare authorization for WMS service
     headers = {}
     if "access_token" not in additional_kwargs.keys():
-        if thumbnail_url.startswith(settings.OGC_SERVER["default"]["LOCATION"]):
+        if thumbnail_url.startswith(ogc_server_settings.LOCATION):
             # for the Geoserver backend, use Basic Auth, if access_token is not provided
             _user = settings.OGC_SERVER["default"].get("USER")
             _pwd = settings.OGC_SERVER["default"].get("PASSWORD")


### PR DESCRIPTION
References: #7675

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
