### PR TITLE
[Fixes #8376] Fix letsencrypt certificate handling

### DIFF
--- a/scripts/docker/letsencrypt/Dockerfile
+++ b/scripts/docker/letsencrypt/Dockerfile
@@ -1,8 +1,4 @@
-FROM alpine:3.8
-
-# 1-2. Install system dependencies
-RUN apk add --no-cache certbot py-pip && pip install pyopenssl==16.0.0 # Need to downgrade PyOpenSSL to 16.0.0 to avoid conflicts and solve the cryptography error : https://github.com/plesk/letsencrypt-plesk/issues/117
-
+FROM certbot/certbot:v1.21.0
 
 # Installing scripts
 ADD docker-entrypoint.sh /docker-entrypoint.sh
@@ -14,6 +10,7 @@ RUN /usr/bin/crontab /crontab && \
     rm /crontab
 
 # Setup the entrypoint
+WORKDIR /
 ENTRYPOINT ["./docker-entrypoint.sh"]
 
 # We run cron in foreground to update the certificates

--- a/scripts/docker/letsencrypt/docker-entrypoint.sh
+++ b/scripts/docker/letsencrypt/docker-entrypoint.sh
@@ -9,7 +9,7 @@ echo "STARTING LETSENCRYPT ENTRYPOINT ---------------------"
 date
 
 # We make the config dir
-mkdir -p "/spcgeonode-certificates/$LETSENCRYPT_MODE"
+mkdir -p "/geonode-certificates/$LETSENCRYPT_MODE"
 
 # Do not exit script in case of error
 set +e
@@ -17,10 +17,10 @@ set +e
 # We run the command
 if [ "$LETSENCRYPT_MODE" == "staging" ]; then
     printf "\nTrying to get STAGING certificate\n"
-    certbot --config-dir "/spcgeonode-certificates/$LETSENCRYPT_MODE" certonly --webroot -w "/spcgeonode-certificates" -d "$HTTPS_HOST" -m "$ADMIN_EMAIL" --agree-tos --non-interactive --staging --server https://acme-v02.api.letsencrypt.org/directory
+    certbot --config-dir "/geonode-certificates/$LETSENCRYPT_MODE" certonly --webroot -w "/geonode-certificates" -d "$HTTPS_HOST" -m "$ADMIN_EMAIL" --agree-tos --non-interactive --staging
 elif [ "$LETSENCRYPT_MODE" == "production" ]; then
     printf "\nTrying to get PRODUCTION certificate\n"
-    certbot --config-dir "/spcgeonode-certificates/$LETSENCRYPT_MODE" certonly --webroot -w "/spcgeonode-certificates" -d "$HTTPS_HOST" -m "$ADMIN_EMAIL" --agree-tos --non-interactive --server https://acme-v02.api.letsencrypt.org/directory
+    certbot --config-dir "/geonode-certificates/$LETSENCRYPT_MODE" certonly --webroot -w "/geonode-certificates" -d "$HTTPS_HOST" -m "$ADMIN_EMAIL" --agree-tos --non-interactive --server https://acme-v02.api.letsencrypt.org/directory
 else
     printf "\nNot trying to get certificate (simulating failure, because LETSENCRYPT_MODE variable was neither staging nor production\n"
     /bin/false


### PR DESCRIPTION
Proposed for fixing GeoNode#8376

## Change list

- Change to the entrypoint script and directory structures so that the provisioned cert and challenges can be accessed by nginx container as well
- Since `spcgeonode` was deprecated, the directory references are changed to `geonode-certificates` according to the `docker-compose.yml` in the root directory
- Certbot now has official docker image. Meanwhile certbot from apk package was stuck in version 0.xx . To avoid CLI and ACME API mismatch in the previous containers, we use the latest pinned version of certbot as base image.

Since letsencrypt testing involves provisioning a real DNS address and real server. I don't know how to include testing for this, but I tested it manually on a server for some project.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
