### PR TITLE
[Fixes #7896] Thumbnail creation fix and celery update

### DIFF
--- a/celery_dev.sh
+++ b/celery_dev.sh
@@ -2,4 +2,4 @@ set -a
 . ./.env_dev
 set +a
 
-celery -A geonode.celery_app:app worker --without-gossip --without-mingle -Ofair -B -E --statedb=worker.state -s celerybeat-schedule --loglevel=DEBUG --concurrency=10 -n worker1@%h
+celery -A geonode.celery_app:app worker --without-gossip --without-mingle -Ofair -B -E -s django_celery_beat.schedulers:DatabaseScheduler --loglevel=DEBUG --concurrency=2 -n worker1@%h

--- a/geonode/base/models.py
+++ b/geonode/base/models.py
@@ -1640,10 +1640,15 @@ class ResourceBase(PolymorphicModel, PermissionLevelMixin, ItemBase):
                     image = None
 
             if upload_path and image:
-                name, ext = os.path.splitext(filename)
+                name = os.path.basename(filename)
                 remove_thumbs(name)
                 actual_name = storage_manager.save(upload_path, ContentFile(image))
-                url = storage_manager.url(actual_name)
+                actual_file_name = os.path.basename(actual_name)
+
+                if filename != actual_file_name:
+                    upload_path = upload_path.replace(filename, actual_file_name)
+
+                url = storage_manager.url(upload_path)
 
                 try:
                     # Optimize the Thumbnail size and resolution

--- a/requirements.txt
+++ b/requirements.txt
@@ -120,6 +120,8 @@ python-dateutil==2.8.2
 pytz==2021.1
 requests==2.26.0
 timeout-decorator==0.5.0
+pylibmc==1.6.1
+sherlock==0.3.2
 
 # required by monitoring
 psutil==5.8.0


### PR DESCRIPTION
References: #7896

- update celery_dev.sh with the new developements
- update requirements.txt with libraries required to run async flow
- Fix bug related to the thumbnail. Now if the actual filename returned by the storage manager is different from the one in the original upload path, it will be replaced with the new filename

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
