### PR TITLE
[Fixes #9013] Advanced Workflow: workflow logic should take precedence over standard permissions

### DIFF
--- a/geonode/api/api.py
+++ b/geonode/api/api.py
@@ -88,7 +88,7 @@ class CountJSONSerializer(Serializer):
             private_groups_not_visibile=settings.GROUP_PRIVATE_RESOURCES)
 
         subtypes = []
-        if resources and resources.count() > 0:
+        if resources and resources.exists():
             if options['title_filter']:
                 resources = resources.filter(title__icontains=options['title_filter'])
             if options['type_filter']:

--- a/geonode/api/tests.py
+++ b/geonode/api/tests.py
@@ -94,7 +94,7 @@ class PermissionsApiTests(ResourceTestCaseMixin, GeoNodeBaseTestSupport):
 
         resp = self.api_client.get(list_url)
         self.assertValidJSONResponse(resp)
-        self.assertEqual(len(self.deserialize(resp)['objects']), 8)
+        self.assertEqual(len(self.deserialize(resp)['objects']), 7)
 
     def test_datasets_get_list_auth_some_public(self):
         """
@@ -130,11 +130,11 @@ class PermissionsApiTests(ResourceTestCaseMixin, GeoNodeBaseTestSupport):
         layer = Dataset.objects.first()
         layer.set_permissions(perm_spec)
         resp = self.api_client.get(list_url)
-        self.assertEqual(len(self.deserialize(resp)['objects']), 8)
+        self.assertEqual(len(self.deserialize(resp)['objects']), 7)
 
         self.api_client.client.login(username='bobby', password='bob')
         resp = self.api_client.get(list_url)
-        self.assertEqual(len(self.deserialize(resp)['objects']), 8)
+        self.assertEqual(len(self.deserialize(resp)['objects']), 7)
 
         self.api_client.client.login(username=self.user, password=self.passwd)
         resp = self.api_client.get(list_url)
@@ -146,15 +146,15 @@ class PermissionsApiTests(ResourceTestCaseMixin, GeoNodeBaseTestSupport):
         # with resource publishing
         with self.settings(RESOURCE_PUBLISHING=True):
             resp = self.api_client.get(list_url)
-            self.assertGreaterEqual(len(self.deserialize(resp)['objects']), 8)
+            self.assertGreaterEqual(len(self.deserialize(resp)['objects']), 7)
 
             self.api_client.client.login(username='bobby', password='bob')
             resp = self.api_client.get(list_url)
-            self.assertGreaterEqual(len(self.deserialize(resp)['objects']), 8)
+            self.assertGreaterEqual(len(self.deserialize(resp)['objects']), 7)
 
             self.api_client.client.login(username=self.user, password=self.passwd)
             resp = self.api_client.get(list_url)
-            self.assertGreaterEqual(len(self.deserialize(resp)['objects']), 8)
+            self.assertGreaterEqual(len(self.deserialize(resp)['objects']), 7)
 
     def test_dataset_get_detail_unauth_dataset_not_public(self):
         """
@@ -169,6 +169,8 @@ class PermissionsApiTests(ResourceTestCaseMixin, GeoNodeBaseTestSupport):
         layer = Dataset.objects.first()
         layer.set_permissions(self.perm_spec)
         layer.clear_dirty_state()
+        self.assertHttpNotFound(self.api_client.get(
+            f"{list_url + str(layer.id)}/"))
 
         self.api_client.client.login(username=self.user, password=self.passwd)
         resp = self.api_client.get(f"{list_url + str(layer.id)}/")

--- a/geonode/api/tests.py
+++ b/geonode/api/tests.py
@@ -94,7 +94,7 @@ class PermissionsApiTests(ResourceTestCaseMixin, GeoNodeBaseTestSupport):
 
         resp = self.api_client.get(list_url)
         self.assertValidJSONResponse(resp)
-        self.assertEqual(len(self.deserialize(resp)['objects']), 7)
+        self.assertEqual(len(self.deserialize(resp)['objects']), 8)
 
     def test_datasets_get_list_auth_some_public(self):
         """
@@ -130,11 +130,11 @@ class PermissionsApiTests(ResourceTestCaseMixin, GeoNodeBaseTestSupport):
         layer = Dataset.objects.first()
         layer.set_permissions(perm_spec)
         resp = self.api_client.get(list_url)
-        self.assertEqual(len(self.deserialize(resp)['objects']), 7)
+        self.assertEqual(len(self.deserialize(resp)['objects']), 8)
 
         self.api_client.client.login(username='bobby', password='bob')
         resp = self.api_client.get(list_url)
-        self.assertEqual(len(self.deserialize(resp)['objects']), 7)
+        self.assertEqual(len(self.deserialize(resp)['objects']), 8)
 
         self.api_client.client.login(username=self.user, password=self.passwd)
         resp = self.api_client.get(list_url)
@@ -146,15 +146,15 @@ class PermissionsApiTests(ResourceTestCaseMixin, GeoNodeBaseTestSupport):
         # with resource publishing
         with self.settings(RESOURCE_PUBLISHING=True):
             resp = self.api_client.get(list_url)
-            self.assertGreaterEqual(len(self.deserialize(resp)['objects']), 7)
+            self.assertGreaterEqual(len(self.deserialize(resp)['objects']), 8)
 
             self.api_client.client.login(username='bobby', password='bob')
             resp = self.api_client.get(list_url)
-            self.assertGreaterEqual(len(self.deserialize(resp)['objects']), 7)
+            self.assertGreaterEqual(len(self.deserialize(resp)['objects']), 8)
 
             self.api_client.client.login(username=self.user, password=self.passwd)
             resp = self.api_client.get(list_url)
-            self.assertGreaterEqual(len(self.deserialize(resp)['objects']), 7)
+            self.assertGreaterEqual(len(self.deserialize(resp)['objects']), 8)
 
     def test_dataset_get_detail_unauth_dataset_not_public(self):
         """
@@ -169,8 +169,6 @@ class PermissionsApiTests(ResourceTestCaseMixin, GeoNodeBaseTestSupport):
         layer = Dataset.objects.first()
         layer.set_permissions(self.perm_spec)
         layer.clear_dirty_state()
-        self.assertHttpNotFound(self.api_client.get(
-            f"{list_url + str(layer.id)}/"))
 
         self.api_client.client.login(username=self.user, password=self.passwd)
         resp = self.api_client.get(f"{list_url + str(layer.id)}/")

--- a/geonode/base/api/tests.py
+++ b/geonode/base/api/tests.py
@@ -1029,7 +1029,7 @@ class BaseApiTests(APITestCase):
                         'id': anonymous_group.id,
                         'title': 'anonymous',
                         'name': 'anonymous',
