### PR TITLE
[Fixes #8667] Implement the upload of files from remote locations

### DIFF
--- a/geonode/resource/data_retriever.py
+++ b/geonode/resource/data_retriever.py
@@ -1,0 +1,144 @@
+import io
+import os
+import shutil
+import smart_open
+import tempfile
+
+from django.conf import settings
+from django.core.files.uploadedfile import UploadedFile
+
+
+BUFFER_CHUNK_SIZE = 64 * 1024
+
+
+def file_chunks_iterable(file, chunk_size=None):
+    """
+    Read the file and yield chunks of ``chunk_size`` bytes (defaults to
+    ``BUFFER_CHUNK_SIZE``).
+    """
+    chunk_size = chunk_size or BUFFER_CHUNK_SIZE
+    try:
+        file.seek(0)
+    except (AttributeError, io.UnsupportedOperation):
+        pass
+
+    while True:
+        data = file.read(chunk_size)
+        if not data:
+            break
+        yield data
+
+
+class DataRetriever(object):
+    def __init__(self, file):
+        self.temporary_folder = None
+        self.file_path = None
+
+        self._is_django_form_file = False
+        self._django_form_file = None
+        self._original_file_uri = None
+        self._smart_open_uri = None
+
+        if isinstance(file, UploadedFile):
+            # File provided by django form
+            self._django_form_file = file
+            self._is_django_form_file = True
+        elif isinstance(file, str):
+            self._is_django_form_file = False
+            self._original_file_uri = file
+            self._smart_open_uri = smart_open.parse_uri(file)
+        else:
+            raise ValueError()
+
+    def delete_temporary_file(self):
+        if (self.temporary_folder and
+            self.file_path and
+            os.path.exists(self.temporary_folder) and
+            os.path.isfile(self.file_path)
+        ):
+            # Remove File
+            os.remove(self.file_path)
+            # Verify and remove temp folder
+            folder_is_empty = len(os.listdir(self.temporary_folder)) == 0
+            folder_is_not_static_root = settings.STATIC_ROOT != os.path.dirname(os.path.abspath(self.temporary_folder))
+            if folder_is_empty and folder_is_not_static_root:
+                os.rmdir(self.temporary_folder)
+
+        self.temporary_folder = None
+        self.file_path = None
+
+    def get_path(self, allow_transfer=True):
+        if not self.file_path:
+            if allow_transfer:
+                self.transfer_remote_file()
+            else:
+                raise ValueError()
+        return self.file_path
+
+    def transfer_remote_file(self, temporary_folder=None):
+        self.temporary_folder = temporary_folder or tempfile.mkdtemp(dir=settings.STATIC_ROOT)
+        self.file_path = os.path.join(self.temporary_folder, self.name)
+        if self._is_django_form_file:
+            with open(self.file_path, "wb") as tmp_file:
+                for chunk in self._django_form_file.chunks():
+                    tmp_file.write(chunk)
+        else:
+            with open(self.file_path, "wb") as tmp_file, smart_open.open(uri=self._original_file_uri, mode="rb") as original_file:
+                for chunk in file_chunks_iterable(original_file):
+                    tmp_file.write(chunk)
+        return self.file_path
+
+    @property
+    def size(self):
+        return os.path.getsize(self.file_path)
+
+    @property
+    def name(self):
+        if self.file_path:
+            return os.path.basename(self.file_path)
+
+        if self._is_django_form_file:
+            return self._django_form_file.name
+
+        return os.path.basename(self._smart_open_uri.uri_path)
+
+
+class DataRetrieverGroup(object):
+    def __init__(self, files, tranfer_at_creation=False):
+        self.temporary_folder = None
+        self.file_paths = {}
+
+        self.data_retrievers = {
+            key: DataRetriever(value) for key, value in files.items() if value
+        }
+        if tranfer_at_creation:
+            self.transfer_remote_files()
+
+    def transfer_remote_files(self):
+        self.temporary_folder = tempfile.mkdtemp(dir=settings.STATIC_ROOT)
+        for key, value in self.data_retrievers.items():
+            file_path = value.transfer_remote_file(self.temporary_folder)
+            self.file_paths[key] = file_path
+
+    def get_paths(self, allow_transfer=False):
+        if not self.file_paths:
+            if allow_transfer:
+                self.transfer_remote_files()
+            else:
+                raise ValueError()
+        return self.file_paths.copy()
+
+    def delete_files(self):
+        if (self.temporary_folder and
+            os.path.exists(self.temporary_folder) and
+            settings.STATIC_ROOT != os.path.dirname(os.path.abspath(self.temporary_folder))
+        ):
+            shutil.rmtree(self.temporary_folder, ignore_errors=True)
+        self.temporary_folder = None
+        self.file_paths = {}
+
+    def get(self, key, default=None):
+        return self.data_retrievers.get(key, default)
+
+    def items(self):
+        return self.data_retrievers.items()

--- a/geonode/upload/api/tests.py
+++ b/geonode/upload/api/tests.py
@@ -299,6 +299,47 @@ class UploadApiTests(GeoNodeLiveTestSupport, APITestCase):
                     f"probably not json, status {response.status_code} / {response.content}"))
             return response, response.content
 
