### PR TITLE
[Backport 3.3.x][Fixes #8937] User with perms can edit approved and published resources when Advanced workflow is enabled

### DIFF
--- a/geonode/base/populate_test_data.py
+++ b/geonode/base/populate_test_data.py
@@ -345,7 +345,6 @@ def create_single_layer(name, keywords=None, owner=None, group=None, **kwargs):
         group=group,
         **kwargs
     )
-
     layer.save()
 
     if isinstance(keywords, list):

--- a/geonode/base/populate_test_data.py
+++ b/geonode/base/populate_test_data.py
@@ -314,7 +314,7 @@ def dump_models(path=None):
         f.write(result)
 
 
-def create_single_layer(name, keywords=None, owner=None, group=None):
+def create_single_layer(name, keywords=None, owner=None, group=None, **kwargs):
     admin, created = get_user_model().objects.get_or_create(username='admin')
     if created:
         admin.is_superuser = True
@@ -342,7 +342,8 @@ def create_single_layer(name, keywords=None, owner=None, group=None):
         storeType="dataStore",
         resource_type="layer",
         typename=f"geonode:{title}",
-        group=group
+        group=group,
+        **kwargs
     )
 
     layer.save()

--- a/geonode/base/tests.py
+++ b/geonode/base/tests.py
@@ -26,9 +26,9 @@ from urllib.parse import urlparse
 from unittest.mock import patch, Mock
 from imagekit.cachefiles.backends import Simple
 
-from guardian.shortcuts import assign_perm, get_perms
+from guardian.shortcuts import assign_perm
 
-from geonode.base.utils import OwnerRightsRequestViewUtils, ManageResourceOwnerPermissions
+from geonode.base.utils import OwnerRightsRequestViewUtils
 from geonode.base.templatetags.base_tags import display_change_perms_button
 from geonode.documents.models import Document
 from geonode.layers.models import Layer
@@ -662,75 +662,6 @@ class ConfigurationTest(GeoNodeBaseTestSupport):
         response = web_client.get('/')
 
         self.assertEqual(response.status_code, 503, 'User is allowed to get index page')
-
-
-class TestOwnerPermissionManagement(TestCase):
-    """
-    Only Layers has custom permissions so this is the only model which is tested.
-    Models are always treat in the same way
-    """
-
-    def setUp(self):
-        User = get_user_model()
-        self.user = User.objects.create(username='test', email='test@test.com')
-        self.la = Layer.objects.create(owner=self.user, title='test', is_approved=True)
-
-    @override_settings(ADMIN_MODERATE_UPLOADS=True)
-    def test_owner_has_no_permissions(self):
-        l_manager = ManageResourceOwnerPermissions(self.la)
-        l_manager.set_owner_permissions_according_to_workflow()
-
-        self.assertEqual(self._retrieve_resource_perms_definition(self.la, ['read', 'download']).sort(),
-                         get_perms(self.user, self.la.get_self_resource()).sort()
-                         )
-
-    @override_settings(ADMIN_MODERATE_UPLOADS=False)
-    def test_user_has_own_permissions(self):
-        l_manager = ManageResourceOwnerPermissions(self.la)
-        l_manager.set_owner_permissions_according_to_workflow()
-
-        self.assertEqual(self._retrieve_resource_perms_definition(self.la).sort(),
-                         get_perms(self.user, self.la.get_self_resource()).sort()
-                         )
-
-    @override_settings(ADMIN_MODERATE_UPLOADS=True)
-    def test_user_has_permissions_restored(self):
-        self.la.is_approved = False
-        self.la.save()
-        l_manager = ManageResourceOwnerPermissions(self.la)
-        l_manager.set_owner_permissions_according_to_workflow()
-
-        self.assertEqual(self._retrieve_resource_perms_definition(self.la).sort(),
-                         get_perms(self.user, self.la.get_self_resource()).sort()
-                         )
-
-    @override_settings(ADMIN_MODERATE_UPLOADS=True)
-    def test_remove_and_add_perms(self):
-        l_manager = ManageResourceOwnerPermissions(self.la)
-        l_manager.set_owner_permissions_according_to_workflow()
-
-        self.assertEqual(self._retrieve_resource_perms_definition(self.la, ['read', 'download']).sort(),
-                         get_perms(self.user, self.la.get_self_resource()).sort()
-                         )
-
-        self.la.is_approved = False
-        self.la.save()
-
-        l_manager.set_owner_permissions_according_to_workflow()
-
-        self.assertEqual(self._retrieve_resource_perms_definition(self.la).sort(),
-                         get_perms(self.user, self.la.get_self_resource()).sort()
-                         )
-
-    def _retrieve_resource_perms_definition(self, resource, perm_key_bundle=[]):
-        ret = []
-        if perm_key_bundle:
-            for key in perm_key_bundle:
-                ret.extend(resource.BASE_PERMISSIONS.get(key, []))
-                ret.extend(resource.PERMISSIONS.get(key, []))
-        else:
-            [ret.extend(r) for r in list(resource.BASE_PERMISSIONS.values()) + list(resource.PERMISSIONS.values())]
-        return ret
 
 
 class TestOwnerRightsRequestUtils(TestCase):

