### PR TITLE
Fixed #8072 error in docker-compose local start due to bad env variable ALLOWED_HOSTS in .env

### DIFF
--- a/.env
+++ b/.env
@@ -41,7 +41,7 @@ ASYNC_SIGNALS=True
 
 SITEURL=http://localhost/
 
-ALLOWED_HOSTS="['django', '*']"
+ALLOWED_HOSTS=['django', '*']
 
 # Data Uploader
 DEFAULT_BACKEND_UPLOADER=geonode.importer


### PR DESCRIPTION
The ALLOWED_HOSTS variable in .env file is not imported from docker-compose. There is an error in how the variable is written there, double quotes should be removed. Needs to be: ALLOWED_HOSTS=['django', '\*'] instead of ALLOWED_HOSTS="['django', '\*']".

This PR fixes a syntax error in the ALLLOWED_HOSTS variable, needed to launch correctly GeoNode with docker in v 3.2.X in a local machine.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [X] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [X] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [X] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [X] PR for bug fixes and small new features are presented as a single commit
- [X] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
