### PR TITLE
[Fixes #8154] GeoNode tries to retrieve Geofence rules for Geoserver …

### DIFF
--- a/geonode/security/utils.py
+++ b/geonode/security/utils.py
@@ -486,7 +486,8 @@ def list_geofence_layer_rules_xml(workspace, layer_name):
     if response.status_code >= 200 and response.status_code < 300:
         gs_rules = etree.fromstring(response.content)
         for rule in gs_rules:
-            if rule.find("layer").text == layer_name:
+            layer_field = rule.find("layer")
+            if layer_field is not None and hasattr(layer_field, "text") and layer_field.text == layer_name:
                 rules.append(rule)
 
     return rules


### PR DESCRIPTION
…layer even if no rules are assigned to them

## Context

In `list_geofence_layer_rules` there is a check to verify that the layer field is not `None`. ([link](https://github.com/GeoNode/geonode/blob/d27b221c44953a48b0d727f71f174e0d7deaeec5/geonode/security/utils.py#L465))
```python
if rule["layer"] and rule["layer"] == layer_name:
    rules.append(rule)
```
That check was forgotten in the function `list_geofence_layer_rules_xml` (see file changes) during the development of #8113. 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
