### PR TITLE
[Fixes #8422] Added pluggable service types

### DIFF
--- a/geonode/services/forms.py
+++ b/geonode/services/forms.py
@@ -27,9 +27,9 @@ import taggit
 from . import enumerations
 from .models import Service
 from .serviceprocessors import get_service_handler
+from .utils import get_service_type_choices
 
 logger = logging.getLogger(__name__)
-
 
 class CreateServiceForm(forms.Form):
     url = forms.CharField(
@@ -47,18 +47,7 @@ class CreateServiceForm(forms.Form):
     )
     type = forms.ChoiceField(
         label=_("Service Type"),
-        choices=(
-            # (enumerations.AUTO, _('Auto-detect')),
-            # (enumerations.OWS, _('Paired WMS/WFS/WCS')),
-            (enumerations.WMS, _('Web Map Service')),
-            (enumerations.GN_WMS, _('GeoNode (Web Map Service)')),
-            # (enumerations.GN_CSW, _('GeoNode (Catalogue Service)')),
-            # (enumerations.CSW, _('Catalogue Service')),
-            (enumerations.REST_MAP, _('ArcGIS REST MapServer')),
-            # (enumerations.REST_IMG, _('ArcGIS REST ImageServer')),
-            # (enumerations.OGP, _('OpenGeoPortal')),
-            # (enumerations.HGL, _('Harvard Geospatial Library')),
-        ),
+        choices=tuple(get_service_type_choices()),
         initial='AUTO',
     )
 

--- a/geonode/services/forms.py
+++ b/geonode/services/forms.py
@@ -31,6 +31,7 @@ from .utils import get_service_type_choices
 
 logger = logging.getLogger(__name__)
 
+
 class CreateServiceForm(forms.Form):
     url = forms.CharField(
         label=_("Service URL"),

--- a/geonode/services/serviceprocessors/handler.py
+++ b/geonode/services/serviceprocessors/handler.py
@@ -26,25 +26,28 @@ from django.utils.datastructures import OrderedDict
 from .. import enumerations
 from .arcgis import ArcMapServiceHandler, ArcImageServiceHandler
 from .wms import WmsServiceHandler, GeoNodeServiceHandler
+from ..utils import parse_services_types
 
 logger = logging.getLogger(__name__)
 
 
-def get_service_handler(base_url, proxy_base=None, service_type=enumerations.AUTO):
+service_handlers = OrderedDict({
+    enumerations.WMS: {"OWS": True, "handler": WmsServiceHandler},
+    enumerations.GN_WMS: {"OWS": True, "handler": GeoNodeServiceHandler},
+    # enumerations.WFS: {"OWS": True, "handler": ServiceHandlerBase},
+    # enumerations.TMS: {"OWS": False, "handler": ServiceHandlerBase},
+    enumerations.REST_MAP: {"OWS": False, "handler": ArcMapServiceHandler},
+    enumerations.REST_IMG: {"OWS": False, "handler": ArcImageServiceHandler},
+    # enumerations.CSW: {"OWS": False, "handler": ServiceHandlerBase},
+    # enumerations.HGL: {"OWS": True, "handler": ServiceHandlerBase},  # TODO: verify this
+    # enumerations.OGP: {"OWS": False, "handler": ServiceHandlerBase},  # TODO: verify this
+    **parse_services_types(),
+})
+
+def get_service_handler(base_url, proxy_base=None, service_type=enumerations.AUTO, handlers=service_handlers):
     """Return the appropriate remote service handler for the input URL.
     If the service type is not explicitly passed in it will be guessed from
     """
-    handlers = OrderedDict({
-        enumerations.WMS: {"OWS": True, "handler": WmsServiceHandler},
-        enumerations.GN_WMS: {"OWS": True, "handler": GeoNodeServiceHandler},
-        # enumerations.WFS: {"OWS": True, "handler": ServiceHandlerBase},
-        # enumerations.TMS: {"OWS": False, "handler": ServiceHandlerBase},
-        enumerations.REST_MAP: {"OWS": False, "handler": ArcMapServiceHandler},
-        enumerations.REST_IMG: {"OWS": False, "handler": ArcImageServiceHandler},
-        # enumerations.CSW: {"OWS": False, "handler": ServiceHandlerBase},
-        # enumerations.HGL: {"OWS": True, "handler": ServiceHandlerBase},  # TODO: verify this
-        # enumerations.OGP: {"OWS": False, "handler": ServiceHandlerBase},  # TODO: verify this
-    })
     if service_type in (enumerations.AUTO, enumerations.OWS):
         if service_type == enumerations.AUTO:
             to_check = handlers.keys()

--- a/geonode/services/serviceprocessors/handler.py
+++ b/geonode/services/serviceprocessors/handler.py
@@ -44,6 +44,7 @@ service_handlers = OrderedDict({
     **parse_services_types(),
 })
 
+
 def get_service_handler(base_url, proxy_base=None, service_type=enumerations.AUTO, handlers=service_handlers):
     """Return the appropriate remote service handler for the input URL.
     If the service type is not explicitly passed in it will be guessed from

--- a/geonode/services/tests.py
+++ b/geonode/services/tests.py
@@ -17,7 +17,6 @@
 #
 #########################################################################
 import logging
-from unittest.mock import MagicMock
 
 from urllib.error import HTTPError
 from geonode.services.enumerations import WMS, INDEXED
@@ -934,10 +933,12 @@ class WmsServiceHarvestingTestCase(StaticLiveServerTestCase):
                 # self.selenium.find_element_by_id('option_atlantis:tiger_roads_tiger_roads').click()
                 # self.selenium.find_element_by_tag_name('form').submit()
 
+
 SERVICES_TYPE_MODULES = [
     "geonode.services.tests.dummy_services_type",
     "geonode.services.tests.dummy_services_type2",
 ]
+
 
 class TestServiceViews(GeoNodeBaseTestSupport):
     def setUp(self):
@@ -975,7 +976,7 @@ class TestServiceViews(GeoNodeBaseTestSupport):
         self.assertDictEqual(expected, elems)
 
     @override_settings(SERVICES_TYPE_MODULES=SERVICES_TYPE_MODULES)
-    def test_will_use_multiple_service_types_defined(self):
+    def test_will_use_multiple_service_types_defined_for_choices(self):
         elems = set(get_service_type_choices())
         expected = {
             ("test", "Test Number 1"),
@@ -987,19 +988,22 @@ class TestServiceViews(GeoNodeBaseTestSupport):
             (enumerations.REST_MAP, 'ArcGIS REST MapServer'),
         }
         self.assertSetEqual(expected, elems)
+
+
 '''
 Just a dummy function required for the smoke test above
 '''
 
+
 class dummy_services_type:
-    services_type={
+    services_type = {
         "test": {"OWS": True, "handler": "TestHandler", "label": "Test Number 1", "management_view": "path.to.view1"},
         "test2": {"OWS": False, "handler": "TestHandler2", "label": "Test Number 2", "management_view": "path.to.view2"},
     }
 
 
 class dummy_services_type2:
-    services_type={
+    services_type = {
         "test3": {"OWS": True, "handler": "TestHandler3", "label": "Test Number 3", "management_view": "path.to.view3"},
         "test4": {"OWS": False, "handler": "TestHandler4", "label": "Test Number 4", "management_view": "path.to.view4"},
     }

--- a/geonode/services/utils.py
+++ b/geonode/services/utils.py
@@ -197,4 +197,4 @@ def get_service_type_choices():
         # (enumerations.HGL, _('Harvard Geospatial Library')),
     ]
 
-    return list(set(parsed+default))
+    return list(set(parsed + default))

--- a/geonode/services/utils.py
+++ b/geonode/services/utils.py
@@ -21,7 +21,6 @@ import re
 import math
 import logging
 
-from geonode import settings
 from django.conf import settings as django_settings
 from django.utils.translation import ugettext as _
 
@@ -165,6 +164,7 @@ def test_resource_table_status(test_cls, table, is_row_filtered):
         test_cls.assertEqual(result["visible_rows_count"], 20)
         test_cls.assertEqual(result["hidden_row_count"], 0)
 
+
 def parse_services_types():
     from django.utils.module_loading import import_string
     services_type_modules = (
@@ -180,6 +180,7 @@ def parse_services_types():
             **custom_services_type_module.services_type
         }
     return custom_services_types
+
 
 def get_service_type_choices():
     parsed = [(key, value["label"]) for key, value in parse_services_types().items()]


### PR DESCRIPTION
For this purpose we need a hook inside the Geonode project to let inherited projects use custom service types and handlers. In order to do this we implemented a method in utils library under the services package that accept an environment variable (named SERVICES_TYPE_MODULES)
Ref to #8422 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