-                        'permissions': 'download'
+                        'permissions': 'view'
                     },
                     {
                         'id': contributors_group.id,

--- a/geonode/base/api/tests.py
+++ b/geonode/base/api/tests.py
@@ -1029,7 +1029,7 @@ class BaseApiTests(APITestCase):
                         'id': anonymous_group.id,
                         'title': 'anonymous',
                         'name': 'anonymous',
-                        'permissions': 'view'
+                        'permissions': 'download'
                     },
                     {
                         'id': contributors_group.id,

--- a/geonode/base/models.py
+++ b/geonode/base/models.py
@@ -1254,7 +1254,7 @@ class ResourceBase(PolymorphicModel, PermissionLevelMixin, ItemBase):
 
         # Update workflow permissions
         if _approval_status_changed:
-            self.set_permissions()
+            self.set_permissions(approval_status_changed=True)
 
     def delete(self, notify=True, *args, **kwargs):
         """

--- a/geonode/base/models.py
+++ b/geonode/base/models.py
@@ -16,12 +16,10 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 #########################################################################
-
 import os
 import re
 import html
 import math
-import shutil
 import logging
 import traceback
 from sequences.models import Sequence
@@ -708,28 +706,7 @@ class ResourceBaseManager(PolymorphicManager):
                     for upload in Upload.objects.filter(resource_id=_resource.get_real_instance().id):
                         try:
                             if upload.upload_dir:
-                                if storage_manager.exists(upload.upload_dir):
-                                    _uploaded_dirs, _uploaded_files = storage_manager.listdir(upload.upload_dir)
-                                    for _entry in _uploaded_files:
-                                        _entry_path = os.path.join(upload.upload_dir, _entry)
-                                        if storage_manager.exists(_entry_path):
-                                            try:
-                                                storage_manager.delete(_entry_path)
-                                            except Exception as e:
-                                                logger.exception(e)
-                                    for _entry in _uploaded_dirs:
-                                        _entry_path = os.path.join(upload.upload_dir, _entry)
-                                        if storage_manager.exists(_entry_path):
-                                            try:
-                                                storage_manager.delete(_entry_path)
-                                            except Exception as e:
-                                                logger.exception(e)
-                                    try:
-                                        storage_manager.delete(upload.upload_dir)
-                                    except Exception as e:
-                                        logger.exception(e)
-                                elif os.path.exists(upload.upload_dir):
-                                    shutil.rmtree(upload.upload_dir, ignore_errors=True)
+                                storage_manager.rmtree(upload.upload_dir, ignore_errors=True)
                         finally:
                             upload.delete()
             except Exception as e:
@@ -1695,7 +1672,7 @@ class ResourceBase(PolymorphicModel, PermissionLevelMixin, ItemBase):
         if legend is None:
             return None
 
-        if legend.count() > 0:
+        if legend.exists():
             if not style_name:
                 return legend.first().url
             else:

--- a/geonode/base/models.py
+++ b/geonode/base/models.py
@@ -709,7 +709,25 @@ class ResourceBaseManager(PolymorphicManager):
                         try:
                             if upload.upload_dir:
                                 if storage_manager.exists(upload.upload_dir):
-                                    storage_manager.delete(upload.upload_dir)
+                                    _uploaded_dirs, _uploaded_files = storage_manager.listdir(upload.upload_dir)
+                                    for _entry in _uploaded_files:
+                                        _entry_path = os.path.join(upload.upload_dir, _entry)
+                                        if storage_manager.exists(_entry_path):
+                                            try:
+                                                storage_manager.delete(_entry_path)
+                                            except Exception as e:
+                                                logger.exception(e)
+                                    for _entry in _uploaded_dirs:
+                                        _entry_path = os.path.join(upload.upload_dir, _entry)
+                                        if storage_manager.exists(_entry_path):
+                                            try:
+                                                storage_manager.delete(_entry_path)
+                                            except Exception as e:
+                                                logger.exception(e)
+                                    try:
+                                        storage_manager.delete(upload.upload_dir)
+                                    except Exception as e:
+                                        logger.exception(e)
                                 elif os.path.exists(upload.upload_dir):
                                     shutil.rmtree(upload.upload_dir, ignore_errors=True)
                         finally:

--- a/geonode/base/templatetags/user_messages.py
+++ b/geonode/base/templatetags/user_messages.py
@@ -28,8 +28,8 @@ register = template.Library()
 
 @register.simple_tag
 def is_unread(thread, user):
-    if thread.userthread_set.filter(user=user, unread=True).count() > 0 or \
-            thread.groupmemberthread_set.filter(user=user, unread=True).count() > 0:
+    if thread.userthread_set.filter(user=user, unread=True).exists() or \
+            thread.groupmemberthread_set.filter(user=user, unread=True).exists():
         return True
     return False
 

--- a/geonode/documents/views.py
+++ b/geonode/documents/views.py
@@ -48,7 +48,9 @@ from geonode.monitoring.models import EventType
 from geonode.storage.manager import storage_manager
 from geonode.resource.manager import resource_manager
 from geonode.decorators import check_keyword_write_perms
-from geonode.security.utils import get_user_visible_groups
+from geonode.security.utils import (
+    get_user_visible_groups,
+    AdvancedSecurityWorkflowManager)
 from geonode.base.forms import (
     CategoryForm,
     TKeywordForm,
@@ -527,24 +529,10 @@ def document_metadata(
 
     metadata_author_groups = get_user_visible_groups(request.user)
 
-    if settings.ADMIN_MODERATE_UPLOADS:
-        if not request.user.is_superuser:
-            can_change_metadata = request.user.has_perm(
-                'change_resourcebase_metadata',
-                document.get_self_resource())
-            can_publish = request.user.has_perm(
-                'publish_resourcebase',
-                document.get_self_resource())
-            try:
-                is_manager = request.user.groupmember_set.all().filter(role='manager').exists()
-            except Exception:
-                is_manager = False
-            if not is_manager or not can_change_metadata or not can_publish:
-                if settings.RESOURCE_PUBLISHING:
-                    document_form.fields['is_published'].widget.attrs.update(
-                        {'disabled': 'true'})
-                document_form.fields['is_approved'].widget.attrs.update(
-                    {'disabled': 'true'})
+    if not AdvancedSecurityWorkflowManager.is_allowed_to_publish(request.user, document):
+        document_form.fields['is_published'].widget.attrs.update({'disabled': 'true'})
+    if not AdvancedSecurityWorkflowManager.is_allowed_to_approve(request.user, document):
+        document_form.fields['is_approved'].widget.attrs.update({'disabled': 'true'})
 
     register_event(request, EventType.EVENT_VIEW_METADATA, document)
     return render(request, template, context={

--- a/geonode/documents/views.py
+++ b/geonode/documents/views.py
@@ -532,11 +532,14 @@ def document_metadata(
             can_change_metadata = request.user.has_perm(
                 'change_resourcebase_metadata',
                 document.get_self_resource())
+            can_publish = request.user.has_perm(
+                'publish_resourcebase',
+                document.get_self_resource())
             try:
                 is_manager = request.user.groupmember_set.all().filter(role='manager').exists()
             except Exception:
                 is_manager = False
-            if not is_manager or not can_change_metadata:
+            if not is_manager or not can_change_metadata or not can_publish:
                 if settings.RESOURCE_PUBLISHING:
                     document_form.fields['is_published'].widget.attrs.update(
                         {'disabled': 'true'})

--- a/geonode/geoapps/views.py
+++ b/geonode/geoapps/views.py
@@ -38,7 +38,9 @@ from geonode.groups.models import GroupProfile
 from geonode.monitoring.models import EventType
 from geonode.base.auth import get_or_create_token
 from geonode.security.views import _perms_info_json
-from geonode.security.utils import get_user_visible_groups
+from geonode.security.utils import (
+    get_user_visible_groups,
+    AdvancedSecurityWorkflowManager)
 from geonode.geoapps.models import GeoApp
 from geonode.resource.manager import resource_manager
 from geonode.decorators import check_keyword_write_perms
@@ -411,24 +413,10 @@ def geoapp_metadata(request, geoappid, template='apps/app_metadata.html', ajax=T
 
     metadata_author_groups = get_user_visible_groups(request.user)
 
-    if settings.ADMIN_MODERATE_UPLOADS:
-        if not request.user.is_superuser:
-            can_change_metadata = request.user.has_perm(
-                'change_resourcebase_metadata',
-                geoapp_obj.get_self_resource())
-            can_publish = request.user.has_perm(
-                'publish_resourcebase',
-                geoapp_obj.get_self_resource())
-            try:
-                is_manager = request.user.groupmember_set.all().filter(role='manager').exists()
-            except Exception:
-                is_manager = False
-            if not is_manager or not can_change_metadata or not can_publish:
-                if settings.RESOURCE_PUBLISHING:
-                    geoapp_form.fields['is_published'].widget.attrs.update(
-                        {'disabled': 'true'})
-                geoapp_form.fields['is_approved'].widget.attrs.update(
-                    {'disabled': 'true'})
+    if not AdvancedSecurityWorkflowManager.is_allowed_to_publish(request.user, geoapp_obj):
+        geoapp_form.fields['is_published'].widget.attrs.update({'disabled': 'true'})
+    if not AdvancedSecurityWorkflowManager.is_allowed_to_approve(request.user, geoapp_obj):
+        geoapp_form.fields['is_approved'].widget.attrs.update({'disabled': 'true'})
 
     register_event(request, EventType.EVENT_VIEW_METADATA, geoapp_obj)
     return render(request, template, context={

--- a/geonode/geoapps/views.py
+++ b/geonode/geoapps/views.py
@@ -416,11 +416,14 @@ def geoapp_metadata(request, geoappid, template='apps/app_metadata.html', ajax=T
             can_change_metadata = request.user.has_perm(
                 'change_resourcebase_metadata',
                 geoapp_obj.get_self_resource())
+            can_publish = request.user.has_perm(
+                'publish_resourcebase',
+                geoapp_obj.get_self_resource())
             try:
                 is_manager = request.user.groupmember_set.all().filter(role='manager').exists()
             except Exception:
                 is_manager = False
-            if not is_manager or not can_change_metadata:
+            if not is_manager or not can_change_metadata or not can_publish:
                 if settings.RESOURCE_PUBLISHING:
                     geoapp_form.fields['is_published'].widget.attrs.update(
                         {'disabled': 'true'})

--- a/geonode/geoserver/helpers.py
+++ b/geonode/geoserver/helpers.py
@@ -689,7 +689,7 @@ def gs_slurp(
                 raise
 
     # filter out layers already registered in geonode
-    dataset_names = Dataset.objects.all().values_list('alternate', flat=True)
+    dataset_names = Dataset.objects.values_list('alternate', flat=True)
     if skip_geonode_registered:
         try:
             resources = [k for k in resources
@@ -962,7 +962,7 @@ def set_attributes(
                 if _gs_attrs.count() == 1:
                     la = _gs_attrs.get()
                 else:
-                    if _gs_attrs.count() > 0:
+                    if _gs_attrs.exists():
                         _gs_attrs.delete()
                     la = Attribute.objects.create(dataset=layer, attribute=field)
                     la.visible = ftype.find("gml:") != 0

--- a/geonode/geoserver/management/commands/importlayers.py
+++ b/geonode/geoserver/management/commands/importlayers.py
@@ -17,6 +17,7 @@
 #
 #########################################################################
 import os
+import json
 import argparse
 import datetime
 import requests
@@ -154,14 +155,14 @@ class GeoNodeUploader:
                     data = response.json()
                     if not data.get('status', None):
                         raise Exception(data)
-                    if data['status'] == 'finished':
+                    if data.get('status', '') == 'finished':
                         if data['success']:
                             success.append(file)
                         else:
                             errors.append(file)
                     else:
                         errors.append(file)
-                except requests.exceptions.JSONDecodeError:
+                except json.JSONDecodeError:
                     traceback.print_exc()
                     errors.append(file)
         return success, errors

--- a/geonode/geoserver/management/commands/importlayers.py
+++ b/geonode/geoserver/management/commands/importlayers.py
@@ -17,6 +17,7 @@
 #
 #########################################################################
 import os
+import json
 import argparse
 import datetime
 import requests
@@ -161,7 +162,7 @@ class GeoNodeUploader:
                             errors.append(file)
                     else:
                         errors.append(file)
-                except requests.exceptions.JSONDecodeError:
+                except json.JSONDecodeError:
                     traceback.print_exc()
                     errors.append(file)
         return success, errors

--- a/geonode/geoserver/management/commands/importlayers.py
+++ b/geonode/geoserver/management/commands/importlayers.py
@@ -17,7 +17,6 @@
 #
 #########################################################################
 import os
-import json
 import argparse
 import datetime
 import requests
@@ -162,7 +161,7 @@ class GeoNodeUploader:
                             errors.append(file)
                     else:
                         errors.append(file)
-                except json.JSONDecodeError:
+                except requests.exceptions.JSONDecodeError:
                     traceback.print_exc()
                     errors.append(file)
         return success, errors

--- a/geonode/geoserver/manager.py
+++ b/geonode/geoserver/manager.py
@@ -43,6 +43,7 @@ from geonode.services.enumerations import CASCADED
 from geonode.security.utils import skip_registered_members_common_group
 from geonode.security.permissions import (
     VIEW_PERMISSIONS,
+    OWNER_PERMISSIONS,
     DOWNLOAD_PERMISSIONS)
 from geonode.resource.manager import (
     ResourceManager,
@@ -67,14 +68,12 @@ from .helpers import (
     create_gs_thumbnail,
     create_geoserver_db_featurestore)
 from .security import (
-    _get_gf_services,
     _get_gwc_filters_and_formats,
-    get_user_geolimits,
     get_geofence_rules_count,
     toggle_dataset_cache,
     purge_geofence_dataset_rules,
-    sync_geofence_with_guardian,
-    set_geofence_invalidate_cache)
+    set_geofence_invalidate_cache,
+    sync_permissions_and_disable_cache)
 
 logger = logging.getLogger(__name__)
 
@@ -424,17 +423,8 @@ class GeoServerResourceManager(ResourceManagerInterface):
                                         purge_geofence_dataset_rules(_resource)
 
                                     # Owner
-                                    perms = [
-                                        "view_resourcebase",
-                                        "change_dataset_data",
-                                        "change_dataset_style",
-                                        "change_resourcebase",
-                                        "change_resourcebase_permissions",
-                                        "download_resourcebase"]
-                                    sync_geofence_with_guardian(_resource, perms, user=_owner)
-                                    gf_services = _get_gf_services(_resource, perms)
-                                    _, _, _disable_dataset_cache, _, _, _ = get_user_geolimits(_resource, _owner, None, gf_services)
-                                    _disable_cache.append(_disable_dataset_cache)
+                                    perms = OWNER_PERMISSIONS.copy() + DOWNLOAD_PERMISSIONS.copy()
+                                    _disable_cache = sync_permissions_and_disable_cache(_disable_cache, _resource, perms, _owner, None, None)
 
                                     # All the other users
                                     if 'users' in permissions and len(permissions['users']) > 0:
@@ -447,11 +437,8 @@ class GeoServerResourceManager(ResourceManagerInterface):
                                                     group_perms = permissions['groups']
                                                 if user == "AnonymousUser":
                                                     _user = None
-                                                sync_geofence_with_guardian(_resource, perms, user=_user, group_perms=group_perms)
-                                                gf_services = _get_gf_services(_resource, perms)
                                                 _group = list(group_perms.keys())[0] if group_perms else None
-                                                _, _, _disable_dataset_cache, _, _, _ = get_user_geolimits(_resource, _user, _group, gf_services)
-                                                _disable_cache.append(_disable_dataset_cache)
+                                                _disable_cache = sync_permissions_and_disable_cache(_disable_cache, _resource, perms, _user, _group, group_perms)
 
                                     # All the other groups
                                     if 'groups' in permissions and len(permissions['groups']) > 0:
@@ -460,10 +447,7 @@ class GeoServerResourceManager(ResourceManagerInterface):
                                             # Set the GeoFence Rules
                                             if _group and _group.name and _group.name == 'anonymous':
                                                 _group = None
-                                            sync_geofence_with_guardian(_resource, perms, group=_group)
-                                            gf_services = _get_gf_services(_resource, perms)
-                                            _, _, _disable_dataset_cache, _, _, _ = get_user_geolimits(_resource, None, _group, gf_services)
-                                            _disable_cache.append(_disable_dataset_cache)
+                                            _disable_cache = sync_permissions_and_disable_cache(_disable_cache, _resource, perms, None, _group, None)
                                 else:
                                     anonymous_can_view = settings.DEFAULT_ANONYMOUS_VIEW_PERMISSION
                                     anonymous_can_download = settings.DEFAULT_ANONYMOUS_DOWNLOAD_PERMISSION
@@ -472,42 +456,23 @@ class GeoServerResourceManager(ResourceManagerInterface):
                                         purge_geofence_dataset_rules(_resource.get_self_resource())
 
                                     # Owner & Managers
-                                    perms = [
-                                        "view_resourcebase",
-                                        "change_dataset_data",
-                                        "change_dataset_style",
-                                        "change_resourcebase",
-                                        "change_resourcebase_permissions",
-                                        "download_resourcebase"]
-                                    sync_geofence_with_guardian(_resource, perms, user=_owner)
-                                    gf_services = _get_gf_services(_resource, perms)
-                                    _, _, _disable_dataset_cache, _, _, _ = get_user_geolimits(_resource, _owner, None, gf_services)
-                                    _disable_cache.append(_disable_dataset_cache)
+                                    perms = OWNER_PERMISSIONS.copy() + DOWNLOAD_PERMISSIONS.copy()
+                                    _disable_cache = sync_permissions_and_disable_cache(_disable_cache, _resource, perms, _owner, None, None)
 
                                     _resource_groups, _group_managers = _resource.get_group_managers(group=_resource.group)
                                     for _group_manager in _group_managers:
-                                        sync_geofence_with_guardian(_resource, perms, user=_group_manager)
-                                        _, _, _disable_dataset_cache, _, _, _ = get_user_geolimits(_resource, _group_manager, None, gf_services)
-                                        _disable_cache.append(_disable_dataset_cache)
+                                        _disable_cache = sync_permissions_and_disable_cache(_disable_cache, _resource, perms, _group_manager, None, None)
 
                                     for user_group in _resource_groups:
                                         if not skip_registered_members_common_group(user_group):
-                                            sync_geofence_with_guardian(_resource, perms, group=user_group)
-                                            _, _, _disable_dataset_cache, _, _, _ = get_user_geolimits(_resource, None, user_group, gf_services)
-                                            _disable_cache.append(_disable_dataset_cache)
+                                            _disable_cache = sync_permissions_and_disable_cache(_disable_cache, _resource, perms, None, user_group, None)
 
                                     # Anonymous
                                     if anonymous_can_view:
-                                        sync_geofence_with_guardian(_resource, VIEW_PERMISSIONS, user=None, group=None)
-                                        gf_services = _get_gf_services(_resource, VIEW_PERMISSIONS)
-                                        _, _, _disable_dataset_cache, _, _, _ = get_user_geolimits(_resource, None, None, gf_services)
-                                        _disable_cache.append(_disable_dataset_cache)
+                                        _disable_cache = sync_permissions_and_disable_cache(_disable_cache, _resource, VIEW_PERMISSIONS, None, None, None)
 
                                     if anonymous_can_download:
-                                        sync_geofence_with_guardian(_resource, DOWNLOAD_PERMISSIONS, user=None, group=None)
-                                        gf_services = _get_gf_services(_resource, DOWNLOAD_PERMISSIONS)
-                                        _, _, _disable_dataset_cache, _, _, _ = get_user_geolimits(_resource, None, None, gf_services)
-                                        _disable_cache.append(_disable_dataset_cache)
+                                        _disable_cache = sync_permissions_and_disable_cache(_disable_cache, _resource, DOWNLOAD_PERMISSIONS, None, None, None)
 
                                 if _disable_cache:
                                     filters, formats = _get_gwc_filters_and_formats(_disable_cache)

--- a/geonode/geoserver/manager.py
+++ b/geonode/geoserver/manager.py
@@ -39,10 +39,10 @@ from geonode.base.models import ResourceBase
 from geonode.thumbs.utils import MISSING_THUMB
 from geonode.utils import get_dataset_workspace
 from geonode.services.enumerations import CASCADED
-from geonode.security.permissions import VIEW_PERMISSIONS, DOWNLOAD_PERMISSIONS
-from geonode.security.utils import (
-    get_user_groups,
-    skip_registered_members_common_group)
+from geonode.security.utils import skip_registered_members_common_group
+from geonode.security.permissions import (
+    VIEW_PERMISSIONS,
+    DOWNLOAD_PERMISSIONS)
 from geonode.resource.manager import (
     ResourceManager,
     ResourceManagerInterface)
@@ -474,13 +474,13 @@ class GeoServerResourceManager(ResourceManagerInterface):
                             _, _, _disable_dataset_cache, _, _, _ = get_user_geolimits(instance, _owner, None, gf_services)
                             _disable_cache.append(_disable_dataset_cache)
 
-                            _member_group_perm, _group_managers = instance.get_group_managers(get_user_groups(_owner))
+                            _resource_groups, _group_managers = instance.get_group_managers(group=instance.group)
                             for _group_manager in _group_managers:
                                 sync_geofence_with_guardian(instance, perms, user=_group_manager)
                                 _, _, _disable_dataset_cache, _, _, _ = get_user_geolimits(instance, _group_manager, None, gf_services)
                                 _disable_cache.append(_disable_dataset_cache)
 
-                            for user_group in get_user_groups(_owner):
+                            for user_group in _resource_groups:
                                 if not skip_registered_members_common_group(user_group):
                                     sync_geofence_with_guardian(instance, perms, group=user_group)
                                     _, _, _disable_dataset_cache, _, _, _ = get_user_geolimits(instance, None, user_group, gf_services)

--- a/geonode/geoserver/manager.py
+++ b/geonode/geoserver/manager.py
@@ -44,7 +44,8 @@ from geonode.security.utils import skip_registered_members_common_group
 from geonode.security.permissions import (
     VIEW_PERMISSIONS,
     OWNER_PERMISSIONS,
-    DOWNLOAD_PERMISSIONS)
+    DOWNLOAD_PERMISSIONS,
+    DATASET_ADMIN_PERMISSIONS)
 from geonode.resource.manager import (
     ResourceManager,
     ResourceManagerInterface)
@@ -423,7 +424,7 @@ class GeoServerResourceManager(ResourceManagerInterface):
                                         purge_geofence_dataset_rules(_resource)
 
                                     # Owner
-                                    perms = OWNER_PERMISSIONS.copy() + DOWNLOAD_PERMISSIONS.copy()
+                                    perms = OWNER_PERMISSIONS.copy() + DATASET_ADMIN_PERMISSIONS.copy() + DOWNLOAD_PERMISSIONS.copy()
                                     _disable_cache = sync_permissions_and_disable_cache(_disable_cache, _resource, perms, _owner, None, None)
 
                                     # All the other users
@@ -456,7 +457,7 @@ class GeoServerResourceManager(ResourceManagerInterface):
                                         purge_geofence_dataset_rules(_resource.get_self_resource())
 
                                     # Owner & Managers
-                                    perms = OWNER_PERMISSIONS.copy() + DOWNLOAD_PERMISSIONS.copy()
+                                    perms = OWNER_PERMISSIONS.copy() + DATASET_ADMIN_PERMISSIONS.copy() + DOWNLOAD_PERMISSIONS.copy()
                                     _disable_cache = sync_permissions_and_disable_cache(_disable_cache, _resource, perms, _owner, None, None)
 
                                     _resource_groups, _group_managers = _resource.get_group_managers(group=_resource.group)

--- a/geonode/geoserver/manager.py
+++ b/geonode/geoserver/manager.py
@@ -402,7 +402,8 @@ class GeoServerResourceManager(ResourceManagerInterface):
             return False
         return True
 
-    def set_permissions(self, uuid: str, /, instance: ResourceBase = None, owner: settings.AUTH_USER_MODEL = None, permissions: dict = {}, created: bool = False) -> bool:
+    def set_permissions(self, uuid: str, /, instance: ResourceBase = None, owner: settings.AUTH_USER_MODEL = None,
+                        permissions: dict = {}, created: bool = False, approval_status_changed: bool = False) -> bool:
         _resource = instance or ResourceManager._get_instance(uuid)
 
         try:

--- a/geonode/geoserver/security.py
+++ b/geonode/geoserver/security.py
@@ -505,7 +505,7 @@ def sync_geofence_with_guardian(dataset, perms, user=None, group=None, group_per
         if user and group_perms:
             if isinstance(user, str):
                 user = get_user_model().objects.get(username=user)
-            user_groups = list(user.groups.all().values_list('name', flat=True))
+            user_groups = list(user.groups.values_list('name', flat=True))
             for _group, _perm in group_perms.items():
                 if 'change_dataset_data' in _perm and _group in user_groups:
                     _skip_perm = True
@@ -585,7 +585,7 @@ def sync_resources_with_guardian(resource=None):
         dirty_resources = ResourceBase.objects.filter(id=resource.id)
     else:
         dirty_resources = ResourceBase.objects.filter(dirty_state=True)
-    if dirty_resources and dirty_resources.count() > 0:
+    if dirty_resources and dirty_resources.exists():
         logger.debug(" --------------------------- synching with guardian!")
         for r in dirty_resources:
             if r.polymorphic_ctype.name == 'dataset':
@@ -625,20 +625,20 @@ def get_user_geolimits(layer, user, group, gf_services):
     if user:
         _user = user if isinstance(user, str) else user.username
         users_geolimits = layer.users_geolimits.filter(user=get_user_model().objects.get(username=_user))
-        gf_services["*"] = users_geolimits.count() > 0 if not gf_services["*"] else gf_services["*"]
-        _disable_dataset_cache = users_geolimits.count() > 0
+        gf_services["*"] = users_geolimits.exists() if not gf_services["*"] else gf_services["*"]
+        _disable_dataset_cache = users_geolimits.exists()
 
     if group:
         _group = group if isinstance(group, str) else group.name
         if GroupProfile.objects.filter(group__name=_group).count() == 1:
             groups_geolimits = layer.groups_geolimits.filter(group=GroupProfile.objects.get(group__name=_group))
-            gf_services["*"] = groups_geolimits.count() > 0 if not gf_services["*"] else gf_services["*"]
-            _disable_dataset_cache = groups_geolimits.count() > 0
+            gf_services["*"] = groups_geolimits.exists() if not gf_services["*"] else gf_services["*"]
+            _disable_dataset_cache = groups_geolimits.exists()
 
     if not user and not group:
         anonymous_geolimits = layer.users_geolimits.filter(user=get_anonymous_user())
-        gf_services["*"] = anonymous_geolimits.count() > 0 if not gf_services["*"] else gf_services["*"]
-        _disable_dataset_cache = anonymous_geolimits.count() > 0
+        gf_services["*"] = anonymous_geolimits.exists() if not gf_services["*"] else gf_services["*"]
+        _disable_dataset_cache = anonymous_geolimits.exists()
     return _group, _user, _disable_dataset_cache, users_geolimits, groups_geolimits, anonymous_geolimits
 
 

--- a/geonode/geoserver/security.py
+++ b/geonode/geoserver/security.py
@@ -679,8 +679,8 @@ def _get_gwc_filters_and_formats(disable_cache: list = []) -> typing.Tuple[list,
 
 
 def sync_permissions_and_disable_cache(cache_rules, resource, perms, user, group, group_perms):
-    sync_geofence_with_guardian(resource, perms, user=user, group_perms=group_perms)
-    gf_services = _get_gf_services(resource, perms)
-    _, _, _disable_dataset_cache, _, _, _ = get_user_geolimits(resource, user, group, gf_services)
+    sync_geofence_with_guardian(dataset=resource, perms=perms, user=user, group=group, group_perms=group_perms)
+    gf_services = _get_gf_services(layer=resource, perms=perms)
+    _, _, _disable_dataset_cache, _, _, _ = get_user_geolimits(layer=resource, user=user, group=group, gf_services=gf_services)
     cache_rules.append(_disable_dataset_cache)
     return cache_rules

--- a/geonode/geoserver/security.py
+++ b/geonode/geoserver/security.py
@@ -676,3 +676,11 @@ def _get_gwc_filters_and_formats(disable_cache: list = []) -> typing.Tuple[list,
         filters = None
         formats = None
     return (filters, formats)
+
+
+def sync_permissions_and_disable_cache(cache_rules, resource, perms, user, group, group_perms):
+    sync_geofence_with_guardian(resource, perms, user=user, group_perms=group_perms)
+    gf_services = _get_gf_services(resource, perms)
+    _, _, _disable_dataset_cache, _, _, _ = get_user_geolimits(resource, user, group, gf_services)
+    cache_rules.append(_disable_dataset_cache)
+    return cache_rules

--- a/geonode/geoserver/security.py
+++ b/geonode/geoserver/security.py
@@ -679,8 +679,11 @@ def _get_gwc_filters_and_formats(disable_cache: list = []) -> typing.Tuple[list,
 
 
 def sync_permissions_and_disable_cache(cache_rules, resource, perms, user, group, group_perms):
-    sync_geofence_with_guardian(dataset=resource, perms=perms, user=user, group=group, group_perms=group_perms)
+    if group_perms:
+        sync_geofence_with_guardian(dataset=resource, perms=perms, user=user, group_perms=group_perms)
+    else:
+        sync_geofence_with_guardian(dataset=resource, perms=perms, user=user, group=group)
     gf_services = _get_gf_services(layer=resource, perms=perms)
     _, _, _disable_dataset_cache, _, _, _ = get_user_geolimits(layer=resource, user=user, group=group, gf_services=gf_services)
     cache_rules.append(_disable_dataset_cache)
-    return cache_rules
+    return list(set(cache_rules))

--- a/geonode/geoserver/tests/test_server.py
+++ b/geonode/geoserver/tests/test_server.py
@@ -1191,7 +1191,7 @@ class LayerTests(GeoNodeBaseTestSupport):
 
             # Delete all 'original' and 'metadata' links
             _links.delete()
-            self.assertFalse(_links.count() > 0, "No links have been deleted")
+            self.assertFalse(_links.exists(), "No links have been deleted")
             # Delete resources metadata
             _datasets = Dataset.objects.exclude(
                 Q(metadata_xml__isnull=True) |
@@ -1219,7 +1219,7 @@ class LayerTests(GeoNodeBaseTestSupport):
             # Check links
             _post_migrate_links = Link.objects.filter(link_type__in=_def_link_types)
             self.assertTrue(
-                _post_migrate_links.count() > 0,
+                _post_migrate_links.exists(),
                 "No links have been restored"
             )
             # Check layers
@@ -1238,7 +1238,7 @@ class LayerTests(GeoNodeBaseTestSupport):
                     link_type='original'
                 )
                 self.assertTrue(
-                    _post_migrate_links_orig.count() > 0,
+                    _post_migrate_links_orig.exists(),
                     f"No 'original' links has been found for the layer '{_lyr.alternate}'"
                 )
                 for _link_orig in _post_migrate_links_orig:

--- a/geonode/groups/forms.py
+++ b/geonode/groups/forms.py
@@ -52,8 +52,13 @@ class GroupForm(TranslationModelForm):
         cleaned_data = self.cleaned_data
 
         name = cleaned_data.get("title")
+        if not name or GroupProfile.objects.filter(title__iexact=self.cleaned_data["title"]).count() > 0:
+            raise forms.ValidationError(
+                _("A group already exists with that name."))
         slug = slugify(name)
-
+        if not slug or GroupProfile.objects.filter(slug__iexact=self.cleaned_data["slug"]).count() > 0:
+            raise forms.ValidationError(
+                _("A group already exists with that slug."))
         cleaned_data["slug"] = slug
 
         return cleaned_data

--- a/geonode/groups/forms.py
+++ b/geonode/groups/forms.py
@@ -36,14 +36,14 @@ class GroupForm(TranslationModelForm):
 
     def clean_slug(self):
         if GroupProfile.objects.filter(
-                slug__iexact=self.cleaned_data["slug"]).count() > 0:
+                slug__iexact=self.cleaned_data["slug"]).exists():
             raise forms.ValidationError(
                 _("A group already exists with that slug."))
         return self.cleaned_data["slug"].lower()
 
     def clean_title(self):
         if GroupProfile.objects.filter(
-                title__iexact=self.cleaned_data["title"]).count() > 0:
+                title__iexact=self.cleaned_data["title"]).exists():
             raise forms.ValidationError(
                 _("A group already exists with that name."))
         return self.cleaned_data["title"]
@@ -52,11 +52,11 @@ class GroupForm(TranslationModelForm):
         cleaned_data = self.cleaned_data
 
         name = cleaned_data.get("title")
-        if not name or GroupProfile.objects.filter(title__iexact=self.cleaned_data["title"]).count() > 0:
+        if not name or GroupProfile.objects.filter(title__iexact=self.cleaned_data["title"]).exists():
             raise forms.ValidationError(
                 _("A group already exists with that name."))
         slug = slugify(name)
-        if not slug or GroupProfile.objects.filter(slug__iexact=self.cleaned_data["slug"]).count() > 0:
+        if not slug or GroupProfile.objects.filter(slug__iexact=self.cleaned_data["slug"]).exists():
             raise forms.ValidationError(
                 _("A group already exists with that slug."))
         cleaned_data["slug"] = slug
@@ -72,7 +72,7 @@ class GroupUpdateForm(forms.ModelForm):
 
     def clean_name(self):
         if GroupProfile.objects.filter(
-                name__iexact=self.cleaned_data["title"]).count() > 0:
+                name__iexact=self.cleaned_data["title"]).exists():
             if self.cleaned_data["title"] == self.instance.name:
                 pass  # same instance
             else:

--- a/geonode/groups/models.py
+++ b/geonode/groups/models.py
@@ -162,7 +162,7 @@ class GroupProfile(models.Model):
 
     def get_members(self):
         """
-        Returns a queryset of the group's managers.
+        Returns a queryset of the group's members.
         """
         return get_user_model().objects.filter(
             Q(id__in=self.member_queryset().filter(

--- a/geonode/groups/models.py
+++ b/geonode/groups/models.py
@@ -160,13 +160,23 @@ class GroupProfile(models.Model):
     def member_queryset(self):
         return self.groupmember_set.all()
 
+    def get_members(self):
+        """
+        Returns a queryset of the group's managers.
+        """
+        return get_user_model().objects.filter(
+            Q(id__in=self.member_queryset().filter(
+                role=GroupMember.MEMBER).values_list(
+                "user",
+                flat=True)))
+
     def get_managers(self):
         """
         Returns a queryset of the group's managers.
         """
         return get_user_model().objects.filter(
             Q(id__in=self.member_queryset().filter(
-                role='manager').values_list(
+                role=GroupMember.MANAGER).values_list(
                 "user",
                 flat=True)))
 
@@ -206,10 +216,9 @@ class GroupProfile(models.Model):
             raise ValueError("The invited user cannot be anonymous")
         _members = GroupMember.objects.filter(group=self, user=user)
         if _members.count():
-            for member in _members:
-                member.demote()
+            for _member in _members:
+                _member.delete()
                 user.groups.remove(self.group)
-                member.delete()
         else:
             logger.warning(f"The invited user \"{user.username}\" is not a member")
 
@@ -256,7 +265,7 @@ class GroupMember(models.Model):
         # add django.contrib.auth.group to user
         self.user.groups.add(self.group.group)
         super().save(*args, **kwargs)
-        self._handle_perms(self.role)
+        self._handle_perms(role=self.role)
 
     def delete(self, *args, **kwargs):
         self.user.groups.remove(self.group.group)
@@ -266,12 +275,12 @@ class GroupMember(models.Model):
     def promote(self, *args, **kwargs):
         self.role = "manager"
         super().save(*args, **kwargs)
-        self._handle_perms(self.role)
+        self._handle_perms(role=self.role)
 
     def demote(self, *args, **kwargs):
         self.role = "member"
         super().save(*args, **kwargs)
-        self._handle_perms(self.role)
+        self._handle_perms(role=self.role)
 
     def _handle_perms(self, role=None):
         from geonode.security.utils import AdvancedSecurityWorkflowManager

--- a/geonode/groups/tests.py
+++ b/geonode/groups/tests.py
@@ -541,7 +541,7 @@ class GroupsSmokeTest(GeoNodeBaseTestSupport):
         self.assertEqual(response.status_code, 302)
         self.assertFalse(
             GroupProfile.objects.filter(
-                id=self.bar.id).count() > 0)
+                id=self.bar.id).exists())
 
     def test_delete_group_view_no_perms(self):
         """

--- a/geonode/layers/models.py
+++ b/geonode/layers/models.py
@@ -289,7 +289,7 @@ class Dataset(ResourceBase):
         # Get custom attribute sort order and labels if any
         cfg = {}
         visible_attributes = self.attribute_set.visible()
-        if (visible_attributes.count() > 0):
+        if (visible_attributes.exists()):
             cfg["getFeatureInfo"] = {
                 "fields": [lyr.attribute for lyr in visible_attributes],
                 "propertyNames": {lyr.attribute: lyr.attribute_label for lyr in visible_attributes},

--- a/geonode/layers/utils.py
+++ b/geonode/layers/utils.py
@@ -280,7 +280,7 @@ def get_default_user():
     """
     superusers = get_user_model().objects.filter(
         is_superuser=True).order_by('id')
-    if superusers.count() > 0:
+    if superusers.exists():
         # Return the first created superuser
         return superusers[0]
     else:

--- a/geonode/layers/views.py
+++ b/geonode/layers/views.py
@@ -727,12 +727,15 @@ def dataset_metadata(
             can_change_metadata = request.user.has_perm(
                 'change_resourcebase_metadata',
                 layer.get_self_resource())
+            can_publish = request.user.has_perm(
+                'publish_resourcebase',
+                layer.get_self_resource())
             try:
                 is_manager = request.user.groupmember_set.all().filter(role='manager').exists()
             except Exception:
                 is_manager = False
 
-            if not is_manager or not can_change_metadata:
+            if not is_manager or not can_change_metadata or not can_publish:
                 if settings.RESOURCE_PUBLISHING:
                     dataset_form.fields['is_published'].widget.attrs.update(
                         {'disabled': 'true'})

--- a/geonode/layers/views.py
+++ b/geonode/layers/views.py
@@ -688,7 +688,7 @@ def dataset_metadata(
         from geonode.upload.models import Upload
 
         up_sessions = Upload.objects.filter(resource_id=layer.resourcebase_ptr_id)
-        if up_sessions.count() > 0 and up_sessions[0].user != layer.owner:
+        if up_sessions.exists() and up_sessions[0].user != layer.owner:
             up_sessions.update(user=layer.owner)
 
         register_event(request, EventType.EVENT_CHANGE_METADATA, layer)

--- a/geonode/maps/tests.py
+++ b/geonode/maps/tests.py
@@ -611,7 +611,7 @@ community."
             )
             resource_manager.set_permissions(None, instance=map_created, permissions=None, created=True)
             self.assertFalse(map_created.is_approved)
-            self.assertTrue(map_created.is_published)
+            self.assertFalse(map_created.is_published)
 
     def testMapsNotifications(self):
         with self.settings(

--- a/geonode/maps/views.py
+++ b/geonode/maps/views.py
@@ -277,11 +277,14 @@ def map_metadata(request, mapid, template="maps/map_metadata.html", ajax=True):
             can_change_metadata = request.user.has_perm(
                 'change_resourcebase_metadata',
                 map_obj.get_self_resource())
+            can_publish = request.user.has_perm(
+                'publish_resourcebase',
+                map_obj.get_self_resource())
             try:
                 is_manager = request.user.groupmember_set.all().filter(role='manager').exists()
             except Exception:
                 is_manager = False
-            if not is_manager or not can_change_metadata:
+            if not is_manager or not can_change_metadata or not can_publish:
                 if settings.RESOURCE_PUBLISHING:
                     map_form.fields['is_published'].widget.attrs.update(
                         {'disabled': 'true'})

--- a/geonode/monitoring/tests/integration.py
+++ b/geonode/monitoring/tests/integration.py
@@ -274,7 +274,7 @@ class RequestsTestCase(MonitoringTestBase):
             rq = RequestEvent.objects.all().last()
             self.assertTrue(rq.response_time > 0)
             self.assertEqual(
-                list(rq.resources.all().values_list('name', 'type')), [(_l.alternate, 'dataset',)])
+                list(rq.resources.values_list('name', 'type')), [(_l.alternate, 'dataset',)])
             self.assertEqual(rq.request_method, 'GET')
 
     def test_gn_error(self):
@@ -678,7 +678,7 @@ class MonitoringChecksTestCase(MonitoringTestBase):
             notifications = NotificationCheck.objects.all()
             for n in notifications:
                 if n.is_error:
-                    self.assertTrue(MetricNotificationCheck.objects.all().count() > 0)
+                    self.assertTrue(MetricNotificationCheck.objects.all().exists())
                     for nrow in jout['data']:
                         nitem = MetricNotificationCheck.objects.get(id=nrow['id'])
                         for nkey, nval in nrow.items():
@@ -699,7 +699,7 @@ class MonitoringChecksTestCase(MonitoringTestBase):
             notifications = NotificationCheck.objects.all()
             for n in notifications:
                 if n.is_error:
-                    self.assertTrue(MetricNotificationCheck.objects.all().count() > 0)
+                    self.assertTrue(MetricNotificationCheck.objects.all().exists())
                     for nrow in jout['data']:
                         nitem = MetricNotificationCheck.objects.get(id=nrow['id'])
                         for nkey, nval in nrow.items():
@@ -816,7 +816,7 @@ class MonitoringChecksTestCase(MonitoringTestBase):
         self.assertEqual(nresp.status_code, 200)
         ndata = json.loads(ensure_string(nresp.content))
         self.assertEqual({n['id'] for n in ndata['data']},
-                         set(NotificationCheck.objects.all().values_list('id', flat=True)))
+                         set(NotificationCheck.objects.values_list('id', flat=True)))
         mail.outbox = []
         self.assertEqual(len(mail.outbox), 0)
         capi.emit_notifications(start)

--- a/geonode/people/adapters.py
+++ b/geonode/people/adapters.py
@@ -138,7 +138,7 @@ class LocalAccountAdapter(DefaultAccountAdapter, BaseInvitationsAdapter):
         user = context.get("inviter") if context.get("inviter") else context.get("user")
         full_name = " ".join((user.first_name, user.last_name)) if user.first_name or user.last_name else None
         user_groups = GroupProfile.objects.filter(
-            slug__in=user.groupmember_set.all().values_list("group__slug", flat=True))
+            slug__in=user.groupmember_set.values_list("group__slug", flat=True))
         enhanced_context = context.copy()
         enhanced_context.update({
             "username": user.username,

--- a/geonode/people/utils.py
+++ b/geonode/people/utils.py
@@ -28,7 +28,7 @@ def get_default_user():
     """
     superusers = get_user_model().objects.filter(
         is_superuser=True).order_by('id')
-    if superusers.count() > 0:
+    if superusers.exists():
         # Return the first created superuser
         return superusers[0]
     else:

--- a/geonode/resource/manager.py
+++ b/geonode/resource/manager.py
@@ -185,7 +185,8 @@ class ResourceManagerInterface(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def set_permissions(self, uuid: str, /, instance: ResourceBase = None, owner: settings.AUTH_USER_MODEL = None, permissions: dict = {}, created: bool = False) -> bool:
+    def set_permissions(self, uuid: str, /, instance: ResourceBase = None, owner: settings.AUTH_USER_MODEL = None,
+                        permissions: dict = {}, created: bool = False, approval_status_changed: bool = False) -> bool:
         """Sets the permissions of a resource.
 
          - It optionally gets a JSON 'perm_spec' through the 'permissions' parameter
@@ -575,7 +576,8 @@ class ResourceManager(ResourceManagerInterface):
                 _resource.set_dirty_state()
         return False
 
-    def set_permissions(self, uuid: str, /, instance: ResourceBase = None, owner: settings.AUTH_USER_MODEL = None, permissions: dict = {}, created: bool = False) -> bool:
+    def set_permissions(self, uuid: str, /, instance: ResourceBase = None, owner: settings.AUTH_USER_MODEL = None,
+                        permissions: dict = {}, created: bool = False, approval_status_changed: bool = False) -> bool:
         _resource = instance or ResourceManager._get_instance(uuid)
         if _resource:
             _resource = _resource.get_real_instance()
@@ -605,7 +607,8 @@ class ResourceManager(ResourceManagerInterface):
                         _permissions = None
 
                     # Fixup Advanced Workflow permissions
-                    _perm_spec = AdvancedSecurityWorkflowManager.get_permissions(_resource.uuid, instance=_resource, permissions=_permissions, created=created)
+                    _perm_spec = AdvancedSecurityWorkflowManager.get_permissions(_resource.uuid, instance=_resource, permissions=_permissions,
+                                                                                 created=created, approval_status_changed=approval_status_changed)
 
                     """
                     Cleanup the Guardian tables

--- a/geonode/resource/manager.py
+++ b/geonode/resource/manager.py
@@ -580,7 +580,6 @@ class ResourceManager(ResourceManagerInterface):
         if _resource:
             _resource = _resource.get_real_instance()
             _resource.set_processing_state(enumerations.STATE_RUNNING)
-            _prev_perm_spec = copy.deepcopy(_resource.get_all_level_info())
             logger.debug(f'Finalizing (permissions and notifications) on resource {instance}')
             try:
                 with transaction.atomic():
@@ -729,12 +728,10 @@ class ResourceManager(ResourceManagerInterface):
                         _resource = AdvancedSecurityWorkflowManager.handle_moderated_uploads(_resource.uuid, instance=_resource)
 
                     # Fixup GIS Backend Security Rules Accordingly
-                    if not _resource.compare_perms(_prev_perm_spec, _perm_spec):
-                        # Avoid setting the permissions if nothing changed
-                        if not self._concrete_resource_manager.set_permissions(
-                                uuid, instance=_resource, owner=owner, permissions=_perm_spec, created=created):
-                            # This might not be a severe error. E.g. for datasets outside of local GeoServer
-                            logger.error(Exception("Could not complete concrete manager operation successfully!"))
+                    if not self._concrete_resource_manager.set_permissions(
+                            uuid, instance=_resource, owner=owner, permissions=_perm_spec, created=created):
+                        # This might not be a severe error. E.g. for datasets outside of local GeoServer
+                        logger.error(Exception("Could not complete concrete manager operation successfully!"))
                 _resource.set_processing_state(enumerations.STATE_PROCESSED)
                 return True
             except Exception as e:

--- a/geonode/resource/manager.py
+++ b/geonode/resource/manager.py
@@ -372,6 +372,7 @@ class ResourceManager(ResourceManagerInterface):
             finally:
                 _resource.save(notify=notify)
                 resourcebase_post_save(_resource.get_real_instance())
+                _resource.set_permissions()
         return _resource
 
     def ingest(self, files: typing.List[str], /, uuid: str = None, resource_type: typing.Optional[object] = None, defaults: dict = {}, **kwargs) -> ResourceBase:
@@ -605,7 +606,7 @@ class ResourceManager(ResourceManagerInterface):
                         _permissions = None
 
                     # Fixup Advanced Workflow permissions
-                    _perm_spec = AdvancedSecurityWorkflowManager.get_permissions(_resource.uuid, instance=_resource, permissions=_permissions)
+                    _perm_spec = AdvancedSecurityWorkflowManager.get_permissions(_resource.uuid, instance=_resource, permissions=_permissions, created=created)
 
                     """
                     Cleanup the Guardian tables

--- a/geonode/security/models.py
+++ b/geonode/security/models.py
@@ -216,7 +216,7 @@ class PermissionLevelMixin:
         # default permissions for owner and owner's groups
         _owner = owner or self.owner
         user_groups = Group.objects.filter(
-            name__in=_owner.groupmember_set.all().values_list("group__slug", flat=True))
+            name__in=_owner.groupmember_set.values_list("group__slug", flat=True))
 
         # Anonymous
         anonymous_can_view = settings.DEFAULT_ANONYMOUS_VIEW_PERMISSION

--- a/geonode/security/models.py
+++ b/geonode/security/models.py
@@ -238,7 +238,7 @@ class PermissionLevelMixin:
         AdvancedSecurityWorkflowManager.handle_moderated_uploads(self.uuid, instance=self)
         return resource_manager.set_permissions(self.uuid, instance=self, owner=owner, permissions=perm_spec, created=created)
 
-    def set_permissions(self, perm_spec=None, created=False):
+    def set_permissions(self, perm_spec=None, created=False, approval_status_changed=False):
         """
         Sets an object's the permission levels based on the perm_spec JSON.
 
@@ -258,7 +258,7 @@ class PermissionLevelMixin:
         }
         """
         from geonode.resource.manager import resource_manager
-        return resource_manager.set_permissions(self.uuid, instance=self, permissions=perm_spec, created=created)
+        return resource_manager.set_permissions(self.uuid, instance=self, permissions=perm_spec, created=created, approval_status_changed=approval_status_changed)
 
     def compare_perms(self, prev_perm_spec, perm_spec):
         """

--- a/geonode/security/models.py
+++ b/geonode/security/models.py
@@ -32,7 +32,6 @@ from django.contrib.auth.models import Group, Permission
 from django.contrib.contenttypes.models import ContentType
 
 from guardian.shortcuts import (
-    assign_perm,
     get_perms,
     get_groups_with_perms)
 

--- a/geonode/security/tests.py
+++ b/geonode/security/tests.py
@@ -493,20 +493,20 @@ class SecurityTests(ResourceTestCaseMixin, GeoNodeBaseTestSupport):
         layer.set_permissions(perm_spec)
         geofence_rules_count = get_geofence_rules_count()
         _log(f"1. geofence_rules_count: {geofence_rules_count} ")
-        self.assertEqual(geofence_rules_count, 5)
+        self.assertGreaterEqual(geofence_rules_count, 13)
 
         perm_spec = {
             "users": {"admin": ["view_resourcebase"]}, "groups": []}
         layer.set_permissions(perm_spec)
         geofence_rules_count = get_geofence_rules_count()
         _log(f"2. geofence_rules_count: {geofence_rules_count} ")
-        self.assertEqual(geofence_rules_count, 7)
+        self.assertGreaterEqual(geofence_rules_count, 15)
 
         perm_spec = {'users': {"admin": ['change_dataset_data']}, 'groups': []}
         layer.set_permissions(perm_spec)
         geofence_rules_count = get_geofence_rules_count()
         _log(f"3. geofence_rules_count: {geofence_rules_count} ")
-        self.assertEqual(geofence_rules_count, 7)
+        self.assertGreaterEqual(geofence_rules_count, 15)
 
         # FULL WFS-T
         perm_spec = {
@@ -522,7 +522,7 @@ class SecurityTests(ResourceTestCaseMixin, GeoNodeBaseTestSupport):
         }
         layer.set_permissions(perm_spec)
         geofence_rules_count = get_geofence_rules_count()
-        self.assertEqual(geofence_rules_count, 10)
+        self.assertEqual(geofence_rules_count, 18)
 
         rules_objs = get_geofence_rules(entries=10)
         _deny_wfst_rule_exists = False
@@ -547,7 +547,7 @@ class SecurityTests(ResourceTestCaseMixin, GeoNodeBaseTestSupport):
         }
         layer.set_permissions(perm_spec)
         geofence_rules_count = get_geofence_rules_count()
-        self.assertEqual(geofence_rules_count, 13)
+        self.assertEqual(geofence_rules_count, 21)
 
         rules_objs = get_geofence_rules(entries=13)
         _deny_wfst_rule_exists = False
@@ -577,9 +577,9 @@ class SecurityTests(ResourceTestCaseMixin, GeoNodeBaseTestSupport):
         }
         layer.set_permissions(perm_spec)
         geofence_rules_count = get_geofence_rules_count()
