### PR TITLE
[Fixes #8474] Regression on geoapp API POST and PUT requests

### DIFF
--- a/geonode/base/api/serializers.py
+++ b/geonode/base/api/serializers.py
@@ -326,7 +326,7 @@ class ResourceBaseSerializer(
 
         self.fields['pk'] = serializers.CharField(read_only=True)
         self.fields['uuid'] = serializers.CharField(read_only=True)
-        self.fields['resource_type'] = serializers.CharField(read_only=True)
+        self.fields['resource_type'] = serializers.CharField(required=False)
         self.fields['polymorphic_ctype_id'] = serializers.CharField(read_only=True)
         self.fields['owner'] = DynamicRelationField(UserSerializer, embed=True, many=False, read_only=True, required=False)
         self.fields['poc'] = ContactRoleField('poc', read_only=True)
@@ -440,6 +440,7 @@ class ResourceBaseSerializer(
             "thumbnail_url": {"required": False},
             "blob": {"required": False, "write_only": True},
             "owner": {"required": False},
+            "resource_type": {"required": False}
         }
 
     def to_internal_value(self, data):

--- a/geonode/geoapps/api/tests.py
+++ b/geonode/geoapps/api/tests.py
@@ -93,13 +93,12 @@ class GeoAppsApiTests(APITestCase):
         # Bobby
         self.assertTrue(self.client.login(username='bobby', password='bob'))
         # Create
-        url = reverse('geoapps-list')
+        url = f"{reverse('geoapps-list')}?include[]=data"
         data = {
-            "geoapp": {
-                "name": "Test Create",
-                "title": "Test Create",
-                "owner": "bobby"
-            }
+            "name": "Test Create",
+            "title": "Test Create",
+            "resource_type": "geostory",
+            "owner": "bobby"
         }
         response = self.client.post(url, data=data, format='json')
         self.assertEqual(response.status_code, 201)  # 201 - Created
@@ -114,6 +113,7 @@ class GeoAppsApiTests(APITestCase):
         # Update: PATCH
         url = reverse('geoapps-detail', kwargs={'pk': self.gep_app.pk})
         data = {
+            "resource_type": "geostory",
             "blob": {
                 "test_data": {
                     "test": [
@@ -133,6 +133,10 @@ class GeoAppsApiTests(APITestCase):
         self.assertEqual(len(response.data), 1)
         # Pagination
         self.assertTrue('data' in response.data['geoapp'])
+        self.assertEqual(
+            response.data['geoapp']['resource_type'],
+            'geostory'
+        )
         self.assertEqual(
             response.data['geoapp']['data'],
             {

--- a/geonode/resource/utils.py
+++ b/geonode/resource/utils.py
@@ -194,8 +194,17 @@ def update_resource(instance: ResourceBase, xml_file: str = None, regions: list 
         defaults['date'] = instance.date or timezone.now()
 
     to_update = {}
+    for _key in ('name', ):
+        if hasattr(instance, _key):
+            if _key in defaults:
+                to_update[_key] = defaults.pop(_key)
+            else:
+                to_update[_key] = getattr(instance, _key)
+        elif _key in defaults:
+            defaults.pop(_key)
+
     if isinstance(instance, Dataset):
-        for _key in ('name', 'workspace', 'store', 'subtype', 'alternate', 'typename'):
+        for _key in ('workspace', 'store', 'subtype', 'alternate', 'typename'):
             if hasattr(instance, _key):
                 if _key in defaults:
                     to_update[_key] = defaults.pop(_key)


### PR DESCRIPTION
References:  #8474

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
