### PR TITLE
[Backport][Fixes #8913] Duplicate keyword error raised on massive upload

### DIFF
--- a/geonode/base/models.py
+++ b/geonode/base/models.py
@@ -25,7 +25,7 @@ import shutil
 import logging
 import traceback
 
-from django.db import models
+from django.db import models, transaction
 from django.conf import settings
 from django.utils.functional import cached_property
 from django.utils.html import escape
@@ -465,13 +465,22 @@ class _HierarchicalTagManager(_TaggableManager):
         tag_objs = set(tags) - str_tags
         # If str_tags has 0 elements Django actually optimizes that to not do a
         # query.  Malcolm is very smart.
-        existing = self.through.tag_model().objects.filter(
+        '''
+        To avoid concurrency with the keyword in case of a massive upload.
+        With the transaction block and the select_for_update,
+        we can easily handle the concurrency.
+        DOC: https://docs.djangoproject.com/en/3.2/ref/models/querysets/#select-for-update
+        '''
+        existing = self.through.tag_model().objects.select_for_update().filter(
             name__in=str_tags, **tag_kwargs
         )
         tag_objs.update(existing)
         new_ids = set()
-        for new_tag in str_tags - set(t.name for t in existing):
-            if new_tag:
+        with transaction.atomic():
+            tag_objs.update(existing)
+            new_ids = set()
+            _new_keyword = str_tags - set(t.name for t in existing)
+            for new_tag in list(_new_keyword):
                 new_tag = escape(new_tag)
                 new_tag_obj = HierarchicalKeyword.add_root(name=new_tag)
                 tag_objs.add(new_tag_obj)

--- a/geonode/upload/utils.py
+++ b/geonode/upload/utils.py
@@ -720,18 +720,17 @@ class KeywordHandler:
 
     def _set_free_keyword(self, keywords):
         if len(keywords) > 0:
-            if not self.instance.keywords:
-                self.instance.keywords = keywords
-            else:
-                self.instance.keywords.add(*keywords)
+            if self.instance.keywords.exists():
+                self.instance.keywords.clear()
+
+            self.instance.keywords.add(*keywords)
         return keywords
 
     def _set_tkeyword(self, tkeyword):
         if len(tkeyword) > 0:
-            if not self.instance.tkeywords:
-                self.instance.tkeywords = tkeyword
-            else:
-                self.instance.tkeywords.add(*tkeyword)
+            if self.instance.tkeywords.exists():
+                self.instance.tkeywords.clear()
+            self.instance.tkeywords.add(*tkeyword)
         return [t.alt_label for t in tkeyword]
 
 


### PR DESCRIPTION
ref #8913 

This PR I want to introduce:
- Add transaction atomic bloc to keyword manager to avoid duplication error due to the concurrency

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