-        self.assertEqual(geofence_rules_count, 7)
+        self.assertEqual(geofence_rules_count, 15)
 
-        rules_objs = get_geofence_rules(entries=7)
+        rules_objs = get_geofence_rules(entries=15)
         _deny_wfst_rule_exists = False
         for rule in rules_objs['rules']:
             if rule['service'] == "WFS" and \
@@ -593,13 +593,13 @@ class SecurityTests(ResourceTestCaseMixin, GeoNodeBaseTestSupport):
         layer.set_permissions(perm_spec)
         geofence_rules_count = get_geofence_rules_count()
         _log(f"4. geofence_rules_count: {geofence_rules_count} ")
-        self.assertEqual(geofence_rules_count, 7)
+        self.assertGreaterEqual(geofence_rules_count, 15)
 
         perm_spec = {'users': {}, 'groups': {'bar': ['change_resourcebase']}}
         layer.set_permissions(perm_spec)
         geofence_rules_count = get_geofence_rules_count()
         _log(f"5. geofence_rules_count: {geofence_rules_count} ")
-        self.assertEqual(geofence_rules_count, 5)
+        self.assertGreaterEqual(geofence_rules_count, 13)
 
         # Testing GeoLimits
         # Reset GeoFence Rules
@@ -647,10 +647,10 @@ class SecurityTests(ResourceTestCaseMixin, GeoNodeBaseTestSupport):
             "users": {"bobby": ["view_resourcebase"]}, "groups": []}
         layer.set_permissions(perm_spec)
         geofence_rules_count = get_geofence_rules_count()
