### PR TITLE
[Backport][Fixes #8873] Permissions not checked on the direct download button of a resource

### DIFF
--- a/geonode/layers/tests.py
+++ b/geonode/layers/tests.py
@@ -1217,13 +1217,33 @@ class DatasetsTest(GeoNodeBaseTestSupport):
             response = self.client.get(url)
             self.assertTrue(response.status_code == 200)
 
-    def test_dataset_download_call_the_catalog_now_work_without_download_resurcebase_perm(self):
+    def test_dataset_download_call_the_catalog_not_work_without_download_resurcebase_perm(self):
         dataset = Dataset.objects.first()
         dataset.set_permissions({'users': {"bobby": ['base.view_resourcebase']}})
         self.client.login(username="bobby", password="bob")
         url = reverse('dataset_download', args=[dataset.alternate])
         response = self.client.get(url)
         self.assertEqual(404, response.status_code)
+
+    def test_dataset_download_call_the_catalog_work_anonymous(self):
+        # if settings.USE_GEOSERVER is false, the URL must be redirected
+        _response = MagicMock(
+            status_code=200,
+            text="",  # noqa
+            headers={"Content-Type": ""}
+        )
+        dataset = Dataset.objects.first()
+        layer = create_dataset(
+            dataset.title,
+            dataset.title,
+            dataset.owner,
+            'Point'
+        )
+        with patch("geonode.layers.views.Catalog.http_request") as mocked_catalog:
+            mocked_catalog.return_value = _response
+            url = reverse('dataset_download', args=[layer.alternate])
+            response = self.client.get(url)
+            self.assertTrue(response.status_code == 200)
 
 
 class TestLayerDetailMapViewRights(GeoNodeBaseTestSupport):

--- a/geonode/layers/views.py
+++ b/geonode/layers/views.py
@@ -798,7 +798,6 @@ def dataset_metadata_advanced(request, layername):
         template='datasets/dataset_metadata_advanced.html')
 
 
-@login_required
 def dataset_download(request, layername):
     try:
         dataset = _resolve_dataset(


### PR DESCRIPTION
backport https://github.com/GeoNode/geonode/pull/8882
<Include a few sentences describing the overall goals for this Pull Request>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [ ] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [ ] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
