### PR TITLE
[Fixes #8341] Duplicate permission on layers

### DIFF
--- a/geonode/security/models.py
+++ b/geonode/security/models.py
@@ -139,6 +139,12 @@ class PermissionLevelMixin:
         except Exception:
             tb = traceback.format_exc()
             logger.debug(tb)
+        # Remove duplicated perms if any
+        if info:
+            for _k, _v in info.items():
+                for _kk, _vv in info[_k].items():
+                    if _vv and isinstance(_vv, list):
+                        info[_k][_kk] = list(set(_vv))
         return info
 
     def get_self_resource(self):

--- a/geonode/security/tests.py
+++ b/geonode/security/tests.py
@@ -1225,6 +1225,15 @@ class PermissionsTest(GeoNodeBaseTestSupport):
         current_perms = layer.get_all_level_info()
         self.assertGreaterEqual(len(current_perms['users']), 1)
 
+        # Test that there are no duplicates on returned permissions
+        for _k, _v in current_perms.items():
+            for _kk, _vv in current_perms[_k].items():
+                if _vv and isinstance(_vv, list):
+                    self.assertListEqual(
+                        _vv,
+                        list(set(_vv))
+                    )
+
         # Test that the User permissions specified in the perm_spec were
         # applied properly
         for username, perm in self.perm_spec['users'].items():


### PR DESCRIPTION
References: #8341

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
