### PR TITLE
[Fixes #8908] Review API v2 allowed methods

### DIFF
--- a/geonode/base/api/permissions.py
+++ b/geonode/base/api/permissions.py
@@ -163,7 +163,7 @@ class IsManagerEditOrAdmin(permissions.BasePermission):
         if request.method in ['POST', 'DELETE']:
             return user and (user.is_superuser or user.is_staff)
 
-        return self.has_permission(self, request, view)
+        return True
 
     def has_object_permission(self, request, view, obj):
         # Read permissions are allowed to any request,

--- a/geonode/base/api/permissions.py
+++ b/geonode/base/api/permissions.py
@@ -159,8 +159,8 @@ class IsManagerEditOrAdmin(permissions.BasePermission):
     Object-level permission to only allow admin and managers to edit a group.
     """
     def has_permission(self, request, view):
-        user = request.user
         if request.method in ['POST', 'DELETE']:
+            user = request.user
             return user and (user.is_superuser or user.is_staff)
 
         return True
@@ -170,12 +170,14 @@ class IsManagerEditOrAdmin(permissions.BasePermission):
         # so we'll always allow GET, HEAD or OPTIONS requests
         if request.method in permissions.SAFE_METHODS:
             return True
+
         user = request.user
         if user and user.is_superuser or user.is_staff:
             return True
-        if user and isinstance(obj, GroupProfile) and obj.user_is_role(user, "manager"):
-            if request.method == 'PATCH':
-                return True
+
+        is_group_manager = user and isinstance(obj, GroupProfile) and obj.user_is_role(user, "manager")
+        if is_group_manager and request.method == 'PATCH':
+            return True
 
         return False
 

--- a/geonode/base/api/tests.py
+++ b/geonode/base/api/tests.py
@@ -159,6 +159,13 @@ class BaseApiTests(APITestCase):
             response = self.client.post(url, data=data, format='json')
             self.assertEqual(response.status_code, 403)
 
+            # Group manager
+            group = GroupProfile.objects.create(slug="test_group_manager", title="test_group_manager")
+            group.join(get_user_model().objects.get(username='norman'), role='manager')
+            self.assertTrue(self.client.login(username='norman', password='norman'))
+            response = self.client.post(url, data=data, format='json')
+            self.assertEqual(response.status_code, 403)
+
             # Admin
             self.assertTrue(self.client.login(username='admin', password='admin'))
             response = self.client.post(url, data=data, format='json')
@@ -166,6 +173,7 @@ class BaseApiTests(APITestCase):
             self.assertEqual(response.json()['group_profile']['title'], 'group title')
         finally:
             GroupProfile.objects.get(slug='group_title').delete()
+            group.delete()
 
     def test_edit_group(self):
         """
@@ -339,6 +347,13 @@ class BaseApiTests(APITestCase):
             self.assertTrue(self.client.login(username="user_test_delete", password="user"))
             response = self.client.patch(url, data=data, format='json')
             self.assertEqual(response.status_code, 403)
+            # Group manager
+            group = GroupProfile.objects.create(slug="test_group_manager", title="test_group_manager")
+            group.join(user)
+            group.join(get_user_model().objects.get(username='norman'), role='manager')
+            self.assertTrue(self.client.login(username='norman', password='norman'))
+            response = self.client.post(url, data=data, format='json')
+            self.assertEqual(response.status_code, 403)
             # Admin can edit user
             self.assertTrue(self.client.login(username="admin", password="admin"))
             response = self.client.patch(url, data={'first_name': 'user_admin'}, format='json')
@@ -346,6 +361,7 @@ class BaseApiTests(APITestCase):
             self.assertEqual(get_user_model().objects.get(username='user_test_delete').first_name, 'user_admin')
         finally:
             user.delete()
+            group.delete()
 
     def test_delete_user_profile(self):
         """

--- a/geonode/base/api/tests.py
+++ b/geonode/base/api/tests.py
@@ -83,7 +83,7 @@ class BaseApiTests(APITestCase):
         create_models(b'map')
         create_models(b'dataset')
 
-    def test_gropus_list(self):
+    def test_groups_list(self):
         """
         Ensure we can access the gropus list.
         """
@@ -135,6 +135,108 @@ class BaseApiTests(APITestCase):
             priv_2.delete()
             pub_invite_1.delete()
             pub_invite_2.delete()
+
+    def test_create_group(self):
+        """
+        Ensure only Admins can create groups.
+        """
+        data = {
+            "title": "group title",
+            "group": 1,
+            "slug": "group_title",
+            "description": "test",
+            "access": "private",
+            "categories": []
+            }
+        try:
+            # Anonymous
+            url = reverse('group-profiles-list')
+            response = self.client.post(url, data=data, format='json')
+            self.assertEqual(response.status_code, 403)
+
+            # Registered member
+            self.assertTrue(self.client.login(username='bobby', password='bob'))
+            response = self.client.post(url, data=data, format='json')
+            self.assertEqual(response.status_code, 201)
+
+            # # Admin
+            self.assertTrue(self.client.login(username='admin', password='admin'))
+            data = {
+                "title": "group title 1",
+                "group": 1,
+                "slug": "group_title_1",
+                "description": "test",
+                "access": "private",
+                "categories": []
+            }
+            response = self.client.post(url, data=data, format='json')
+            self.assertEqual(response.status_code, 201)
+            self.assertEqual(response.json()['group_profile']['title'], 'group title 1')
+        finally:
+            GroupProfile.objects.get(slug='group_title').delete()
+
+    def test_edit_group(self):
+        """
+        Ensure only admins and group managers can edit a group.
+        """
+        group = GroupProfile.objects.create(slug="pub_1", title="pub_1", access="public")
+        data = {'title': 'new_title'}
+        try:
+            # Anonymous
+            url = f"{reverse('group-profiles-list')}/{group.id}/"
+            response = self.client.patch(url, data=data, format='json')
+            self.assertEqual(response.status_code, 403)
+
+            # Registered member
+            self.assertTrue(self.client.login(username='bobby', password='bob'))
+            response = self.client.patch(url, data=data, format='json')
+            self.assertEqual(response.status_code, 200)
+
+            # Group manager
+            group.join(get_user_model().objects.get(username='bobby'), role='mamnager')
+            response = self.client.patch(url, data=data, format='json')
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(GroupProfile.objects.get(id=group.id).title, data['title'])
+
+            # Admin
+            self.assertTrue(self.client.login(username='admin', password='admin'))
+            response = self.client.patch(url, data={'title': 'admin_title'}, format='json')
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(GroupProfile.objects.get(id=group.id).title, 'admin_title')
+        finally:
+            group.delete()
+
+    def test_delete_group(self):
+        """
+        Ensure only admins can delete a group.
+        """
+        group = GroupProfile.objects.create(slug="pub_1", title="pub_1", access="public")
+        group1 = GroupProfile.objects.create(slug="pub_1", title="pub_1", access="public")
+        group2 = GroupProfile.objects.create(slug="pub_1", title="pub_1", access="public")
+        try:
+            # Anonymous
+            url = f"{reverse('group-profiles-list')}/{group.id}/"
+            response = self.client.delete(url, format='json')
+            self.assertEqual(response.status_code, 403)
+
+            # Registered member
+            self.assertTrue(self.client.login(username='bobby', password='bob'))
+            response = self.client.delete(url, format='json')
+            self.assertEqual(response.status_code, 204)
+
+            # Group manager
+            group1.join(get_user_model().objects.get(username='bobby'), role='manager')
+            response = self.client.delete(f"{reverse('group-profiles-list')}/{group1.id}/", format='json')
+            self.assertEqual(response.status_code, 204)
+
+            # Admin can access all groups
+            self.assertTrue(self.client.login(username='admin', password='admin'))
+            response = self.client.delete(f"{reverse('group-profiles-list')}/{group2.id}/", format='json')
+            self.assertEqual(response.status_code, 204)
+        finally:
+            group.delete()
+            group1.delete()
+            group2.delete()
 
     def test_users_list(self):
         """
@@ -222,23 +324,71 @@ class BaseApiTests(APITestCase):
         self.assertEqual(response.status_code, 201)
         # default contributor group_perm is returned in perms
         self.assertIn('add_resource', response.data['user']['perms'])
+        # Anonymous
+        self.assertIsNone(self.client.logout())
+        response = self.client.post(url, data={'username': 'new_user_1'}, format='json')
+        self.assertEqual(response.status_code, 403)
 
-    def test_delete_users(self):
+    def test_update_user_profile(self):
         """
-        Ensure users cannot delete others.
+        Ensure users cannot update others.
         """
-        norman = get_user_model().objects.get(username='norman')
-        url = reverse('users-detail', kwargs={'pk': norman.pk})
-        # Anonymous can read
-        response = self.client.get(url, format='json')
-        self.assertEqual(response.status_code, 200)
-        # Anonymous can't write
-        response = self.client.delete(url, format='json')
-        self.assertEqual(response.status_code, 403)
-        # Bob can't delete Norman
-        self.assertTrue(self.client.login(username="bobby", password="bob"))
-        response = self.client.delete(url, format='json')
-        self.assertEqual(response.status_code, 403)
+        try:
+            user = get_user_model().objects.create_user(
+                username='user_test_delete',
+                email="user_test_delete@geonode.org",
+                password='user')
+            url = reverse('users-detail', kwargs={'pk': user.pk})
+            data = {'first_name': 'user'}
+            # Anonymous
+            response = self.client.patch(url, data=data, format='json')
+            self.assertEqual(response.status_code, 403)
+            # Another registered user
+            self.assertTrue(self.client.login(username="bobby", password="bob"))
+            response = self.client.patch(url, data=data, format='json')
+            self.assertEqual(response.status_code, 403)
+            # User self profile
+            self.assertTrue(self.client.login(username="user_test_delete", password="user"))
+            response = self.client.patch(url, data=data, format='json')
+            self.assertEqual(response.status_code, 403)
+            # Admin can edit user
+            self.assertTrue(self.client.login(username="admin", password="admin"))
+            response = self.client.patch(url, data={'first_name': 'user_admin'}, format='json')
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(get_user_model().objects.get(username='user_test_delete').first_name, 'user_admin')
+        finally:
+            user.delete()
+
+    def test_delete_user_profile(self):
+        """
+        Ensure only admins can delete profiles.
+        """
+        try:
+            user = get_user_model().objects.create_user(
+                username='user_test_delete',
+                email="user_test_delete@geonode.org",
+                password='user')
+            url = reverse('users-detail', kwargs={'pk': user.pk})
+            # Anonymous can read
+            response = self.client.get(url, format='json')
+            self.assertEqual(response.status_code, 200)
+            # Anonymous can't delete user
+            response = self.client.delete(url, format='json')
+            self.assertEqual(response.status_code, 403)
+            # Bob can't delete user
+            self.assertTrue(self.client.login(username="bobby", password="bob"))
+            response = self.client.delete(url, format='json')
+            self.assertEqual(response.status_code, 403)
+            # User can not delete self profile
+            self.assertTrue(self.client.login(username="user_test_delete", password="user"))
+            response = self.client.delete(url, format='json')
+            self.assertEqual(response.status_code, 403)
+            # Admin can delete user
+            self.assertTrue(self.client.login(username="admin", password="admin"))
+            response = self.client.delete(url, format='json')
+            self.assertEqual(response.status_code, 204)
+        finally:
+            user.delete()
 
     def test_base_resources(self):
         """

--- a/geonode/base/api/views.py
+++ b/geonode/base/api/views.py
@@ -87,6 +87,7 @@ from .permissions import (
     IsSelfOrAdminOrReadOnly,
     IsOwnerOrAdmin,
     IsOwnerOrReadOnly,
+    IsManagerEditOrAdmin,
     ResourceBasePermissionsFilter
 )
 from .serializers import (
@@ -164,7 +165,7 @@ class GroupViewSet(DynamicModelViewSet):
     API endpoint that allows gropus to be viewed or edited.
     """
     authentication_classes = [SessionAuthentication, BasicAuthentication, OAuth2Authentication]
-    permission_classes = [IsAuthenticatedOrReadOnly, ]
+    permission_classes = [IsAuthenticatedOrReadOnly, IsManagerEditOrAdmin, ]
     filter_backends = [
         DynamicFilterBackend, DynamicSortingFilter, DynamicSearchFilter
     ]

--- a/geonode/documents/api/views.py
+++ b/geonode/documents/api/views.py
@@ -46,6 +46,7 @@ class DocumentViewSet(DynamicModelViewSet):
     """
     API endpoint that allows documents to be viewed or edited.
     """
+    http_method_names = ['get', 'patch', 'put']
     authentication_classes = [SessionAuthentication, BasicAuthentication, OAuth2Authentication]
     permission_classes = [IsAuthenticatedOrReadOnly, IsOwnerOrReadOnly]
     filter_backends = [

--- a/geonode/geoapps/api/tests.py
+++ b/geonode/geoapps/api/tests.py
@@ -165,8 +165,8 @@ class GeoAppsApiTests(APITestCase):
 
         # Delete
         response = self.client.delete(url, format='json')
-        self.assertEqual(response.status_code, 204)  # 204 - No Content
+        self.assertEqual(response.status_code, 405)  # 405 - Method Not Allowed
 
         response = self.client.get(
             f"{url}?include[]=data", format='json')
-        self.assertEqual(response.status_code, 404)  # 404 - Not Found
+        self.assertEqual(response.status_code, 200)

--- a/geonode/geoapps/api/views.py
+++ b/geonode/geoapps/api/views.py
@@ -40,6 +40,7 @@ class GeoAppViewSet(DynamicModelViewSet):
     """
     API endpoint that allows geoapps to be viewed or edited.
     """
+    http_method_names = ['get', 'patch', 'post', 'put']
     authentication_classes = [SessionAuthentication, BasicAuthentication, OAuth2Authentication]
     permission_classes = [IsAuthenticatedOrReadOnly, IsOwnerOrReadOnly]
     filter_backends = [

--- a/geonode/layers/api/views.py
+++ b/geonode/layers/api/views.py
@@ -46,6 +46,7 @@ class DatasetViewSet(DynamicModelViewSet):
     """
     API endpoint that allows layers to be viewed or edited.
     """
+    http_method_names = ['get', 'patch', 'put']
     authentication_classes = [SessionAuthentication, BasicAuthentication, OAuth2Authentication]
     permission_classes = [IsAuthenticatedOrReadOnly, IsOwnerOrReadOnly]
     filter_backends = [

--- a/geonode/maps/api/views.py
+++ b/geonode/maps/api/views.py
@@ -52,6 +52,7 @@ class MapViewSet(DynamicModelViewSet):
     API endpoint that allows maps to be viewed or edited.
     """
 
+    http_method_names = ['get', 'patch', 'post', 'put']
     authentication_classes = [SessionAuthentication, BasicAuthentication, OAuth2Authentication]
     permission_classes = [IsAuthenticatedOrReadOnly, IsOwnerOrReadOnly]
     filter_backends = [

--- a/geonode/resource/api/urls.py
+++ b/geonode/resource/api/urls.py
@@ -17,15 +17,9 @@
 #
 #########################################################################
 from django.urls import path
-from rest_framework.urlpatterns import format_suffix_patterns
 
 from . import views
 
 urlpatterns = [
-    path('resource-service/search/', views.resource_service_search),
-    path('resource-service/search/<str:resource_type>', views.resource_service_search),
-    path('resource-service/exists/<str:uuid>', views.resource_service_exists),
     path('resource-service/execution-status/<str:execution_id>', views.resource_service_execution_status, name='rs-execution-status')
 ]
-
-urlpatterns = format_suffix_patterns(urlpatterns)

--- a/geonode/upload/api/tests.py
+++ b/geonode/upload/api/tests.py
@@ -903,7 +903,7 @@ class UploadSizeLimitTests(APITestCase):
         response = self.client.patch(url, data={"max_size": 2621440})
 
         # Assertions
-        self.assertEqual(response.status_code, 405)
+        self.assertEqual(response.status_code, 403)
         self.assertTrue(response.wsgi_request.user.is_anonymous)
 
     def test_put_size_limit_admin_user(self):
@@ -925,7 +925,7 @@ class UploadSizeLimitTests(APITestCase):
         response = self.client.put(url, data={"slug": "some-size-limit", "max_size": 2621440})
 
         # Assertions
-        self.assertEqual(response.status_code, 405)
+        self.assertEqual(response.status_code, 403)
         self.assertTrue(response.wsgi_request.user.is_anonymous)
 
     def test_post_size_limit_admin_user(self):
@@ -974,7 +974,7 @@ class UploadSizeLimitTests(APITestCase):
         response = self.client.delete(url)
 
         # Assertions
-        self.assertEqual(response.status_code, 405)
+        self.assertEqual(response.status_code, 403)
         self.assertTrue(response.wsgi_request.user.is_anonymous)
 
 

--- a/geonode/upload/api/tests.py
+++ b/geonode/upload/api/tests.py
@@ -1074,12 +1074,8 @@ class UploadParallelismLimitTests(APITestCase):
         response = self.client.patch(url, data={"max_number": 3})
 
         # Assertions
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 405)
         self.assertEqual(response.wsgi_request.user, self.admin)
-        # Response Content
-        parallelism_limit = response.json()['upload-parallelism-limit']
-        self.assertEqual(parallelism_limit['slug'], self.default_parallelism_limit.slug)
-        self.assertEqual(parallelism_limit['max_number'], 3)
 
     def test_patch_parallelism_limit_norman_user(self):
         url = reverse('upload-parallelism-limits-detail', args=(self.default_parallelism_limit.slug,))
@@ -1111,12 +1107,8 @@ class UploadParallelismLimitTests(APITestCase):
         response = self.client.put(url, data={"slug": self.default_parallelism_limit.slug, "max_number": 7})
 
         # Assertions
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 405)
         self.assertEqual(response.wsgi_request.user, self.admin)
-        # Response Content
-        parallelism_limit = response.json()['upload-parallelism-limit']
-        self.assertEqual(parallelism_limit['slug'], self.default_parallelism_limit.slug)
-        self.assertEqual(parallelism_limit['max_number'], 7)
 
     def test_put_parallelism_limit_anonymous_user(self):
         url = reverse('upload-parallelism-limits-detail', args=(self.default_parallelism_limit.slug,))
@@ -1164,7 +1156,7 @@ class UploadParallelismLimitTests(APITestCase):
         response = self.client.delete(url)
 
         # Assertions
-        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.status_code, 405)
         self.assertEqual(response.wsgi_request.user, self.admin)
 
     def test_delete_parallelism_limit_admin_user_protected(self):
@@ -1175,7 +1167,7 @@ class UploadParallelismLimitTests(APITestCase):
         response = self.client.delete(url)
 
         # Assertions
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, 405)
         self.assertEqual(response.wsgi_request.user, self.admin)
 
     def test_delete_parallelism_limit_anonymous_user(self):

--- a/geonode/upload/api/tests.py
+++ b/geonode/upload/api/tests.py
@@ -892,13 +892,8 @@ class UploadSizeLimitTests(APITestCase):
         response = self.client.patch(url, data={"max_size": 5242880})
 
         # Assertions
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 405)
         self.assertEqual(response.wsgi_request.user, self.admin)
-        # Response Content
-        size_limit = response.json()['upload-size-limit']
-        self.assertEqual(size_limit['slug'], 'some-size-limit')
-        self.assertEqual(size_limit['max_size'], 5242880)
-        self.assertEqual(size_limit['max_size_label'], '5.0\xa0MB')
 
     def test_patch_size_limit_anonymous_user(self):
         url = reverse('upload-size-limits-detail', args=('some-size-limit',))
@@ -908,7 +903,7 @@ class UploadSizeLimitTests(APITestCase):
         response = self.client.patch(url, data={"max_size": 2621440})
 
         # Assertions
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, 405)
         self.assertTrue(response.wsgi_request.user.is_anonymous)
 
     def test_put_size_limit_admin_user(self):
@@ -919,13 +914,8 @@ class UploadSizeLimitTests(APITestCase):
         response = self.client.put(url, data={"slug": "some-size-limit", "max_size": 5242880})
 
         # Assertions
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 405)
         self.assertEqual(response.wsgi_request.user, self.admin)
-        # Response Content
-        size_limit = response.json()['upload-size-limit']
-        self.assertEqual(size_limit['slug'], 'some-size-limit')
-        self.assertEqual(size_limit['max_size'], 5242880)
-        self.assertEqual(size_limit['max_size_label'], '5.0\xa0MB')
 
     def test_put_size_limit_anonymous_user(self):
         url = reverse('upload-size-limits-detail', args=('some-size-limit',))
@@ -935,7 +925,7 @@ class UploadSizeLimitTests(APITestCase):
         response = self.client.put(url, data={"slug": "some-size-limit", "max_size": 2621440})
 
         # Assertions
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, 405)
         self.assertTrue(response.wsgi_request.user.is_anonymous)
 
     def test_post_size_limit_admin_user(self):
@@ -973,7 +963,7 @@ class UploadSizeLimitTests(APITestCase):
         response = self.client.delete(url)
 
         # Assertions
-        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.status_code, 405)
         self.assertEqual(response.wsgi_request.user, self.admin)
 
     def test_delete_size_limit_anonymous_user(self):
@@ -984,7 +974,7 @@ class UploadSizeLimitTests(APITestCase):
         response = self.client.delete(url)
 
         # Assertions
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, 405)
         self.assertTrue(response.wsgi_request.user.is_anonymous)
 
 

--- a/geonode/upload/api/views.py
+++ b/geonode/upload/api/views.py
@@ -62,7 +62,6 @@ class UploadViewSet(DynamicModelViewSet):
     """
     parser_class = [FileUploadParser, ]
 
-    http_method_names = ['get', 'post']
     authentication_classes = [SessionAuthentication, BasicAuthentication, OAuth2Authentication]
     permission_classes = [IsAuthenticatedOrReadOnly, IsOwnerOrReadOnly]
     filter_backends = [

--- a/geonode/upload/api/views.py
+++ b/geonode/upload/api/views.py
@@ -203,6 +203,7 @@ class UploadSizeLimitViewSet(DynamicModelViewSet):
 
 
 class UploadParallelismLimitViewSet(DynamicModelViewSet):
+    http_method_names = ['get', 'post']
     authentication_classes = [SessionAuthentication, BasicAuthentication, OAuth2Authentication]
     permission_classes = [IsSelfOrAdminOrReadOnly]
     queryset = UploadParallelismLimit.objects.all()

--- a/geonode/upload/api/views.py
+++ b/geonode/upload/api/views.py
@@ -62,6 +62,7 @@ class UploadViewSet(DynamicModelViewSet):
     """
     parser_class = [FileUploadParser, ]
 
+    http_method_names = ['get', 'post']
     authentication_classes = [SessionAuthentication, BasicAuthentication, OAuth2Authentication]
     permission_classes = [IsAuthenticatedOrReadOnly, IsOwnerOrReadOnly]
     filter_backends = [
@@ -180,6 +181,7 @@ class UploadViewSet(DynamicModelViewSet):
 
 
 class UploadSizeLimitViewSet(DynamicModelViewSet):
+    http_method_names = ['get', 'post']
     authentication_classes = [SessionAuthentication, BasicAuthentication, OAuth2Authentication]
     permission_classes = [IsSelfOrAdminOrReadOnly]
     queryset = UploadSizeLimit.objects.all()


### PR DESCRIPTION
References: #8908

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
