### PR TITLE
[Fixes #9042] Disable caching header in GeoNode proxy for the REST API

### DIFF
--- a/geonode/geoserver/tests/test_server.py
+++ b/geonode/geoserver/tests/test_server.py
@@ -1273,3 +1273,10 @@ attribute of the layer '{_lyr.alternate}'"
                         _post_migrate_link_meta,
                         f"No '{name}' links have been found in the catalogue for the resource '{_lyr.alternate}'"
                     )
+
+    @on_ogc_backend(geoserver.BACKEND_PACKAGE)
+    def test_gs_proxy_never_caches(self):
+        url = reverse('gs_styles')
+        response = self.client.get(url)
+        self.assertTrue(response.has_header('Cache-Control'))
+        self.assertEqual(response.headers.get('Cache-Control'), 'max-age=0, no-cache, no-store, must-revalidate, private')

--- a/geonode/geoserver/views.py
+++ b/geonode/geoserver/views.py
@@ -81,7 +81,7 @@ from .helpers import (
     _invalidate_geowebcache_dataset)
 
 from django.views.decorators.csrf import csrf_exempt
-from django.views.decorators.cache import cache_control
+from django.views.decorators.cache import never_cache
 
 logger = logging.getLogger(__name__)
 
@@ -464,7 +464,7 @@ def check_geoserver_access(request,
 
 
 @csrf_exempt
-@cache_control(public=True, must_revalidate=True, max_age=30)
+@never_cache
 def geoserver_proxy(request,
                     proxy_path,
                     downstream_path,


### PR DESCRIPTION
References: #9042

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
