### PR TITLE
[Fixes #8124] By removing anyone from initial perms won't allow to ad…

### DIFF
--- a/geonode/security/permissions.py
+++ b/geonode/security/permissions.py
@@ -355,6 +355,19 @@ class PermSpec(PermSpecConverterBase):
 
         if anonymous_perms:
             group_perms.append(anonymous_perms)
+        else:
+            anonymous_group = Group.objects.get(name='anonymous')
+            group_perms.append(
+                {
+                    'id': anonymous_group.id,
+                    'title': 'anonymous',
+                    'name': 'anonymous',
+                    'permissions': _to_compact_perms(
+                        get_group_perms(anonymous_group, self._resource),
+                        self._resource.resource_type,
+                        self._resource.subtype)
+                }
+            )
         if contributors_perms:
             group_perms.append(contributors_perms)
         elif Group.objects.filter(name=groups_settings.REGISTERED_MEMBERS_GROUP_NAME).exists():

--- a/geonode/security/tests.py
+++ b/geonode/security/tests.py
@@ -1607,6 +1607,68 @@ class SecurityTests(ResourceTestCaseMixin, GeoNodeBaseTestSupport):
         """
         standard_user = get_user_model().objects.get(username="bobby")
         dataset = Dataset.objects.filter(owner=standard_user).first()
+
+        perm_spec = {
+            'users': {
+                'bobby': [
+                    'view_resourcebase',
+                    'download_resourcebase',
+                    'change_dataset_style'
+                ]
+            },
+            'groups': {}
+        }
+
+        _p = PermSpec(perm_spec, dataset)
+        self.assertDictEqual(
+            json.loads(str(_p)),
+            {
+                "users":
+                    {
+                        "bobby":
+                            [
+                                "view_resourcebase",
+                                "download_resourcebase",
+                                "change_dataset_style"
+                        ]
+                    },
+                "groups": {}
+            }
+        )
+
+        self.assertDictEqual(
+            _p.compact,
+            {
+                'users':
+                [
+                    {
+                        'id': standard_user.id,
+                        'username': standard_user.username,
+                        'first_name': standard_user.first_name,
+                        'last_name': standard_user.last_name,
+                        'avatar': 'https://www.gravatar.com/avatar/d41d8cd98f00b204e9800998ecf8427e/?s=240',
+                        'permissions': 'owner'
+                    }
+                ],
+                'organizations': [],
+                'groups':
+                [
+                    {
+                        'id': 3,
+                        'title': 'anonymous',
+                        'name': 'anonymous',
+                        'permissions': 'none'
+                    },
+                    {
+                        'id': 2,
+                        'name': 'registered-members',
+                        'permissions': 'none',
+                        'title': 'Registered Members'
+                    }
+                ]
+            }
+        )
+
         perm_spec = {
             'users': {
                 'AnonymousUser': [
@@ -1751,6 +1813,7 @@ class SecurityRulesTests(TestCase):
     """
 
     def setUp(self):
+        self.maxDiff = None
         self._l = create_single_dataset("test_dataset")
 
     def test_sync_resources_with_guardian_delay_false(self):
@@ -1787,6 +1850,7 @@ class SecurityRulesTests(TestCase):
 class TestGetUserGeolimits(TestCase):
 
     def setUp(self):
+        self.maxDiff = None
         self.layer = create_single_dataset("main-layer")
         self.owner = get_user_model().objects.get(username='admin')
         self.perms = {'*': ''}


### PR DESCRIPTION
…d them back anymore

References: #8124

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
