### PR TITLE
[Fixes #8937] User with perms can edit approved and published resources when Advanced workflow is enabled

### DIFF
--- a/geonode/security/utils.py
+++ b/geonode/security/utils.py
@@ -576,17 +576,10 @@ class AdvancedSecurityWorkflowManager:
                 if group_managers:
                     for group_manager in group_managers:
                         prev_perms = perm_spec['users'].get(group_manager, []) if isinstance(perm_spec['users'], dict) else []
-                        # AF: Should be a manager being able to change the dataset data and style too by default?
-                        #     For the time being let's give to the manager "management" perms only.
-                        # if _resource.polymorphic_ctype.name == 'layer':
-                        #     perm_spec['users'][group_manager] = list(
-                        #         set(prev_perms + view_perms + admin_perms + LAYER_ADMIN_PERMISSIONS))
-                        # else:
                         prev_perms += view_perms + admin_perms.copy()
                         if _resource.is_published or AdvancedSecurityWorkflowManager.is_simple_publishing_workflow():
                             prev_perms.remove('publish_resourcebase')
-                        perm_spec['users'][group_manager] = list(
-                            set(prev_perms))
+                        perm_spec['users'][group_manager] = list(set(prev_perms))
 
                 # Handle the Group Members perms
                 if member_group_perm:


### PR DESCRIPTION
References: #8937

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
