### PR TITLE
[3.3.x][Fixes #8362] Permissions to brand new group managers  (#8367)

### DIFF
--- a/geonode/documents/views.py
+++ b/geonode/documents/views.py
@@ -225,8 +225,11 @@ class DocumentUploadView(CreateView):
 
         if settings.ADMIN_MODERATE_UPLOADS:
             self.object.is_approved = False
+            self.object.was_approved = False
         if settings.RESOURCE_PUBLISHING:
             self.object.is_published = False
+            self.object.was_published = False
+
         self.object.save()
         form.save_many2many()
         self.object.set_permissions(form.cleaned_data['permissions'])

--- a/geonode/geoserver/createlayer/utils.py
+++ b/geonode/geoserver/createlayer/utils.py
@@ -79,8 +79,10 @@ def create_gn_layer(workspace, datastore, name, title, owner_name):
 
     if settings.ADMIN_MODERATE_UPLOADS:
         layer.is_approved = False
+        layer.was_approved = False
     if settings.RESOURCE_PUBLISHING:
         layer.is_published = False
+        layer.was_published = False
 
     layer.save()
     return layer

--- a/geonode/groups/models.py
+++ b/geonode/groups/models.py
@@ -287,7 +287,11 @@ class GroupMember(models.Model):
             .filter(group=self.group.group)
             .exclude(owner=self.user)
         )
-        _resources = set([_r for _r in queryset.iterator()] + [_r for _r in self.group.resources()])
+        # A.F.: By including 'self.group.resources()' here, we will look also for resources
+        #       having permissions related to the current 'group' and not only the ones assigned
+        #       to the 'group' through the metadata settings.
+        # _resources = set([_r for _r in queryset.iterator()] + [_r for _r in self.group.resources()])
+        _resources = queryset.iterator()
         for _r in _resources:
             perm_spec = None
             if perms:

--- a/geonode/groups/models.py
+++ b/geonode/groups/models.py
@@ -18,6 +18,7 @@
 #########################################################################
 import os
 import logging
+
 from shutil import copyfile
 
 from django.conf import settings
@@ -36,7 +37,7 @@ from taggit.managers import TaggableManager
 
 from guardian.shortcuts import get_objects_for_user, get_objects_for_group
 
-from geonode.security.permissions import VIEW_PERMISSIONS
+from geonode.security.permissions import VIEW_PERMISSIONS, ADMIN_PERMISSIONS
 
 logger = logging.getLogger(__name__)
 
@@ -263,7 +264,7 @@ class GroupMember(models.Model):
     def promote(self, *args, **kwargs):
         self.role = "manager"
         super().save(*args, **kwargs)
-        self._handle_perms()
+        self._handle_perms(perms=VIEW_PERMISSIONS + ADMIN_PERMISSIONS)
 
     def demote(self, *args, **kwargs):
         self.role = "member"