-        self.assertEqual(geofence_rules_count, 8)
+        self.assertEqual(geofence_rules_count, 13)
 
-        rules_objs = get_geofence_rules(entries=8)
-        self.assertEqual(len(rules_objs['rules']), 8)
+        rules_objs = get_geofence_rules(entries=13)
+        self.assertEqual(len(rules_objs['rules']), 13)
         # Order is important
         _limit_rule_position = -1
         for cnt, rule in enumerate(rules_objs['rules']):
@@ -686,10 +686,10 @@ class SecurityTests(ResourceTestCaseMixin, GeoNodeBaseTestSupport):
             'users': {}, 'groups': {'bar': ['change_resourcebase']}}
         layer.set_permissions(perm_spec)
         geofence_rules_count = get_geofence_rules_count()
-        self.assertEqual(geofence_rules_count, 6)
+        self.assertEqual(geofence_rules_count, 11)
 
-        rules_objs = get_geofence_rules(entries=6)
-        self.assertEqual(len(rules_objs['rules']), 6)
+        rules_objs = get_geofence_rules(entries=11)
+        self.assertEqual(len(rules_objs['rules']), 11)
         # Order is important
         _limit_rule_position = -1
         for cnt, rule in enumerate(rules_objs['rules']):
@@ -1171,12 +1171,6 @@ class SecurityTests(ResourceTestCaseMixin, GeoNodeBaseTestSupport):
 
         # Set the Permissions
         layer.set_permissions(self.perm_spec)
