### PR TITLE
[Fixes #8740] Adopt default permissions for new resources

### DIFF
--- a/geonode/documents/forms.py
+++ b/geonode/documents/forms.py
@@ -181,7 +181,7 @@ class DocumentCreateForm(TranslationModelForm, DocumentFormMixin):
             attrs={
                 'name': 'permissions',
                 'id': 'permissions'}),
-        required=True)
+        required=False)
 
     links = forms.MultipleChoiceField(
         label=_("Link to"),
@@ -209,6 +209,9 @@ class DocumentCreateForm(TranslationModelForm, DocumentFormMixin):
         Ensures the JSON field is JSON.
         """
         permissions = self.cleaned_data['permissions']
+
+        if not self.fields['permissions'].required and (permissions is None or permissions == ''):
+            return None
 
         try:
             return json.loads(permissions)

--- a/geonode/documents/tests.py
+++ b/geonode/documents/tests.py
@@ -196,9 +196,6 @@ class DocumentsTest(GeoNodeBaseTestSupport):
         # title is required
         self.assertTrue('title' in form.errors)
 
-        # permissions are required
-        self.assertTrue('permissions' in form.errors)
-
         # since neither a doc_file nor a doc_url are included __all__ should be
         # in form.errors.
         self.assertTrue('__all__' in form.errors)

--- a/geonode/geoserver/createlayer/templates/createlayer/dataset_create.html
+++ b/geonode/geoserver/createlayer/templates/createlayer/dataset_create.html
@@ -46,17 +46,6 @@
     </section>
 
   </div>
-
-  {% display_change_perms_button resource request.user perms_list as display_perms_button %}
-  {% if display_perms_button %}
-  <div class="col-md-4">
-    <h3>{% trans "Permissions"  %}</h3>
-    <form id="permission_form">
-      {% include "_permissions.html" %}
-    </form>
-  </div>
-  {% endif %}
-
 </div>
 {% endblock %}
 

--- a/geonode/geoserver/createlayer/tests.py
+++ b/geonode/geoserver/createlayer/tests.py
@@ -17,14 +17,12 @@
 #
 #########################################################################
 
-from geonode.tests.base import GeoNodeBaseTestSupport
-
 import os
-import dj_database_url
 
 from django.conf import settings
 from django.urls import reverse
 
+from geonode.tests.base import GeoNodeBaseTestSupport
 from geonode import geoserver
 from geonode import GeoNodeException
 from geonode.layers.models import Dataset
@@ -32,29 +30,6 @@ from geonode.decorators import on_ogc_backend
 from geonode.geoserver.signals import gs_catalog
 
 from .utils import create_dataset
-
-
-r"""
-How to run the tests
---------------------
-
-Create a user and database for the datastore:
-
-    $ sudo su postgres
-    $ psql
-    postgres=# CREATE USER geonode with password 'geonode';
-    postgres=# ALTER USER geonode WITH LOGIN;
-    postgres=# ALTER USER geonode WITH SUPERUSER;
-    postgres=# CREATE DATABASE datastore WITH OWNER geonode;
-    postgres=# \c datastore
-    datastore=# CREATE EXTENSION postgis;
-
-Add 'geonode.geoserver.createlayer' in GEONODE_INTERNAL_APPS
-
-Then, as usual, run "paver run_tests"
-
-"""
-
 
 class CreateLayerCoreTest(GeoNodeBaseTestSupport):
 
@@ -67,21 +42,17 @@ class CreateLayerCoreTest(GeoNodeBaseTestSupport):
         super().setUp()
         # createlayer must use postgis as a datastore
         # set temporary settings to use a postgis datastore
-        DATASTORE_URL = 'postgis://geonode:geonode@localhost:5432/datastore'
-        postgis_db = dj_database_url.parse(DATASTORE_URL, conn_max_age=0)
-        settings.DATABASES['datastore'] = postgis_db
-        settings.OGC_SERVER['default']['DATASTORE'] = 'datastore'
+        #DATASTORE_URL = 'postgis://geonode:geonode@localhost:5432/datastore'
+        #postgis_db = dj_database_url.parse(DATASTORE_URL, conn_max_age=0)
+        #settings.DATABASES['datastore'] = postgis_db
+        #settings.OGC_SERVER['default']['DATASTORE'] = 'datastore'
 
     def tearDown(self):
         super(GeoNodeBaseTestSupport, self).tearDown()
         # move to original settings
-        settings.OGC_SERVER['default']['DATASTORE'] = ''
-        del settings.DATABASES['datastore']
+        #settings.OGC_SERVER['default']['DATASTORE'] = ''
+        #del settings.DATABASES['datastore']
         # TODO remove stuff from django and geoserver catalog
-
-    def test_dataset_creation_without_postgis(self):
-        # TODO implement this: must raise an error message
-        pass
 
     @on_ogc_backend(geoserver.BACKEND_PACKAGE)
     def test_dataset_creation(self):
@@ -94,6 +65,9 @@ class CreateLayerCoreTest(GeoNodeBaseTestSupport):
         else:
             dataset_name = 'point_dataset'
             dataset_title = 'A layer for points'
+            print(settings.DATABASES['datastore'])
+            print('#######')
+            print(settings.OGC_SERVER['default']['DATASTORE'])
 
             create_dataset(
                 dataset_name,
@@ -109,20 +83,23 @@ class CreateLayerCoreTest(GeoNodeBaseTestSupport):
 
             # check if it is in geoserver
             gs_dataset = cat.get_layer(dataset_name)
-            self.assertIsNotNone(gs_dataset)
-            self.assertEqual(gs_dataset.name, dataset_name)
+            try:
+                self.assertIsNotNone(gs_dataset)
+                self.assertEqual(gs_dataset.name, dataset_name)
+            
+                resource = gs_dataset.resource
+                # we must have only one attibute ('the_geom')
+                self.assertEqual(len(resource.attributes), 1)
 
-            resource = gs_dataset.resource
-            # we must have only one attibute ('the_geom')
-            self.assertEqual(len(resource.attributes), 1)
+                # check layer corrispondence between django and geoserver
+                self.assertEqual(resource.title, dataset_title)
+                self.assertEqual(resource.projection, layer.srid)
 
-            # check layer corrispondence between django and geoserver
-            self.assertEqual(resource.title, dataset_title)
-            self.assertEqual(resource.projection, layer.srid)
-
-            # check if layer detail page is accessible with client
-            response = self.client.get(reverse('dataset_embed', args=(f'geonode:{dataset_name}',)))
-            self.assertEqual(response.status_code, 200)
+                # check if layer detail page is accessible with client
+                response = self.client.get(reverse('dataset_embed', args=(f'geonode:{dataset_name}',)))
+                self.assertEqual(response.status_code, 200)
+            finally:
+                cat.delete(gs_dataset)
 
     def test_dataset_creation_with_wrong_geometry_type(self):
         """
@@ -167,14 +144,10 @@ class CreateLayerCoreTest(GeoNodeBaseTestSupport):
 
             cat = gs_catalog
             gs_dataset = cat.get_layer(dataset_name)
-            resource = gs_dataset.resource
+            try:
+                resource = gs_dataset.resource
 
-            # we must have one attibute for the geometry, and 4 other ones
-            self.assertEqual(len(resource.attributes), 5)
-
-    def test_dataset_creation_with_permissions(self):
-        """
-        Try creating a layer with permissions.
-        """
-        # TODO
-        pass
+                # we must have one attibute for the geometry, and 4 other ones
+                self.assertEqual(len(resource.attributes), 5)
+            finally:
+                cat.delete(gs_dataset)

--- a/geonode/geoserver/createlayer/tests.py
+++ b/geonode/geoserver/createlayer/tests.py
@@ -31,6 +31,7 @@ from geonode.geoserver.signals import gs_catalog
 
 from .utils import create_dataset
 
+
 class CreateLayerCoreTest(GeoNodeBaseTestSupport):
 
     """
@@ -42,16 +43,16 @@ class CreateLayerCoreTest(GeoNodeBaseTestSupport):
         super().setUp()
         # createlayer must use postgis as a datastore
         # set temporary settings to use a postgis datastore
-        #DATASTORE_URL = 'postgis://geonode:geonode@localhost:5432/datastore'
-        #postgis_db = dj_database_url.parse(DATASTORE_URL, conn_max_age=0)
-        #settings.DATABASES['datastore'] = postgis_db
-        #settings.OGC_SERVER['default']['DATASTORE'] = 'datastore'
+        # DATASTORE_URL = 'postgis://geonode:geonode@localhost:5432/datastore'
+        # postgis_db = dj_database_url.parse(DATASTORE_URL, conn_max_age=0)
+        # settings.DATABASES['datastore'] = postgis_db
+        # settings.OGC_SERVER['default']['DATASTORE'] = 'datastore'
 
     def tearDown(self):
         super(GeoNodeBaseTestSupport, self).tearDown()
         # move to original settings
-        #settings.OGC_SERVER['default']['DATASTORE'] = ''
-        #del settings.DATABASES['datastore']
+        # settings.OGC_SERVER['default']['DATASTORE'] = ''
+        # del settings.DATABASES['datastore']
         # TODO remove stuff from django and geoserver catalog
 
     @on_ogc_backend(geoserver.BACKEND_PACKAGE)
@@ -86,7 +87,7 @@ class CreateLayerCoreTest(GeoNodeBaseTestSupport):
             try:
                 self.assertIsNotNone(gs_dataset)
                 self.assertEqual(gs_dataset.name, dataset_name)
-            
+
                 resource = gs_dataset.resource
                 # we must have only one attibute ('the_geom')
                 self.assertEqual(len(resource.attributes), 1)

--- a/geonode/geoserver/createlayer/utils.py
+++ b/geonode/geoserver/createlayer/utils.py
@@ -222,4 +222,5 @@ def create_gs_dataset(name, title, geometry_type, attributes=None):
         logger.error(f'Response was: {req.text}')
         raise Exception(f"Dataset could not be created in GeoServer {req.text}")
 
+    cat.reload()
     return workspace, datastore

--- a/geonode/geoserver/createlayer/views.py
+++ b/geonode/geoserver/createlayer/views.py
@@ -24,9 +24,10 @@ from django.shortcuts import render
 from django.template.defaultfilters import slugify
 from django.shortcuts import redirect
 
+from geonode.security.permissions import DEFAULT_PERMS_SPEC
+
 from .forms import NewDatasetForm
 from .utils import create_dataset
-
 
 @login_required
 def dataset_create(request, template='createlayer/dataset_create.html'):
@@ -43,7 +44,7 @@ def dataset_create(request, template='createlayer/dataset_create.html'):
                 title = form.cleaned_data['title']
                 geometry_type = form.cleaned_data['geometry_type']
                 attributes = form.cleaned_data['attributes']
-                permissions = form.cleaned_data["permissions"]
+                permissions = DEFAULT_PERMS_SPEC
                 layer = create_dataset(name, title, request.user.username, geometry_type, attributes)
                 layer.set_permissions(json.loads(permissions), created=True)
                 return redirect(layer)

--- a/geonode/geoserver/createlayer/views.py
+++ b/geonode/geoserver/createlayer/views.py
@@ -29,6 +29,7 @@ from geonode.security.permissions import DEFAULT_PERMS_SPEC
 from .forms import NewDatasetForm
 from .utils import create_dataset
 
+
 @login_required
 def dataset_create(request, template='createlayer/dataset_create.html'):
     """

--- a/geonode/layers/forms.py
+++ b/geonode/layers/forms.py
@@ -36,6 +36,10 @@ class JSONField(forms.CharField):
 
     def clean(self, text):
         text = super().clean(text)
+
+        if not self.required and (text is None or text == ''):
+            return None
+
         try:
             return json.loads(text)
         except ValueError:

--- a/geonode/security/permissions.py
+++ b/geonode/security/permissions.py
@@ -24,11 +24,13 @@ import collections
 from avatar.templatetags.avatar_tags import avatar_url
 from guardian.shortcuts import get_group_perms, get_anonymous_user
 
+from django.conf import settings
 from django.contrib.auth.models import Group
 from django.contrib.auth import get_user_model
 
 from geonode.utils import build_absolute_uri
 from geonode.groups.conf import settings as groups_settings
+
 
 # Permissions mapping
 PERMISSIONS = {
@@ -83,6 +85,14 @@ SERVICE_PERMISSIONS = [
     "change_resourcebase_metadata",
     "add_resourcebase_from_service"
 ]
+
+DEFAULT_PERMISSIONS = []
+if settings.DEFAULT_ANONYMOUS_VIEW_PERMISSION:
+    DEFAULT_PERMISSIONS += VIEW_PERMISSIONS
+if settings.DEFAULT_ANONYMOUS_DOWNLOAD_PERMISSION:
+    DEFAULT_PERMISSIONS += DOWNLOAD_PERMISSIONS
+
+DEFAULT_PERMS_SPEC = json.dumps({"users":{"AnonymousUser":DEFAULT_PERMISSIONS},"groups":{}})
 
 NONE_RIGHTS = "none"
 VIEW_RIGHTS = "view"

--- a/geonode/security/permissions.py
+++ b/geonode/security/permissions.py
@@ -92,7 +92,7 @@ if settings.DEFAULT_ANONYMOUS_VIEW_PERMISSION:
 if settings.DEFAULT_ANONYMOUS_DOWNLOAD_PERMISSION:
     DEFAULT_PERMISSIONS += DOWNLOAD_PERMISSIONS
 
-DEFAULT_PERMS_SPEC = json.dumps({"users":{"AnonymousUser":DEFAULT_PERMISSIONS},"groups":{}})
+DEFAULT_PERMS_SPEC = json.dumps({"users": {"AnonymousUser": DEFAULT_PERMISSIONS}, "groups": {}})
 
 NONE_RIGHTS = "none"
 VIEW_RIGHTS = "view"

--- a/geonode/upload/forms.py
+++ b/geonode/upload/forms.py
@@ -61,7 +61,7 @@ class LayerUploadForm(forms.Form):
 
     abstract = forms.CharField(required=False)
     dataset_title = forms.CharField(required=False)
-    permissions = JSONField()
+    permissions = JSONField(required=False)
 
     metadata_uploaded_preserve = forms.BooleanField(required=False)
     metadata_upload_form = forms.BooleanField(required=False)


### PR DESCRIPTION
ref #8740 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
