### PR TITLE
[Fixes #8647] Fix upload API

### DIFF
--- a/geonode/geoserver/helpers.py
+++ b/geonode/geoserver/helpers.py
@@ -198,9 +198,10 @@ _style_templates = dict(
 )
 
 STYLES_VERSION = {
-    "1.0.0" : "sld10",
-    "1.1.0" : "sld11"
+    "1.0.0": "sld10",
+    "1.1.0": "sld11"
 }
+
 
 def _extract_style_version_from_sld(sld):
     """
@@ -211,7 +212,6 @@ def _extract_style_version_from_sld(sld):
         return STYLES_VERSION[root.attrib["version"].strip()]
     except Exception:
         return STYLES_VERSION["1.0.0"]
-
 
 
 def _style_name(resource):

--- a/geonode/geoserver/management/commands/importlayers.py
+++ b/geonode/geoserver/management/commands/importlayers.py
@@ -136,7 +136,7 @@ class GeoNodeUploader:
                             params[name] = os.path.basename(value.name)
 
                     response = client.post(
-                        urljoin(self.host, "/api/v2/uploads/upload/"),
+                        urljoin(self.host, "/api/v2/uploads/upload_legacy/"),
                         auth=HTTPBasicAuth(self.username, self.password),
                         data=params,
                         files=files,

--- a/geonode/upload/api/tests.py
+++ b/geonode/upload/api/tests.py
@@ -397,7 +397,7 @@ class UploadApiTests(GeoNodeLiveTestSupport, APITestCase):
         # Try to upload a good raster file and check the session IDs
         fname = os.path.join(GOOD_DATA, 'raster', 'relief_san_andres.tif')
         resp, data = self.rest_upload_file(fname)
-        self.assertEqual(resp.status_code, 201)
+        self.assertEqual(resp.status_code, 200)
 
         url = reverse('uploads-list')
         # Anonymous

--- a/geonode/upload/api/views.py
+++ b/geonode/upload/api/views.py
@@ -94,7 +94,6 @@ class UploadViewSet(DynamicModelViewSet):
             response_success = data.get('success', False)
             redirect_to = data.get('redirect_to', '')
             if required_input or not response_success or not redirect_to or response_status == 'finished':
-                response = Response(data=data, status=response.status_code)
                 return response, None, True
 
             # Prepare next step
@@ -110,7 +109,6 @@ class UploadViewSet(DynamicModelViewSet):
             next_step = response.url.split(reverse("data_upload"))[1].split("?id=")[0]
             return response, next_step, False
         else:
-            response = Response(status=response.status_code)
             return response, None, True
 
     @extend_schema(methods=['put'],

--- a/geonode/upload/api/views.py
+++ b/geonode/upload/api/views.py
@@ -152,6 +152,53 @@ class UploadViewSet(DynamicModelViewSet):
         # After performing 7 steps if we don't get any final response
         return response
 
+    @extend_schema(methods=['put'],
+                   responses={201: None},
+                   description="""
+        Starts an upload session based on the Dataset Upload Form.
+
+        the form params look like:
+        ```
+            'csrfmiddlewaretoken': self.csrf_token,
+            'permissions': '{ "users": {"AnonymousUser": ["view_resourcebase"]} , "groups":{}}',
+            'time': 'false',
+            'charset': 'UTF-8',
+            'base_file': base_file,
+            'dbf_file': dbf_file,
+            'shx_file': shx_file,
+            'prj_file': prj_file,
+            'tif_file': tif_file
+        ```
+        """)
+    @action(detail=False, methods=['post'])
+    def upload_legacy(self, request, format=None):
+        if not getattr(request, 'FILES', None):
+            raise ParseError(_("Empty content"))
+
+        user = request.user
+        if not user or not user.is_authenticated:
+            return Response(status=status.HTTP_401_UNAUTHORIZED)
+
+        response = upload_view(request, None)
+        if response.status_code == 200:
+            content = response.content
+            if isinstance(content, bytes):
+                content = content.decode('UTF-8')
+            data = json.loads(content)
+
+            import_id = int(data["redirect_to"].split("?id=")[1].split("&")[0])
+            request.method = 'GET'
+            request.GET['id'] = import_id
+
+            upload_view(request, 'check')
+            response = upload_view(request, 'final')
+            content = response.content
+            if isinstance(content, bytes):
+                content = content.decode('UTF-8')
+            data = json.loads(content)
+            return Response(data=data, status=status.HTTP_201_CREATED)
+        return Response(status=response.status_code)
+
 
 class UploadSizeLimitViewSet(DynamicModelViewSet):
     authentication_classes = [SessionAuthentication, BasicAuthentication, OAuth2Authentication]

--- a/geonode/upload/utils.py
+++ b/geonode/upload/utils.py
@@ -248,6 +248,11 @@ if not _ALLOW_MOSAIC_STEP:
         _pages[t] = tuple(steps)
 
 
+def get_max_amount_of_steps():
+    # We add 1 here to count the save step (implied as first step)
+    return max([len(page) for page in _pages.values()]) + 1
+
+
 def get_next_step(upload_session, offset=1):
     assert upload_session.upload_type is not None
 


### PR DESCRIPTION
references: #8647 

## What was done
* Upload by api changed.
    * Instead of running always these 3 steps: `save`, `check`, `final`
    * It calls the next step given by the `redirect_to` field in response.
    * It stops when:
         * it performs the final step
         * in case of errors or
         * when we count more than the max amount of steps. (defined by the [list of steps](https://github.com/GeoNode/geonode/blob/master/geonode/upload/utils.py#L200-L223) - currently, a max of 7 steps)
    * It uses the url query params to be used in the next calls, instead of ignoring it.

## How to test
* Try to upload different files at:  http://master.demo.geonode.org/catalogue/#/upload/dataset
    * Files that requires manual steps: SRS step, time step, csv...
    * Files that do not requires manual steps: shp, prj files etc...

## Others
* We should not close the page while the upload flow is running, this will stop the push of upload steps.
* When uploading a large amount of files, all these upload processes will start together instead of one at the time, this is not good. 
* The legacy view is not removed, because it's used by the `importlayers` management command.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
