### PR TITLE
[Fixes #8772] Previous owner is assigned to the cloned resource, instead of the user that performed the clone operation

### DIFF
--- a/geonode/base/api/tests.py
+++ b/geonode/base/api/tests.py
@@ -20,6 +20,8 @@ import sys
 import json
 import logging
 import re
+import os
+import gisdata
 
 from PIL import Image
 from io import BytesIO
@@ -41,6 +43,7 @@ from geonode.tests.base import GeoNodeBaseTestSupport
 from geonode.base import enumerations
 from geonode.groups.models import GroupProfile
 from geonode.thumbs.exceptions import ThumbnailError
+from geonode.layers.utils import get_files
 from geonode.base.models import (
     HierarchicalKeyword,
     Region,
@@ -1695,6 +1698,50 @@ class BaseApiTests(APITestCase):
                 ]
             }
         )
+
+    def test_resource_service_copy(self):
+        files = os.path.join(gisdata.GOOD_DATA, "vector/san_andres_y_providencia_water.shp")
+        files_as_dict, _ = get_files(files)
+        resource = Dataset.objects.create(
+            owner=get_user_model().objects.get(username='admin'),
+            name='test_copy',
+            store='geonode_data',
+            subtype="vector",
+            alternate="geonode:test_copy",
+            uuid=str(uuid1()),
+            files=list(files_as_dict.values())
+        )
+        bobby = get_user_model().objects.get(username='bobby')
+        copy_url = reverse('base-resources-resource-service-copy', kwargs={'pk': resource.pk})
+        response = self.client.put(copy_url, data={'title': 'cloned_resource'})
+        self.assertEqual(response.status_code, 403)
+        # set perms to enable user clone resource
+        self.assertTrue(self.client.login(username="admin", password="admin"))
+        perm_spec = {
+            'users': [
+                {
+                    'id': bobby.id,
+                    'username': bobby.username,
+                    'first_name': bobby.first_name,
+                    'last_name': bobby.last_name,
+                    'avatar': '',
+                    'permissions': 'manage'
+                }
+            ]
+        }
+        set_perms_url = urljoin(f"{reverse('base-resources-detail', kwargs={'pk': resource.pk})}/", 'permissions')
+        data = f"uuid={resource.uuid}&permissions={json.dumps(perm_spec)}"
+        response = self.client.patch(set_perms_url, data=data, content_type='application/x-www-form-urlencoded')
+        self.assertEqual(response.status_code, 200)
+        # clone resource
+        self.assertTrue(self.client.login(username="bobby", password="bob"))
+        response = self.client.put(copy_url)
+        self.assertEqual(response.status_code, 200)
+        cloned_resource = Dataset.objects.last()
+        self.assertEqual(cloned_resource.owner.username, 'bobby')
+        # clean
+        resource.delete()
+        cloned_resource.delete()
 
 
 class TestExtraMetadataBaseApi(GeoNodeBaseTestSupport):

--- a/geonode/resource/manager.py
+++ b/geonode/resource/manager.py
@@ -485,6 +485,8 @@ class ResourceManager(ResourceManagerInterface):
                     anonymous_group = 'anonymous' if 'anonymous' in _perms['groups'] else Group.objects.get(name='anonymous')
                     _perms['groups'].pop(anonymous_group)
                 self.set_permissions(_resource.uuid, instance=_resource, owner=_owner, permissions=_perms)
+                # Refresh from DB
+                _resource.refresh_from_db()
                 return self.update(_resource.uuid, _resource, vals=to_update)
         return instance
 


### PR DESCRIPTION

<Include a few sentences describing the overall goals for this Pull Request>
References #8772 
## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
