### PR TITLE
[Fixes #8637] Thumbnail not generated on creating a map

### DIFF
--- a/geonode/maps/api/tests.py
+++ b/geonode/maps/api/tests.py
@@ -26,6 +26,7 @@ from rest_framework.test import APITestCase
 from geonode.base.populate_test_data import create_models
 from geonode.layers.models import Dataset
 from geonode.maps.models import Map, MapLayer
+from geonode.thumbs.utils import MISSING_THUMB
 
 logger = logging.getLogger(__name__)
 
@@ -159,6 +160,7 @@ class MapsApiTests(APITestCase):
         self.assertEqual(response_maplayer["extra_params"], {"msId": "Stamen.Watercolor__0"})
         self.assertEqual(response_maplayer["current_style"], "some-style-first-layer")
         self.assertIsNotNone(response_maplayer["dataset"])
+        self.assertNotIn(MISSING_THUMB, response.data["map"]['thumbnail_url'])
 
 
 DUMMY_MAPDATA = {

--- a/geonode/maps/api/views.py
+++ b/geonode/maps/api/views.py
@@ -118,12 +118,14 @@ class MapViewSet(DynamicModelViewSet):
             uuid=str(uuid4()),
         )
 
-        # thumbnail, events and resouce routines
+        # events and resouce routines
         self._post_change_routines(
             instance=instance,
             create_action_perfomed=True,
             additional_data=post_creation_data,
         )
+        # Handle thumbnail generation
+        resource_manager.set_thumbnail(instance.uuid, instance=instance, overwrite=False)
 
     def perform_update(self, serializer):
         # Check instance permissions with resolve_object


### PR DESCRIPTION
<Include a few sentences describing the overall goals for this Pull Request>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
