### PR TITLE
[Bckport to 3.2.x][Fixes #8429]GeoApps have empty uuid (#8473)

### DIFF
--- a/geonode/base/models.py
+++ b/geonode/base/models.py
@@ -2004,11 +2004,15 @@ def resourcebase_post_save(instance, *args, **kwargs):
             if license and len(license) > 0:
                 instance.license = license[0]
 
+        if instance.uuid is None or instance.uuid == '':
+            instance.uuid = str(uuid.uuid1())
+
         ResourceBase.objects.filter(id=instance.id).update(
             thumbnail_url=instance.get_thumbnail_url(),
             detail_url=instance.get_absolute_url(),
             csw_insert_date=now(),
-            license=instance.license)
+            license=instance.license,
+            uuid=instance.uuid)
         instance.refresh_from_db()
     except Exception:
         tb = traceback.format_exc()

--- a/geonode/geoapps/api/tests.py
+++ b/geonode/geoapps/api/tests.py
@@ -122,6 +122,9 @@ class BaseApiTests(APITestCase, URLPatternsTestCase):
         }
         response = self.client.post(url, data=data, format='json')
         self.assertEqual(response.status_code, 201)  # 201 - Created
+        #   Check uuid is populate
+        app = GeoApp.objects.last()
+        self.assertTrue(app.uuid)
 
         response = self.client.get(url, format='json')
         self.assertEqual(response.status_code, 200)

--- a/geonode/geoapps/tests.py
+++ b/geonode/geoapps/tests.py
@@ -47,3 +47,5 @@ class TestGeoAppViews(GeoNodeBaseTestSupport):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(gep_app.thumbnail_url, GeoApp.objects.get(id=gep_app.id).thumbnail_url)
         self.assertEqual(GeoApp.objects.get(id=gep_app.id).title, 'New title')
+        #   Check uuid is populate
+        self.assertTrue(GeoApp.objects.get(id=gep_app.id).uuid)


### PR DESCRIPTION
* [Fixes #8429]GeoApps have empty uuid

* save uuid on resource

(cherry picked from commit 702837981e79c975fcca5dcd594bfb3ea3501971)

<Include a few sentences describing the overall goals for this Pull Request>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [ ] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [ ] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
