### PR TITLE
[Fixes #7974] Thumbnails not created when uploading a new dataset

### DIFF
--- a/geonode/base/models.py
+++ b/geonode/base/models.py
@@ -1667,7 +1667,7 @@ class ResourceBase(PolymorphicModel, PermissionLevelMixin, ItemBase):
                     cover = ImageOps.fit(im, (_default_thumb_size['width'], _default_thumb_size['height']))
 
                     # Saving the thumb into a temporary directory on file system
-                    tmp_location = f"{settings.MEDIA_ROOT}/{upload_path}"
+                    tmp_location = os.path.abspath(f"{settings.MEDIA_ROOT}/{upload_path}")
                     cover.save(tmp_location, format='PNG')
 
                     with open(tmp_location, 'rb+') as img:


### PR DESCRIPTION
References: #7974

The `settings.MEDIA_ROOT` is not defined with a non-docker installation, so the system will create it something like: `/opt/path/uploaded` while when running with docker, the `settings.MEDIA_ROOT` is defined like this:  `/opt/path/uploaded/`

By default the save_thumbnail, add a slash to create the correct path for the thumbnail with this line:
https://github.com/GeoNode/geonode/blob/212f81cb8bdaa22b8588957f1a27f8b3af1a3e8e/geonode/base/models.py#L1670

so when it's time to check if we need to remove the temporary image, it checks the path:
https://github.com/GeoNode/geonode/blob/212f81cb8bdaa22b8588957f1a27f8b3af1a3e8e/geonode/base/models.py#L1677-L1679

so with Docker, we will have:
```python
tmp_location='/opt/uploaded//thumbs/img.jpg
storage_manager.path(upload_path)='/opt/uploaded/thumbs/img.jpg
```

Since are different, it will remove the temporary image. By adding this, we will take care of the double slashes inside the path:
`tmp_location = os.path.abspath(f"{settings.MEDIA_ROOT}/{upload_path}")` so we will have:

```python
tmp_location='/opt/uploaded/thumbs/img.jpg
storage_manager.path(upload_path)='/opt/uploaded/thumbs/img.jpg
```

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate it if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