+    def rest_upload_by_path(self, _file, username=GEONODE_USER, password=GEONODE_PASSWD):
+        """ function that uploads a file, or a collection of files, to
+        the GeoNode"""
+        assert authenticate(username=username, password=password)
+        self.assertTrue(self.client.login(username=username, password=password))
+        spatial_files = ("dbf_file_path", "shx_file_path", "prj_file_path")
+        base, ext = os.path.splitext(_file)
+        params = {
+            # make public since wms client doesn't do authentication
+            'permissions': '{ "users": {"AnonymousUser": ["view_resourcebase"]} , "groups":{}}',
+            'time': 'false',
+            'charset': 'UTF-8'
+        }
+
+        # deal with shapefiles
+        if ext.lower() == '.shp':
+            for spatial_file in spatial_files:
+                ext, _, _ = spatial_file.split('_')
+                file_path = f"{base}.{ext}"
+                # sometimes a shapefile is missing an extra file,
+                # allow for that
+                if os.path.exists(file_path):
+                    params[spatial_file] = file_path
+
+        params['base_file_path'] = _file
+
+        url = urljoin(
+            f"{reverse('uploads-list')}/",
+            'upload/')
+        logger.error(f" ---- UPLOAD URL: {url}")
+        response = self.client.post(url, data=params)
+
+        try:
+            logger.error(f" -- response: {response.status_code} / {response.json()}")
+            return response, response.json()
+        except (ValueError, TypeError):
+            logger.exception(
+                ValueError(
+                    f"probably not json, status {response.status_code} / {response.content}"))
+            return response, response.content
+
     # AF: Intermittent failures on CircleCI
     # @as_superuser
     # def test_live_login(self):
@@ -398,6 +439,87 @@ class UploadApiTests(GeoNodeLiveTestSupport, APITestCase):
         fname = os.path.join(GOOD_DATA, 'raster', 'relief_san_andres.tif')
         resp, data = self.rest_upload_file(fname)
         self.assertEqual(resp.status_code, 200)
+
+        url = reverse('uploads-list')
+        # Anonymous
+        self.client.logout()
+        response = self.client.get(url, format='json')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 5)
+        self.assertEqual(response.data['total'], 0)
+        # Pagination
+        self.assertEqual(len(response.data['uploads']), 0)
+        logger.debug(response.data)
+
+        # Admin
+        self.assertTrue(self.client.login(username=GEONODE_USER, password=GEONODE_PASSWD))
+        response = self.client.get(url, format='json')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 5)
+        self.assertEqual(response.data['total'], 1)
+        # Pagination
+        self.assertEqual(len(response.data['uploads']), 1)
+        logger.debug(response.data)
+        upload_data = response.data['uploads'][0]
+        self.assertIsNotNone(upload_data)
+        self.assertEqual(upload_data['name'], 'relief_san_andres')
+
+        if upload_data['state'] != enumerations.STATE_PROCESSED:
+            self.assertEqual(upload_data['progress'], 100.0)
+            self.assertIsNone(upload_data['resume_url'])
+            self.assertIsNone(upload_data['delete_url'])
+            self.assertIsNotNone(upload_data['detail_url'])
+
+            self.assertIn('uploadfile_set', upload_data)
+            self.assertEqual(len(upload_data['uploadfile_set']), 2)
+        else:
+            self.assertEqual(upload_data['progress'], 100.0)
+            self.assertIsNone(upload_data['resume_url'])
+            self.assertIsNone(upload_data['delete_url'])
+            self.assertIsNotNone(upload_data['detail_url'])
+
+        self.assertNotIn('resource', upload_data)
+        self.assertNotIn('session', upload_data)
+
+        url = reverse('uploads-detail', kwargs={'pk': upload_data['id']})
+        response = self.client.get(f"{url}?full=true", format='json')
+        self.assertEqual(response.status_code, 200)
+        upload_data = response.data['upload']
+        self.assertIsNotNone(upload_data)
+        self.assertIn('resource', upload_data)
+        self.assertIn('ptype', upload_data['resource'])
+        self.assertIn('ows_url', upload_data['resource'])
+        self.assertIn('subtype', upload_data['resource'])
+
+        self.assertIn('session', upload_data)
+
+        self.assertIn('uploadfile_set', upload_data)
+        self.assertGreaterEqual(len(upload_data['uploadfile_set']), 1)
+
+        self.assertNotIn('upload_dir', upload_data)
+
+        if upload_data['delete_url'] is not None:
+            response = self.client.get(upload_data['delete_url'], format='json')
+            self.assertEqual(response.status_code, 200)
+
+            response = self.client.get(reverse('uploads-list'), format='json')
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(len(response.data), 5)
+            self.assertEqual(response.data['total'], 0)
+            # Pagination
+            self.assertEqual(len(response.data['uploads']), 0)
+            logger.debug(response.data)
+
+    def test_rest_uploads_by_path(self):
+        """
+        Ensure we can access the Local Server Uploads list.
+        """
+        # Try to upload a good raster file and check the session IDs
+        fname = os.path.join(GOOD_DATA, 'raster', 'relief_san_andres.tif')
+        resp, data = self.rest_upload_by_path(fname)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(data['status'], 'finished')
+        self.assertTrue(data['success'])
 
         url = reverse('uploads-list')
         # Anonymous