@@ -278,10 +279,6 @@ class GroupMember(models.Model):
         If the user is demoted, we assign by default at least the view and the download permission
         to the resource
         '''
-        # TODO: The following queryset includes only the resources accessible to the user
-        #       and assigned to the current group, via the metadata editor.
-        #       It may not include the "group.resources()", i.e. the resources accessible
-        #       by the group.
         queryset = (
             get_objects_for_user(
                 self.user,
@@ -290,7 +287,8 @@ class GroupMember(models.Model):
             .filter(group=self.group.group)
             .exclude(owner=self.user)
         )
-        for _r in queryset.iterator():
+        _resources = set([_r for _r in queryset.iterator()] + [_r for _r in self.group.resources()])
+        for _r in _resources:
             perm_spec = None
             if perms:
                 perm_spec = _r.get_all_level_info()

--- a/geonode/layers/utils.py
+++ b/geonode/layers/utils.py
@@ -553,7 +553,7 @@ def file_upload(filename,
             defaults['is_approved'] = defaults['was_approved'] = is_approved
         if settings.RESOURCE_PUBLISHING:
             is_published = False
-            defaults['is_approved'] = defaults['was_published'] = is_approved
+            defaults['is_published'] = defaults['was_published'] = is_published
 
     # set metadata
     if 'xml' in files:

--- a/geonode/layers/utils.py
+++ b/geonode/layers/utils.py
@@ -531,14 +531,6 @@ def file_upload(filename,
         srid_url = f"http://www.spatialreference.org/ref/{srid.replace(':', '/').lower()}/"  # noqa
         bbox_polygon.srid = int(srid.split(':')[1])
 
-    # by default, if RESOURCE_PUBLISHING=True then layer.is_published
-    # must be set to False
-    if not overwrite:
-        if settings.RESOURCE_PUBLISHING:
-            is_published = False
-        if settings.ADMIN_MODERATE_UPLOADS:
-            is_approved = False
-
     defaults = {
         'upload_session': upload_session,
         'title': title,
@@ -552,6 +544,16 @@ def file_upload(filename,
         'license': license,
         'category': category
     }
+
+    # by default, if RESOURCE_PUBLISHING=True then layer.is_published
+    # must be set to False
+    if not overwrite:
+        if settings.ADMIN_MODERATE_UPLOADS:
+            is_approved = False
+            defaults['is_approved'] = defaults['was_approved'] = is_approved
+        if settings.RESOURCE_PUBLISHING:
+            is_published = False
+            defaults['is_approved'] = defaults['was_published'] = is_approved
 
     # set metadata
     if 'xml' in files:

--- a/geonode/security/tests.py
+++ b/geonode/security/tests.py
@@ -862,7 +862,7 @@ class PermissionsTest(GeoNodeBaseTestSupport):
 
         featureType = etree.ElementTree(dlxml.fromstring(r.text))
         metadata = featureType.findall('./[metadata]')
-        self.assertEqual(len(metadata), 1)
+        self.assertEqual(len(metadata), 0)
 
         payload = """<featureType>
         <metadata>

--- a/geonode/security/tests.py
+++ b/geonode/security/tests.py
@@ -17,6 +17,7 @@
 #
 #########################################################################
 import os
+import copy
 import json
 import base64
 import logging
@@ -861,7 +862,7 @@ class PermissionsTest(GeoNodeBaseTestSupport):
 
         featureType = etree.ElementTree(dlxml.fromstring(r.text))
         metadata = featureType.findall('./[metadata]')
-        self.assertEqual(len(metadata), 0)
+        self.assertEqual(len(metadata), 1)
 
         payload = """<featureType>
         <metadata>
@@ -1207,14 +1208,23 @@ class PermissionsTest(GeoNodeBaseTestSupport):
         """
 
         # Get a layer to work with
-        layer = Layer.objects.all()[0]
+        layer = Layer.objects.first()
 
         # FIXME Test a comprehensive set of permissions specifications
+
+        # Set the Default Permissions
+        layer.set_default_permissions()
+
+        # Test that the Permissions for anonymous user are set
+        self.assertTrue(
+            self.anonymous_user.has_perm(
+                'view_resourcebase',
+                layer.get_self_resource()))
 
         # Set the Permissions
         layer.set_permissions(self.perm_spec)
 
-        # Test that the Permissions for anonymous user is are set
+        # Test that the Permissions for anonymous user are un-set
         self.assertFalse(
             self.anonymous_user.has_perm(
                 'view_resourcebase',
@@ -1358,7 +1368,7 @@ class PermissionsTest(GeoNodeBaseTestSupport):
         # grab a layer
         layer = Layer.objects.filter(owner=bob).first()
         layer.set_default_permissions()
-        # verify bobby has view/change permissions on it but not manage
+        # verify bobby has view/change and manage permissions on it
         self.assertTrue(
             bob.has_perm(
                 'change_resourcebase_permissions',
@@ -1817,30 +1827,46 @@ class TestGetVisibleResources(ResourceTestCaseMixin, GeoNodeBaseTestSupport):
 
     def test_get_visible_resources(self):
         standard_user = get_user_model().objects.get(username="bobby")
-        anonymous_group = Group.objects.get(name='anonymous')
         layers = Layer.objects.all()
         # update user's perm on a layer,
         # this should not return the layer since it will not be in user's allowed resources
-        x = Layer.objects.get(title='common bar')
-        remove_perm('view_resourcebase', standard_user, x.get_self_resource())
-        remove_perm('change_resourcebase', standard_user, x.get_self_resource())
-        remove_perm('view_resourcebase', anonymous_group, x.get_self_resource())
-        remove_perm('change_resourcebase', anonymous_group, x.get_self_resource())
-        actual = get_visible_resources(
-            queryset=layers,
-            user=standard_user,
-            admin_approval_required=True,
-            unpublished_not_visible=True,
-            private_groups_not_visibile=True)
-        self.assertNotIn(x.title, list(actual.values_list('title', flat=True)))
-        # get layers as admin, this should return all layers with metadata_only = True
-        actual = get_visible_resources(
-            queryset=layers,
-            user=self.user,
-            admin_approval_required=True,
-            unpublished_not_visible=True,
-            private_groups_not_visibile=True)
-        self.assertIn(x.title, list(actual.values_list('title', flat=True)))
+        x = Layer.objects.filter(~Q(owner=standard_user)).first()
+        x_perms = copy.deepcopy(x.get_all_level_info())
+        try:
+            Layer.objects.filter(id=x.id).update(is_approved=False, is_published=False)
+            x.refresh_from_db()
+            x.set_permissions(
+                {
+                    'users': {
+                        'bobby': []
+                    },
+                    'groups': {
+                        'anonymous': [],
+                        'registered-members': []
+                    }
+                }
+            )
+            self.assertFalse(standard_user.has_perm('view_resourcebase', x.get_self_resource()))
+            self.assertFalse(standard_user.has_perm('change_resourcebase', x.get_self_resource()))
+            actual = get_visible_resources(
+                queryset=layers,
+                user=standard_user,
+                admin_approval_required=True,
+                unpublished_not_visible=True,
+                private_groups_not_visibile=True)
+            self.assertNotIn(x.title, list(actual.values_list('title', flat=True)))
+            # get layers as admin, this should return all layers with metadata_only = True
+            actual = get_visible_resources(
+                queryset=layers,
+                user=self.user,
+                admin_approval_required=True,
+                unpublished_not_visible=True,
+                private_groups_not_visibile=True)
+            self.assertIn(x.title, list(actual.values_list('title', flat=True)))
+        finally:
+            Layer.objects.filter(id=x.id).update(is_approved=True, is_published=True)
+            x.refresh_from_db()
+            x.set_permissions(x_perms)
 
 
 class TestGetUserGeolimits(TestCase):
@@ -1913,9 +1939,9 @@ class SetPermissionsTestCase(GeoNodeBaseTestSupport):
                         "change_resourcebase_metadata",
                         "delete_resourcebase",
                         "download_resourcebase",
-                        "publish_resourcebase",
-                        "change_resourcebase_permissions",
                         "view_resourcebase",
+                        "change_resourcebase_permissions",
+                        "publish_resourcebase"
                     ],
                     self.group_manager: [
                         "change_resourcebase",
@@ -1924,7 +1950,7 @@ class SetPermissionsTestCase(GeoNodeBaseTestSupport):
                         "download_resourcebase",
                         "publish_resourcebase",
                         "change_resourcebase_permissions",
-                        "view_resourcebase",
+                        "view_resourcebase"
                     ],
                     self.group_member: ["download_resourcebase", "view_resourcebase"],
                     self.not_group_member: ["download_resourcebase", "view_resourcebase"],


### PR DESCRIPTION
References: #8362

This PR fixes few problema on the Advanced Workflow missing in the the previous one related to the same issue.

In particular the group managers had different set of permissions when uploading a new layer and when promoting a new member.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [ ] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [ ] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
