### PR TITLE
[Backport to 3.2.x][Fixes #8198] A comma in the title of a resource breaks the update of…

### DIFF
--- a/geonode/api/resourcebase_api.py
+++ b/geonode/api/resourcebase_api.py
@@ -650,6 +650,12 @@ class CommonModelApi(ModelResource):
         else:
             return []
 
+    def hydrate_title(self, bundle):
+        title = bundle.data.get("title", None)
+        if title:
+            bundle.data["title"] = title.replace(",", "_")
+        return bundle
+
 
 class ResourceBaseResource(CommonModelApi):
 

--- a/geonode/base/forms.py
+++ b/geonode/base/forms.py
@@ -519,6 +519,12 @@ class ResourceBaseForm(TranslationModelForm):
                     _unsescaped_kwds.append(str(_k))
         return _unsescaped_kwds
 
+    def clean_title(self):
+        title = self.cleaned_data.get("title", None)
+        if title:
+            title = title.replace(",", "_")
+        return title
+
     class Meta:
         exclude = (
             'contacts',

--- a/geonode/base/models.py
+++ b/geonode/base/models.py
@@ -1015,6 +1015,11 @@ class ResourceBase(PolymorphicModel, PermissionLevelMixin, ItemBase):
     def raw_data_quality_statement(self):
         return self._remove_html_tags(self.data_quality_statement)
 
+    def clean(self):
+        if self.title:
+            self.title = self.title.replace(",", "_")
+        return super().clean()
+
     def save(self, notify=False, *args, **kwargs):
         """
         Send a notification when a resource is created or updated

--- a/geonode/layers/tests.py
+++ b/geonode/layers/tests.py
@@ -1397,6 +1397,37 @@ class TestLayerDetailMapViewRights(GeoNodeBaseTestSupport):
         response = self.client.get(reverse('layer_detail', args=(self.layer.alternate,)))
         self.assertEqual(response.context['map_layers'], [self.map_layer])
 
+    def test_update_with_a_comma_in_title_is_replaced_by_undescore(self):
+        """
+        Test that when changing the dataset title, if the entered title has a comma it is replaced by an undescore.
+        """
+        self.test_dataset = resource_manager.create(
+            None,
+            resource_type=Dataset,
+            defaults=dict(
+                owner=self.not_admin,
+                title='test',
+                is_approved=True
+            )
+        )
+
+        data = {
+            'resource-title': 'test,comma,2021',
+            'resource-owner': self.test_dataset.owner.id,
+            'resource-date': str(self.test_dataset.date),
+            'resource-date_type': self.test_dataset.date_type,
+            'resource-language': self.test_dataset.language,
+            'dataset_attribute_set-TOTAL_FORMS': 0,
+            'dataset_attribute_set-INITIAL_FORMS': 0,
+        }
+
+        url = reverse('dataset_metadata', args=(self.test_dataset.alternate,))
+        self.client.login(username=self.not_admin.username, password='very-secret')
+        response = self.client.post(url, data=data)
+        self.test_dataset.refresh_from_db()
+        self.assertEqual(self.test_dataset.title, 'test_comma_2021')
+        self.assertEqual(response.status_code, 200)
+
 
 '''
 Smoke test to explain how the uuidhandler will override the uuid for the layers


### PR DESCRIPTION
…… (#8284)

* [Fixes #8198] A comma in the title of a resource breaks the update of resource info and CSW response

* [CircleCI] Increase test coverage

(cherry picked from commit d882a965ff57abf7e13f62a6f926f2a6f9168975)

# Conflicts:
#	geonode/base/models.py
#	geonode/layers/tests.py

<Include a few sentences describing the overall goals for this Pull Request>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [ ] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [ ] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