--- a/geonode/upload/api/views.py
+++ b/geonode/upload/api/views.py
@@ -140,9 +140,6 @@ class UploadViewSet(DynamicModelViewSet):
         """)
     @action(detail=False, methods=['post'])
     def upload(self, request, format=None):
-        if not getattr(request, 'FILES', None):
-            raise ParseError(_("Empty content"))
-
         user = request.user
         if not user or not user.is_authenticated:
             return Response(status=status.HTTP_401_UNAUTHORIZED)

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,7 @@ wrapt==1.13.3
 jsonschema==4.4.0
 zipstream-new==1.1.8
 rdflib==6.1.1
+smart_open==5.2.1
 
 # Django Apps
 django-allauth==0.47.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,6 +49,7 @@ install_requires =
     jsonschema==4.4.0
     zipstream-new==1.1.8
     rdflib==6.1.1
+    smart_open==5.2.1
 
     # Django Apps
     django-allauth==0.47.0


### PR DESCRIPTION
references: #8667 

## What was done
* The `smart_open` library was added.
* DataRetriever and DataRetrieverGroup component were created.
* Added fields `*_path` to the UploadForm, now it's possible to add a file sending it (`base_file`) or by its path (`base_file_path`).
* The `*_path` field is handled by [smart_open](https://github.com/RaRe-Technologies/smart_open), so it can accept http, s3, server local files etc...
* Files are now transferred to a tmp folder during upload.
     * Even if the file is local, this is needed. Some processes only works if the uploaded files are the only files in the refereed folder.
* Upload process updated to make use of these components.

## How to test
* Request:
```
curl --location --request POST 'http://localhost:8000/api/v2/uploads/upload/' \
--header 'Authorization: Basic YWRtaW46YWRtaW4=' \
--header 'Cookie: csrftoken=V7g4BJKNmgqRFltoM5GizihCa9uV2eWD4g213CJQPDK1lROupIE44MArEWhtyLvv; sessionid=x20mqic58gc0oct5mkko30v1iwi8l294' \
--form 'permissions="{ \"users\": {\"AnonymousUser\": [\"view_resourcebase\"]} , \"groups\":{}}"' \
--form 'time="false"' \
--form 'charset="UTF-8"' \
--form 'base_file_path="https://github.com/GeoNode/gisdata/raw/master/gisdata/data/good/vector/san_andres_y_providencia_administrative.shp"' \
--form 'dbf_file_path="https://github.com/GeoNode/gisdata/raw/master/gisdata/data/good/vector/san_andres_y_providencia_administrative.dbf"' \
--form 'prj_file_path="https://github.com/GeoNode/gisdata/raw/master/gisdata/data/good/vector/san_andres_y_providencia_administrative.prj"' \
--form 'shp_file_path="https://github.com/GeoNode/gisdata/raw/master/gisdata/data/good/vector/san_andres_y_providencia_administrative.shp"' \
--form 'shx_file_path="https://github.com/GeoNode/gisdata/raw/master/gisdata/data/good/vector/san_andres_y_providencia_administrative.shx"'
```
* Expected response:
```json
{
   "bbox" : "-81.9087270,12.1189965,-79.9333322,15.5027746",
   "crs" : {
      "properties" : "EPSG:4326",
      "type" : "name"
   },
   "id" : 86,
   "status" : "finished",
   "success" : true,
   "url" : "/catalogue/#/dataset/84"
}
```

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [x] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
