### PR TITLE
[Fixes #7735] Editing layer metadata in admin interface throws an error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
 
       - run:
           name: Build the stack
-          command: docker-compose -f docker-compose-test.yml build
+          command: docker-compose -f docker-compose-test.yml build --no-cache
           working_directory: ./
 
       - when:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Change Log
 
+## [3.2.1](https://github.com/GeoNode/geonode/tree/3.2.1) (2021-07-16)
+
+### Breaking Changes
+
+ - Based on MapStore client [3.2.1](https://github.com/GeoNode/geonode-mapstore-client/releases/tag/3.2.1)
+ - MapStore client is no more compatible with 3.0.x train
+ - [GNIP 88: Upgrade from Django 2.2 to 3.2](https://github.com/GeoNode/geonode/issues/7366)
+   - Not compatible anymore with Django 2.2.*
+
+### Features
+
+ - Python upgrade 3.7+
+ - Django upgrade 2.2.20+
+ - GeoServer upgrade 2.18.3
+
+ - Highlights GeoNode 3.2:
+   - [Introduce the adoption of groups to define users permissions, and define add_resource permission for users](https://github.com/GeoNode/geonode/issues/7355)
+
+  - [Features](https://github.com/GeoNode/geonode/issues?q=is%3Aissue+is%3Aclosed+milestone%3A3.2.1+label%3Afeature)
+  - [Enhancements](https://github.com/GeoNode/geonode/issues?q=is%3Aissue+is%3Aclosed+milestone%3A3.2.1+label%3Aenhancement)
+  - [Security Fixes](https://github.com/GeoNode/geonode/issues?q=is%3Aissue+is%3Aclosed+milestone%3A3.2.1+label%3Asecurity)
+  - [Severe Issues](https://github.com/GeoNode/geonode/issues?q=is%3Aissue+is%3Aclosed+milestone%3A3.2.1+label%3Ablocker)
+  - [Regressions](https://github.com/GeoNode/geonode/issues?q=is%3Aissue+is%3Aclosed+milestone%3A3.2.1+label%3Aregression)
+  - [Bug Fixes](https://github.com/GeoNode/geonode/issues?q=is%3Aissue+is%3Aclosed+milestone%3A3.2.1+label%3Amajor)
+  - [Minor Issues](https://github.com/GeoNode/geonode/issues?q=is%3Aissue+is%3Aclosed+milestone%3A3.2.1+label%3Aminor)
+  - [Performance](https://github.com/GeoNode/geonode/issues?q=is%3Aissue+is%3Aclosed+milestone%3A3.2.1+label%3Aperformance)
+  - [Translations](https://github.com/GeoNode/geonode/issues?q=is%3Aissue+is%3Aclosed+milestone%3A3.2.1+label%3Atranslations)
+  - [Dependencies](https://github.com/GeoNode/geonode/pulls?q=is%3Apr+is%3Aclosed+milestone%3A3.2.1+label%3Adependencies)
+
+### Full Changelog
+
+[https://github.com/GeoNode/geonode/compare/3.2.0...3.2.1](https://github.com/GeoNode/geonode/compare/3.2.0...3.2.1)
+
 ## [3.2.0](https://github.com/GeoNode/geonode/tree/3.2.0) (2021-04-29)
 ### Breaking Changes
 

--- a/geonode/base/models.py
+++ b/geonode/base/models.py
@@ -30,7 +30,6 @@ from sequences import get_next_value
 from django.db import models
 from django.db.models import Max
 from django.conf import settings
-from django.core import serializers
 from django.utils.html import escape
 from django.utils.timezone import now
 from django.db.models import Q, signals
@@ -68,9 +67,10 @@ from geonode.singleton import SingletonModel
 from geonode.base.bbox_utils import BBOXHelper, polygon_from_bbox
 from geonode.utils import (
     bbox_to_wkt,
+    find_by_attr,
     is_monochromatic_image)
 from geonode.groups.models import GroupProfile
-from geonode.security.utils import get_visible_resources
+from geonode.security.utils import get_visible_resources, get_geoapp_subtypes
 from geonode.security.models import PermissionLevelMixin
 
 from geonode.notifications_helper import (
@@ -334,15 +334,15 @@ class HierarchicalKeywordManager(MP_NodeManager):
 
 class HierarchicalKeyword(TagBase, MP_Node):
     node_order_by = ['name']
-
     objects = HierarchicalKeywordManager()
 
     @classmethod
-    def dump_bulk_tree(cls, user, parent=None, keep_ids=True, type=None):
-        """Dumps a tree branch to a python data structure."""
+    def resource_keywords_tree(cls, user, parent=None, resource_type=None, resource_name=None):
+        """ Returns resource keywords tree as a dict object. """
         user = user or get_anonymous_user()
-        ctype_filter = [type, ] if type else ['layer', 'map', 'document']
-        qset = cls._get_serializable_model().get_tree(parent)
+        resource_types = [resource_type] if resource_type else ['layer', 'map', 'document'] + get_geoapp_subtypes()
+        qset = cls.get_tree(parent)
+
         if settings.SKIP_PERMS_FILTER:
             resources = ResourceBase.objects.all()
         else:
@@ -350,60 +350,82 @@ class HierarchicalKeyword(TagBase, MP_Node):
                 user,
                 'base.view_resourcebase'
             )
+
         resources = resources.filter(
-            polymorphic_ctype__model__in=ctype_filter,
+            polymorphic_ctype__model__in=resource_types,
         )
+
+        if resource_name is not None:
+            resources = resources.filter(title=resource_name)
+
         resources = get_visible_resources(
             resources,
             user,
             admin_approval_required=settings.ADMIN_MODERATE_UPLOADS,
             unpublished_not_visible=settings.RESOURCE_PUBLISHING,
             private_groups_not_visibile=settings.GROUP_PRIVATE_RESOURCES)
-        ret, lnk = [], {}
-        try:
-            for pyobj in qset.order_by('name'):
-                serobj = serializers.serialize('python', [pyobj])[0]
-                # django's serializer stores the attributes in 'fields'
-                fields = serobj['fields']
-                depth = fields['depth'] or 1
-                tags_count = 0
-                try:
-                    tags_count = TaggedContentItem.objects.filter(
-                        content_object__in=resources,
-                        tag=HierarchicalKeyword.objects.get(slug=fields['slug'])).count()
-                except Exception:
-                    pass
-                if tags_count > 0:
-                    fields['text'] = fields['name']
-                    fields['href'] = fields['slug']
-                    fields['tags'] = [tags_count]
-                    del fields['name']
-                    del fields['slug']
-                    del fields['path']
-                    del fields['numchild']
-                    del fields['depth']
-                    if 'id' in fields:
-                        # this happens immediately after a load_bulk
-                        del fields['id']
-                    newobj = {}
-                    for field in fields:
-                        newobj[field] = fields[field]
-                    if keep_ids:
-                        newobj['id'] = serobj['pk']
 
-                    if (not parent and depth == 1) or \
-                            (parent and depth == parent.depth):
-                        ret.append(newobj)
+        tree = {}
+
+        for hkw in qset.order_by('name'):
+            slug = hkw.slug
+            tags_count = 0
+
+            tags_count = TaggedContentItem.objects.filter(
+                    content_object__in=resources,
+                    tag=hkw
+                    ).count()
+
+            if tags_count > 0:
+                newobj = {"id": hkw.pk, "text": hkw.name, "href": slug, 'tags': [tags_count]}
+                depth = hkw.depth or 1
+
+                # No use case, so purpose of 'parent' param is not clear.
+                # So following first 'if' statement is left unchanged
+                if (not parent and depth == 1) or \
+                        (parent and depth == parent.depth):
+                    if hkw.pk not in tree:
+                        tree[hkw.pk] = newobj
+                        tree[hkw.pk]["nodes"] = []
                     else:
-                        parentobj = pyobj.get_parent()
-                        parentser = lnk[parentobj.pk]
-                        if 'nodes' not in parentser:
-                            parentser['nodes'] = []
-                        parentser['nodes'].append(newobj)
-                    lnk[pyobj.pk] = newobj
-        except Exception:
-            pass
-        return ret
+                        tree[hkw.pk]['tags'] = [tags_count]
+                else:
+                    tree = cls._keywords_tree_of_a_child(hkw, tree, newobj)
+
+        return list(tree.values())
+
+    @classmethod
+    def _keywords_tree_of_a_child(cls, child, tree, newobj):
+        qs = cls.get_tree(child.get_root())
+        parent = qs[0]
+
+        if parent.id not in tree:
+            tree[parent.id] = {"id": parent.id, "text": parent.name, "href": parent.slug, "tags": [], "nodes": []}
+
+        node = tree[parent.id]
+
+        for kw in qs:
+            if child.is_descendant_of(kw):
+                if kw.depth > 1:
+                    item_found = None
+                    if node["nodes"]:
+                        item_found = find_by_attr(node["nodes"], kw.id)
+
+                    if item_found is None:
+                        node["nodes"].append({"id": kw.id, "text": kw.name, "href": kw.slug, "nodes": []})
+                        node = node["nodes"][-1]
+                    else:
+                        node = item_found
+
+        # All leaves appended but a child which is not a leaf may not be added
+        # again, as a leaf, but only its tag count be updated
+        item_found = find_by_attr(node["nodes"], newobj["id"])
+        if item_found is not None:
+            item_found["tags"] = newobj["tags"]
+        else:
+            node["nodes"].append(newobj)
+
+        return tree
 
 
 class TaggedContentItem(ItemBase):

--- a/geonode/groups/tests.py
+++ b/geonode/groups/tests.py
@@ -828,7 +828,7 @@ class GroupsSmokeTest(GeoNodeBaseTestSupport):
                             html=False)
         self.assertContains(response,
                             'Maps',
-                            count=5,
+                            count=3,
                             status_code=200,
                             msg_prefix='',
                             html=False)

--- a/geonode/layers/api/views.py
+++ b/geonode/layers/api/views.py
@@ -66,7 +66,7 @@ class LayerViewSet(DynamicModelViewSet):
     )
     @action(
         detail=False,
-        url_path="(?P<dataset_id>\d+)/set_thumbnail_from_bbox", # noqa
+        url_path="(?P<dataset_id>\d+)/set_thumbnail_from_bbox",  # noqa
         url_name="set-thumb-from-bbox",
         methods=["post"],
         permission_classes=[

--- a/geonode/layers/tests.py
+++ b/geonode/layers/tests.py
@@ -41,9 +41,11 @@ from django.contrib.auth import get_user_model
 
 from django.conf import settings
 from django.test.utils import override_settings
+from django.contrib.admin.sites import AdminSite
 
 from geonode.layers import utils
 from geonode.layers import LayersAppConfig
+from geonode.layers.admin import LayerAdmin
 from geonode.decorators import on_ogc_backend
 from geonode.maps.models import Map, MapLayer
 from geonode.utils import DisableDjangoSignals
@@ -117,6 +119,20 @@ class LayersTest(GeoNodeBaseTestSupport):
         create_layer_data(self.sut.resourcebase_ptr_id)
         create_layer_data(Layer.objects.first().resourcebase_ptr_id)
         self.r = namedtuple('GSCatalogRes', ['resource'])
+
+        site = AdminSite()
+        self.admin = LayerAdmin(Layer, site)
+
+        self.request_admin = RequestFactory().get('/admin')
+        self.request_admin.user = get_user_model().objects.get(username='admin')
+
+    # Admin Tests
+
+    def test_admin_save_model(self):
+        obj = Layer.objects.first()
+        self.assertEqual(len(obj.keywords.all()), 2)
+        form = self.admin.get_form(self.request_admin, obj=obj, change=True)
+        self.admin.save_model(self.request_admin, obj, form, True)
 
     # Data Tests
 

--- a/geonode/layers/tests.py
+++ b/geonode/layers/tests.py
@@ -374,7 +374,7 @@ class LayersTest(GeoNodeBaseTestSupport):
         self.assertEqual(response.status_code, 200)
 
         from geonode.base.models import HierarchicalKeyword as hk
-        keywords = hk.resource_keywords_tree(get_user_model().objects.get(username='admin'), type='layer')
+        keywords = hk.resource_keywords_tree(get_user_model().objects.get(username='admin'), resource_type='layer')
 
         self.assertEqual(len(keywords), 13)
 

--- a/geonode/layers/tests.py
+++ b/geonode/layers/tests.py
@@ -374,7 +374,7 @@ class LayersTest(GeoNodeBaseTestSupport):
         self.assertEqual(response.status_code, 200)
 
         from geonode.base.models import HierarchicalKeyword as hk
-        keywords = hk.dump_bulk_tree(get_user_model().objects.get(username='admin'), type='layer')
+        keywords = hk.resource_keywords_tree(get_user_model().objects.get(username='admin'), type='layer')
 
         self.assertEqual(len(keywords), 13)
 

--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -1409,8 +1409,8 @@ DEFAULT_TILE_SIZE = os.environ.get('DEFAULT_TILE_SIZE', 512)
 
 # Where should newly created maps be focused?
 DEFAULT_MAP_CENTER = (
-    ast.literal_eval(os.environ.get('DEFAULT_MAP_CENTER_X', 0)),
-    ast.literal_eval(os.environ.get('DEFAULT_MAP_CENTER_Y', 0)))
+    ast.literal_eval(os.environ.get('DEFAULT_MAP_CENTER_X', '0')),
+    ast.literal_eval(os.environ.get('DEFAULT_MAP_CENTER_Y', '0')))
 
 # How tightly zoomed should newly created maps be?
 # 0 = entire world;

--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -1408,7 +1408,9 @@ DEFAULT_LAYER_FORMAT = os.environ.get('DEFAULT_LAYER_FORMAT', "image/png")
 DEFAULT_TILE_SIZE = os.environ.get('DEFAULT_TILE_SIZE', 512)
 
 # Where should newly created maps be focused?
-DEFAULT_MAP_CENTER = (os.environ.get('DEFAULT_MAP_CENTER_X', 0), os.environ.get('DEFAULT_MAP_CENTER_Y', 0))
+DEFAULT_MAP_CENTER = (
+    ast.literal_eval(os.environ.get('DEFAULT_MAP_CENTER_X', 0)),
+    ast.literal_eval(os.environ.get('DEFAULT_MAP_CENTER_Y', 0)))
 
 # How tightly zoomed should newly created maps be?
 # 0 = entire world;

--- a/geonode/utils.py
+++ b/geonode/utils.py
@@ -2118,3 +2118,12 @@ def is_monochromatic_image(image_url, image_data=None):
     except Exception as e:
         logger.debug(e)
         return False
+
+
+def find_by_attr(lst, val, attr="id"):
+    """ Returns an object if the id matches in any list of objects """
+    for item in lst:
+        if attr in item and item[attr] == val:
+            return item
+
+    return None

--- a/geonode/views.py
+++ b/geonode/views.py
@@ -165,7 +165,8 @@ def ident_json(request):
 def h_keywords(request):
     from geonode.base.models import HierarchicalKeyword as hk
     p_type = request.GET.get('type', None)
-    keywords = hk.dump_bulk_tree(request.user, type=p_type)
+    resource_name = request.GET.get('resource_name', None)
+    keywords = hk.resource_keywords_tree(request.user, resource_type=p_type, resource_name=resource_name)
 
     subtypes = []
     if p_type == 'geoapp':
@@ -177,7 +178,7 @@ def h_keywords(request):
                         subtypes.append(_model.__name__.lower())
 
     for _type in subtypes:
-        _bulk_tree = hk.dump_bulk_tree(request.user, type=_type)
+        _bulk_tree = hk.resource_keywords_tree(request.user, resource_type=_type, resource_name=resource_name)
         if isinstance(_bulk_tree, list):
             for _elem in _bulk_tree:
                 keywords.append(_elem)


### PR DESCRIPTION
References: #7735

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
