### PR TITLE
[Fixes #8446] Fix thumbnail creation for new empty maps

### DIFF
--- a/geonode/thumbs/thumbnails.py
+++ b/geonode/thumbs/thumbnails.py
@@ -25,6 +25,7 @@ from PIL import Image, UnidentifiedImageError
 from typing import List, Union, Optional, Tuple
 
 from django.conf import settings
+from django.templatetags.static import static
 from django.utils.module_loading import import_string
 
 from geonode.maps.models import Map, MapLayer
@@ -33,7 +34,6 @@ from geonode.utils import OGC_Servers_Handler
 from geonode.utils import get_dataset_name, get_dataset_workspace
 from geonode.thumbs import utils
 from geonode.thumbs.exceptions import ThumbnailError
-
 
 logger = logging.getLogger(__name__)
 
@@ -95,7 +95,7 @@ def create_thumbnail(
 
     # handle custom, uploaded thumbnails, which may have different extensions from the default thumbnail
     thumbnail_exists = False
-    if instance.thumbnail_url and instance.thumbnail_url != utils.MISSING_THUMB:
+    if instance.thumbnail_url and instance.thumbnail_url != static(utils.MISSING_THUMB):
         thumbnail_exists = utils.thumb_exists(instance.thumbnail_url.rsplit('/')[-1])
 
     if (thumbnail_exists or utils.thumb_exists(default_thumbnail_name)) and not overwrite:

--- a/geonode/thumbs/utils.py
+++ b/geonode/thumbs/utils.py
@@ -29,7 +29,6 @@ from uuid import uuid4
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.templatetags.static import static
 
 from geonode.utils import (
     bbox_to_projection,
@@ -40,7 +39,7 @@ from geonode.storage.manager import storage_manager
 
 logger = logging.getLogger(__name__)
 
-MISSING_THUMB = static(settings.MISSING_THUMBNAIL)
+MISSING_THUMB = settings.MISSING_THUMBNAIL
 
 
 def make_bbox_to_pixels_transf(src_bbox: Union[List, Tuple], dest_bbox: Union[List, Tuple]) -> Callable:


### PR DESCRIPTION
references: #8446 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
