### PR TITLE
[Fixes #8551] raster uploads require sending the same file twice

### DIFF
--- a/geonode/tests/utils.py
+++ b/geonode/tests/utils.py
@@ -228,9 +228,6 @@ class Client(DjangoTestClient):
                 # allow for that
                 if os.path.exists(file_path):
                     params[spatial_file] = open(file_path, 'rb')
-        elif ext.lower() == '.tif':
-            file_path = base + ext
-            params['tif_file'] = open(file_path, 'rb')
 
         with open(_file, 'rb') as base_file:
             params['base_file'] = base_file
@@ -244,9 +241,6 @@ class Client(DjangoTestClient):
         for spatial_file in spatial_files:
             if isinstance(params.get(spatial_file), IOBase):
                 params[spatial_file].close()
-
-        if isinstance(params.get("tif_file"), IOBase):
-            params['tif_file'].close()
 
         try:
             return resp, resp.json()

--- a/geonode/upload/api/tests.py
+++ b/geonode/upload/api/tests.py
@@ -214,9 +214,6 @@ class UploadApiTests(GeoNodeLiveTestSupport, APITestCase):
                 # allow for that
                 if os.path.exists(file_path):
                     params[spatial_file] = open(file_path, 'rb')
-        elif ext.lower() == '.tif':
-            file_path = base + ext
-            params['tif_file'] = open(file_path, 'rb')
 
         with open(_file, 'rb') as base_file:
             params['base_file'] = base_file
@@ -241,9 +238,6 @@ class UploadApiTests(GeoNodeLiveTestSupport, APITestCase):
         for spatial_file in spatial_files:
             if isinstance(params.get(spatial_file), IOBase):
                 params[spatial_file].close()
-
-        if isinstance(params.get("tif_file"), IOBase):
-            params['tif_file'].close()
 
         try:
             logger.error(f" -- response: {response.status_code} / {response.json()}")
@@ -277,9 +271,6 @@ class UploadApiTests(GeoNodeLiveTestSupport, APITestCase):
                 # allow for that
                 if os.path.exists(file_path):
                     params[spatial_file] = open(file_path, 'rb')
-        elif ext.lower() == '.tif':
-            file_path = base + ext
-            params['tif_file'] = open(file_path, 'rb')
 
         with open(_file, 'rb') as base_file:
             params['base_file'] = base_file
@@ -296,9 +287,6 @@ class UploadApiTests(GeoNodeLiveTestSupport, APITestCase):
         for spatial_file in spatial_files:
             if isinstance(params.get(spatial_file), IOBase):
                 params[spatial_file].close()
-
-        if isinstance(params.get("tif_file"), IOBase):
-            params['tif_file'].close()
 
         try:
             logger.error(f" -- response: {response.status_code} / {response.json()}")

--- a/geonode/upload/upload_validators.py
+++ b/geonode/upload/upload_validators.py
@@ -105,6 +105,8 @@ def validate_uploaded_files(cleaned, uploaded_files, field_spatial_types):
                 valid_extensions.append(extension)
             except AttributeError:
                 pass
+    if not valid_extensions:
+        valid_extensions = [f"{base_ext.lower()}"]
     return valid_extensions
 
 


### PR DESCRIPTION
References: #8551

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
