### PR TITLE
[Backport to 3.2.x][Fixes #8083] Remote Services "_resolve_layer" doe…

### DIFF
--- a/geonode/layers/views.py
+++ b/geonode/layers/views.py
@@ -17,8 +17,6 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 #########################################################################
-from geonode.upload.upload import _update_layer_with_xml_info
-from geonode.layers.metadata import parse_metadata
 import re
 import os
 import json
@@ -59,6 +57,8 @@ from guardian.shortcuts import get_objects_for_user
 
 from geonode import geoserver
 from geonode.base.auth import get_or_create_token
+from geonode.layers.metadata import parse_metadata
+from geonode.upload.upload import _update_layer_with_xml_info
 from geonode.base.forms import CategoryForm, TKeywordForm, BatchPermissionsForm, ThesaurusAvailableForm
 from geonode.base.views import batch_modify, get_url_for_model
 from geonode.base.models import (
@@ -150,14 +150,11 @@ def _resolve_layer(request, alternate, permission='base.view_resourcebase',
     Resolve the layer by the provided typename (which may include service name) and check the optional permission.
     """
     service_typename = alternate.split(":", 1)
-    if Service.objects.filter(name=service_typename[0]).exists():
+    if Service.objects.filter(name=service_typename[0]).count() == 1:
         query = {
-            'alternate': service_typename[1]
+            'alternate': service_typename[1],
+            'remote_service': Service.objects.filter(name=service_typename[0]).get()
         }
-        if len(service_typename) > 1:
-            query['store'] = service_typename[0]
-        else:
-            query['storeType'] = 'remoteStore'
         return resolve_object(
             request,
             Layer,
@@ -363,7 +360,6 @@ def layer_detail(request, layername, template='layers/layer_detail.html'):
         raise Http404(_("Not found"))
     if not layer:
         raise Http404(_("Not found"))
-
     permission_manager = ManageResourceOwnerPermissions(layer)
     permission_manager.set_owner_permissions_according_to_workflow()
 

--- a/geonode/services/tests.py
+++ b/geonode/services/tests.py
@@ -503,6 +503,9 @@ class ModuleFunctionsTestCase(StandardTestCase):
             geonode_layer = Layer.objects.filter(remote_service=geonode_service).get()
             self.assertIsNotNone(geonode_layer)
             self.assertNotEqual(geonode_layer.srid, "EPSG:4326")
+            self.client.login(username='admin', password='admin')
+            response = self.client.get(reverse('layer_detail', args=(geonode_layer.name,)))
+            self.assertEqual(response.status_code, 200)
             harvest_job, created = HarvestJob.objects.get_or_create(
                 service=geonode_service,
                 resource_id=geonode_layer.alternate
@@ -718,6 +721,9 @@ class WmsServiceHandlerTestCase(GeoNodeBaseTestSupport):
             geonode_layer = handler._create_layer(geonode_service, **resource_fields)
             self.assertIsNotNone(geonode_layer)
             self.assertNotEqual(geonode_layer.srid, "EPSG:4326")
+            self.client.login(username='admin', password='admin')
+            response = self.client.get(reverse('layer_detail', args=(geonode_layer.name,)))
+            self.assertEqual(response.status_code, 200)
             harvest_job, created = HarvestJob.objects.get_or_create(
                 service=geonode_service,
                 resource_id=geonode_layer.alternate


### PR DESCRIPTION
…s not work properly anymore

(cherry picked from commit 55ddaa018a94ce869b5e97315cb605dc59a1bf5d)

<Include a few sentences describing the overall goals for this Pull Request>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [ ] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [ ] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
