### PR TITLE
[Backport to 3.2.x] [Fixes #7741] Expose document link as embed_url inside API v2 response

### DIFF
--- a/geonode/documents/api/tests.py
+++ b/geonode/documents/api/tests.py
@@ -34,7 +34,7 @@ from geonode.documents.models import Document
 from geonode.maps.views import map_embed
 from geonode.geoapps.views import geoapp_edit
 from geonode.layers.views import layer_upload, layer_embed
-from geonode.documents.views import document_download
+from geonode.documents.views import document_download, document_link
 
 from geonode import geoserver
 from geonode.utils import check_ogc_backend
@@ -91,6 +91,9 @@ class DocumentsApiTests(APITestCase, URLPatternsTestCase):
         url(r'^(?P<mapid>[^/]+)/embed$', map_embed, name='map_embed'),
         url(r'^(?P<layername>[^/]+)/embed$', layer_embed, name='layer_embed'),
         url(r'^(?P<geoappid>[^/]+)/embed$', geoapp_edit, {'template': 'apps/app_embed.html'}, name='geoapp_embed'),
+        url(r'^developer/$', TemplateView.as_view(template_name='developer.html'), name='developer'),
+        url(r'^about/$', TemplateView.as_view(template_name='about.html'), name='about'),
+        url(r'^(?P<docid>\d+)/link/?$', document_link, name='document_link'),
     ]
 
     if check_ogc_backend(geoserver.BACKEND_PACKAGE):
@@ -117,6 +120,10 @@ class DocumentsApiTests(APITestCase, URLPatternsTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 5)
         self.assertEqual(response.data['total'], 9)
+
+        # Test embed_url is provided
+        self.assertIn('link', response.data['documents'][0]['embed_url'])
+
         # Pagination
         self.assertEqual(len(response.data['documents']), 9)
         logger.debug(response.data)

--- a/geonode/documents/models.py
+++ b/geonode/documents/models.py
@@ -140,6 +140,10 @@ class Document(ResourceBase):
     def class_name(self):
         return self.__class__.__name__
 
+    @property
+    def embed_url(self):
+        return reverse('document_link', args=(self.id,))
+
     class Meta(ResourceBase.Meta):
         pass
 


### PR DESCRIPTION
(cherry picked from commit dcaaed932b37131b0ce37a15b8641111d9f21106)

<Include a few sentences describing the overall goals for this Pull Request>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [ ] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [ ] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
