### PR TITLE
[Fixes #8873] Permissions not checked on the direct download button of a resource

### DIFF
--- a/geonode/layers/tests.py
+++ b/geonode/layers/tests.py
@@ -1217,6 +1217,13 @@ class DatasetsTest(GeoNodeBaseTestSupport):
             response = self.client.get(url)
             self.assertTrue(response.status_code == 200)
 
+    def test_dataset_download_call_the_catalog_now_work_without_download_resurcebase_perm(self):
+        dataset = Dataset.objects.first()
+        dataset.set_permissions({'users': {"bobby": ['base.view_resourcebase']}})
+        self.client.login(username="bobby", password="bob")
+        url = reverse('dataset_download', args=[dataset.alternate])
+        response = self.client.get(url)
+        self.assertEqual(404, response.status_code)
 
 class TestLayerDetailMapViewRights(GeoNodeBaseTestSupport):
 

--- a/geonode/layers/tests.py
+++ b/geonode/layers/tests.py
@@ -1225,6 +1225,7 @@ class DatasetsTest(GeoNodeBaseTestSupport):
         response = self.client.get(url)
         self.assertEqual(404, response.status_code)
 
+
 class TestLayerDetailMapViewRights(GeoNodeBaseTestSupport):
 
     fixtures = [

--- a/geonode/layers/views.py
+++ b/geonode/layers/views.py
@@ -804,8 +804,8 @@ def dataset_download(request, layername):
         dataset = _resolve_dataset(
             request,
             layername,
-            'base.change_resourcebase_metadata',
-            _PERMISSION_MSG_METADATA)
+            'base.download_resourcebase',
+            _PERMISSION_MSG_GENERIC)
     except Exception as e:
         raise Http404(Exception(_("Not found"), e))
 


### PR DESCRIPTION
relates to #8873 

Base permission changed on direct download link

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate it if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