-
-        # Test that the Permissions for anonymous user is are set
-        self.assertFalse(
-            self.anonymous_user.has_perm(
-                'view_resourcebase',
-                layer.get_self_resource()))
 
         # Test that previous permissions for users other than ones specified in
         # the perm_spec (and the layers owner) were removed
@@ -2111,10 +2105,10 @@ class SetPermissionsTestCase(GeoNodeBaseTestSupport):
                         "publish_resourcebase",
                         "view_resourcebase",
                     ],
-                    self.group_manager: [],
-                    self.group_member: [],
-                    self.not_group_member: [],
-                    self.anonymous_user: [],
+                    self.group_manager: ["view_resourcebase", "download_resourcebase"],
+                    self.group_member: ["view_resourcebase", "download_resourcebase"],
+                    self.not_group_member: ["view_resourcebase", "download_resourcebase"],
+                    self.anonymous_user: ["view_resourcebase", "download_resourcebase"],
                 },
             ),
             (
@@ -2167,7 +2161,6 @@ class SetPermissionsTestCase(GeoNodeBaseTestSupport):
                         "delete_resourcebase",
                         "download_resourcebase",
                         "view_resourcebase",
-                        "publish_resourcebase",
                         "change_resourcebase_permissions"
                     ],
                     self.group_manager: [
@@ -2176,11 +2169,12 @@ class SetPermissionsTestCase(GeoNodeBaseTestSupport):
                         "delete_resourcebase",
                         "download_resourcebase",
                         "change_resourcebase_permissions",
-                        "view_resourcebase"
+                        "view_resourcebase",
+                        "publish_resourcebase"
                     ],
                     self.group_member: ["download_resourcebase", "view_resourcebase"],
-                    self.not_group_member: ["download_resourcebase", "view_resourcebase"],
-                    self.anonymous_user: ["download_resourcebase", "view_resourcebase"],
+                    self.not_group_member: [],
+                    self.anonymous_user: [],
                 },
             ),
             (
@@ -2192,7 +2186,6 @@ class SetPermissionsTestCase(GeoNodeBaseTestSupport):
                         "delete_resourcebase",
                         "download_resourcebase",
                         "view_resourcebase",
-                        "publish_resourcebase",
                         "change_resourcebase_permissions"
                     ],
                     self.group_manager: [
@@ -2201,11 +2194,12 @@ class SetPermissionsTestCase(GeoNodeBaseTestSupport):
                         "delete_resourcebase",
                         "download_resourcebase",
                         "view_resourcebase",
-                        "change_resourcebase_permissions"
+                        "change_resourcebase_permissions",
+                        "publish_resourcebase"
                     ],
                     self.group_member: ["download_resourcebase", "view_resourcebase"],
-                    self.not_group_member: ["download_resourcebase", "view_resourcebase"],
-                    self.anonymous_user: ["download_resourcebase", "view_resourcebase"],
+                    self.not_group_member: ["view_resourcebase"],
+                    self.anonymous_user: [],
                 },
             ),
         ]
@@ -2229,6 +2223,9 @@ class SetPermissionsTestCase(GeoNodeBaseTestSupport):
                 {"users": {}, "groups": {}},
                 {
                     self.author: [
+                        "change_resourcebase",
+                        "change_resourcebase_metadata",
+                        "delete_resourcebase",
                         "download_resourcebase",
                         "view_resourcebase",
                     ],
@@ -2242,14 +2239,17 @@ class SetPermissionsTestCase(GeoNodeBaseTestSupport):
                         "view_resourcebase",
                     ],
                     self.group_member: ["download_resourcebase", "view_resourcebase"],
-                    self.not_group_member: ["download_resourcebase", "view_resourcebase"],
-                    self.anonymous_user: ["download_resourcebase", "view_resourcebase"],
+                    self.not_group_member: [],
+                    self.anonymous_user: [],
                 },
             ),
             (
                 {"users": {}, "groups": {"second_custom_group": ["view_resourcebase"]}},
                 {
                     self.author: [
+                        "change_resourcebase",
+                        "change_resourcebase_metadata",
+                        "delete_resourcebase",
                         "download_resourcebase",
                         "view_resourcebase",
                     ],
@@ -2263,8 +2263,8 @@ class SetPermissionsTestCase(GeoNodeBaseTestSupport):
                         "view_resourcebase",
                     ],
                     self.group_member: ["download_resourcebase", "view_resourcebase"],
-                    self.not_group_member: ["download_resourcebase", "view_resourcebase"],
-                    self.anonymous_user: ["download_resourcebase", "view_resourcebase"],
+                    self.not_group_member: ["view_resourcebase"],
+                    self.anonymous_user: [],
                 },
             ),
         ]
@@ -2304,10 +2304,10 @@ class SetPermissionsTestCase(GeoNodeBaseTestSupport):
                         "publish_resourcebase",
                         "view_resourcebase",
                     ],
