### PR TITLE
[Fixes #7835][Backport 3.2.x] The first time a map is saved thumbnail is created using the default style instead of the selected one

### DIFF
--- a/geonode/layers/tests.py
+++ b/geonode/layers/tests.py
@@ -334,7 +334,7 @@ class LayersTest(GeoNodeBaseTestSupport):
 
         self.assertEqual(
             set(lyr.keyword_list()), {
-                '&lt;IMG SRC=&#x27;javascript:true;&#x27;&gt;Science', 'Europe&lt;script&gt;true;&lt;/script&gt;',
+                '&lt;IMG SRC=&#39;javascript:true;&#39;&gt;Science', 'Europe&lt;script&gt;true;&lt;/script&gt;',
                 'here', 'keywords', 'land_&lt;script&gt;true;&lt;/script&gt;covering', 'populartag', 'saving',
                 'ß', 'ä', 'ö', 'ü', '論語'})
 
@@ -349,7 +349,7 @@ class LayersTest(GeoNodeBaseTestSupport):
         self.assertEqual(response.status_code, 200)
 
         from geonode.base.models import HierarchicalKeyword as hk
-        keywords = hk.resource_keywords_tree(get_user_model().objects.get(username='admin'), type='layer')
+        keywords = hk.resource_keywords_tree(get_user_model().objects.get(username='admin'), resource_type='layer')
 
         self.assertEqual(len(keywords), 13)
 

--- a/geonode/thumbs/tests/test_unit.py
+++ b/geonode/thumbs/tests/test_unit.py
@@ -131,7 +131,7 @@ class ThumbnailsUnitTest(GeoNodeBaseTestSupport):
         locations, bbox = thumbnails._layers_locations(layer)
 
         self.assertFalse(bbox, "Expected BBOX not to be calculated")
-        self.assertEqual(locations, [[settings.OGC_SERVER["default"]["LOCATION"], [layer.alternate]]])
+        self.assertEqual(locations, [[settings.OGC_SERVER["default"]["LOCATION"], [layer.alternate], []]])
 
     def test_layers_locations_layer_default_bbox(self):
         expected_bbox = [-8238681.428369759, -8220320.787127878, 4969844.155936863, 4984363.9488296695, "epsg:3857"]
@@ -141,7 +141,7 @@ class ThumbnailsUnitTest(GeoNodeBaseTestSupport):
 
         self.assertEqual(bbox[-1].upper(), "EPSG:3857", "Expected calculated BBOX CRS to be EPSG:3857")
         self.assertEqual(bbox, expected_bbox, "Expected calculated BBOX to match pre-converted one.")
-        self.assertEqual(locations, [[settings.OGC_SERVER["default"]["LOCATION"], [layer.alternate]]])
+        self.assertEqual(locations, [[settings.OGC_SERVER["default"]["LOCATION"], [layer.alternate], []]])
 
     def test_layers_locations_layer_bbox(self):
         layer = Layer.objects.get(title_en="theaters_nyc")
@@ -150,16 +150,24 @@ class ThumbnailsUnitTest(GeoNodeBaseTestSupport):
 
         self.assertEqual(bbox[0:4], layer.bbox[0:4], "Expected calculated BBOX to match layer's")
         self.assertEqual(bbox[-1].lower(), layer.bbox[-1].lower(), "Expected calculated BBOX's CRS to match layer's")
-        self.assertEqual(locations, [[settings.OGC_SERVER["default"]["LOCATION"], [layer.alternate]]])
+        self.assertEqual(locations, [[settings.OGC_SERVER["default"]["LOCATION"], [layer.alternate], []]])
 
     def test_layers_locations_simple_map(self):
         layer = Layer.objects.get(title_en="theaters_nyc")
         map = Map.objects.get(title_en="theaters_nyc_map")
-
+        MapLayer(
+            map=map,
+            name="Meteorite_Landings_from_NASA_Open_Data_Portal1",
+            stack_order=1,
+            visibility=True,
+            ows_url="https://maps.geo-solutions.it/geoserver/wms",
+            layer_params="""{\"id\": 1, \"title\": \"Open Street Map\", \"style\": \"test_style\", \"type\": \"osm\", \"singleTile\": false, \"dimensions\": [], \"hideLoading\": false,
+            \"handleClickOnLayer\": false, \"useForElevation\": false, \"hidden\": false, \"extraParams\": {\"msId\": \"mapnik__0\"}, \"wrapDateLine\": true, \"displayOutsideMaxExtent\": true}"""
+            ).save()
         locations, bbox = thumbnails._layers_locations(map)
 
         self.assertFalse(bbox, "Expected BBOX not to be calculated")
-        self.assertEqual(locations, [[settings.OGC_SERVER["default"]["LOCATION"], [layer.alternate]]])
+        self.assertEqual(locations, [[settings.OGC_SERVER["default"]["LOCATION"], ["geonode:Meteorite_Landings_from_NASA_Open_Data_Portal1", layer.alternate], ["test_style"]]])
 
     def test_layers_locations_simple_map_default_bbox(self):
         expected_bbox = [-8238681.428369759, -8220320.787127878, 4969844.155936863, 4984363.9488296695, "epsg:3857"]
@@ -171,7 +179,7 @@ class ThumbnailsUnitTest(GeoNodeBaseTestSupport):
 
         self.assertEqual(bbox[-1].upper(), "EPSG:3857", "Expected calculated BBOX CRS to be EPSG:3857")
         self.assertEqual(bbox, expected_bbox, "Expected calculated BBOX to match pre-converted one.")
-        self.assertEqual(locations, [[settings.OGC_SERVER["default"]["LOCATION"], [layer.alternate]]])
+        self.assertEqual(locations, [[settings.OGC_SERVER["default"]["LOCATION"], [layer.alternate], []]])
 
     def test_layers_locations_composition_map_default_bbox(self):
         expected_bbox = [-18411664.521739896, 1414810.0631394347, -20040289.59992574, 16329038.485056708, 'EPSG:3857']
@@ -179,11 +187,13 @@ class ThumbnailsUnitTest(GeoNodeBaseTestSupport):
             [
                 settings.GEOSERVER_LOCATION,
                 ["geonode:theaters_nyc", "geonode:Meteorite_Landings_from_NASA_Open_Data_Portal1"],
+                []
             ],
             [
                 "http://www502.regione.toscana.it/wmsraster/com.rt.wms.RTmap/wms?map=wmsgeologia&map_resolution=91&",
                 ["rt_geologia.dbg_risorse_minerarie"],
-            ],
+                []
+            ]
         ]
 
         map = Map.objects.get(title_en="composition_map")


### PR DESCRIPTION
<Include a few sentences describing the overall goals for this Pull Request>
References #7835

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
