### PR TITLE
[Fixes #7750] GeoNode shows incorrect keywords

### DIFF
--- a/geonode/base/factories.py
+++ b/geonode/base/factories.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+#########################################################################
+#
+# Copyright (C) 2021 Open Source Geospatial Foundation - all rights reserved
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#########################################################################
+
+from django.contrib.auth import get_user_model
+
+import factory
+
+from geonode.layers.models import Layer
+from geonode.maps.models import Map
+from geonode.documents.models import Document
+
+
+class UserFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = get_user_model()
+
+    username = factory.Sequence(lambda n: f"Username {n+1}")
+    email = factory.Sequence(lambda n: f"email{n+1}@geonodetests.com")
+
+
+class LayerFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = Layer
+
+    owner = factory.SubFactory(UserFactory)
+    title = factory.Sequence(lambda n: f"Layer {n+1}")
+
+    @factory.post_generation
+    def keywords(self, create, extracted, **kwargs):
+        if not create:
+            # Simple build strategy.
+            return
+
+        if extracted:
+            # Use the passed in list
+            for keyword in extracted:
+                self.keywords.add(keyword)
+
+
+class MapFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = Map
+
+    owner = factory.SubFactory(UserFactory)
+    title = factory.Sequence(lambda n: f"Map {n+1}")
+    zoom = 0
+    center_x = 0.0
+    center_y = 0.0
+
+    @factory.post_generation
+    def keywords(self, create, extracted, **kwargs):
+        if not create:
+            return
+
+        if extracted:
+            for keyword in extracted:
+                self.keywords.add(keyword)
+
+
+class DocumentFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = Document
+
+    owner = factory.SubFactory(UserFactory)
+    title = factory.Sequence(lambda n: f"Document {n+1}")
+
+    @factory.post_generation
+    def keywords(self, create, extracted, **kwargs):
+        if not create:
+            return
+
+        if extracted:
+            for keyword in extracted:
+                self.keywords.add(keyword)

--- a/geonode/base/models.py
+++ b/geonode/base/models.py
@@ -345,7 +345,8 @@ class HierarchicalKeyword(TagBase, MP_Node):
         """Dumps a tree branch to a python data structure."""
         user = user or get_anonymous_user()
         ctype_filter = [type, ] if type else ['layer', 'map', 'document']
-        qset = cls._get_serializable_model().get_tree(parent)
+        qset = cls.get_tree(parent)
+
         if settings.SKIP_PERMS_FILTER:
             resources = ResourceBase.objects.all()
         else:
@@ -356,56 +357,50 @@ class HierarchicalKeyword(TagBase, MP_Node):
         resources = resources.filter(
             polymorphic_ctype__model__in=ctype_filter,
         )
+
+        # Resources should be clean & public.
+        # Refer: set_default_permissions() and clear_dirty_state()
         resources = get_visible_resources(
             resources,
             user,
             admin_approval_required=settings.ADMIN_MODERATE_UPLOADS,
             unpublished_not_visible=settings.RESOURCE_PUBLISHING,
             private_groups_not_visibile=settings.GROUP_PRIVATE_RESOURCES)
-        ret, lnk = [], {}
-        try:
-            for pyobj in qset.order_by('name'):
-                serobj = serializers.serialize('python', [pyobj])[0]
-                # django's serializer stores the attributes in 'fields'
-                fields = serobj['fields']
-                depth = fields['depth'] or 1
-                tags_count = 0
-                try:
-                    tags_count = TaggedContentItem.objects.filter(
-                        content_object__in=resources,
-                        tag=HierarchicalKeyword.objects.get(slug=fields['slug'])).count()
-                except Exception:
-                    pass
-                if tags_count > 0:
-                    fields['text'] = fields['name']
-                    fields['href'] = fields['slug']
-                    fields['tags'] = [tags_count]
-                    del fields['name']
-                    del fields['slug']
-                    del fields['path']
-                    del fields['numchild']
-                    del fields['depth']
-                    if 'id' in fields:
-                        # this happens immediately after a load_bulk
-                        del fields['id']
-                    newobj = {}
-                    for field in fields:
-                        newobj[field] = fields[field]
-                    if keep_ids:
-                        newobj['id'] = serobj['pk']
 
-                    if (not parent and depth == 1) or \
-                            (parent and depth == parent.depth):
-                        ret.append(newobj)
-                    else:
-                        parentobj = pyobj.get_parent()
-                        parentser = lnk[parentobj.pk]
-                        if 'nodes' not in parentser:
-                            parentser['nodes'] = []
-                        parentser['nodes'].append(newobj)
-                    lnk[pyobj.pk] = newobj
-        except Exception:
-            pass
+        ret = []
+
+        for h_keyword in qset.order_by('name'):
+            serialized_hkw = serializers.serialize('python', [h_keyword])[0]
+
+            # django's serializer stores the attributes in 'fields'
+            fields = serialized_hkw['fields']
+
+            tags_count = 0
+            tags_count = TaggedContentItem.objects.filter(
+                content_object__in=resources,
+                tag=HierarchicalKeyword.objects.get(slug=fields['slug'])).count()
+
+            if tags_count > 0:
+                fields['text'] = fields.pop('name')
+                fields['href'] = fields.pop('slug')
+                fields['tags'] = [tags_count]
+                del fields['path']
+                del fields['numchild']
+                del fields['depth']
+
+                if 'id' in fields:
+                    # this happens immediately after a load_bulk
+                    del fields['id']
+
+                newobj = {}
+                for field in fields:
+                    newobj[field] = fields[field]
+
+                if keep_ids:
+                    newobj['id'] = serialized_hkw['pk']
+
+                ret.append(newobj)
+
         return ret
 
 

--- a/geonode/base/templatetags/base_tags.py
+++ b/geonode/base/templatetags/base_tags.py
@@ -425,6 +425,7 @@ def display_change_perms_button(resource, user, perms):
     else:
         return not getattr(settings, 'ADMIN_MODERATE_UPLOADS', False)
 
+
 @register.simple_tag
 def get_layer_count_by_services(service_id, user):
     return get_visible_resources(

--- a/geonode/base/utils.py
+++ b/geonode/base/utils.py
@@ -218,3 +218,8 @@ class ManageResourceOwnerPermissions:
                     assign_perm(perm, self.resource.owner, self.resource)
                 elif perm not in {'change_resourcebase_permissions', 'publish_resourcebase'}:
                     assign_perm(perm, self.resource.owner, self.resource)
+
+
+def make_public(resource):
+    resource.set_default_permissions()
+    resource.clear_dirty_state()


### PR DESCRIPTION
<Include a few sentences describing the overall goals for this Pull Request>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [X] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [X] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [X] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [X] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [X] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [X] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [X] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**

Seeing the issues in the previous testing I approached for using far lighter `APITestCase` and avoided the `GeoNodeBaseTestSupport` mixin and created `factories` in the base app, which I have not only used for this test but it also worked for the earlier test case which failed for the 'exotic encoding text'. In future we can use the factories to avoid, wherever intended, the `GeoNodeBaseTestSupport` which is far heavier, and `create_layer_data()` which is 'hard-coded' data so also obscure the data for readability of the tests.

Also added in the base.utils the `make_public` function as cleaning the 'dirty_state' and making public of a resource, goes hand in hand here, and have many use cases.