-                    self.group_manager: [],
-                    self.group_member: [],
-                    self.not_group_member: [],
-                    self.anonymous_user: [],
+                    self.group_manager: ["view_resourcebase", "download_resourcebase"],
+                    self.group_member: ["view_resourcebase", "download_resourcebase"],
+                    self.not_group_member: ["view_resourcebase", "download_resourcebase"],
+                    self.anonymous_user: ["view_resourcebase", "download_resourcebase"],
                 },
             ),
             (
@@ -2322,10 +2322,10 @@ class SetPermissionsTestCase(GeoNodeBaseTestSupport):
                         "publish_resourcebase",
                         "view_resourcebase",
                     ],
-                    self.group_manager: ["view_resourcebase"],
-                    self.group_member: ["view_resourcebase"],
-                    self.not_group_member: ["view_resourcebase", "change_resourcebase"],
-                    self.anonymous_user: ["view_resourcebase"],
+                    self.group_manager: ["view_resourcebase", "download_resourcebase"],
+                    self.group_member: ["view_resourcebase", "download_resourcebase"],
+                    self.not_group_member: ["view_resourcebase", "download_resourcebase", "change_resourcebase"],
+                    self.anonymous_user: ["view_resourcebase", "download_resourcebase"],
                 },
             ),
         ]
@@ -2349,6 +2349,11 @@ class SetPermissionsTestCase(GeoNodeBaseTestSupport):
             .first()
         expected = {
             self.author: [
+                "change_resourcebase_metadata",
+                "delete_resourcebase",
+                "publish_resourcebase",
+                "change_resourcebase_permissions",
+                "change_resourcebase",
                 "download_resourcebase",
                 "view_resourcebase",
             ],
@@ -2405,6 +2410,11 @@ class SetPermissionsTestCase(GeoNodeBaseTestSupport):
         self.assertEqual(sut.role, "member")
         expected = {
             self.author: [
+                "change_resourcebase_metadata",
+                "change_resourcebase",
+                "delete_resourcebase",
+                "change_resourcebase_permissions",
+                "publish_resourcebase",
                 "download_resourcebase",
                 "view_resourcebase",
             ],
@@ -2485,6 +2495,7 @@ class SetPermissionsTestCase(GeoNodeBaseTestSupport):
                 "delete_resourcebase",
                 "download_resourcebase",
                 "view_resourcebase",
+                "publish_resourcebase",
                 "change_resourcebase_permissions"
             ],
         }

--- a/geonode/security/tests.py
+++ b/geonode/security/tests.py
@@ -493,20 +493,20 @@ class SecurityTests(ResourceTestCaseMixin, GeoNodeBaseTestSupport):
         layer.set_permissions(perm_spec)
         geofence_rules_count = get_geofence_rules_count()
         _log(f"1. geofence_rules_count: {geofence_rules_count} ")
-        self.assertGreaterEqual(geofence_rules_count, 13)
+        self.assertEqual(geofence_rules_count, 5)
 
         perm_spec = {
             "users": {"admin": ["view_resourcebase"]}, "groups": []}
         layer.set_permissions(perm_spec)
         geofence_rules_count = get_geofence_rules_count()
         _log(f"2. geofence_rules_count: {geofence_rules_count} ")
-        self.assertGreaterEqual(geofence_rules_count, 15)
+        self.assertEqual(geofence_rules_count, 7)
 
         perm_spec = {'users': {"admin": ['change_dataset_data']}, 'groups': []}
         layer.set_permissions(perm_spec)
         geofence_rules_count = get_geofence_rules_count()
         _log(f"3. geofence_rules_count: {geofence_rules_count} ")
-        self.assertGreaterEqual(geofence_rules_count, 15)
+        self.assertEqual(geofence_rules_count, 7)
 
         # FULL WFS-T
         perm_spec = {
@@ -522,7 +522,7 @@ class SecurityTests(ResourceTestCaseMixin, GeoNodeBaseTestSupport):
         }
         layer.set_permissions(perm_spec)
         geofence_rules_count = get_geofence_rules_count()
-        self.assertEqual(geofence_rules_count, 18)
+        self.assertEqual(geofence_rules_count, 10)
 
         rules_objs = get_geofence_rules(entries=10)
         _deny_wfst_rule_exists = False
@@ -547,7 +547,7 @@ class SecurityTests(ResourceTestCaseMixin, GeoNodeBaseTestSupport):
         }
         layer.set_permissions(perm_spec)
         geofence_rules_count = get_geofence_rules_count()
-        self.assertEqual(geofence_rules_count, 21)
+        self.assertEqual(geofence_rules_count, 13)
 
         rules_objs = get_geofence_rules(entries=13)
         _deny_wfst_rule_exists = False
@@ -577,9 +577,9 @@ class SecurityTests(ResourceTestCaseMixin, GeoNodeBaseTestSupport):
         }
         layer.set_permissions(perm_spec)
         geofence_rules_count = get_geofence_rules_count()
-        self.assertEqual(geofence_rules_count, 15)
+        self.assertEqual(geofence_rules_count, 7)
 
-        rules_objs = get_geofence_rules(entries=15)
+        rules_objs = get_geofence_rules(entries=7)
         _deny_wfst_rule_exists = False
         for rule in rules_objs['rules']:
             if rule['service'] == "WFS" and \
@@ -593,13 +593,13 @@ class SecurityTests(ResourceTestCaseMixin, GeoNodeBaseTestSupport):
         layer.set_permissions(perm_spec)
         geofence_rules_count = get_geofence_rules_count()
         _log(f"4. geofence_rules_count: {geofence_rules_count} ")
-        self.assertGreaterEqual(geofence_rules_count, 15)
+        self.assertEqual(geofence_rules_count, 7)
 
         perm_spec = {'users': {}, 'groups': {'bar': ['change_resourcebase']}}
         layer.set_permissions(perm_spec)
         geofence_rules_count = get_geofence_rules_count()
         _log(f"5. geofence_rules_count: {geofence_rules_count} ")
-        self.assertGreaterEqual(geofence_rules_count, 13)
+        self.assertEqual(geofence_rules_count, 5)
 
         # Testing GeoLimits
         # Reset GeoFence Rules
@@ -647,10 +647,10 @@ class SecurityTests(ResourceTestCaseMixin, GeoNodeBaseTestSupport):
             "users": {"bobby": ["view_resourcebase"]}, "groups": []}
         layer.set_permissions(perm_spec)
         geofence_rules_count = get_geofence_rules_count()
-        self.assertEqual(geofence_rules_count, 13)
+        self.assertEqual(geofence_rules_count, 8)
 
-        rules_objs = get_geofence_rules(entries=13)
-        self.assertEqual(len(rules_objs['rules']), 13)
+        rules_objs = get_geofence_rules(entries=8)
+        self.assertEqual(len(rules_objs['rules']), 8)
         # Order is important
         _limit_rule_position = -1
         for cnt, rule in enumerate(rules_objs['rules']):
@@ -686,10 +686,10 @@ class SecurityTests(ResourceTestCaseMixin, GeoNodeBaseTestSupport):
             'users': {}, 'groups': {'bar': ['change_resourcebase']}}
         layer.set_permissions(perm_spec)
         geofence_rules_count = get_geofence_rules_count()
-        self.assertEqual(geofence_rules_count, 11)
+        self.assertEqual(geofence_rules_count, 6)
 
-        rules_objs = get_geofence_rules(entries=11)
-        self.assertEqual(len(rules_objs['rules']), 11)
+        rules_objs = get_geofence_rules(entries=6)
+        self.assertEqual(len(rules_objs['rules']), 6)
         # Order is important
         _limit_rule_position = -1
         for cnt, rule in enumerate(rules_objs['rules']):

--- a/geonode/security/tests.py
+++ b/geonode/security/tests.py
@@ -2588,7 +2588,7 @@ class TestPermissionChanges(GeoNodeBaseTestSupport):
         self.assertions_for_approved_and_published_is_false()
 
         # Admin publishes and approves resource
-        response = response = self.admin_approve_and_publish_resource()
+        response = self.admin_approve_and_publish_resource()
         self.assertEqual(response.status_code, 200)
         self.assertions_for_approved_or_published_is_true()
 
@@ -2601,7 +2601,7 @@ class TestPermissionChanges(GeoNodeBaseTestSupport):
         try:
             GroupMember.objects.get(group=self.owner_group, user=self.author).promote()
             # Admin publishes and approves the resource
-            response = response = self.admin_approve_and_publish_resource()
+            response = self.admin_approve_and_publish_resource()
             self.assertEqual(response.status_code, 200)
             resource_perm_specs = self.resource.get_all_level_info()
 

--- a/geonode/security/tests.py
+++ b/geonode/security/tests.py
@@ -2223,8 +2223,6 @@ class SetPermissionsTestCase(GeoNodeBaseTestSupport):
                 {"users": {}, "groups": {}},
                 {
                     self.author: [
-                        "change_resourcebase",
-                        "change_resourcebase_metadata",
                         "delete_resourcebase",
                         "download_resourcebase",
                         "view_resourcebase",
@@ -2247,8 +2245,6 @@ class SetPermissionsTestCase(GeoNodeBaseTestSupport):
                 {"users": {}, "groups": {"second_custom_group": ["view_resourcebase"]}},
                 {
                     self.author: [
-                        "change_resourcebase",
-                        "change_resourcebase_metadata",
                         "delete_resourcebase",
                         "download_resourcebase",
                         "view_resourcebase",

--- a/geonode/security/tests.py
+++ b/geonode/security/tests.py
@@ -2162,8 +2162,6 @@ class SetPermissionsTestCase(GeoNodeBaseTestSupport):
                 {"users": {}, "groups": {}},
                 {
                     self.author: [
-                        "change_resourcebase",
-                        "change_resourcebase_metadata",
                         "delete_resourcebase",
                         "download_resourcebase",
                         "view_resourcebase",
@@ -2187,8 +2185,6 @@ class SetPermissionsTestCase(GeoNodeBaseTestSupport):
                 {"users": [], "groups": {"second_custom_group": ["view_resourcebase"]}},
                 {
                     self.author: [
-                        "change_resourcebase",
-                        "change_resourcebase_metadata",
                         "delete_resourcebase",
                         "download_resourcebase",
                         "view_resourcebase",
@@ -2351,11 +2347,7 @@ class SetPermissionsTestCase(GeoNodeBaseTestSupport):
             .first()
         expected = {
             self.author: [
-                "change_resourcebase_metadata",
                 "delete_resourcebase",
-                "publish_resourcebase",
-                "change_resourcebase_permissions",
-                "change_resourcebase",
                 "download_resourcebase",
                 "view_resourcebase",
             ],
@@ -2412,11 +2404,7 @@ class SetPermissionsTestCase(GeoNodeBaseTestSupport):
         self.assertEqual(sut.role, "member")
         expected = {
             self.author: [
-                "change_resourcebase_metadata",
-                "change_resourcebase",
                 "delete_resourcebase",
-                "change_resourcebase_permissions",
-                "publish_resourcebase",
                 "download_resourcebase",
                 "view_resourcebase",
             ],
@@ -2443,12 +2431,9 @@ class SetPermissionsTestCase(GeoNodeBaseTestSupport):
         self.assertEqual(sut.role, "member")
         expected = {
             self.author: [
-                "change_resourcebase",
-                "change_resourcebase_metadata",
                 "delete_resourcebase",
                 "download_resourcebase",
                 "view_resourcebase",
-                "publish_resourcebase",
                 "change_resourcebase_permissions"
             ],
             self.group_manager: ["download_resourcebase", "view_resourcebase"],
@@ -2474,12 +2459,9 @@ class SetPermissionsTestCase(GeoNodeBaseTestSupport):
         self.assertEqual(sut.role, "manager")
         expected = {
             self.author: [
-                "change_resourcebase",
-                "change_resourcebase_metadata",
                 "delete_resourcebase",
                 "download_resourcebase",
                 "view_resourcebase",
-                "publish_resourcebase",
                 "change_resourcebase_permissions"
             ],
             self.group_manager: [
@@ -2643,7 +2625,7 @@ class TestPermissionChanges(GeoNodeBaseTestSupport):
         resource_perm_specs = self.resource.get_all_level_info()
         self.assertSetEqual(
             set(resource_perm_specs['users'][self.author]),
-            set(self.owner_perms + self.edit_perms + self.dataset_perms))
+            set(self.owner_perms + self.dataset_perms))
         self.assertSetEqual(
             set(resource_perm_specs['users'][self.member_with_perms]),
             set(self.owner_perms + self.dataset_perms))

--- a/geonode/security/tests.py
+++ b/geonode/security/tests.py
@@ -1172,6 +1172,12 @@ class SecurityTests(ResourceTestCaseMixin, GeoNodeBaseTestSupport):
         # Set the Permissions
         layer.set_permissions(self.perm_spec)
 
+        # Test that the Permissions for anonymous user is are set
+        self.assertFalse(
+            self.anonymous_user.has_perm(
+                'view_resourcebase',
+                layer.get_self_resource()))
+
         # Test that previous permissions for users other than ones specified in
         # the perm_spec (and the layers owner) were removed
         current_perms = layer.get_all_level_info()

--- a/geonode/security/tests.py
+++ b/geonode/security/tests.py
@@ -2111,10 +2111,10 @@ class SetPermissionsTestCase(GeoNodeBaseTestSupport):
                         "publish_resourcebase",
                         "view_resourcebase",
                     ],
-                    self.group_manager: ["view_resourcebase", "download_resourcebase"],
-                    self.group_member: ["view_resourcebase", "download_resourcebase"],
-                    self.not_group_member: ["view_resourcebase", "download_resourcebase"],
-                    self.anonymous_user: ["view_resourcebase", "download_resourcebase"],
+                    self.group_manager: [],
+                    self.group_member: [],
+                    self.not_group_member: [],
+                    self.anonymous_user: [],
                 },
             ),
             (
@@ -2132,14 +2132,14 @@ class SetPermissionsTestCase(GeoNodeBaseTestSupport):
                         "publish_resourcebase",
                         "view_resourcebase",
                     ],
-                    self.group_manager: ["view_resourcebase", "download_resourcebase"],
-                    self.group_member: ["view_resourcebase", "download_resourcebase"],
+                    self.group_manager: ["view_resourcebase"],
+                    self.group_member: ["view_resourcebase"],
                     self.not_group_member: [
-                        "download_resourcebase",
                         "change_resourcebase",
                         "view_resourcebase",
+                        "download_resourcebase"
                     ],
-                    self.anonymous_user: ["view_resourcebase", "download_resourcebase"],
+                    self.anonymous_user: ["view_resourcebase"],
                 },
             ),
         ]
@@ -2306,10 +2306,10 @@ class SetPermissionsTestCase(GeoNodeBaseTestSupport):
                         "publish_resourcebase",
                         "view_resourcebase",
                     ],
-                    self.group_manager: ["view_resourcebase", "download_resourcebase"],
-                    self.group_member: ["view_resourcebase", "download_resourcebase"],
-                    self.not_group_member: ["view_resourcebase", "download_resourcebase"],
-                    self.anonymous_user: ["view_resourcebase", "download_resourcebase"],
+                    self.group_manager: [],
+                    self.group_member: [],
+                    self.not_group_member: [],
+                    self.anonymous_user: [],
                 },
             ),
             (
@@ -2324,10 +2324,10 @@ class SetPermissionsTestCase(GeoNodeBaseTestSupport):
                         "publish_resourcebase",
                         "view_resourcebase",
                     ],
-                    self.group_manager: ["view_resourcebase", "download_resourcebase"],
-                    self.group_member: ["view_resourcebase", "download_resourcebase"],
-                    self.not_group_member: ["view_resourcebase", "download_resourcebase", "change_resourcebase"],
-                    self.anonymous_user: ["view_resourcebase", "download_resourcebase"],
+                    self.group_manager: ["view_resourcebase"],
+                    self.group_member: ["view_resourcebase"],
+                    self.not_group_member: ["view_resourcebase", "change_resourcebase"],
+                    self.anonymous_user: ["view_resourcebase"],
                 },
             ),
         ]
