### PR TITLE
[Fixes #8083] Remote Services "_resolve_dataset" does not work proper…

### DIFF
--- a/geonode/layers/views.py
+++ b/geonode/layers/views.py
@@ -147,14 +147,11 @@ def _resolve_dataset(request, alternate, permission='base.view_resourcebase', ms
     Resolve the layer by the provided typename (which may include service name) and check the optional permission.
     """
     service_typename = alternate.split(":", 1)
-    if Service.objects.filter(name=service_typename[0]).exists():
+    if Service.objects.filter(name=service_typename[0]).count() == 1:
         query = {
-            'alternate': service_typename[1]
+            'alternate': service_typename[1],
+            'remote_service': Service.objects.filter(name=service_typename[0]).get()
         }
-        if len(service_typename) > 1:
-            query['store'] = service_typename[0]
-        else:
-            query['subtype'] = 'remote'
         return resolve_object(
             request,
             Dataset,

--- a/geonode/services/tests.py
+++ b/geonode/services/tests.py
@@ -505,6 +505,9 @@ class ModuleFunctionsTestCase(StandardTestCase):
             self.assertIsNotNone(geonode_dataset)
             self.assertNotEqual(geonode_dataset.srid, "EPSG:4326")
             self.assertEqual(geonode_dataset.sourcetype, base_enumerations.SOURCE_TYPE_REMOTE)
+            self.client.login(username='admin', password='admin')
+            response = self.client.get(reverse('dataset_detail', args=(geonode_dataset.name,)))
+            self.assertEqual(response.status_code, 200)
             harvest_job, created = HarvestJob.objects.get_or_create(
                 service=geonode_service,
                 resource_id=geonode_dataset.alternate
@@ -721,6 +724,9 @@ class WmsServiceHandlerTestCase(GeoNodeBaseTestSupport):
             self.assertIsNotNone(geonode_dataset)
             self.assertNotEqual(geonode_dataset.srid, "EPSG:4326")
             self.assertEqual(geonode_dataset.sourcetype, base_enumerations.SOURCE_TYPE_REMOTE)
+            self.client.login(username='admin', password='admin')
+            response = self.client.get(reverse('dataset_detail', args=(geonode_dataset.name,)))
+            self.assertEqual(response.status_code, 200)
             harvest_job, created = HarvestJob.objects.get_or_create(
                 service=geonode_service,
                 resource_id=geonode_dataset.alternate


### PR DESCRIPTION
…ly anymore

References: #8083

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.



The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
