### PR TITLE
Typo in crs definition for epsg:4326

### DIFF
--- a/geonode/utils.py
+++ b/geonode/utils.py
@@ -859,7 +859,7 @@ _viewer_projection_lookup = {
         "maxExtent": max_extent,
     },
     "EPSG:4326": {
-        "max_resolution": FULL_ROTATION_DEG / 256,
+        "maxResolution": FULL_ROTATION_DEG / 256,
         "units": "degrees",
         "maxExtent": [-180, -90, 180, 90]
     }


### PR DESCRIPTION
There's a typo in the definition of the coordinate ref. system 4326
The value defined as max_resolution should be instead maxResolution


For all pull requests:

- [ X] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 