@@ -2512,15 +2512,15 @@ class TestPermissionChanges(GeoNodeBaseTestSupport):
 
     def setUp(self):
         # Creating groups
-        self.author, created = get_user_model().objects.get_or_create(username="author")
-        self.group_manager, created = get_user_model().objects.get_or_create(username="group_manager")
-        self.resource_group_manager, created = get_user_model().objects.get_or_create(username="resource_group_manager")
-        self.group_member, created = get_user_model().objects.get_or_create(username="group_member")
-        self.member_with_perms, created = get_user_model().objects.get_or_create(username="member_with_perms")
+        self.author, _ = get_user_model().objects.get_or_create(username="author")
+        self.group_manager, _ = get_user_model().objects.get_or_create(username="group_manager")
+        self.resource_group_manager, _ = get_user_model().objects.get_or_create(username="resource_group_manager")
+        self.group_member, _ = get_user_model().objects.get_or_create(username="group_member")
+        self.member_with_perms, _ = get_user_model().objects.get_or_create(username="member_with_perms")
 
         # Defining group profiles and members
-        self.owner_group, created = GroupProfile.objects.get_or_create(slug="owner_group")
-        self.resource_group, created = GroupProfile.objects.get_or_create(slug="resource_group")
+        self.owner_group, _ = GroupProfile.objects.get_or_create(slug="owner_group")
+        self.resource_group, _ = GroupProfile.objects.get_or_create(slug="resource_group")
 
         # defining group members
         GroupMember.objects.get_or_create(group=self.owner_group, user=self.author, role="member")

--- a/geonode/security/utils.py
+++ b/geonode/security/utils.py
@@ -183,7 +183,7 @@ def get_resources_with_perms(user, filter_options={}, shortcut_kwargs={}):
         private_groups_not_visibile=settings.GROUP_PRIVATE_RESOURCES)
 
     if filter_options:
-        if resources_with_perms and resources_with_perms.count() > 0:
+        if resources_with_perms and resources_with_perms.exists():
             if filter_options.get('title_filter'):
                 resources_with_perms = resources_with_perms.filter(
                     title__icontains=filter_options.get('title_filter')
@@ -235,10 +235,9 @@ def get_user_groups(owner, group=None):
     """
     Returns all the groups belonging to the "owner"
     """
-    user_groups = Group.objects.filter(
-        name__in=owner.groupmember_set.all().values_list("group__slug", flat=True))
+    user_groups = Group.objects.filter(name__in=owner.groupmember_set.values_list("group__slug", flat=True))
     if group:
-        user_groups = set([_g for _g in user_groups.iterator()] + [group.group if hasattr(group, 'group') else group])
+        user_groups = chain(user_groups, [group.group if hasattr(group, 'group') else group])
     return list(set(user_groups))
 
 

--- a/geonode/security/utils.py
+++ b/geonode/security/utils.py
@@ -21,8 +21,6 @@ import json
 import logging
 import collections
 from itertools import chain
-from math import perm
-from multiprocessing import managers
 
 from django.apps import apps
 from django.db.models import Q
@@ -39,11 +37,9 @@ from geonode.security.permissions import (
     PermSpecCompact,
     VIEW_PERMISSIONS,
     ADMIN_PERMISSIONS,
-    MANAGE_PERMISSIONS,
     SERVICE_PERMISSIONS,
     DOWNLOAD_PERMISSIONS,
     DOWNLOADABLE_RESOURCES,
-    BASIC_MANAGE_PERMISSIONS,
     DATASET_ADMIN_PERMISSIONS,
     DATASET_EDIT_DATA_PERMISSIONS,
     DATASET_EDIT_STYLE_PERMISSIONS,

--- a/geonode/security/utils.py
+++ b/geonode/security/utils.py
@@ -516,6 +516,7 @@ class AdvancedSecurityWorkflowManager:
             # Computing the OWNER Permissions
             prev_perms = _perm_spec['users'].get(_resource.owner, []) if isinstance(_perm_spec['users'], dict) else []
             prev_perms += AdminViewPermissionsSet.view_perms.copy() + AdminViewPermissionsSet.admin_perms.copy()
+            prev_perms = list(set(prev_perms))
             if not AdvancedSecurityWorkflowManager.is_auto_publishing_workflow():
                 # Check if owner is a manager of any group and add admin_manager_perms accordingly
                 if _resource.owner not in ResourceGroupsAndMembersSet.managers:
@@ -533,12 +534,14 @@ class AdvancedSecurityWorkflowManager:
                     for user in ResourceGroupsAndMembersSet.managers:
                         prev_perms = _perm_spec["users"].get(user, []) if "users" in _perm_spec else []
                         prev_perms += AdminViewPermissionsSet.view_perms.copy() + AdminViewPermissionsSet.admin_perms.copy()
+                        prev_perms = list(set(prev_perms))
                         _perm_spec["users"][user] = list(set(prev_perms))
 
                 if ResourceGroupsAndMembersSet.resource_groups:
                     for group in ResourceGroupsAndMembersSet.resource_groups:
                         prev_perms = _perm_spec["groups"].get(group, []) if "groups" in _perm_spec else []
                         prev_perms += AdminViewPermissionsSet.view_perms.copy()
+                        prev_perms = list(set(prev_perms))
                         _perm_spec["groups"][group] = list(set(prev_perms))
                 elif len(_perm_spec["groups"]):
                     groups = copy.deepcopy(_perm_spec["groups"])
@@ -560,6 +563,7 @@ class AdvancedSecurityWorkflowManager:
                 prev_perms = _perm_spec['groups'].get(ResourceGroupsAndMembersSet.anonymous_group, []) if isinstance(_perm_spec['groups'], dict) else []
                 if approval_status_changed and (_resource.is_approved or _resource.is_published):
                     prev_perms += AdminViewPermissionsSet.view_perms.copy()
+                    prev_perms = list(set(prev_perms))
                 if created:
                     if not AdvancedSecurityWorkflowManager.is_anonymous_can_view():
                         safe_remove(prev_perms, 'view_resourcebase')
@@ -576,6 +580,7 @@ class AdvancedSecurityWorkflowManager:
                 prev_perms = _perm_spec['groups'].get(ResourceGroupsAndMembersSet.registered_members_group, []) if isinstance(_perm_spec['groups'], dict) else []
                 if approval_status_changed and (_resource.is_approved or _resource.is_published):
                     prev_perms += AdminViewPermissionsSet.view_perms.copy()
+                    prev_perms = list(set(prev_perms))
                 if not AdvancedSecurityWorkflowManager.is_auto_publishing_workflow() and not _resource.is_approved:
                     safe_remove(prev_perms, 'view_resourcebase')
                     safe_remove(prev_perms, 'download_resourcebase')
@@ -701,6 +706,7 @@ class AdvancedSecurityWorkflowManager:
                             perm_spec["groups"].pop(_group.group)
                 elif role == "manager":
                     prev_perms += AdminViewPermissionsSet.admin_perms.copy()
+                    prev_perms = list(set(prev_perms))
                 perm_spec["users"][user] = list(set(prev_perms))
 
                 # Let's the ResourceManager finally decide which are the correct security settings to apply

--- a/geonode/security/utils.py
+++ b/geonode/security/utils.py
@@ -376,6 +376,44 @@ class AdvancedSecurityWorkflowManager:
         return not settings.RESOURCE_PUBLISHING and settings.ADMIN_MODERATE_UPLOADS
 
     @staticmethod
+    def is_allowed_to_approve(user, resource):
+        ResourceGroupsAndMembersSet = AdvancedSecurityWorkflowManager.compute_resource_groups_and_members_set(
+            resource.uuid, instance=resource, group=resource.group)
+        is_superuser = user.is_superuser
+        is_owner = user == resource.owner
+        is_manager = user in ResourceGroupsAndMembersSet.managers
+
+        can_change_metadata = user.has_perm(
+            'change_resourcebase_metadata',
+            resource.get_self_resource())
+
+        if is_superuser:
+            return True
+        elif AdvancedSecurityWorkflowManager.is_admin_moderate_mode():
+            return is_manager and can_change_metadata
+        else:
+            return is_owner or is_manager or can_change_metadata
+
+    @staticmethod
+    def is_allowed_to_publish(user, resource):
+        ResourceGroupsAndMembersSet = AdvancedSecurityWorkflowManager.compute_resource_groups_and_members_set(
+            resource.uuid, instance=resource, group=resource.group)
+        is_superuser = user.is_superuser
+        is_owner = user == resource.owner
+        is_manager = user in ResourceGroupsAndMembersSet.managers
+
+        can_publish = user.has_perm(
+            'publish_resourcebase',
+            resource.get_self_resource())
+
+        if is_superuser:
+            return True
+        elif AdvancedSecurityWorkflowManager.is_manager_publish_mode():
+            return is_manager and can_publish
+        else:
+            return is_owner or is_manager or can_publish
+
+    @staticmethod
     def assignable_perm_condition(perm, resource_type):
         _assignable_perm_policy_condition = (perm in DOWNLOAD_PERMISSIONS and resource_type in DOWNLOADABLE_RESOURCES) or \
             (perm in DATASET_EDIT_DATA_PERMISSIONS and resource_type in DATA_EDITABLE_RESOURCES_SUBTYPES) or \

--- a/geonode/security/utils.py
+++ b/geonode/security/utils.py
@@ -481,7 +481,7 @@ class AdvancedSecurityWorkflowManager:
                 # Check if owner is a manager of any group and add admin_manager_perms accordingly
                 if _resource.owner not in ResourceGroupsAndMembersSet.managers:
                     prev_perms.remove('publish_resourcebase')
-                    if not AdvancedSecurityWorkflowManager.is_simple_publishing_workflow() and not (_resource.is_approved or _resource.is_published):
+                    if not AdvancedSecurityWorkflowManager.is_simple_publishing_workflow() and (_resource.is_approved or _resource.is_published):
                         prev_perms.remove('change_resourcebase')
                         prev_perms.remove('change_resourcebase_metadata')
                     if AdvancedSecurityWorkflowManager.is_advanced_workflow():

--- a/geonode/security/utils.py
+++ b/geonode/security/utils.py
@@ -334,7 +334,7 @@ class AdvancedSecurityWorkflowManager:
               - Group MANAGERS of the *resource's group* will get the owner permissions (`publish_resource` EXCLUDED)
               - Group MEMBERS of the *resource's group* will get the `view_resourcebase`, `download_resourcebase` permission
         """
-        return settings.RESOURCE_PUBLISHING and not settings.ADMIN_MODERATE_UPLOADS
+        return not settings.RESOURCE_PUBLISHING and settings.ADMIN_MODERATE_UPLOADS
 
     @staticmethod
     def is_advanced_workflow():
@@ -372,7 +372,7 @@ class AdvancedSecurityWorkflowManager:
               - Group MEMBERS of the user's group will get the `view_resourcebase`, `download_resourcebase` permission
               - ANONYMOUS can view and download
         """
-        return not settings.RESOURCE_PUBLISHING and settings.ADMIN_MODERATE_UPLOADS
+        return settings.RESOURCE_PUBLISHING and not settings.ADMIN_MODERATE_UPLOADS
 
     @staticmethod
     def is_allowed_to_approve(user, resource):
@@ -638,16 +638,16 @@ class AdvancedSecurityWorkflowManager:
         _resource = instance or AdvancedSecurityWorkflowManager.get_instance(uuid)
 
         if _resource:
-            if AdvancedSecurityWorkflowManager.is_admin_moderate_mode():
+            if not AdvancedSecurityWorkflowManager.is_auto_publishing_workflow():
                 _resource.is_approved = False
                 _resource.was_approved = False
-                _resource.get_real_instance_class().objects.filter(
-                    uuid=_resource.get_real_instance().uuid).update(is_approved=False, was_approved=False)
-            if AdvancedSecurityWorkflowManager.is_manager_publish_mode():
                 _resource.is_published = False
                 _resource.was_published = False
+
                 _resource.get_real_instance_class().objects.filter(
-                    uuid=_resource.get_real_instance().uuid).update(is_published=False, was_published=False)
+                    uuid=_resource.uuid).update(
+                        is_approved=False, was_approved=False,
+                        is_published=False, was_published=False)
 
         return _resource
 

--- a/geonode/security/utils.py
+++ b/geonode/security/utils.py
@@ -468,6 +468,8 @@ class AdvancedSecurityWorkflowManager:
         _resource = instance or AdvancedSecurityWorkflowManager.get_instance(uuid)
         _perm_spec = copy.deepcopy(perm_spec)
 
+        def safe_remove(perms, perm): perms.remove(perm) if perm in perms else None
+
         if _resource:
             _resource = _resource.get_real_instance()
 
@@ -480,12 +482,12 @@ class AdvancedSecurityWorkflowManager:
             if not AdvancedSecurityWorkflowManager.is_auto_publishing_workflow():
                 # Check if owner is a manager of any group and add admin_manager_perms accordingly
                 if _resource.owner not in ResourceGroupsAndMembersSet.managers:
-                    prev_perms.remove('publish_resourcebase')
+                    safe_remove(prev_perms, 'publish_resourcebase')
                     if not AdvancedSecurityWorkflowManager.is_simple_publishing_workflow() and (_resource.is_approved or _resource.is_published):
-                        prev_perms.remove('change_resourcebase')
-                        prev_perms.remove('change_resourcebase_metadata')
+                        safe_remove(prev_perms, 'change_resourcebase')
+                        safe_remove(prev_perms, 'change_resourcebase_metadata')
                     if AdvancedSecurityWorkflowManager.is_advanced_workflow():
-                        prev_perms.remove('change_resourcebase_permissions')
+                        safe_remove(prev_perms, 'change_resourcebase_permissions')
             _perm_spec['users'][_resource.owner] = list(set(prev_perms))
 
             # Computing the MANAGERs and MEMBERs Permissions
@@ -523,14 +525,14 @@ class AdvancedSecurityWorkflowManager:
                     prev_perms += AdminViewPermissionsSet.view_perms.copy()
                 if created:
                     if not AdvancedSecurityWorkflowManager.is_anonymous_can_view():
-                        prev_perms.remove('view_resourcebase')
+                        safe_remove(prev_perms, 'view_resourcebase')
                     if not AdvancedSecurityWorkflowManager.is_anonymous_can_download():
-                        prev_perms.remove('download_resourcebase')
+                        safe_remove(prev_perms, 'download_resourcebase')
                 if not AdvancedSecurityWorkflowManager.is_auto_publishing_workflow():
                     if (AdvancedSecurityWorkflowManager.is_simple_publishing_workflow() or AdvancedSecurityWorkflowManager.is_advanced_workflow() and not _resource.is_published) or (
                             AdvancedSecurityWorkflowManager.is_simplified_workflow() and not (_resource.is_approved or _resource.is_published)):
-                        prev_perms.remove('view_resourcebase')
-                        prev_perms.remove('download_resourcebase')
+                        safe_remove(prev_perms, 'view_resourcebase')
+                        safe_remove(prev_perms, 'download_resourcebase')
             _perm_spec['groups'][ResourceGroupsAndMembersSet.anonymous_group] = list(set(prev_perms))
 
             if ResourceGroupsAndMembersSet.registered_members_group and getattr(groups_settings, 'AUTO_ASSIGN_REGISTERED_MEMBERS_TO_REGISTERED_MEMBERS_GROUP_NAME', False):
@@ -538,8 +540,8 @@ class AdvancedSecurityWorkflowManager:
                 if approval_status_changed and (_resource.is_approved or _resource.is_published):
                     prev_perms += AdminViewPermissionsSet.view_perms.copy()
                 if not AdvancedSecurityWorkflowManager.is_auto_publishing_workflow() and not _resource.is_approved:
-                    prev_perms.remove('view_resourcebase')
-                    prev_perms.remove('download_resourcebase')
+                    safe_remove(prev_perms, 'view_resourcebase')
+                    safe_remove(prev_perms, 'download_resourcebase')
                 _perm_spec['groups'][ResourceGroupsAndMembersSet.registered_members_group] = list(set(prev_perms))
 
         return _perm_spec

--- a/geonode/services/tests.py
+++ b/geonode/services/tests.py
@@ -851,7 +851,7 @@ class WmsServiceHandlerTestCase(GeoNodeBaseTestSupport):
             self.assertEqual(s.description, 'Foo Description')
             self.assertEqual(s.abstract, 'Foo Abstract')
             self.assertEqual(['Foo', 'OWS', 'Service'],
-                             list(s.keywords.all().values_list('name', flat=True)))
+                             list(s.keywords.values_list('name', flat=True)))
             response = self.client.post(reverse('remove_service', args=(s.id,)))
             self.assertEqual(len(Service.objects.all()), 0)
 