--- a/geonode/base/utils.py
+++ b/geonode/base/utils.py
@@ -33,9 +33,8 @@ from datetime import datetime, timedelta
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
-# Geonode functionality
-from guardian.shortcuts import get_perms, remove_perm, assign_perm
 
+# Geonode functionality
 from geonode.layers.models import Layer
 from geonode.base.models import ResourceBase, Link, Configuration
 from geonode.thumbs.utils import (
@@ -168,47 +167,6 @@ class OwnerRightsRequestViewUtils:
     @staticmethod
     def is_admin_publish_mode():
         return settings.ADMIN_MODERATE_UPLOADS
-
-
-class ManageResourceOwnerPermissions:
-    def __init__(self, resource):
-        self.resource = resource
-
-    def set_owner_permissions_according_to_workflow(self):
-        if self.resource.is_approved and OwnerRightsRequestViewUtils.is_admin_publish_mode():
-            self._disable_owner_write_permissions()
-        else:
-            self._restore_owner_permissions()
-
-    def _disable_owner_write_permissions(self):
-
-        for perm in get_perms(self.resource.owner, self.resource.get_self_resource()):
-            remove_perm(perm, self.resource.owner, self.resource.get_self_resource())
-
-        for perm in get_perms(self.resource.owner, self.resource):
-            remove_perm(perm, self.resource.owner, self.resource)
-
-        for perm in self.resource.BASE_PERMISSIONS.get('read') + self.resource.BASE_PERMISSIONS.get('download'):
-            if not settings.RESOURCE_PUBLISHING and not settings.ADMIN_MODERATE_UPLOADS:
-                assign_perm(perm, self.resource.owner, self.resource.get_self_resource())
-            elif perm not in {'change_resourcebase_permissions', 'publish_resourcebase'}:
-                assign_perm(perm, self.resource.owner, self.resource.get_self_resource())
-
-    def _restore_owner_permissions(self):
-
-        for perm_list in self.resource.BASE_PERMISSIONS.values():
-            for perm in perm_list:
-                if not settings.RESOURCE_PUBLISHING and not settings.ADMIN_MODERATE_UPLOADS:
-                    assign_perm(perm, self.resource.owner, self.resource.get_self_resource())
-                elif perm not in {'change_resourcebase_permissions', 'publish_resourcebase'}:
-                    assign_perm(perm, self.resource.owner, self.resource.get_self_resource())
-
-        for perm_list in self.resource.PERMISSIONS.values():
-            for perm in perm_list:
-                if not settings.RESOURCE_PUBLISHING and not settings.ADMIN_MODERATE_UPLOADS:
-                    assign_perm(perm, self.resource.owner, self.resource)
-                elif perm not in {'change_resourcebase_permissions', 'publish_resourcebase'}:
-                    assign_perm(perm, self.resource.owner, self.resource)
 
 
 def validate_extra_metadata(data, instance):

--- a/geonode/documents/views.py
+++ b/geonode/documents/views.py
@@ -35,7 +35,6 @@ from django.views.generic.edit import UpdateView, CreateView
 from django.db.models import F
 from django.forms.utils import ErrorList
 
-from geonode.base.utils import ManageResourceOwnerPermissions
 from geonode.decorators import check_keyword_write_perms
 from geonode.documents.utils import get_download_response
 from geonode.utils import resolve_object
@@ -97,9 +96,6 @@ def document_detail(request, docid):
         raise Http404(_("Not found"))
     if not document:
         raise Http404(_("Not found"))
-
-    permission_manager = ManageResourceOwnerPermissions(document)
-    permission_manager.set_owner_permissions_according_to_workflow()
 
     # Add metadata_author or poc if missing
     document.add_missing_metadata_author_or_poc()

--- a/geonode/layers/views.py
+++ b/geonode/layers/views.py
@@ -101,7 +101,7 @@ from geonode.utils import (
 from geonode.geoserver.helpers import (
     ogc_server_settings,
     set_layer_style)
-from geonode.base.utils import ManageResourceOwnerPermissions
+
 from geonode.tasks.tasks import set_permissions
 
 from celery.utils.log import get_logger
@@ -363,8 +363,6 @@ def layer_detail(request, layername, template='layers/layer_detail.html'):
         raise Http404(_("Not found"))
     if not layer:
         raise Http404(_("Not found"))
-    permission_manager = ManageResourceOwnerPermissions(layer)
-    permission_manager.set_owner_permissions_according_to_workflow()
 
     # Add metadata_author or poc if missing
     layer.add_missing_metadata_author_or_poc()

--- a/geonode/maps/views.py
+++ b/geonode/maps/views.py
@@ -75,8 +75,6 @@ from deprecated import deprecated
 
 from dal import autocomplete
 
-from geonode.base.utils import ManageResourceOwnerPermissions
-
 if check_ogc_backend(geoserver.BACKEND_PACKAGE):
     # FIXME: The post service providing the map_status object
     # should be moved to geonode.geoserver.
@@ -128,9 +126,6 @@ def map_detail(request, mapid, template='maps/map_detail.html'):
         raise Http404(_("Not found"))
     if not map_obj:
         raise Http404(_("Not found"))
-
-    permission_manager = ManageResourceOwnerPermissions(map_obj)
-    permission_manager.set_owner_permissions_according_to_workflow()
 
     # Add metadata_author or poc if missing
     map_obj.add_missing_metadata_author_or_poc()

--- a/geonode/security/models.py
+++ b/geonode/security/models.py
@@ -670,6 +670,7 @@ class PermissionLevelMixin:
                     edit_perms = ADMIN_PERMISSIONS + LAYER_ADMIN_PERMISSIONS
                     new_perms = {"users": {}, "groups": {}}
                     for user, perms in perm_spec["users"].items():
+                        # if owner is a group manager, take the group manager permissions set above
                         if user in group_managers or user.is_superuser:
                             new_perms["users"][user] = perms
                         else:

--- a/geonode/security/tests.py
+++ b/geonode/security/tests.py
@@ -1930,69 +1930,6 @@ class SetPermissionsTestCase(GeoNodeBaseTestSupport):
         self.resource = create_single_layer(name="test_layer", owner=self.author, group=self.group_profile.group)
         self.anonymous_user = get_anonymous_user()
 
-    @override_settings(RESOURCE_PUBLISHING=False)
-    @override_settings(ADMIN_MODERATE_UPLOADS=False)
-    def test_set_compact_permissions(self):
-        """
-          **AUTO PUBLISHING** - test_set_compact_permissions
-            - `RESOURCE_PUBLISHING = False`
-            - `ADMIN_MODERATE_UPLOADS = False`
-        """
-        use_cases = [
-            (
-                PermSpec({
-                    "users": {},
-                    "groups": {}
-                }, self.resource).compact,
-                {
-                    self.author: [
-                        "change_resourcebase",
-                        "change_resourcebase_metadata",
-                        "change_resourcebase_permissions",
-                        "delete_resourcebase",
-                        "download_resourcebase",
-                        "publish_resourcebase",
-                        "view_resourcebase",
-                    ],
-                    self.group_manager: [],
-                    self.group_member: [],
-                    self.not_group_member: [],
-                    self.anonymous_user: [],
-                },
-            ),
-            (
-                PermSpec({
-                    "users": {"AnonymousUser": ["view_resourcebase"]},
-                    "groups": {"second_custom_group": ["change_resourcebase"]}
-                }, self.resource).compact,
-                {
-                    self.author: [
-                        "change_resourcebase",
-                        "change_resourcebase_metadata",
-                        "change_resourcebase_permissions",
-                        "delete_resourcebase",
-                        "download_resourcebase",
-                        "publish_resourcebase",
-                        "view_resourcebase",
-                    ],
-                    self.group_manager: ["view_resourcebase", "download_resourcebase"],
-                    self.group_member: ["view_resourcebase", "download_resourcebase"],
-                    self.not_group_member: [
-                        "download_resourcebase",
-                        "change_resourcebase",
-                        "view_resourcebase",
-                    ],
-                    self.anonymous_user: ["view_resourcebase", "download_resourcebase"],
-                },
-            ),
-        ]
-        for counter, item in enumerate(use_cases):
-            permissions, expected = item
-            self.resource.set_permissions(permissions)
-            for authorized_subject, expected_perms in expected.items():
-                perms_got = [x for x in self.resource.get_self_resource().get_user_perms(authorized_subject)]
-                self.assertSetEqual(set(expected_perms), set(perms_got), msg=f"use case #{counter} - user: {authorized_subject.username}")
-
     @override_settings(RESOURCE_PUBLISHING=True)
     def test_permissions_are_set_as_expected_resource_publishing_True(self):
         """

--- a/geonode/security/tests.py
+++ b/geonode/security/tests.py
@@ -1999,9 +1999,6 @@ class SetPermissionsTestCase(GeoNodeBaseTestSupport):
                 {"users": {}, "groups": {}},
                 {
                     self.author: [
-                        "change_resourcebase",
-                        "change_resourcebase_metadata",
-                        "delete_resourcebase",
                         "download_resourcebase",
                         "view_resourcebase",
                     ],
@@ -2023,9 +2020,6 @@ class SetPermissionsTestCase(GeoNodeBaseTestSupport):
                 {"users": {}, "groups": {"second_custom_group": ["view_resourcebase"]}},
                 {
                     self.author: [
-                        "change_resourcebase",
-                        "change_resourcebase_metadata",
-                        "delete_resourcebase",
                         "download_resourcebase",
                         "view_resourcebase",
                     ],
@@ -2111,9 +2105,6 @@ class SetPermissionsTestCase(GeoNodeBaseTestSupport):
         self.assertEqual(sut.role, "manager")
         expected = {
             self.author: [
-                "change_resourcebase",
-                "change_resourcebase_metadata",
-                "delete_resourcebase",
                 "download_resourcebase",
                 "view_resourcebase",
             ],
@@ -2155,9 +2146,6 @@ class SetPermissionsTestCase(GeoNodeBaseTestSupport):
         self.assertEqual(sut.role, "member")
         expected = {
             self.author: [
-                "change_resourcebase",
-                "change_resourcebase_metadata",
-                "delete_resourcebase",
                 "download_resourcebase",
                 "view_resourcebase",
             ],

--- a/geonode/security/tests.py
+++ b/geonode/security/tests.py
@@ -2254,7 +2254,7 @@ class TestPermissionChanges(GeoNodeBaseTestSupport):
         self.member_with_perms, created = get_user_model().objects.get_or_create(username="member_with_perms")
 
         # Defining group profiles and members
-        self.owner_group, created = GroupProfile.objects.get_or_create(slug="custom_group")
+        self.owner_group, created = GroupProfile.objects.get_or_create(slug="owner_group")
         self.resource_group, created = GroupProfile.objects.get_or_create(slug="resource_group")
 
         # defining group members
@@ -2317,12 +2317,12 @@ class TestPermissionChanges(GeoNodeBaseTestSupport):
         self.assertEqual(response.status_code, 200)
         self.assertions_for_approved_or_published_is_true()
 
-        # Un approve resource
+        # # Un approve resource
         self.data.pop('resource-is_approved')
         response = self.client.post(self.url, data=self.data)
         self.resource.refresh_from_db()
         self.assertEqual(response.status_code, 200)
-        # self.assertions_for_approved_and_published_is_false()
+        self.assertions_for_approved_and_published_is_false()
 
         # Admin publishes and approves resource
         response = response = self.admin_approve_and_publish_resource()

--- a/geonode/security/tests.py
+++ b/geonode/security/tests.py
@@ -1907,7 +1907,7 @@ class TestGetUserGeolimits(TestCase):
 
 class SetPermissionsTestCase(GeoNodeBaseTestSupport):
     def setUp(self):
-        # Creating anonymous group<
+        # Creating anonymous group
         # Creating groups and asign also to the anonymous_group
         self.author, created = get_user_model().objects.get_or_create(username="author")
         self.group_manager, created = get_user_model().objects.get_or_create(username="group_manager")
@@ -2269,6 +2269,8 @@ class TestPermissionChanges(GeoNodeBaseTestSupport):
             owner=self.author,
             is_approved=False,
             is_published=False,
+            was_approved=False,
+            was_published=False,
             group=self.resource_group.group)
 
         self.owner_perms = [
@@ -2288,6 +2290,7 @@ class TestPermissionChanges(GeoNodeBaseTestSupport):
             'resource-date_type': 'publication',
             'resource-language': self.resource.language,
             'resource-is_approved': 'on',
+            'resource-group': self.resource_group.group.id,
             'layer_attribute_set-TOTAL_FORMS': 0,
             'layer_attribute_set-INITIAL_FORMS': 0,
         }
@@ -2313,14 +2316,12 @@ class TestPermissionChanges(GeoNodeBaseTestSupport):
         self.group_manager.save()
         self.assertTrue(self.client.login(username="group_manager", password='group_manager'))
         response = self.client.post(self.url, data=self.data)
-        self.resource.refresh_from_db()
         self.assertEqual(response.status_code, 200)
         self.assertions_for_approved_or_published_is_true()
 
-        # # Un approve resource
+        # Un approve resource
         self.data.pop('resource-is_approved')
         response = self.client.post(self.url, data=self.data)
-        self.resource.refresh_from_db()
         self.assertEqual(response.status_code, 200)
         self.assertions_for_approved_and_published_is_false()
 
@@ -2353,7 +2354,7 @@ class TestPermissionChanges(GeoNodeBaseTestSupport):
         self.assertTrue(is_equal(self.resource.get_all_level_info()['users'][self.author], self.safe_perms))
         self.assertTrue(is_equal(self.resource.get_all_level_info()['users'][self.member_with_perms], self.safe_perms))
         self.assertTrue(is_equal(self.resource.get_all_level_info()['users'][self.group_manager], self.owner_perms + self.adv_owner_limit))
-        # self.assertTrue(is_equal(self.resource.get_all_level_info()['users'][self.resource_group_manager], self.owner_perms + self.adv_owner_limit))
+        self.assertTrue(is_equal(self.resource.get_all_level_info()['users'][self.resource_group_manager], self.owner_perms + self.adv_owner_limit))
         self.assertTrue(is_equal(self.resource.get_all_level_info()['groups'][self.owner_group.group], self.safe_perms))
         self.assertTrue(is_equal(self.resource.get_all_level_info()['groups'][self.resource_group.group], self.safe_perms))
 
@@ -2361,7 +2362,7 @@ class TestPermissionChanges(GeoNodeBaseTestSupport):
         self.assertTrue(is_equal(self.resource.get_all_level_info()['users'][self.author], self.owner_perms + self.layer_perms))
         self.assertTrue(is_equal(self.resource.get_all_level_info()['users'][self.member_with_perms], self.safe_perms))
         self.assertTrue(is_equal(self.resource.get_all_level_info()['users'][self.group_manager], self.owner_perms + self.adv_owner_limit))
-        # self.assertTrue(is_equal(self.resource.get_all_level_info()['users'][self.resource_group_manager], self.owner_perms + self.adv_owner_limit))
+        self.assertTrue(is_equal(self.resource.get_all_level_info()['users'][self.resource_group_manager], self.owner_perms + self.adv_owner_limit))
         self.assertTrue(is_equal(self.resource.get_all_level_info()['groups'][self.owner_group.group], self.safe_perms))
         self.assertTrue(is_equal(self.resource.get_all_level_info()['groups'][self.resource_group.group], self.safe_perms))
 

--- a/geonode/security/utils.py
+++ b/geonode/security/utils.py
@@ -698,12 +698,9 @@ def get_owner_permissions_according_to_workflow(resource):
     return []
 
 
-def set_owner_permissions(resource, members=None, perms_list=[]):
+def set_owner_permissions(resource, members=None):
     """assign permissions to the owner"""
-    if perms_list:
-        owner_permissions = perms_list
-    else:
-        owner_permissions = get_owner_permissions_according_to_workflow(resource)
+    owner_permissions = get_owner_permissions_according_to_workflow(resource)
     for perm in owner_permissions:
         try:
             assign_perm(perm, resource.owner, resource)

--- a/geonode/security/utils.py
+++ b/geonode/security/utils.py
@@ -40,6 +40,12 @@ from guardian.shortcuts import (
     get_objects_for_user)
 
 from geonode import geoserver
+from geonode.security.permissions import (
+    ADMIN_PERMISSIONS,
+    LAYER_ADMIN_PERMISSIONS,
+    VIEW_PERMISSIONS,
+    SERVICE_PERMISSIONS,
+)
 from geonode.utils import get_layer_workspace
 from geonode.decorators import on_ogc_backend
 from geonode.groups.models import GroupProfile
@@ -115,7 +121,6 @@ def get_users_with_perms(obj):
     """
     Override of the Guardian get_users_with_perms
     """
-    from .permissions import (VIEW_PERMISSIONS, ADMIN_PERMISSIONS, LAYER_ADMIN_PERMISSIONS, SERVICE_PERMISSIONS)
     ctype = ContentType.objects.get_for_model(obj)
     permissions = {}
     PERMISSIONS_TO_FETCH = VIEW_PERMISSIONS + ADMIN_PERMISSIONS + LAYER_ADMIN_PERMISSIONS + SERVICE_PERMISSIONS
@@ -661,34 +666,42 @@ def _get_gf_services(layer, perms):
     return gf_services
 
 
-def set_owner_permissions(resource, members=None):
-    """assign all admin permissions to the owner"""
+def get_owner_permissions_according_to_workflow(resource):
     from .permissions import (VIEW_PERMISSIONS, ADMIN_PERMISSIONS, LAYER_ADMIN_PERMISSIONS, SERVICE_PERMISSIONS)
     if resource.polymorphic_ctype:
         # Owner & Manager Admin Perms
         admin_perms = VIEW_PERMISSIONS + ADMIN_PERMISSIONS
-        for perm in admin_perms:
-            if perm not in {'change_resourcebase_permissions', 'publish_resourcebase'} or not settings.RESOURCE_PUBLISHING or not settings.ADMIN_MODERATE_UPLOADS:
-                assign_perm(perm, resource.owner, resource.get_self_resource())
-            if members:
-                if perm not in {'change_resourcebase_permissions', 'publish_resourcebase'} or settings.ADMIN_MODERATE_UPLOADS:
-                    for user in members:
-                        assign_perm(perm, user, resource.get_self_resource())
 
-        # Set the GeoFence Owner Rule
+        # get the GeoFence Owner Rule
         if resource.polymorphic_ctype.name == 'layer':
-            for perm in LAYER_ADMIN_PERMISSIONS:
-                assign_perm(perm, resource.owner, resource.layer)
-                if members:
-                    for user in members:
-                        assign_perm(perm, user, resource.layer)
+            admin_perms.extend(LAYER_ADMIN_PERMISSIONS)
 
         if resource.polymorphic_ctype.name == 'service':
-            for perm in SERVICE_PERMISSIONS:
-                assign_perm(perm, resource.owner, resource.service)
-                if members:
-                    for user in members:
-                        assign_perm(perm, user, resource.service)
+            admin_perms.extend(SERVICE_PERMISSIONS)
+
+        if settings.RESOURCE_PUBLISHING and settings.ADMIN_MODERATE_UPLOADS:
+            # Filter permissions when Advanced workflow is enabled
+            admin_manager_perms = ['change_resourcebase_permissions', 'publish_resourcebase']
+            if resource.is_approved or resource.is_published:
+                return VIEW_PERMISSIONS
+            # TODO check if owner is a manager to any group and add admin_manager_perms
+            return [perm for perm in admin_perms if perm not in admin_manager_perms]
+        else:
+            return admin_perms
+    return []
+
+
+def set_owner_permissions(resource, members=None, perms_list=[]):
+    """assign permissions to the owner"""
+    if perms_list:
+        owner_permissions = perms_list
+    else:
+        owner_permissions = get_owner_permissions_according_to_workflow(resource)
+    for perm in owner_permissions:
+        try:
+            assign_perm(perm, resource.owner, resource)
+        except Permission.DoesNotExist:
+            assign_perm(perm, resource.owner, resource.get_self_resource())
 
 
 def remove_object_permissions(instance, purge=True):

--- a/geonode/security/utils.py
+++ b/geonode/security/utils.py
@@ -702,9 +702,12 @@ def set_owner_permissions(resource, members=None):
     """assign permissions to the owner"""
     owner_permissions = get_owner_permissions_according_to_workflow(resource)
     for perm in owner_permissions:
-        try:
-            assign_perm(perm, resource.owner, resource)
-        except Permission.DoesNotExist:
+        if resource.polymorphic_ctype.name == 'layer' and perm in (
+            'change_layer_data', 'change_layer_style',
+            'add_layer', 'change_layer', 'delete_layer'
+        ):
+            assign_perm(perm, resource.owner, resource.layer)
+        else:
             assign_perm(perm, resource.owner, resource.get_self_resource())
 
 

--- a/test_dev.sh
+++ b/test_dev.sh
@@ -4,5 +4,5 @@ set -a
 set +a
 
 # paver setup_data
-sudo -u postgres dropdb test_geonode
+# dropdb -U postgres test_geonode
 coverage run --branch --source=geonode manage.py test -v 3 --keepdb $@


### PR DESCRIPTION

References #8937 
<Include a few sentences describing the overall goals for this Pull Request>

This PR introduces the following changes:

- Fixes permissions returned in `get_workflow_perms` when advanced workflow is enabled
- Removes setting of owner permissions in views
- Checks advanced workflow status when setting owner permissons
- Adds test-cases for permissions when advanced workflow is enabled

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
