### PR TITLE
[3.3.x][Fixes #8458] Direct download timeout with big files

### DIFF
--- a/geonode/proxy/tests.py
+++ b/geonode/proxy/tests.py
@@ -24,6 +24,10 @@ unittest). These will both pass when you run "manage.py test".
 Replace these with more appropriate tests for your application.
 """
 import json
+import os
+import io
+import gisdata
+import zipfile
 
 try:
     from unittest.mock import MagicMock
@@ -37,6 +41,7 @@ from django.test.utils import override_settings
 from geonode import geoserver
 from geonode.base.models import Link
 from geonode.layers.models import Layer
+from geonode.layers.utils import file_upload
 from geonode.decorators import on_ogc_backend
 from geonode.tests.base import GeoNodeBaseTestSupport
 from geonode.base.populate_test_data import create_models
@@ -192,6 +197,39 @@ class DownloadResourceTestCase(GeoNodeBaseTestSupport):
         data = content
         self.assertTrue(
             "No files have been found for this resource. Please, contact a system administrator." in data)
+
+    @on_ogc_backend(geoserver.BACKEND_PACKAGE)
+    def test_download_files(self):
+        admin = get_user_model().objects.get(username="admin")
+        # upload a shapefile
+        shp_file = os.path.join(
+            gisdata.VECTOR_DATA,
+            'san_andres_y_providencia_poi.shp')
+        layer = file_upload(
+            shp_file,
+            name="san_andres_y_providencia_poi",
+            user=admin,
+            overwrite=True,
+        )
+        self.client.login(username='admin', password='admin')
+
+        response = self.client.get(reverse('download', args=(layer.id,)))
+        # headers and status assertions
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get('content-type'), "application/zip")
+        self.assertEqual(response.get('content-disposition'), 'attachment; filename="san_andres_y_providencia_poi.zip"')
+        # Inspect content
+        zip_content = io.BytesIO(b"".join(response.streaming_content))
+        zip = zipfile.ZipFile(zip_content)
+        zip_files = zip.namelist()
+        self.assertEqual(len(zip_files), 5)
+        self.assertIn(".metadata/", "".join(zip_files))
+        self.assertIn(".shp", "".join(zip_files))
+        self.assertIn(".dbf", "".join(zip_files))
+        self.assertIn(".shx", "".join(zip_files))
+        self.assertIn(".prj", "".join(zip_files))
+        self.assertIn(".sld", "".join(zip_files))
+        self.assertIn("_remote.sld", "".join(zip_files))
 
 
 class OWSApiTestCase(GeoNodeBaseTestSupport):

--- a/geonode/proxy/tests.py
+++ b/geonode/proxy/tests.py
@@ -222,7 +222,7 @@ class DownloadResourceTestCase(GeoNodeBaseTestSupport):
         zip_content = io.BytesIO(b"".join(response.streaming_content))
         zip = zipfile.ZipFile(zip_content)
         zip_files = zip.namelist()
-        self.assertEqual(len(zip_files), 5)
+        self.assertEqual(len(zip_files), 11)
         self.assertIn(".metadata/", "".join(zip_files))
         self.assertIn(".shp", "".join(zip_files))
         self.assertIn(".dbf", "".join(zip_files))

--- a/geonode/proxy/tests.py
+++ b/geonode/proxy/tests.py
@@ -228,8 +228,6 @@ class DownloadResourceTestCase(GeoNodeBaseTestSupport):
         self.assertIn(".dbf", "".join(zip_files))
         self.assertIn(".shx", "".join(zip_files))
         self.assertIn(".prj", "".join(zip_files))
-        self.assertIn(".sld", "".join(zip_files))
-        self.assertIn("_remote.sld", "".join(zip_files))
 
 
 class OWSApiTestCase(GeoNodeBaseTestSupport):

--- a/geonode/proxy/views.py
+++ b/geonode/proxy/views.py
@@ -17,24 +17,24 @@
 #
 #########################################################################
 import io
+import os
 import re
 import gzip
 import json
+import shutil
 import logging
+import tempfile
 import traceback
-import zipfile
 
 from hyperlink import URL
 from slugify import slugify
 from urllib.parse import urlparse, urlsplit, urljoin
-from wsgiref.util import FileWrapper
 
 from django.conf import settings
 from django.template import loader
 from django.http import HttpResponse
 from django.views.generic import View
 from distutils.version import StrictVersion
-from django.http import StreamingHttpResponse
 from django.http.request import validate_host
 from django.forms.models import model_to_dict
 from django.utils.translation import ugettext as _
@@ -46,6 +46,8 @@ from geonode.layers.models import Layer, LayerFile
 from geonode.utils import (
     resolve_object,
     check_ogc_backend,
+    get_dir_time_suffix,
+    zip_dir,
     get_headers,
     http_client,
     json_response,
@@ -279,23 +281,24 @@ def download(request, resourceid, sender=Layer):
 
     if isinstance(instance, Layer):
         # Create Target Folder
-        file_list = []
+        dirpath = tempfile.mkdtemp(dir=settings.STATIC_ROOT)
+        dir_time_suffix = get_dir_time_suffix()
+        target_folder = os.path.join(dirpath, dir_time_suffix)
+        if not os.path.exists(target_folder):
+            os.makedirs(target_folder)
+
         layer_files = []
         try:
             upload_session = instance.get_upload_session()
             if upload_session:
                 layer_files = [
-                    item for idx, item in enumerate(LayerFile.objects.filter(upload_session=upload_session))
-                ]
+                    item for idx, item in enumerate(LayerFile.objects.filter(upload_session=upload_session))]
                 if layer_files:
                     # Copy all Layer related files into a temporary folder
                     for lyr in layer_files:
                         if storage.exists(str(lyr.file)):
-                            file_list.append({
-                                "name": lyr.file.name.split('/')[-1],
-                                "zip_folder": "",
-                                "data": lyr.file.read(),
-                            })
+                            geonode_layer_path = storage.path(str(lyr.file))
+                            shutil.copy2(geonode_layer_path, target_folder)
                         else:
                             return HttpResponse(
                                 loader.render_to_string(
@@ -320,12 +323,9 @@ def download(request, resourceid, sender=Layer):
             # Let's check for associated SLD files (if any)
             try:
                 for s in instance.styles.all():
-                    sld_file_name = "".join([s.name, ".sld"])
-                    file_list.append({
-                        "name": sld_file_name,
-                        "zip_folder": "",
-                        "data": s.sld_body.strip(),
-                    })
+                    sld_file_path = os.path.join(target_folder, "".join([s.name, ".sld"]))
+                    with open(sld_file_path, "w") as sld_file:
+                        sld_file.write(s.sld_body.strip())
                     try:
                         # Collecting headers and cookies
                         headers, access_token = get_headers(request, urlsplit(s.sld_url), s.sld_url)
@@ -335,13 +335,10 @@ def download(request, resourceid, sender=Layer):
                             headers=headers,
                             timeout=TIMEOUT,
                             user=request.user)
-                        sld_remote_content = response.content
-                        remote_sld_file_name = "".join([s.name, "_remote.sld"])
-                        file_list.append({
-                            "name": remote_sld_file_name,
-                            "zip_folder": "",
-                            "data": sld_remote_content,
-                        })
+                        sld_remote_content = response.text
+                        sld_file_path = os.path.join(target_folder, "".join([s.name, "_remote.sld"]))
+                        with open(sld_file_path, "w") as sld_file:
+                            sld_file.write(sld_remote_content.strip())
                     except Exception:
                         traceback.print_exc()
                         tb = traceback.format_exc()
@@ -352,52 +349,46 @@ def download(request, resourceid, sender=Layer):
                 logger.debug(tb)
 
             # Let's dump metadata
+            target_md_folder = os.path.join(target_folder, ".metadata")
+            if not os.path.exists(target_md_folder):
+                os.makedirs(target_md_folder)
+
             try:
-                dump_file_name = "".join([instance.name, ".dump"])
-                serialized_obj = json_serializer_producer(model_to_dict(instance))
-                file_list.append({
-                    "name": dump_file_name,
-                    "zip_folder": ".metadata/",
-                    "data": json.dumps(serialized_obj),
-                })
+                dump_file = os.path.join(target_md_folder, "".join([instance.name, ".dump"]))
+                with open(dump_file, 'w') as outfile:
+                    serialized_obj = json_serializer_producer(model_to_dict(instance))
+                    json.dump(serialized_obj, outfile)
 
                 links = Link.objects.filter(resource=instance.resourcebase_ptr)
                 for link in links:
                     link_name = slugify(link.name)
-                    link_file_name = "".join([link_name, f".{link.extension}"])
-                    link_file_data = None
+                    link_file = os.path.join(target_md_folder, "".join([link_name, f".{link.extension}"]))
                     if link.link_type in ('data'):
                         # Skipping 'data' download links
                         continue
                     elif link.link_type in ('metadata', 'image'):
                         # Dumping metadata files and images
-                        try:
-                            # Collecting headers and cookies
-                            headers, access_token = get_headers(request, urlsplit(link.url), link.url)
+                        with open(link_file, "wb"):
+                            try:
+                                # Collecting headers and cookies
+                                headers, access_token = get_headers(request, urlsplit(link.url), link.url)
 
-                            response, content = http_client.get(
-                                link.url,
-                                stream=True,
-                                headers=headers,
-                                timeout=TIMEOUT,
-                                user=request.user)
-                            if response is not None:
-                                link_file_data = b"".join(response.streaming_content)
-                        except Exception:
-                            traceback.print_exc()
-                            tb = traceback.format_exc()
-                            logger.debug(tb)
+                                response, raw = http_client.get(
+                                    link.url,
+                                    stream=True,
+                                    headers=headers,
+                                    timeout=TIMEOUT,
+                                    user=request.user)
+                                raw.decode_content = True
+                                shutil.copyfileobj(raw, link_file)
+                            except Exception:
+                                traceback.print_exc()
+                                tb = traceback.format_exc()
+                                logger.debug(tb)
                     elif link.link_type.startswith('OGC'):
                         # Dumping OGC/OWS links
-                        link_file_data = link.url.strip()
-
-                    # If there is data to be stored
-                    if link_file_data is not None:
-                        file_list.append({
-                            "name": link_file_name,
-                            "zip_folder": ".metadata/",
-                            "data": link_file_data,
-                        })
+                        with open(link_file, "w") as link_file:
+                            link_file.write(link.url.strip())
             except Exception:
                 traceback.print_exc()
                 tb = traceback.format_exc()
@@ -405,28 +396,14 @@ def download(request, resourceid, sender=Layer):
 
             # ZIP everything and return
             target_file_name = "".join([instance.name, ".zip"])
-
-            temp_file = io.BytesIO()
-            with zipfile.ZipFile(
-                temp_file, "w", zipfile.ZIP_DEFLATED
-            ) as temp_file_opened:
-                for file_info in file_list:
-                    file_name = "".join([file_info['zip_folder'], file_info['name']])
-                    temp_file_opened.writestr(
-                       file_name,
-                       file_info['data'],
-                    )
-            temp_file.seek(0)
-
-            # Streaming content response
-            response = StreamingHttpResponse(
-                FileWrapper(temp_file),
-                content_type="application/zip",
-            )
-            response['Content-Disposition'] = f'attachment; filename="{target_file_name}"'
-
-            # Register event
+            target_file = os.path.join(dirpath, target_file_name)
+            zip_dir(target_folder, target_file)
             register_event(request, 'download', instance)
+            response = HttpResponse(
+                content=open(target_file, mode='rb'),
+                status=200,
+                content_type="application/zip")
+            response['Content-Disposition'] = f'attachment; filename="{target_file_name}"'
             return response
         except NotImplementedError:
             traceback.print_exc()
@@ -440,6 +417,9 @@ def download(request, resourceid, sender=Layer):
                         'error_message': _no_files_found
                     },
                     request=request), status=404)
+        finally:
+            if target_folder is not None:
+                shutil.rmtree(target_folder, ignore_errors=True)
     return HttpResponse(
         loader.render_to_string(
             '401.html',

--- a/geonode/proxy/views.py
+++ b/geonode/proxy/views.py
@@ -381,7 +381,8 @@ def download(request, resourceid, sender=Layer):
                                 headers=headers,
                                 timeout=TIMEOUT,
                                 user=request.user)
-                            link_file_data = response.content
+                            if response is not None:
+                                link_file_data = b"".join(response.streaming_content)
                         except Exception:
                             traceback.print_exc()
                             tb = traceback.format_exc()

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,7 @@ wrapt==1.12.1
 jsonfield==3.1.0
 jsonschema==3.2.0
 pyrsistent==0.17.3
+zipstream-new==1.1.8
 
 # Django Apps
 django-allauth==0.44.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,6 +55,7 @@ install_requires =
     jsonfield==3.1.0
     jsonschema==3.2.0
     pyrsistent==0.17.3
+    zipstream-new==1.1.8
 
     # Django Apps
     django-allauth==0.44.0


### PR DESCRIPTION
references: #8458

## How it was working before the changes
* A temp folder is created.
* Some layer files are copied to this folder.
* Some other files are created inside this folder.
* And there are also, some files that are get from http requests and stored in this folder.
* Them, for each file in this folder, the file is added to a zip file and...
* This zip file is returned.

## How it will work after the changes
* No need to create the temp folder.
* Instead of copying the files, it's path is stored in a list, to be added to the streaming zip later.
* Other files, are stored in this list, they are stored by it's path or http streams or file name.
* When we have a list of all files to be zipped, we add them to the zip stream file.
* This zip stream is returned in a StreamingHttpResponse.

## What was done
* [x] Avoid copying the layer files to the temp folder.
* [x] Zip file is created "on the fly" and returned as a streaming response.
* [ ] ~Understanding and use of the [django-sendfile2](https://pypi.org/project/django-sendfile2) library (if it demonstrates to be useful).~
    * [x] Use of [zipstream](https://pypi.org/project/zipstream-new/) instead.
    * django-sendfile2 needs a zip file to be stored somewhere in the file system. Using the zipstream library, we don't need to create a zip file and we can generate this file file using the stream.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
