### PR TITLE
[Backport 3.3.x][Fixes #8057] GeoStory: missing tab in recent activities

### DIFF
--- a/geonode/social/apps.py
+++ b/geonode/social/apps.py
@@ -32,5 +32,6 @@ class SocialConfig(AppConfig):
         registry.register(apps.get_app_config('documents').get_model('Document'))
         registry.register(apps.get_app_config('services').get_model('Service'))
         registry.register(apps.get_app_config('dialogos').get_model('Comment'))
+        registry.register(apps.get_app_config('geoapp_geostories').get_model('GeoStory'))
         _auth_user_model = settings.AUTH_USER_MODEL.split('.')
         registry.register(apps.get_app_config(_auth_user_model[0]).get_model(_auth_user_model[1]))

--- a/geonode/social/signals.py
+++ b/geonode/social/signals.py
@@ -31,6 +31,7 @@ from django.utils.translation import ugettext_lazy as _
 
 # from actstream.exceptions import ModelNotActionable
 
+from mapstore2_adapter.geoapps.geostories.models import GeoStory
 from geonode.layers.models import Layer
 from geonode.maps.models import Map
 from geonode.documents.models import Document
@@ -109,6 +110,11 @@ def activity_post_modify_object(sender, instance, created=None, **kwargs):
         logger.exception(e)
 
     try:
+        action_settings['geostory'].update(object_name=getattr(instance, 'title', None),)
+    except Exception as e:
+        logger.exception(e)
+
+    try:
         action = action_settings[obj_type]
         if created:
             # object was created
@@ -119,7 +125,8 @@ def activity_post_modify_object(sender, instance, created=None, **kwargs):
                 # object was saved.
                 if not isinstance(instance, Layer) and \
                         not isinstance(instance, Document) and \
-                        not isinstance(instance, Map):
+                        not isinstance(instance, Map) and \
+                        not isinstance(instance, GeoStory):
                     verb = action.get('updated_verb')
                     raw_action = 'updated'
 
@@ -168,6 +175,9 @@ if activity:
 
     signals.post_save.connect(activity_post_modify_object, sender=Document)
     signals.post_delete.connect(activity_post_modify_object, sender=Document)
+
+    signals.post_save.connect(activity_post_modify_object, sender=GeoStory)
+    signals.post_delete.connect(activity_post_modify_object, sender=GeoStory)
 
 
 def rating_post_save(instance, sender, created, **kwargs):

--- a/geonode/social/templates/social/activity_list.html
+++ b/geonode/social/templates/social/activity_list.html
@@ -20,6 +20,7 @@
       <li class="active"><a href="#all" data-toggle="tab"><i class=""></i>{% trans "All" %}</a></li>
       <li><a href="#layers" data-toggle="tab"><i class="fa fa-square-o rotate-45"></i> {% trans "Layers" %}</a></li>
       <li><a href="#maps" data-toggle="tab"><i class="fa fa-map-marker"></i> {% trans "Maps" %}</a></li>
+      <li><a href="#geostory" data-toggle="tab"><i class="fa fa-gears"></i> {% trans "GeoStory" %}</a></li>
       <li><a href="#documents" data-toggle="tab"><i class="fa fa-newspaper-o"></i> {% trans "Documents" %}</a></li>
       <li><a href="#comments" data-toggle="tab"><i class="fa fa-comment-o"></i> {% trans "Comments" %}</a></li>
     </ul>
@@ -63,6 +64,15 @@
       <article id="comments" class="tab-pane">
         <ul class="no-style-list">
         {% for action in action_list_comments %}
+          {% activity_item action %}
+          {% empty %}
+          <p>{% trans "No actions yet" %}</p>
+        {% endfor %}
+        </ul>
+      </article>
+      <article id="geostory" class="tab-pane">
+        <ul class="no-style-list">
+        {% for action in action_list_geostory %}
           {% activity_item action %}
           {% empty %}
           <p>{% trans "No actions yet" %}</p>

--- a/geonode/social/templatetags/social_tags.py
+++ b/geonode/social/templatetags/social_tags.py
@@ -79,6 +79,9 @@ def activity_item(action, **kwargs):
         if object_type == 'map':
             activity_class = 'map'
 
+        if object_type == 'geostory':
+            activity_class = 'geostory'
+
         if object_type == 'layer':
             activity_class = 'layer'
 

--- a/geonode/social/tests.py
+++ b/geonode/social/tests.py
@@ -25,25 +25,31 @@ Replace this with more appropriate tests for your application.
 """
 import json
 
-from geonode.tests.base import GeoNodeBaseTestSupport
+from rest_framework import status
 
 from actstream import registry
 from actstream.models import Action, actor_stream
-from dialogos.models import Comment
+
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
 from django.utils.translation import ugettext as _
+from django.urls import reverse
+
+from mapstore2_adapter.geoapps.geostories.models import GeoStory
+
+from geonode.tests.base import GeoNodeBaseTestSupport
 from geonode.layers.populate_layers_data import create_layer_data
 from geonode.social.templatetags.social_tags import activity_item
 from geonode.layers.models import Layer
+from dialogos.models import Comment
 
 
-class SimpleTest(GeoNodeBaseTestSupport):
+class RecentActivityTest(GeoNodeBaseTestSupport):
 
     integration = True
 
     def setUp(self):
-        super().setUp()
+        super(RecentActivityTest, self).setUp()
 
         registry.register(Layer)
         registry.register(Comment)
@@ -139,3 +145,71 @@ class SimpleTest(GeoNodeBaseTestSupport):
 
         # Pre-fecthing actstream breaks the actor stream
         self.assertIn(action, actor_stream(self.user))
+
+    def test_geostory_activity(self):
+        """
+        Tests the activity functionality when a geostory is saved.
+        """
+
+        # A new activity should be created for each Layer.
+        self.assertNotEqual(Action.objects.all().count(), GeoStory.objects.all().count())
+        GeoStory.objects.create(owner=self.user, title='test geostory', name='test geostory', is_approved=True)
+        action = Action.objects.all()[0]
+        geostory = action.action_object
+
+        # The activity should read:
+        # geostory.owner (actor) 'uploaded' (verb) geostory (object)
+        self.assertEqual(action.actor, action.action_object.owner)
+        data = action.data
+        if isinstance(data, (str, bytes)):
+            data = json.loads(data)
+        self.assertEqual(data.get('raw_action'), 'created')
+        self.assertEqual(data.get('object_name'), geostory.name)
+        self.assertTrue(isinstance(action.action_object, GeoStory))
+        self.assertIsNone(action.target)
+
+        # Test the  activity_item template tag
+        template_tag = activity_item(Action.objects.all()[0])
+
+        self.assertEqual(template_tag.get('username'), action.actor.username)
+        self.assertEqual(template_tag.get('object_name'), geostory.name)
+        self.assertEqual(template_tag.get('actor'), action.actor)
+        self.assertEqual(template_tag.get('verb'), _('created'))
+        self.assertEqual(template_tag.get('action'), action)
+        self.assertEqual(template_tag.get('activity_class'), 'geostory')
+
+        geostory_name = geostory.name
+        geostory.delete()
+
+        # <user> deleted <object_name>
+        action = Action.objects.all()[0]
+        data = action.data
+        if isinstance(data, (str, bytes)):
+            data = json.loads(data)
+        self.assertEqual(data.get('raw_action'), 'deleted')
+        self.assertEqual(data.get('object_name'), geostory_name)
+
+        # objects are literally deleted so no action object or target should be related to a delete action.
+        self.assertIsNone(action.action_object)
+        self.assertIsNone(action.target)
+
+        # Test the activity_item template tag
+        action = Action.objects.all()[0]
+        template_tag = activity_item(action)
+
+        # Make sure the 'delete' class is returned
+        self.assertEqual(template_tag.get('activity_class'), 'delete')
+
+        # The geostory's name should be returned
+        self.assertEqual(template_tag.get('object_name'), geostory_name)
+        self.assertEqual(template_tag.get('verb'), _('deleted'))
+
+    def test_get_recent_activities(self):
+        url = reverse('recent-activity')
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIsNotNone(response.context_data['action_list_geostory'])
+        self.assertIsNotNone(response.context_data['action_list_layers'])
+        self.assertIsNotNone(response.context_data['action_list_maps'])
+        self.assertIsNotNone(response.context_data['action_list_documents'])
+        self.assertIsNotNone(response.context_data['action_list_comments'])

--- a/geonode/social/views.py
+++ b/geonode/social/views.py
@@ -77,6 +77,8 @@ class RecentActivity(ListView):
             id__in=_filter_actions('document', self.request))[:15]
         context['action_list_comments'] = Action.objects.filter(
             id__in=_filter_actions('comment', self.request))[:15]
+        context['action_list_geostory'] = Action.objects.filter(
+            id__in=_filter_actions('geostory', self.request))[:15]
         return context
 
 

--- a/geonode/static/geonode/css/base.css
+++ b/geonode/static/geonode/css/base.css
@@ -7966,6 +7966,12 @@ footer form {
 .activity-item .map:before {
   content: "\f041";
 }
+.activity-item .geostory {
+  content: "\f085";
+}
+.activity-item .geostory:before {
+  content: "\f085";
+}
 .activity-item .upload {
   content: "\f093";
 }

--- a/geonode/static/geonode/less/base.less
+++ b/geonode/static/geonode/less/base.less
@@ -1442,6 +1442,14 @@ footer {
     content: "\f041";
   }
 
+  .geostory {
+    content: "\f085";
+  }
+
+  .geostory:before {
+    content: "\f085";
+  }
+
   .upload {
     content: "\f093";
   }


### PR DESCRIPTION
<Include a few sentences describing the overall goals for this Pull Request>
References #8057

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
