### PR TITLE
[Fixes #7860]  Replace layer_thumbnail method for maps 

### DIFF
--- a/geonode/base/api/tests.py
+++ b/geonode/base/api/tests.py
@@ -802,7 +802,7 @@ class BaseApiTests(APITestCase):
         self.assertEqual(response.status_code, 403)
         self.assertEqual(expected, response.json())
 
-    @patch("geonode.layers.api.views.create_thumbnail")
+    @patch("geonode.base.api.views.create_thumbnail")
     def test_datasets_set_thumbnail_from_bbox_from_logged_user_for_existing_dataset(self, mock_create_thumbnail):
         """
         Given a logged User and an existing dataset, should create the expected thumbnail url.

--- a/geonode/base/api/tests.py
+++ b/geonode/base/api/tests.py
@@ -17,7 +17,7 @@
 #
 #########################################################################
 import logging
-
+import sys
 from uuid import uuid4
 from PIL import Image
 from io import BytesIO
@@ -787,3 +787,69 @@ class BaseApiTests(APITestCase):
         response = self.client.get(url, format='json')
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data['total'], ThesaurusKeyword.objects.count())
+
+    def test_datasets_set_thumbnail_from_bbox_from_Anonymous_user_raise_permission_error(self):
+        """
+        Given a request with Anonymous user, should raise an authentication error.
+        """
+        dataset_id = sys.maxsize
+        url = reverse('base-resources-set-thumb-from-bbox', args=[dataset_id])
+        # Anonymous
+        expected = {
+            "detail": "Authentication credentials were not provided."
+        }
+        response = self.client.post(url, format='json')
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(expected, response.json())
+
+    @patch("geonode.layers.api.views.create_thumbnail")
+    def test_datasets_set_thumbnail_from_bbox_from_logged_user_for_existing_dataset(self, mock_create_thumbnail):
+        """
+        Given a logged User and an existing dataset, should create the expected thumbnail url.
+        """
+        mock_create_thumbnail.return_value = "http://localhost:8000/mocked_url.jpg"
+        # Admin
+        self.client.login(username="admin", password="admin")
+        dataset_id = Dataset.objects.first().resourcebase_ptr_id
+        url = reverse('base-resources-set-thumb-from-bbox', args=[dataset_id])
+        payload = {
+            "bbox": [
+                -9072629.904175375,
+                -9043966.018568434,
+                1491839.8773032012,
+                1507127.2829602365
+            ],
+            "srid": "EPSG:3857"
+        }
+        response = self.client.post(url, data=payload, format='json')
+
+        expected = {
+            "thumbnail_url": "http://localhost:8000/mocked_url.jpg"
+        }
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(expected, response.json())
+
+    def test_datasets_set_thumbnail_from_bbox_from_logged_user_for_not_existing_dataset(self):
+        """
+        Given a logged User and an not existing dataset, should raise a 404 error.
+        """
+        # Admin
+        self.client.login(username="admin", password="admin")
+        dataset_id = sys.maxsize
+        url = reverse('base-resources-set-thumb-from-bbox', args=[dataset_id])
+        payload = {
+            "bbox": [
+                -9072629.904175375,
+                -9043966.018568434,
+                1491839.8773032012,
+                1507127.2829602365
+            ],
+            "srid": "EPSG:3857"
+        }
+        response = self.client.post(url, data=payload, format='json')
+
+        expected = {
+            "message": f"Resource selected with id {dataset_id} does not exists"
+        }
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(expected, response.json())

--- a/geonode/base/api/views.py
+++ b/geonode/base/api/views.py
@@ -17,6 +17,7 @@
 #
 #########################################################################
 import ast
+from geonode.thumbs.exceptions import ThumbnailError
 from geonode.thumbs.thumbnails import create_thumbnail
 import json
 from django.apps import apps
@@ -436,6 +437,9 @@ class ResourceBaseViewSet(DynamicModelViewSet):
         except ResourceBase.DoesNotExist:
             logger.error(f"Resource selected with id {resource_id} does not exists")
             return Response(data={"message": f"Resource selected with id {resource_id} does not exists"}, status=404, exception=True)
+        except ThumbnailError as e:
+            logger.error(e)
+            return Response(data={"message": e.args[0]}, status=400, exception=True)
         except Exception as e:
             logger.error(e)
             return Response(data={"message": e.args[0]}, status=500, exception=True)

--- a/geonode/base/api/views.py
+++ b/geonode/base/api/views.py
@@ -42,8 +42,8 @@ from geonode.favorite.models import Favorite
 from geonode.base.models import HierarchicalKeyword, Region, ResourceBase, TopicCategory, ThesaurusKeyword
 from geonode.base.api.filters import DynamicSearchFilter, ExtentFilter, FavoriteFilter
 from geonode.groups.models import GroupProfile, GroupMember
-from geonode.documents.models import Document
-from geonode.geoapps.models import GeoApp
+from geonode.layers.models import Dataset
+from geonode.maps.models import Map
 from geonode.security.utils import (
     get_geoapp_subtypes,
     get_visible_resources,
@@ -431,7 +431,7 @@ class ResourceBaseViewSet(DynamicModelViewSet):
         try:
             resource = ResourceBase.objects.get(id=ast.literal_eval(resource_id))
 
-            if isinstance(resource.get_real_instance(), (Document, GeoApp)):
+            if not isinstance(resource.get_real_instance(), (Dataset, Map)):
                 raise NotImplementedError("Not implemented: Endpoint available only for Dataset and Maps")
 
             request_body = request.data if request.data else json.loads(request.body)

--- a/geonode/base/migrations/0060_resourcebase_state.py
+++ b/geonode/base/migrations/0060_resourcebase_state.py
@@ -8,7 +8,7 @@ def update_state_value(apps, schema_editor):
     """Let's update the existing resources to the 'PROCESSED' state
     otherwise those will be set to 'dirty' later on and hidden by the APIs.
     """
-    MyModel = apps.get_model('resourcebase', 'ResourceBase')
+    MyModel = apps.get_model('base', 'ResourceBase')
     MyModel.objects.filter().update(state=enumerations.STATE_PROCESSED)
 
 

--- a/geonode/layers/api/tests.py
+++ b/geonode/layers/api/tests.py
@@ -16,10 +16,8 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 #########################################################################
-import sys
 import logging
 
-from unittest.mock import patch
 from urllib.parse import urljoin
 
 from django.urls import reverse
@@ -95,69 +93,3 @@ class DatasetsApiTests(APITestCase):
         self.assertEqual(response.data['dataset']['raw_constraints_other'], "None")
         self.assertEqual(response.data['dataset']['raw_supplemental_information'], "No information provided í £682m")
         self.assertEqual(response.data['dataset']['raw_data_quality_statement'], "OK    1 2   a b")
-
-    def test_datasets_set_thumbnail_from_bbox_from_Anonymous_user_raise_permission_error(self):
-        """
-        Given a request with Anonymous user, should raise an authentication error.
-        """
-        dataset_id = sys.maxsize
-        url = reverse('datasets-set-thumb-from-bbox', args=[dataset_id])
-        # Anonymous
-        expected = {
-            "detail": "Authentication credentials were not provided."
-        }
-        response = self.client.post(url, format='json')
-        self.assertEqual(response.status_code, 403)
-        self.assertEqual(expected, response.json())
-
-    @patch("geonode.layers.api.views.create_thumbnail")
-    def test_datasets_set_thumbnail_from_bbox_from_logged_user_for_existing_dataset(self, mock_create_thumbnail):
-        """
-        Given a logged User and an existing dataset, should create the expected thumbnail url.
-        """
-        mock_create_thumbnail.return_value = "http://localhost:8000/mocked_url.jpg"
-        # Admin
-        self.client.login(username="admin", password="admin")
-        dataset_id = Dataset.objects.first().resourcebase_ptr_id
-        url = reverse('datasets-set-thumb-from-bbox', args=[dataset_id])
-        payload = {
-            "bbox": [
-                -9072629.904175375,
-                -9043966.018568434,
-                1491839.8773032012,
-                1507127.2829602365
-            ],
-            "srid": "EPSG:3857"
-        }
-        response = self.client.post(url, data=payload, format='json')
-
-        expected = {
-            "thumbnail_url": "http://localhost:8000/mocked_url.jpg"
-        }
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(expected, response.json())
-
-    def test_datasets_set_thumbnail_from_bbox_from_logged_user_for_not_existing_dataset(self):
-        """
-        Given a logged User and an not existing dataset, should raise a 404 error.
-        """
-        # Admin
-        self.client.login(username="admin", password="admin")
-        dataset_id = sys.maxsize
-        url = reverse('datasets-set-thumb-from-bbox', args=[dataset_id])
-        payload = {
-            "bbox": [
-                -9072629.904175375,
-                -9043966.018568434,
-                1491839.8773032012,
-                1507127.2829602365
-            ],
-            "srid": "EPSG:3857"
-        }
-        response = self.client.post(url, data=payload, format='json')
-
-        expected = {
-            "message": f"Dataset selected with id {dataset_id} does not exists"
-        }
-        self.assertEqual(response.status_code, 404)
-        self.assertEqual(expected, response.json())

--- a/geonode/layers/templates/datasets/dataset_detail.html
+++ b/geonode/layers/templates/datasets/dataset_detail.html
@@ -26,7 +26,7 @@
   {% endif %}
   <script type="text/javascript">
     // this is used by thumbnail.js to POST to the thumbnail update view
-    window.thumbnailUpdateUrl = '{% url 'datasets-set-thumb-from-bbox' resource.id %}';
+    window.thumbnailUpdateUrl = '{% url 'base-resources-set-thumb-from-bbox' resource.id %}';
   </script>
   <script type="text/javascript" src="{% static "geonode/js/utils/thumbnail.js" %}"></script>
   {% get_dataset_detail %}

--- a/geonode/layers/templates/layouts/panels.html
+++ b/geonode/layers/templates/layouts/panels.html
@@ -3,7 +3,7 @@
 {% load floppyforms %}
 <script type="text/javascript">
     // this is used by thumbnail.js to POST to the thumbnail update view
-    window.thumbnailUpdateUrl = '{% url 'datasets-set-thumb-from-bbox' resource.id %}';
+    window.thumbnailUpdateUrl = '{% url 'base-resources-set-thumb-from-bbox' resource.id %}';
 </script>
 <!--<link href="{% static "lib/css/bootstrap-select.css" %}" rel="stylesheet" />-->
 <script type="text/javascript" src="{% static "geonode/js/utils/thumbnail.js" %}"></script>

--- a/geonode/maps/templates/layouts/map_panels.html
+++ b/geonode/maps/templates/layouts/map_panels.html
@@ -3,7 +3,7 @@
 {% load floppyforms %}
 <script type="text/javascript">
     // this is used by thumbnail.js to POST to the thumbnail update view
-    window.thumbnailUpdateUrl = '{% url 'map_thumbnail' resource.id %}';
+    window.thumbnailUpdateUrl = '{% url 'base-resources-set-thumb-from-bbox' resource.id %}';
 </script>
 <!--<link href="{% static "lib/css/bootstrap-select.css" %}" rel="stylesheet" />-->
 <script type="text/javascript" src="{% static "geonode/js/utils/thumbnail.js" %}"></script>

--- a/geonode/maps/templates/maps/map_detail.html
+++ b/geonode/maps/templates/maps/map_detail.html
@@ -20,7 +20,7 @@
   {% endif %}
   <script type="text/javascript">
     // this is used by thumbnail.js to POST to the thumbnail update view
-    window.thumbnailUpdateUrl = '{% url 'map_thumbnail' resource.id %}';
+    window.thumbnailUpdateUrl = '{% url 'base-resources-set-thumb-from-bbox' resource.id %}';
   </script>
   <script type="text/javascript" src="{% static "geonode/js/utils/thumbnail.js" %}"></script>
   {% get_map_detail %}

--- a/geonode/maps/urls.py
+++ b/geonode/maps/urls.py
@@ -32,7 +32,7 @@ existing_map_view = views.map_view
 map_embed = views.map_embed
 map_edit = views.map_edit
 map_json = views.map_json
-map_thumbnail = views.map_thumbnail
+
 maps_list = register_url_event()(TemplateView.as_view(template_name='maps/map_list.html'))
 
 urlpatterns = [
@@ -54,7 +54,6 @@ urlpatterns = [
     url(r'^(?P<mapid>[^/]+)/metadata$', views.map_metadata, name='map_metadata'),
     url(r'^(?P<mapid>[^/]+)/metadata_advanced$', views.map_metadata_advanced, name='map_metadata_advanced'),
     url(r'^(?P<mapid>[^/]+)/embed$', map_embed, name='map_embed'),
-    url(r'^(?P<mapid>\d+)/thumbnail$', map_thumbnail, name='map_thumbnail'),
     url(r'^embed/$', views.map_embed, name='map_embed'),
     url(r'^metadata/batch/$', views.map_batch_metadata, name='map_batch_metadata'),
     url(r'^(?P<mapid>[^/]*)/metadata_detail$',

--- a/geonode/maps/views.py
+++ b/geonode/maps/views.py
@@ -60,7 +60,6 @@ from geonode.layers.views import _resolve_dataset
 from geonode.base.auth import get_or_create_token
 from geonode.security.views import _perms_info_json
 from geonode.resource.manager import resource_manager
-from geonode.thumbs.thumbnails import create_thumbnail
 from geonode.decorators import check_keyword_write_perms
 from geonode.documents.models import get_related_documents
 from geonode.base.utils import ManageResourceOwnerPermissions
@@ -1349,37 +1348,6 @@ def ajax_url_lookup(request):
         content=json.dumps(json_dict),
         content_type='text/plain'
     )
-
-
-@require_http_methods(["POST"])
-def map_thumbnail(request, mapid):
-    try:
-        map_obj = _resolve_map(request, mapid)
-    except PermissionDenied:
-        return HttpResponse(_("Not allowed"), status=403)
-    except Exception:
-        raise Http404(_("Not found"))
-    if not map_obj:
-        raise Http404(_("Not found"))
-
-    try:
-
-        request_body = json.loads(request.body)
-        bbox = request_body['bbox'] + [request_body['srid']]
-        zoom = request_body.get('zoom', None)
-
-        create_thumbnail(map_obj, bbox=bbox, background_zoom=zoom, overwrite=True)
-
-        return HttpResponse('Thumbnail saved')
-
-    except Exception as e:
-        logger.exception(e)
-
-        return HttpResponse(
-            content=_('error saving thumbnail'),
-            status=500,
-            content_type='text/plain'
-        )
 
 
 def map_metadata_detail(

--- a/geonode/thumbs/tests/test_integration.py
+++ b/geonode/thumbs/tests/test_integration.py
@@ -558,7 +558,7 @@ class GeoNodeThumbnailsIntegration(GeoNodeBaseTestSupport):
 
         self.client.login(username="norman", password="norman")
         dataset_id = Dataset.objects.get(alternate="geonode:san_andres_y_providencia_coastline").resourcebase_ptr_id
-        thumbnail_post_url = reverse('datasets-set-thumb-from-bbox', args=[dataset_id])
+        thumbnail_post_url = reverse('base-resources-set-thumb-from-bbox', args=[dataset_id])
 
         for bbox, expected_thumb_path in zip(bboxes, expected_thumbs_paths):
             response = self.client.post(


### PR DESCRIPTION
- moved `set_thumbnail_from_bbox` to resourcebase instead of `dataset`
- tests moved from `DatasetApi` to `ResourceBaseApi`

References: #7860

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
