### PR TITLE
[3.3.x][Fixes #8112] Dump and restore Geofence rules in case of requests or transaction failures

### DIFF
--- a/geonode/layers/models.py
+++ b/geonode/layers/models.py
@@ -672,7 +672,6 @@ def pre_delete_layer(instance, sender, **kwargs):
         MapLayer.objects.filter(
             name=instance.alternate,
             ows_url=instance.ows_url).delete()
-        return
 
     logger.debug(
         "Going to delete the styles associated for [%s]",

--- a/geonode/security/models.py
+++ b/geonode/security/models.py
@@ -154,9 +154,9 @@ class PermissionLevelMixin:
         Remove all the permissions except for the owner and assign the
         view permission to the anonymous group
         """
-        geofence_adapter = GeofenceLayerAdapter(self.get_self_resource())
+        geofence_uow = GeofenceLayerRulesUnitOfWork(GeofenceLayerAdapter(self.get_self_resource()))
         try:
-            with GeofenceLayerRulesUnitOfWork(geofence_adapter) as geofence_uow:
+            with geofence_uow:
                 with transaction.atomic():
                     remove_object_permissions(self, purge=False, geofence_uow=geofence_uow)
 
@@ -251,7 +251,7 @@ class PermissionLevelMixin:
                         else:
                             self.set_dirty_state()
         except Exception as e:
-            geofence_adapter.rollback()
+            geofence_uow.rollback()
             raise GeoNodeException(e)
 
     def set_permissions(self, perm_spec, created=False):
@@ -273,9 +273,9 @@ class PermissionLevelMixin:
                 ]
         }
         """
-        geofence_adapter = GeofenceLayerAdapter(self.get_self_resource())
+        geofence_uow = GeofenceLayerRulesUnitOfWork(GeofenceLayerAdapter(self.get_self_resource()))
         try:
-            with GeofenceLayerRulesUnitOfWork(geofence_adapter) as geofence_uow:
+            with geofence_uow:
                 with transaction.atomic():
                     remove_object_permissions(self, purge=False, geofence_uow=geofence_uow)
 
@@ -421,7 +421,7 @@ class PermissionLevelMixin:
                         else:
                             self.set_dirty_state()
         except Exception as e:
-            geofence_adapter.rollback()
+            geofence_uow.rollback()
             raise GeoNodeException(e)
 
     def set_workflow_perms(self, approved=False, published=False):

--- a/geonode/security/tests.py
+++ b/geonode/security/tests.py
@@ -675,7 +675,7 @@ class PermissionsTest(GeoNodeBaseTestSupport):
             if rule['service'] is None and rule['userName'] == 'bobby':
                 self.assertEqual(rule['userName'], 'bobby')
                 self.assertEqual(rule['workspace'], 'CA')
-                self.assertEqual(rule['layer'], 'CA')
+                self.assertEqual(rule['layer'], 'geonode:CA')
                 self.assertEqual(rule['access'], 'LIMIT')
 
                 self.assertTrue('limits' in rule)
@@ -715,7 +715,7 @@ class PermissionsTest(GeoNodeBaseTestSupport):
                 if rule['service'] is None:
                     self.assertEqual(rule['userName'], None)
                     self.assertEqual(rule['workspace'], 'CA')
-                    self.assertEqual(rule['layer'], 'CA')
+                    self.assertEqual(rule['layer'], 'geonode:CA')
                     self.assertEqual(rule['access'], 'LIMIT')
 
                     self.assertTrue('limits' in rule)
@@ -750,7 +750,7 @@ class PermissionsTest(GeoNodeBaseTestSupport):
                     self.assertEqual(rule['service'], None)
                     self.assertEqual(rule['userName'], None)
                     self.assertEqual(rule['workspace'], 'CA')
-                    self.assertEqual(rule['layer'], 'CA')
+                    self.assertEqual(rule['layer'], 'geonode:CA')
                     self.assertEqual(rule['access'], 'LIMIT')
 
                     self.assertTrue('limits' in rule)

--- a/geonode/security/tests.py
+++ b/geonode/security/tests.py
@@ -1156,7 +1156,6 @@ class PermissionsTest(GeoNodeBaseTestSupport):
         geofence_rules_count = get_geofence_rules_count()
         self.assertTrue(geofence_rules_count == 0)
 
-
     @dump_func_name
     @mock.patch('geonode.security.utils.GeofenceLayerRulesUnitOfWork._add_request')
     @mock.patch('geonode.security.utils.GeofenceLayerRulesUnitOfWork._execute_requests')
@@ -1215,7 +1214,6 @@ class PermissionsTest(GeoNodeBaseTestSupport):
         mocked_uow_rollback.assert_called_once()
         geofence_rules_count_end = get_geofence_rules_count()
         self.assertEqual(geofence_rules_count_start, geofence_rules_count_end)
-
 
     @dump_func_name
     @mock.patch('geonode.security.utils.GeofenceLayerRulesUnitOfWork._add_request')
@@ -1276,13 +1274,13 @@ class PermissionsTest(GeoNodeBaseTestSupport):
             Verify that the Geofence UoW Rollback is working properly:
             * Reset the Geofence Rules
             * Set PermSpec A.
-                * Get Geofence state to compare with rollback. 
+                * Get Geofence state to compare with rollback.
             * Set PermSpec B.
-                * Get Geofence state to compare with rollback. 
+                * Get Geofence state to compare with rollback.
             * Try to set PermSpec A again:
                * Simulates something going wrong.
                * Assure thar the Geofence State corresponds to B and not to A.
-               * Successful Rollback. \o/ 
+               * Successful Rollback. \\o/
         """
         # Gathering data
         layer = Layer.objects.all()[0]
@@ -1299,7 +1297,7 @@ class PermissionsTest(GeoNodeBaseTestSupport):
             },
             "groups": []
         }
-        
+
         # Start with a clean set of geofence rules
         purge_geofence_all()
         geofence_rules_count_zero = get_geofence_rules_count()
@@ -1310,7 +1308,7 @@ class PermissionsTest(GeoNodeBaseTestSupport):
 
         # Set the permissions A - Save Geofence XML
         layer.set_permissions(perm_spec_a)
-        geofence_rules_count_perm_spec_a= get_geofence_rules_count()
+        geofence_rules_count_perm_spec_a = get_geofence_rules_count()
         rules = list_geofence_layer_rules_xml(get_layer_workspace(layer), layer.alternate)
         rules_perm_spec_a = b""
         for rule in rules:
@@ -1333,7 +1331,7 @@ class PermissionsTest(GeoNodeBaseTestSupport):
             # Try to set the permissions A again
             with self.assertRaises(GeoNodeException):
                 layer.set_permissions(perm_spec_a)
-            
+
             # Verify the rollback to permission B
             geofence_rules_count_end = get_geofence_rules_count()
             rules = list_geofence_layer_rules_xml(get_layer_workspace(layer), layer.alternate)
@@ -1344,13 +1342,12 @@ class PermissionsTest(GeoNodeBaseTestSupport):
 
             # Assertions - Successful Rollback
             mocked_adapter_toggle_layer_cache.assert_called_once()
-            # Count and RulesXML is same as permission B 
+            # Count and RulesXML is same as permission B
             self.assertEqual(geofence_rules_count_end, geofence_rules_count_perm_spec_b)
             self.assertEqual(rules_perm_spec_end, rules_perm_spec_b)
             # Count and RulesXML is not as permission A
             self.assertNotEqual(geofence_rules_count_end, geofence_rules_count_perm_spec_a)
             self.assertNotEqual(rules_perm_spec_end, rules_perm_spec_a)
-
 
     @dump_func_name
     def test_layer_set_default_permissions(self):

--- a/geonode/security/tests.py
+++ b/geonode/security/tests.py
@@ -27,6 +27,7 @@ import gisdata
 import importlib
 import contextlib
 
+from unittest import mock
 from urllib.request import urlopen, Request
 from tastypie.test import ResourceTestCaseMixin
 
@@ -42,7 +43,7 @@ from guardian.shortcuts import (
     assign_perm,
     remove_perm
 )
-from geonode import geoserver
+from geonode import geoserver, GeoNodeException
 from geonode.base.models import (
     Configuration,
     UserGeoLimit,
@@ -53,7 +54,7 @@ from geonode.people.utils import get_valid_user
 from geonode.layers.models import Layer
 from geonode.groups.models import Group, GroupProfile
 from geonode.compat import ensure_string
-from geonode.utils import check_ogc_backend
+from geonode.utils import check_ogc_backend, get_layer_workspace
 from geonode.tests.utils import check_layer
 from geonode.decorators import on_ogc_backend, dump_func_name
 from geonode.geoserver.helpers import gs_slurp
@@ -68,10 +69,11 @@ from .utils import (
     get_geofence_rules,
     get_geofence_rules_count,
     get_highest_priority,
+    list_geofence_layer_rules_xml,
     set_geofence_all,
     purge_geofence_all,
     sync_geofence_with_guardian,
-    sync_resources_with_guardian
+    sync_resources_with_guardian,
 )
 
 
@@ -1153,6 +1155,202 @@ class PermissionsTest(GeoNodeBaseTestSupport):
         purge_geofence_all()
         geofence_rules_count = get_geofence_rules_count()
         self.assertTrue(geofence_rules_count == 0)
+
+
+    @dump_func_name
+    @mock.patch('geonode.security.utils.GeofenceLayerRulesUnitOfWork._add_request')
+    @mock.patch('geonode.security.utils.GeofenceLayerRulesUnitOfWork._execute_requests')
+    @mock.patch('geonode.security.utils.GeofenceLayerRulesUnitOfWork.rollback')
+    def test_layer_set_default_permissions_unit_of_work(
+        self,
+        mocked_uow_rollback,
+        mocked_uow_execute_requests,
+        mocked_uow_add_request
+    ):
+        """
+            Verify that the GeofenceLayerRulesUnitOfWork is:
+            * Stacking the geofence requests
+            * Execute requests when exiting
+            * Executing rollback when an error is raised
+        """
+        geofence_rules_count_start = get_geofence_rules_count()
+
+        # Configure mock to raise an Exception
+        mocked_uow_execute_requests.side_effect = RuntimeError()
+
+        # Get a Layer object to work with
+        layer = Layer.objects.all()[0]
+
+        # Set the default permissions
+        with self.assertRaises(GeoNodeException):
+            layer.set_default_permissions()
+
+        # Assertions
+        self.assertEqual(mocked_uow_add_request.call_count, 20)
+        expected_requests = [
+            'purge_rules',
+            'update_rule',
+            'update_rule',
+            'update_rule',
+            'update_rule',
+            'update_rule',
+            'set_invalidate_cache',
+            'update_rule',
+            'update_rule',
+            'update_rule',
+            'update_rule',
+            'update_rule',
+            'set_invalidate_cache',
+            'update_rule',
+            'update_rule',
+            'set_invalidate_cache',
+            'update_rule',
+            'update_rule',
+            'set_invalidate_cache',
+            'set_invalidate_cache',
+        ]
+        stacked_requests = [call.args[0]['name'] for call in mocked_uow_add_request.call_args_list]
+        self.assertEqual(expected_requests, stacked_requests)
+        mocked_uow_execute_requests.assert_called_once()
+        mocked_uow_rollback.assert_called_once()
+        geofence_rules_count_end = get_geofence_rules_count()
+        self.assertEqual(geofence_rules_count_start, geofence_rules_count_end)
+
+
+    @dump_func_name
+    @mock.patch('geonode.security.utils.GeofenceLayerRulesUnitOfWork._add_request')
+    @mock.patch('geonode.security.utils.GeofenceLayerRulesUnitOfWork._execute_requests')
+    @mock.patch('geonode.security.utils.GeofenceLayerRulesUnitOfWork.rollback')
+    def test_set_layer_permissions_unit_of_work(
+        self,
+        mocked_uow_rollback,
+        mocked_uow_execute_requests,
+        mocked_uow_add_request,
+    ):
+        """
+            Verify that the GeofenceLayerRulesUnitOfWork is:
+            * Stacking the geofence requests
+            * Execute requests when exiting
+            * Executing rollback when an error is raised
+        """
+        geofence_rules_count_start = get_geofence_rules_count()
+
+        # Configure mock to raise an Exception
+        mocked_uow_execute_requests.side_effect = RuntimeError()
+
+        # Get a layer to work with
+        layer = Layer.objects.all()[0]
+
+        # Set the Permissions
+        with self.assertRaises(GeoNodeException):
+            layer.set_permissions(self.perm_spec)
+
+        # Assertions
+        self.assertEqual(mocked_uow_add_request.call_count, 12)
+        expected_requests = [
+            'purge_rules',
+            'update_rule',
+            'update_rule',
+            'update_rule',
+            'update_rule',
+            'update_rule',
+            'set_invalidate_cache',
+            'update_rule',
+            'update_rule',
+            'set_invalidate_cache',
+            'set_invalidate_cache',
+            'toggle_layer_cache',
+        ]
+        stacked_requests = [call.args[0]['name'] for call in mocked_uow_add_request.call_args_list]
+        self.assertEqual(expected_requests, stacked_requests)
+        mocked_uow_execute_requests.assert_called_once()
+        mocked_uow_rollback.assert_called_once()
+        geofence_rules_count_end = get_geofence_rules_count()
+        self.assertEqual(geofence_rules_count_start, geofence_rules_count_end)
+
+    @dump_func_name
+    def test_layer_permissions_geofence_rollback(
+        self,
+    ):
+        """
+            Verify that the Geofence UoW Rollback is working properly:
+            * Reset the Geofence Rules
+            * Set PermSpec A.
+                * Get Geofence state to compare with rollback. 
+            * Set PermSpec B.
+                * Get Geofence state to compare with rollback. 
+            * Try to set PermSpec A again:
+               * Simulates something going wrong.
+               * Assure thar the Geofence State corresponds to B and not to A.
+               * Successful Rollback. \o/ 
+        """
+        # Gathering data
+        layer = Layer.objects.all()[0]
+        perm_spec_a = {
+            "users": {
+                "admin": ["change_resourcebase", "change_resourcebase_permissions", "view_resourcebase"]
+            },
+            "groups": []
+        }
+        perm_spec_b = {
+            "users": {
+                "admin": ["change_resourcebase", "change_resourcebase_permissions", "view_resourcebase"],
+                "bobby": ["view_resourcebase", "download_resourcebase", "change_layer_style"]
+            },
+            "groups": []
+        }
+        
+        # Start with a clean set of geofence rules
+        purge_geofence_all()
+        geofence_rules_count_zero = get_geofence_rules_count()
+        self.assertEqual(geofence_rules_count_zero, 0)
+
+        # Following as used in others test case, etree library was loaded
+        from lxml import etree
+
+        # Set the permissions A - Save Geofence XML
+        layer.set_permissions(perm_spec_a)
+        geofence_rules_count_perm_spec_a= get_geofence_rules_count()
+        rules = list_geofence_layer_rules_xml(get_layer_workspace(layer), layer.alternate)
+        rules_perm_spec_a = b""
+        for rule in rules:
+            rule.attrib.pop("id")
+            rules_perm_spec_a += etree.tostring(rule)
+
+        # Set the permissions B - Save Geofence XML
+        layer.set_permissions(perm_spec_b)
+        geofence_rules_count_perm_spec_b = get_geofence_rules_count()
+        rules = list_geofence_layer_rules_xml(get_layer_workspace(layer), layer.alternate)
+        rules_perm_spec_b = b""
+        for rule in rules:
+            rule.attrib.pop("id")
+            rules_perm_spec_b += etree.tostring(rule)
+
+        # Force rollback when trying to set permissions to A again.
+        with mock.patch('geonode.security.utils.GeofenceLayerAdapter.toggle_layer_cache') as mocked_adapter_toggle_layer_cache:
+            mocked_adapter_toggle_layer_cache.side_effect = Exception()
+
+            # Try to set the permissions A again
+            with self.assertRaises(GeoNodeException):
+                layer.set_permissions(perm_spec_a)
+            
+            # Verify the rollback to permission B
+            geofence_rules_count_end = get_geofence_rules_count()
+            rules = list_geofence_layer_rules_xml(get_layer_workspace(layer), layer.alternate)
+            rules_perm_spec_end = b""
+            for rule in rules:
+                rule.attrib.pop("id")
+                rules_perm_spec_end += etree.tostring(rule)
+
+            # Assertions - Successful Rollback
+            mocked_adapter_toggle_layer_cache.assert_called_once()
+            # Count and RulesXML is same as permission B 
+            self.assertEqual(geofence_rules_count_end, geofence_rules_count_perm_spec_b)
+            self.assertEqual(rules_perm_spec_end, rules_perm_spec_b)
+            # Count and RulesXML is not as permission A
+            self.assertNotEqual(geofence_rules_count_end, geofence_rules_count_perm_spec_a)
+            self.assertNotEqual(rules_perm_spec_end, rules_perm_spec_a)
+
 
     @dump_func_name
     def test_layer_set_default_permissions(self):

--- a/geonode/security/utils.py
+++ b/geonode/security/utils.py
@@ -80,7 +80,7 @@ class GeofenceLayerAdapter(object):
         layer_name = (
             layer.name
             if layer and hasattr(layer, 'name') else
-            layer.alternate.split(":")[0]
+            layer.alternate
         )
         if xml:
             rules = list_geofence_layer_rules_xml(workspace, layer_name)
@@ -490,7 +490,7 @@ def purge_geofence_layer_rules(resource):
     """
     layer = resource.layer
     workspace = get_layer_workspace(layer)
-    layer_name = layer.name if layer and hasattr(layer, "name") else layer.alternate.split(":")[0]
+    layer_name = layer.name if layer and hasattr(layer, "name") else layer.alternate
     try:
         rules = list_geofence_layer_rules(workspace, layer_name)
         if not rules or len(rules) == 0:
@@ -694,7 +694,7 @@ def set_geofence_all(instance):
     logger.debug(f"Inside set_geofence_all for instance {instance}")
     workspace = get_layer_workspace(resource.layer)
     layer_name = resource.layer.name if resource.layer and hasattr(resource.layer, 'name') \
-        else resource.layer.alternate.split(":")[0]
+        else resource.layer.alternate
     logger.debug(f"going to work in workspace {workspace}")
     try:
         url = settings.OGC_SERVER['default']['LOCATION']
@@ -739,11 +739,8 @@ def sync_geofence_with_guardian(layer, perms, user=None, group=None, group_perms
     """
     Sync Guardian permissions to GeoFence.
     """
-    _layer_name = layer.name if layer and hasattr(layer, 'name') else layer.alternate.split(":")[0]
+    _layer_name = layer.name if layer and hasattr(layer, 'name') else layer.alternate
     _layer_workspace = get_layer_workspace(layer)
-    _rules = list_geofence_layer_rules(_layer_workspace, _layer_name)
-    if not _rules or len(_rules) == 0:
-        _layer_name = layer.alternate
     # Create new rule-set
     gf_services = _get_gf_services(layer, perms)
 

--- a/geonode/security/utils.py
+++ b/geonode/security/utils.py
@@ -52,7 +52,7 @@ class GeofenceRequestError(exceptions.APIException):
     pass
 
 
-class GeofenceLayerAdapter:
+class GeofenceLayerAdapter(object):
     def __init__(self, resource):
         self.resource = resource
         self.__has_committed_changes = False
@@ -131,7 +131,7 @@ class GeofenceLayerAdapter:
             return True
 
 
-class GeofenceLayerRulesUnitOfWork:
+class GeofenceLayerRulesUnitOfWork(object):
     def __init__(self, geofence_adapter):
         self.adapter = geofence_adapter
         self.requests_list = []


### PR DESCRIPTION
References: #8112

## What was done

* `GeofenceAdapter` and  `GeofenceLayerRulesUnitOfWork` were created:
    * When inside the `GeofenceLayerRulesUnitOfWork` the geofence transactions were stacked to be executed at the end (`__exit__`).
*  `GeofenceLayerRulesUnitOfWork` were used as a context manager.
* In case of failure:
    * `geofence_adapter.rollback()` restore the previous state, if needed. 

## How to test

* Django Testing
```
./manage.py test geonode.security.tests.PermissionsTest.test_set_layer_permissions_unit_of_work --keepdb
./manage.py test geonode.security.tests.PermissionsTest.test_layer_set_default_permissions_unit_of_work --keepdb
./manage.py test geonode.security.tests.PermissionsTest.test_layer_permissions_geofence_rollback --keepd
```

* Manual Testing:
    * Run the application.
    * Add a layer.
    * Change its permissions:
    ![image](https://user-images.githubusercontent.com/12943132/133075679-98127ad1-34fa-49e8-b67c-39a6b18ba7d1.png)
    * During execution, check the layer rules count using the following geoserver request:
    ```bash
    # Change `localhost:8080` to your geoserver url, `Basic YWRtaW46Z2Vvc2VydmVy' to your geoserver authorization token and `san_andres_y_providencia_coastline0` to your layer name.
    curl --location --request GET 'http://localhost:8080/geoserver/rest/geofence/rules?workspace=geonode&layer=san_andres_y_providencia_coastline0' \
    --header 'Authorization: Basic YWRtaW46Z2Vvc2VydmVy'
    ```
    * It should reflect the changed you made using the geonode interface.
* For manual testing the rollback:
  * Try to raise an Exception after the Unit of Work block (`geonode/security/models.py#L422`, `PermissionLevelMixin.set_permissions`).
      ```python
                                  self.set_dirty_state()
                  raise Exception()
              except Exception as e:
                  geofence_adapter.rollback()
                  raise GeoNodeException(e)
      ``` 
  * Verify at the geoserver (same cURL as above) if the rules list has been modified during the execution and restored at the end.
  * At the geonode interface, you will have the following message:
  ![image](https://user-images.githubusercontent.com/12943132/133076986-c42798d8-64c5-4c20-a276-c0a570bcee72.png)


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [x] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [x] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
