### PR TITLE
[Fixes #8327] The final file extension is incorrect when exporting data from the attribute table

### DIFF
--- a/geonode/proxy/tests.py
+++ b/geonode/proxy/tests.py
@@ -57,6 +57,7 @@ class ProxyTest(GeoNodeBaseTestSupport):
 
     def setUp(self):
         super().setUp()
+        self.maxDiff = None
         self.admin = get_user_model().objects.get(username='admin')
 
         # FIXME(Ariel): These tests do not work when the computer is offline.
@@ -126,11 +127,62 @@ class ProxyTest(GeoNodeBaseTestSupport):
         self.client.get(f'{self.proxy_url}?url={url}')
         assert request_mock.call_args[0][0] == 'http://example.org/index.html'
 
+    def test_proxy_preserve_headers(self):
+        """The GeoNode Proxy should preserve the original request headers."""
+        import geonode.proxy.views
+
+        _test_headers = {
+            'Access-Control-Allow-Credentials': False,
+            'Access-Control-Allow-Headers': 'Content-Type, Accept, Authorization, Origin, User-Agent',
+            'Access-Control-Allow-Methods': 'GET, POST, PUT, PATCH, OPTIONS',
+            'Cache-Control': 'public, must-revalidate, max-age = 30',
+            'Connection': 'keep-alive',
+            'Content-Language': 'en',
+            'Content-Length': 116559,
+            'Content-Type': 'image/tiff',
+            'Content-Disposition': 'attachment; filename="filename.tif"',
+            'Date': 'Fri, 05 Nov 2021 17: 19: 11 GMT',
+            'Server': 'nginx/1.17.2',
+            'Set-Cookie': 'sessionid = bogus-pocus; HttpOnly; Path=/; SameSite=Lax',
+            'Strict-Transport-Security': 'max-age=3600; includeSubDomains',
+            'Vary': 'Authorization, Accept-Language, Cookie, Origin',
+            'X-Content-Type-Options': 'nosniff',
+            'X-XSS-Protection': '1; mode=block'
+        }
+
+        class Response:
+            status_code = 200
+            content = 'Hello World'
+            headers = _test_headers
+
+        request_mock = MagicMock()
+        request_mock.return_value = (Response(), None)
+
+        geonode.proxy.views.http_client.request = request_mock
+        url = "http://example.org/test/test/../../image.tiff"
+
+        response = self.client.get(f'{self.proxy_url}?url={url}')
+        self.assertDictContainsSubset(
+            dict(response.headers.copy()),
+            {
+                'Content-Type': 'text/plain',
+                'Vary': 'Authorization, Accept-Language, Cookie, Origin',
+                'X-Content-Type-Options': 'nosniff',
+                'X-XSS-Protection': '1; mode=block',
+                'Referrer-Policy': 'same-origin',
+                'X-Frame-Options': 'SAMEORIGIN',
+                'Content-Language': 'en',
+                'Content-Length': '119',
+                'Content-Disposition': 'attachment; filename="filename.tif"'
+            }
+        )
+
 
 class DownloadResourceTestCase(GeoNodeBaseTestSupport):
 
     def setUp(self):
         super().setUp()
+        self.maxDiff = None
         create_models(type='dataset')
 
     @on_ogc_backend(geoserver.BACKEND_PACKAGE)
@@ -187,6 +239,7 @@ class OWSApiTestCase(GeoNodeBaseTestSupport):
 
     def setUp(self):
         super().setUp()
+        self.maxDiff = None
         create_models(type='dataset')
         # prepare some WMS endpoints
         q = Link.objects.all()
@@ -209,6 +262,7 @@ class OWSApiTestCase(GeoNodeBaseTestSupport):
 @override_settings(SITEURL='http://localhost:8000')
 class TestProxyTags(GeoNodeBaseTestSupport):
     def setUp(self):
+        self.maxDiff = None
         self.resource = create_single_dataset('foo_dataset')
         r = RequestFactory()
         self.url = urljoin(settings.SITEURL, reverse("download", args={self.resource.id}))

--- a/geonode/utils.py
+++ b/geonode/utils.py
@@ -345,9 +345,9 @@ def get_dataset_workspace(dataset):
 
 
 def get_headers(request, url, raw_url, allowed_hosts=[]):
-    headers = {}
     cookies = None
     csrftoken = None
+    headers = dict(request.headers.copy())
 
     if settings.SESSION_COOKIE_NAME in request.COOKIES and is_safe_url(
             url=raw_url, allowed_hosts=url.hostname):


### PR DESCRIPTION
References: #8327

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
