### PR TITLE
[Fixes #8318] Wrong match for Geoserver path

### DIFF
--- a/geonode/geoserver/tests/test_helpers.py
+++ b/geonode/geoserver/tests/test_helpers.py
@@ -22,6 +22,7 @@ import logging
 from urllib.parse import urljoin
 
 from django.conf import settings
+from django.urls import reverse
 
 from geonode import geoserver
 from geonode.decorators import on_ogc_backend
@@ -193,3 +194,11 @@ xlink:href="{settings.GEOSERVER_LOCATION}ows?service=WMS&amp;request=GetLegendGr
     def test_remoteStore_should_return_remote(self):
         el = get_dataset_storetype('remoteStore')
         self.assertEqual('remote', el)
+
+    @on_ogc_backend(geoserver.BACKEND_PACKAGE)
+    def test_geoserver_proxy_strip_paths(self):
+        response = self.client.get(f"{reverse('gs_layers')}?service=WFS&version=1.1.0&request=DescribeFeatureType&typeName=geonode:tipi_forestali&outputFormat=application/json&access_token=something")
+        self.assertEqual(response.status_code, 200)
+
+        response = self.client.get(f"{reverse('ows_endpoint')}?service=WFS&version=1.1.0&request=DescribeFeatureType&typeName=geonode:tipi_forestali&outputFormat=image/png&access_token=something")
+        self.assertEqual(response.status_code, 200)

--- a/geonode/geoserver/tests/test_server.py
+++ b/geonode/geoserver/tests/test_server.py
@@ -875,19 +875,19 @@ class LayerTests(GeoNodeBaseTestSupport):
         self.assertEqual(route, '^gs/rest/sldservice')
 
         store_resolver = resolve('/gs/rest/stores/geonode_data/')
-        self.assertEqual(store_resolver.url_name, 'stores')
+        self.assertEqual(store_resolver.url_name, 'gs_stores')
         self.assertEqual(store_resolver.kwargs['store_type'], 'geonode_data')
         self.assertEqual(store_resolver.route, '^gs/rest/stores/(?P<store_type>\\w+)/$')
 
         sld_resolver = resolve('/gs/rest/styles')
-        self.assertIsNone(sld_resolver.url_name)
+        self.assertEqual(sld_resolver.url_name, 'gs_styles')
         self.assertTrue('workspace' not in sld_resolver.kwargs)
         self.assertEqual(sld_resolver.kwargs['proxy_path'], '/gs/rest/styles')
         self.assertEqual(sld_resolver.kwargs['downstream_path'], 'rest/styles')
         self.assertEqual(sld_resolver.route, '^gs/rest/styles')
 
         sld_resolver = resolve('/gs/rest/workspaces/geonode/styles')
-        self.assertIsNone(sld_resolver.url_name)
+        self.assertEqual(sld_resolver.url_name, 'gs_workspaces')
         self.assertEqual(sld_resolver.kwargs['workspace'], 'geonode')
         self.assertEqual(sld_resolver.kwargs['proxy_path'], '/gs/rest/workspaces')
         self.assertEqual(sld_resolver.kwargs['downstream_path'], 'rest/workspaces')

--- a/geonode/geoserver/urls.py
+++ b/geonode/geoserver/urls.py
@@ -23,19 +23,17 @@ from . import views
 
 urlpatterns = [  # 'geonode.geoserver.views',
     # REST Endpoints
-    url(r'^rest/stores/(?P<store_type>\w+)/$',
-        views.stores, name="stores"),
+    url(r'^rest/stores/(?P<store_type>\w+)/$', views.stores, name="gs_stores"),
     url(r'^rest/styles', views.geoserver_proxy, dict(proxy_path='/gs/rest/styles',
-                                                     downstream_path='rest/styles')),
-    url(r'^rest/workspaces/(?P<workspace>\w+)', views.geoserver_proxy,
-        dict(proxy_path='/gs/rest/workspaces',
-             downstream_path='rest/workspaces')),
+                                                     downstream_path='rest/styles'), name="gs_styles"),
+    url(r'^rest/workspaces/(?P<workspace>\w+)', views.geoserver_proxy, dict(proxy_path='/gs/rest/workspaces',
+                                                                            downstream_path='rest/workspaces'), name="gs_workspaces"),
     url(r'^rest/layers', views.geoserver_proxy, dict(proxy_path='/gs/rest/layers',
-                                                     downstream_path='rest/layers')),
+                                                     downstream_path='rest/layers'), name="gs_layers"),
     url(r'^rest/imports', views.geoserver_proxy, dict(proxy_path='/gs/rest/imports',
-                                                      downstream_path='rest/imports')),
+                                                      downstream_path='rest/imports'), name="gs_imports"),
     url(r'^rest/sldservice', views.geoserver_proxy, dict(proxy_path='/gs/rest/sldservice',
-                                                         downstream_path='rest/sldservice')),
+                                                         downstream_path='rest/sldservice'), name="gs_sldservice"),
 
     # OWS Endpoints
     url(r'^ows', views.geoserver_proxy, dict(proxy_path='/gs/ows',

--- a/geonode/geoserver/views.py
+++ b/geonode/geoserver/views.py
@@ -464,7 +464,7 @@ def geoserver_proxy(request,
             raw_url = _url
 
     if downstream_path in 'ows' and (
-        'rest' in path or
+        re.match(r'/(rest).*$', path, re.IGNORECASE) or
             re.match(r'/(w.*s).*$', path, re.IGNORECASE) or
             re.match(r'/(ows).*$', path, re.IGNORECASE)):
         _url = str("".join([ogc_server_settings.LOCATION, '', path[1:]]))


### PR DESCRIPTION
References: #8318

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
