### PR TITLE
[Fixes #8611] Setting style version for upload, re-generate thumbnail 

### DIFF
--- a/geonode/geoserver/helpers.py
+++ b/geonode/geoserver/helpers.py
@@ -61,7 +61,7 @@ from geoserver.store import CoverageStore, DataStore, datastore_from_index, \
 from geoserver.support import DimensionInfo
 from geoserver.workspace import Workspace
 from gsimporter import Client
-from lxml import etree
+from lxml import etree, objectify
 from defusedxml import lxml as dlxml
 from owslib.wcs import WebCoverageService
 from owslib.wms import WebMapService
@@ -191,6 +191,22 @@ LAYER_SUBTYPES = {
     "remoteStore": "remote",
     "vectorTimeSeries": "vector_time"
 }
+
+STYLES_VERSION = {
+    "1.0.0" : "sld10",
+    "1.1.0" : "sld11"
+}
+
+def _extract_style_version_from_sld(sld):
+    """
+        Assume: SLD as a byte
+    """
+    root = objectify.fromstring(sld)
+    try:
+        return STYLES_VERSION[root.attrib["version"].strip()]
+    except Exception:
+        return STYLES_VERSION["1.0.0"]
+
 
 
 def _style_name(resource):
@@ -387,6 +403,7 @@ def set_layer_style(saved_layer, title, sld, base_file=None):
                     overwrite=True, raw=True,
                     workspace=saved_layer.workspace)
             elif sld:
+                style.style_format = _extract_style_version_from_sld(sld)
                 style.update_body(sld)
         except Exception as e:
             logger.exception(e)

--- a/geonode/layers/views.py
+++ b/geonode/layers/views.py
@@ -313,6 +313,8 @@ def layer_style_upload(request):
         sld = request.FILES['sld_file'].read()
 
         set_layer_style(layer, data.get('layer_title'), sld)
+        from geonode.geoserver.tasks import geoserver_create_thumbnail
+        geoserver_create_thumbnail.apply_async(((layer.resourcebase_ptr.id, True, True)))
         body['url'] = layer.get_absolute_url()
         body['bbox'] = layer.bbox_string
         body['crs'] = {

--- a/geonode/layers/views.py
+++ b/geonode/layers/views.py
@@ -313,8 +313,6 @@ def layer_style_upload(request):
         sld = request.FILES['sld_file'].read()
 
         set_layer_style(layer, data.get('layer_title'), sld)
-        from geonode.geoserver.tasks import geoserver_create_thumbnail
-        geoserver_create_thumbnail.apply_async(((layer.resourcebase_ptr.id, True, True)))
         body['url'] = layer.get_absolute_url()
         body['bbox'] = layer.bbox_string
         body['crs'] = {


### PR DESCRIPTION
<Include a few sentences describing the overall goals for this Pull Request>

This PL is to fix https://github.com/GeoNode/geonode/issues/8611
- setting version of the style before uploading (geoserver-restconfig)
- re-generate thumbnail


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [ x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [ ] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