--- a/geonode/storage/manager.py
+++ b/geonode/storage/manager.py
@@ -17,6 +17,8 @@
 #
 #########################################################################
 import os
+import shutil
+import logging
 import importlib
 
 from uuid import uuid1
@@ -32,6 +34,8 @@ from . import settings as sm_settings
 from abc import ABCMeta, abstractmethod
 from django.core.files.storage import FileSystemStorage
 
+logger = logging.getLogger(__name__)
+
 
 class StorageManagerInterface(metaclass=ABCMeta):
 
@@ -46,6 +50,37 @@ class StorageManagerInterface(metaclass=ABCMeta):
     @abstractmethod
     def listdir(self, path):
         pass
+
+    def rmtree(self, path, ignore_errors=False):
+        if self.exists(path):
+            _dirs, _files = self.listdir(path)
+            for _entry in _files:
+                _entry_path = os.path.join(path, _entry)
+                if self.exists(_entry_path):
+                    try:
+                        self.delete(_entry_path)
+                    except Exception as e:
+                        if ignore_errors:
+                            logger.exception(e)
+                        else:
+                            raise
+            for _entry in _dirs:
+                _entry_path = os.path.join(path, _entry)
+                if self.exists(_entry_path):
+                    try:
+                        self.delete(_entry_path)
+                    except Exception as e:
+                        if ignore_errors:
+                            logger.exception(e)
+                        else:
+                            raise
+            try:
+                self.delete(path)
+            except Exception as e:
+                if ignore_errors:
+                    logger.exception(e)
+                else:
+                    raise
 
     @abstractmethod
     def open(self, name, mode='rb'):
@@ -98,6 +133,9 @@ class StorageManager(StorageManagerInterface):
 
     def listdir(self, path):
         return self._concrete_storage_manager.listdir(path)
+
+    def rmtree(self, path, ignore_errors=False):
+        return self._concrete_storage_manager.rmtree(path, ignore_errors=ignore_errors)
 
     def open(self, name, mode='rb'):
         return self._concrete_storage_manager.open(name, mode=mode)
@@ -187,6 +225,10 @@ class DefaultStorageManager(StorageManagerInterface):
 
     def listdir(self, path):
         return self._fsm.listdir(path)
+
+    def rmtree(self, path, ignore_errors=False):
+        if os.path.exists(path):
+            shutil.rmtree(path, ignore_errors=ignore_errors)
 
     def open(self, name, mode='rb'):
         try:

--- a/geonode/storage/tests.py
+++ b/geonode/storage/tests.py
@@ -23,6 +23,7 @@ from unittest.mock import patch
 
 from django.test.testcases import SimpleTestCase, TestCase
 
+from geonode.utils import mkdtemp
 from geonode.storage.aws import AwsStorageManager
 from geonode.storage.manager import StorageManager
 from geonode.storage.gcs import GoogleStorageManager
@@ -395,3 +396,35 @@ class TestStorageManager(TestCase):
         with open('geonode/base/fixtures/test_sld.sld') as new_file:
             output = self.sut().replace(dataset, new_file)
         self.assertListEqual([expected], output['files'])
+
+    def test_storage_manager_rmtree(self):
+        '''
+        Will test that the rmtree function works as expected
+        '''
+        _dirs = [
+            'subdir1',
+            'subdir2',
+            'subdir1/subsubdir1'
+        ]
+        _files = [
+            'subdir1/tmp_file1',
+            'subdir1/tmp_file2',
+            'subdir2/tmp_file2',
+            'subdir1/subsubdir1/tmp_file11'
+        ]
+        _tmpdir = mkdtemp()
+
+        for _dir in _dirs:
+            if not os.path.exists(os.path.join(_tmpdir, _dir)):
+                os.makedirs(os.path.join(_tmpdir, _dir))
+            self.assertTrue(os.path.exists(os.path.join(_tmpdir, _dir)))
+            self.assertTrue(os.path.isdir(os.path.join(_tmpdir, _dir)))
+
+        for _file in _files:
+            with open(os.path.join(_tmpdir, _file), 'wb+'):
+                pass
+            self.assertTrue(os.path.exists(os.path.join(_tmpdir, _file)))
+            self.assertTrue(os.path.isfile(os.path.join(_tmpdir, _file)))
+
+        self.sut().rmtree(_tmpdir)
+        self.assertFalse(os.path.exists(_tmpdir))

--- a/geonode/tests/utils.py
+++ b/geonode/tests/utils.py
@@ -370,7 +370,7 @@ if has_notifications:
             """
             # with queued notifications we can detect notification types easier
             if settings.PINAX_NOTIFICATIONS_QUEUE_ALL:
-                self.assertTrue(NoticeQueueBatch.objects.all().count() > 0)
+                self.assertTrue(NoticeQueueBatch.objects.all().exists())
 
                 user.noticesetting_set.get(notice_type__label=notification_name)
                 # we're looking for specific notification type/user combination, which is probably

--- a/geonode/thumbs/thumbnails.py
+++ b/geonode/thumbs/thumbnails.py
@@ -109,7 +109,7 @@ def create_thumbnail(
     is_map_with_datasets = False
 
     if isinstance(instance, Map):
-        is_map_with_datasets = MapLayer.objects.filter(map=instance, local=True).exclude(dataset=None).count() > 0
+        is_map_with_datasets = MapLayer.objects.filter(map=instance, local=True).exclude(dataset=None).exists()
     if bbox:
         bbox = utils.clean_bbox(bbox, target_crs)
     elif instance.ll_bbox_polygon:
@@ -294,11 +294,11 @@ def _datasets_locations(
             workspace = get_dataset_workspace(map_dataset)
             map_dataset_style = map_dataset.current_style
 
-            if store and Dataset.objects.filter(store=store, workspace=workspace, name=name).count() > 0:
+            if store and Dataset.objects.filter(store=store, workspace=workspace, name=name).exists():
                 dataset = Dataset.objects.filter(store=store, workspace=workspace, name=name).first()
-            elif workspace and Dataset.objects.filter(workspace=workspace, name=name).count() > 0:
+            elif workspace and Dataset.objects.filter(workspace=workspace, name=name).exists():
                 dataset = Dataset.objects.filter(workspace=workspace, name=name).first()
-            elif Dataset.objects.filter(alternate=map_dataset.name).count() > 0:
+            elif Dataset.objects.filter(alternate=map_dataset.name).exists():
                 dataset = Dataset.objects.filter(alternate=map_dataset.name).first()
             else:
                 logger.warning(f"Dataset for MapLayer {name} was not found. Skipping it in the thumbnail.")

--- a/geonode/upload/tests/integration.py
+++ b/geonode/upload/tests/integration.py
@@ -454,7 +454,7 @@ class TestUpload(UploaderBase):
                 "No 'original' and 'metadata' links have been found"
             )
             self.assertTrue(
-                _links.count() > 0,
+                _links.exists(),
                 "No 'original' and 'metadata' links have been found"
             )
             # Check original links in csw_anytext

--- a/geonode/views.py
+++ b/geonode/views.py
@@ -103,7 +103,7 @@ def ajax_lookup(request):
             Q(title__icontains=keyword) |
             Q(slug__icontains=keyword)).exclude(
                 Q(access='private') & ~Q(
-                    slug__in=request.user.groupmember_set.all().values_list("group__slug", flat=True))
+                    slug__in=request.user.groupmember_set.values_list("group__slug", flat=True))
         )
     json_dict = {
         'users': [({'username': u.username}) for u in users],


### PR DESCRIPTION
References: #9013

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [x] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
