### PR TITLE
[Fixes #8101] Fixes to documents embed

### DIFF
--- a/geonode/base/populate_test_data.py
+++ b/geonode/base/populate_test_data.py
@@ -229,6 +229,7 @@ def create_models(type=None, integration=False):
                         ll_bbox_polygon=Polygon.from_bbox((bbox_x0, bbox_y0, bbox_x1, bbox_y1)),
                         srid='EPSG:4326',
                         files=dfile,
+                        extension="gif",
                         metadata_only=title == 'doc metadata true'
                     )
                     m.save()

--- a/geonode/documents/models.py
+++ b/geonode/documents/models.py
@@ -126,7 +126,7 @@ class Document(ResourceBase):
 
     @property
     def embed_url(self):
-        return self.href
+        return reverse('document_embed', args=(self.id,))
 
     class Meta(ResourceBase.Meta):
         pass

--- a/geonode/documents/tests.py
+++ b/geonode/documents/tests.py
@@ -261,6 +261,18 @@ class DocumentsTest(GeoNodeBaseTestSupport):
         response = self.client.get(reverse('document_detail', args=(str(d.id),)))
         self.assertEqual(response.status_code, 200)
 
+    def test_document_embed(self):
+        """/documents/1 -> Test accessing the embed view of a document"""
+        d = Document.objects.all().first()
+        d.set_default_permissions()
+        import logging
+        logger = logging.getLogger(__name__)
+        logger.error(f'---- {d.files[0]} ----')
+        logger.error(f"---- {reverse('document_embed', args=(str(d.id),))} ----")
+        response = self.client.get(reverse('document_embed', args=(str(d.id),)))
+        logger.error(f'---- {response.content} -----')
+        self.assertEqual(response.status_code, 200)
+
     @patch("geonode.documents.tasks.create_document_thumbnail")
     def test_document_metadata_details(self, thumb):
         thumb.return_value = True

--- a/geonode/documents/tests.py
+++ b/geonode/documents/tests.py
@@ -876,4 +876,4 @@ class DocumentViewTestCase(GeoNodeBaseTestSupport):
                 owner=self.not_admin,
                 title="GeoNode Map Doc",
             ))
-        self.assertEqual(doc.embed_url, 'http://geonode.org/map.pdf')
+        self.assertEqual(doc.href, 'http://geonode.org/map.pdf')

--- a/geonode/documents/tests.py
+++ b/geonode/documents/tests.py
@@ -265,12 +265,8 @@ class DocumentsTest(GeoNodeBaseTestSupport):
         """/documents/1 -> Test accessing the embed view of a document"""
         d = Document.objects.all().first()
         d.set_default_permissions()
-        import logging
-        logger = logging.getLogger(__name__)
-        logger.error(f'---- {d.files[0]} ----')
-        logger.error(f"---- {reverse('document_embed', args=(str(d.id),))} ----")
+
         response = self.client.get(reverse('document_embed', args=(str(d.id),)))
-        logger.error(f'---- {response.content} -----')
         self.assertEqual(response.status_code, 200)
 
     @patch("geonode.documents.tasks.create_document_thumbnail")

--- a/geonode/documents/utils.py
+++ b/geonode/documents/utils.py
@@ -89,8 +89,3 @@ def get_download_response(request, docid, attachment=False):
         "File is not available",
         status=404
     )
-
-
-def get_doc_extension(request, docid, attachment=False):
-    document = get_object_or_404(Document, pk=docid)
-    return (document.extension)

--- a/geonode/documents/views.py
+++ b/geonode/documents/views.py
@@ -219,7 +219,6 @@ def document_embed(request, docid):
             loader.render_to_string(
                 '401.html', context={
                     'error_message': _("You are not allowed to view this document.")}, request=request), status=401)
-    
     if document.is_image:
         if document.doc_url:
             imageurl = document.doc_url

--- a/geonode/documents/views.py
+++ b/geonode/documents/views.py
@@ -218,7 +218,7 @@ def document_embed(request, docid):
             loader.render_to_string(
                 '401.html', context={
                     'error_message': _("You are not allowed to view this document.")}, request=request), status=401)
-    if document.files and storage_manager.exists(document.files[0]) and document.extension and document.is_image:
+    if document.is_image:
         context_dict = {
             "image_url":  reverse('document_link', args=(document.id,)),
         }

--- a/geonode/documents/views.py
+++ b/geonode/documents/views.py
@@ -209,6 +209,7 @@ def document_link(request, docid):
 
 
 def document_embed(request, docid):
+    from django.http.response import HttpResponseRedirect
     document = get_object_or_404(Document, pk=docid)
 
     if not request.user.has_perm(
@@ -218,9 +219,16 @@ def document_embed(request, docid):
             loader.render_to_string(
                 '401.html', context={
                     'error_message': _("You are not allowed to view this document.")}, request=request), status=401)
-    if document.is_image:
+    
+    if document.doc_url:
+        return HttpResponseRedirect(document.doc_url)
+    elif document.is_image:
+        if document.doc_url:
+            imageurl = document.doc_url
+        else:
+            imageurl = reverse('document_link', args=(document.id,))
         context_dict = {
-            "image_url":  reverse('document_link', args=(document.id,)),
+            "image_url":  imageurl,
         }
         return render(
             request,

--- a/geonode/documents/views.py
+++ b/geonode/documents/views.py
@@ -220,9 +220,7 @@ def document_embed(request, docid):
                 '401.html', context={
                     'error_message': _("You are not allowed to view this document.")}, request=request), status=401)
     
-    if document.doc_url:
-        return HttpResponseRedirect(document.doc_url)
-    elif document.is_image:
+    if document.is_image:
         if document.doc_url:
             imageurl = document.doc_url
         else:
@@ -235,6 +233,8 @@ def document_embed(request, docid):
             "documents/document_embed.html",
             context_dict
         )
+    if document.doc_url:
+        return HttpResponseRedirect(document.doc_url)
     else:
         return get_download_response(request, docid)
 


### PR DESCRIPTION
References #8101 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
