### PR TITLE
Correctly assign a user when creating a new upload session.

### DIFF
--- a/geonode/layers/utils.py
+++ b/geonode/layers/utils.py
@@ -454,11 +454,11 @@ def file_upload(filename,
     # Create a new upload session
     if layer:
         latest_uploads = UploadSession.objects.filter(resource=layer).order_by('-date')
-        if latest_uploads.count() > 1:
+        if len(latest_uploads) >= 1:
             upload_session = latest_uploads.first()
+            upload_session.user = theuser
         else:
-            upload_session, _created = UploadSession.objects.get_or_create(resource=layer)
-        upload_session.user = theuser
+            upload_session = UploadSession.objects.create(resource=layer, user=theuser)
         upload_session.layerfile_set.all().delete()
     else:
         upload_session = UploadSession.objects.create(user=theuser)


### PR DESCRIPTION
When creating a new `UploadSession` via `get_or_create`, the database has a constraint that a user must be specified. Thus, geonode generates an error when trying to create one with only the layer details specified.

The `default` dictionary on `get_or_create` allows the addition of variables for creation with modifying the search query for existing `UploadSession` objects.


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [ ] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
