### PR TITLE
[Fixes #8858] Support "workspaced" requests on GeoServer proxy view

### DIFF
--- a/geonode/geoserver/tests/test_server.py
+++ b/geonode/geoserver/tests/test_server.py
@@ -740,7 +740,7 @@ class LayerTests(GeoNodeBaseTestSupport):
             **valid_auth_headers
         )
         post_request.user = AnonymousUser()
-        raw_url, headers, access_token = check_geoserver_access(
+        raw_url, headers, access_token, downstream_path = check_geoserver_access(
             post_request,
             '/gs/rest/workspaces',
             'rest/workspaces',
@@ -751,7 +751,19 @@ class LayerTests(GeoNodeBaseTestSupport):
         self.assertIsNotNone(headers)
         self.assertIsNotNone(access_token)
 
-        authorized = style_change_check(post_request, 'rest/workspaces', access_token=access_token)
+        authorized = style_change_check(post_request, downstream_path, style_name='styles', access_token=access_token)
+        self.assertTrue(authorized)
+
+        authorized = style_change_check(post_request, 'rest/styles', style_name=f'{layer.name}', access_token=access_token)
+        self.assertTrue(authorized)
+
+        authorized = style_change_check(post_request, f'rest/workspaces/{layer.workspace}/styles/{layer.name}', style_name=f'{layer.name}', access_token=access_token)
+        self.assertTrue(authorized)
+
+        authorized = style_change_check(post_request, f'rest/layers/{layer.name}', access_token=access_token)
+        self.assertTrue(authorized)
+
+        authorized = style_change_check(post_request, f'rest/workspaces/{layer.workspace}/layers/{layer.name}', access_token=access_token)
         self.assertTrue(authorized)
 
         put_request = rf.put(
@@ -761,7 +773,7 @@ class LayerTests(GeoNodeBaseTestSupport):
             **valid_auth_headers
         )
         put_request.user = AnonymousUser()
-        raw_url, headers, access_token = check_geoserver_access(
+        raw_url, headers, access_token, downstream_path = check_geoserver_access(
             put_request,
             '/gs/rest/workspaces',
             'rest/workspaces',
@@ -777,7 +789,20 @@ class LayerTests(GeoNodeBaseTestSupport):
         # ref: 05b000cdb06b0b6e9b72bd9eb8a8e03abeb204a8
         #  [Regression] "style_change_check" always fails in the case the style does not exist on GeoNode too, preventing a user editing temporary generated styles
         Style.objects.filter(name=layer.name).delete()
-        authorized = style_change_check(put_request, 'rest/workspaces', access_token=access_token)
+
+        authorized = style_change_check(put_request, downstream_path, style_name='styles', access_token=access_token)
+        self.assertTrue(authorized)
+
+        authorized = style_change_check(put_request, 'rest/styles', style_name=f'{layer.name}', access_token=access_token)
+        self.assertTrue(authorized)
+
+        authorized = style_change_check(put_request, f'rest/workspaces/{layer.workspace}/styles/{layer.name}', style_name=f'{layer.name}', access_token=access_token)
+        self.assertTrue(authorized)
+
+        authorized = style_change_check(put_request, f'rest/layers/{layer.name}', access_token=access_token)
+        self.assertTrue(authorized)
+
+        authorized = style_change_check(put_request, f'rest/workspaces/{layer.workspace}/layers/{layer.name}', access_token=access_token)
         self.assertTrue(authorized)
 
         # Check is NOT 'authorized'
@@ -788,7 +813,7 @@ class LayerTests(GeoNodeBaseTestSupport):
             **invalid_auth_headers
         )
         post_request.user = AnonymousUser()
-        raw_url, headers, access_token = check_geoserver_access(
+        raw_url, headers, access_token, downstream_path = check_geoserver_access(
             post_request,
             '/gs/rest/workspaces',
             'rest/workspaces',
@@ -799,7 +824,7 @@ class LayerTests(GeoNodeBaseTestSupport):
         self.assertIsNotNone(headers)
         self.assertIsNone(access_token)
 
-        authorized = style_change_check(post_request, 'rest/workspaces', access_token=access_token)
+        authorized = style_change_check(post_request, downstream_path, access_token=access_token)
         self.assertFalse(authorized)
 
     @on_ogc_backend(geoserver.BACKEND_PACKAGE)

--- a/geonode/geoserver/views.py
+++ b/geonode/geoserver/views.py
@@ -358,7 +358,7 @@ def style_change_check(request, path, style_name=None, access_token=None):
     if request.method in ('PUT', 'POST'):
         if not request.user.is_authenticated and not access_token:
             authorized = False
-        elif re.match(r'^.*/rest/styles.*|^(?<!/rest)(?<!/styles).*/rest/.*/styles.*', path):
+        elif re.match(r'^.*(?<!/rest/)/rest/.*/?styles.*', path):
             # style new/update
             # we will iterate all layers (should be just one if not using GS)
             # to which the posted style is associated
@@ -486,7 +486,7 @@ def geoserver_proxy(request,
     url = urlsplit(raw_url)
 
     if re.match(r'^.*/rest/', url.path) and request.method in ("POST", "PUT", "DELETE"):
-        if re.match(r'^.*/rest/styles.*|^(?<!/rest)(?<!/styles).*/rest/.*/styles.*', url.path):
+        if re.match(r'^.*(?<!/rest/)/rest/.*/?styles.*', url.path):
             logger.debug(
                 f"[geoserver_proxy] Updating Style ---> url {url.geturl()}")
             _style_name, _style_ext = os.path.splitext(os.path.basename(urlsplit(url.geturl()).path))
@@ -505,7 +505,7 @@ def geoserver_proxy(request,
             if _style_name != 'style-check' and (_style_ext == '.json' or _parsed_get_args.get('raw')) and \
                     not re.match(temp_style_name_regex, _style_name):
                 affected_datasets = style_update(request, raw_url, workspace)
-        elif re.match(r'^.*/rest/layers.*|^(?<!/rest)(?<!/layers).*/rest/.*/layers.*', url.path):
+        elif re.match(r'^.*(?<!/rest/)/rest/.*/?layers.*', url.path):
             logger.debug(f"[geoserver_proxy] Updating Dataset ---> url {url.geturl()}")
             try:
                 _dataset_name = os.path.splitext(os.path.basename(request.path))[0]

--- a/geonode/geoserver/views.py
+++ b/geonode/geoserver/views.py
@@ -358,7 +358,7 @@ def style_change_check(request, path, style_name=None, access_token=None):
     if request.method in ('PUT', 'POST'):
         if not request.user.is_authenticated and not access_token:
             authorized = False
-        elif path == 'rest/styles' or re.match(r'.*(/rest/styles)|.*(/rest)/.*(/styles).*', path):
+        elif re.match(r'.*(/rest/styles)|.*(/rest)/.*(/styles).*', path):
             # style new/update
             # we will iterate all layers (should be just one if not using GS)
             # to which the posted style is associated

--- a/geonode/geoserver/views.py
+++ b/geonode/geoserver/views.py
@@ -340,7 +340,7 @@ def dataset_style_manage(request, layername):
             )
 
 
-def style_change_check(request, path, access_token=None):
+def style_change_check(request, path, style_name=None, access_token=None):
     """
     If the layer has not change_dataset_style permission, return a status of
     401 (unauthorized)
@@ -358,16 +358,12 @@ def style_change_check(request, path, access_token=None):
     if request.method in ('PUT', 'POST'):
         if not request.user.is_authenticated and not access_token:
             authorized = False
-        elif path == 'rest/layers' and request.method == 'PUT':
-            # layer update, should be safe to always authorize it
-            authorized = True
-        else:
+        elif path == 'rest/styles' or re.match(r'.*(/rest/styles)|.*(/rest)/.*(/styles).*', path):
             # style new/update
             # we will iterate all layers (should be just one if not using GS)
             # to which the posted style is associated
             # and check if the user has change_style_dataset permissions on each
             # of them
-            style_name = os.path.splitext(request.path)[0].split('/')[-1]
             if style_name == 'styles' and 'raw' in request.GET:
                 authorized = True
             elif re.match(temp_style_name_regex, style_name):
@@ -389,7 +385,8 @@ def style_change_check(request, path, access_token=None):
                                 authorized = True
                                 break
                 except Style.DoesNotExist:
-                    logger.warn(f'There is not a style with such a name: {style_name}.')
+                    if request.method != 'POST':
+                        logger.warn(f'There is not a style with such a name: {style_name}.')
                 except Exception as e:
                     logger.exception(e)
                     authorized = (request.method == 'POST')  # The user is probably trying to create a new style
@@ -463,7 +460,7 @@ def check_geoserver_access(request,
 
     # Collecting headers and cookies
     headers, access_token = get_headers(request, url, unquote(raw_url), allowed_hosts=allowed_hosts)
-    return (raw_url, headers, access_token)
+    return (raw_url, headers, access_token, downstream_path)
 
 
 @csrf_exempt
@@ -479,7 +476,7 @@ def geoserver_proxy(request,
     affected_datasets = None
     allowed_hosts = [urlsplit(ogc_server_settings.public_url).hostname, ]
 
-    raw_url, headers, access_token = check_geoserver_access(
+    raw_url, headers, access_token, downstream_path = check_geoserver_access(
         request,
         proxy_path,
         downstream_path,
@@ -489,14 +486,8 @@ def geoserver_proxy(request,
     url = urlsplit(raw_url)
 
     if request.method in ("POST", "PUT", "DELETE"):
-        if downstream_path in ('rest/styles', 'rest/layers',
-                               'rest/workspaces'):
-            if not style_change_check(request, downstream_path, access_token=access_token):
-                return HttpResponse(
-                    _("You don't have permissions to change style for this layer"),
-                    content_type="text/plain",
-                    status=401)
-            elif downstream_path == 'rest/styles':
+        if re.match(r'.*(/rest/styles)|.*(/rest)/.*(/styles).*|.*(/rest/layers)|.*(/rest)/.*(/layers).*.*(/rest/workspaces)|.*(/rest)/.*(/workspaces).*', url.path):
+            if re.match(r'.*(/rest/styles)|.*(/rest)/.*(/styles).*', url.path):
                 logger.debug(
                     f"[geoserver_proxy] Updating Style ---> url {url.geturl()}")
                 _style_name, _style_ext = os.path.splitext(os.path.basename(urlsplit(url.geturl()).path))
@@ -506,10 +497,16 @@ def geoserver_proxy(request,
                         _style_name, _style_ext = os.path.splitext(_parsed_get_args.get('name'))
                 else:
                     _style_name, _style_ext = os.path.splitext(_style_name)
+
+                if not style_change_check(request, url.path, style_name=_style_name, access_token=access_token):
+                    return HttpResponse(
+                        _("You don't have permissions to change style for this layer"),
+                        content_type="text/plain",
+                        status=401)
                 if _style_name != 'style-check' and (_style_ext == '.json' or _parsed_get_args.get('raw')) and \
                         not re.match(temp_style_name_regex, _style_name):
                     affected_datasets = style_update(request, raw_url, workspace)
-            elif downstream_path == 'rest/layers':
+            elif re.match(r'.*(/rest/layers)|.*(/rest)/.*(/layers).*', url.path):
                 logger.debug(f"[geoserver_proxy] Updating Dataset ---> url {url.geturl()}")
                 try:
                     _dataset_name = os.path.splitext(os.path.basename(request.path))[0]

--- a/geonode/geoserver/views.py
+++ b/geonode/geoserver/views.py
@@ -358,7 +358,7 @@ def style_change_check(request, path, style_name=None, access_token=None):
     if request.method in ('PUT', 'POST'):
         if not request.user.is_authenticated and not access_token:
             authorized = False
-        elif re.match(r'^.*/rest/styles|^.*/rest/.*/styles', path):
+        elif re.match(r'^.*/rest/styles.*|^(?<!/rest)(?<!/styles).*/rest/.*/styles.*', path):
             # style new/update
             # we will iterate all layers (should be just one if not using GS)
             # to which the posted style is associated
@@ -485,8 +485,8 @@ def geoserver_proxy(request,
         allowed_hosts=allowed_hosts)
     url = urlsplit(raw_url)
 
-    if request.method in ("POST", "PUT", "DELETE"):
-        if re.match(r'^.*/rest/styles|^.*/rest/.*/styles', url.path):
+    if re.match(r'^.*/rest/', url.path) and request.method in ("POST", "PUT", "DELETE"):
+        if re.match(r'^.*/rest/styles.*|^(?<!/rest)(?<!/styles).*/rest/.*/styles.*', url.path):
             logger.debug(
                 f"[geoserver_proxy] Updating Style ---> url {url.geturl()}")
             _style_name, _style_ext = os.path.splitext(os.path.basename(urlsplit(url.geturl()).path))
@@ -505,7 +505,7 @@ def geoserver_proxy(request,
             if _style_name != 'style-check' and (_style_ext == '.json' or _parsed_get_args.get('raw')) and \
                     not re.match(temp_style_name_regex, _style_name):
                 affected_datasets = style_update(request, raw_url, workspace)
-        elif re.match(r'^.*/rest/layers|^.*/rest/.*/layers', url.path):
+        elif re.match(r'^.*/rest/layers.*|^(?<!/rest)(?<!/layers).*/rest/.*/layers.*', url.path):
             logger.debug(f"[geoserver_proxy] Updating Dataset ---> url {url.geturl()}")
             try:
                 _dataset_name = os.path.splitext(os.path.basename(request.path))[0]


### PR DESCRIPTION
References: #8858

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
