### PR TITLE
[Fixes #9092] The Upload Workflow never updates the Resource files

### DIFF
--- a/geonode/upload/models.py
+++ b/geonode/upload/models.py
@@ -148,15 +148,16 @@ class Upload(models.Model):
         if not self.upload_dir:
             self.upload_dir = os.path.dirname(upload_session.base_file)
 
-        if resource and not self.resource:
-            if not isinstance(resource, ResourceBase) and hasattr(resource, 'resourcebase_ptr'):
-                self.resource = resource.resourcebase_ptr
-            elif not isinstance(resource, ResourceBase):
-                raise GeoNodeException("Invalid resource uploaded, plase select one of the available")
-            else:
-                self.resource = resource
+        if resource:
+            if not self.resource:
+                if not isinstance(resource, ResourceBase) and hasattr(resource, 'resourcebase_ptr'):
+                    self.resource = resource.resourcebase_ptr
+                elif not isinstance(resource, ResourceBase):
+                    raise GeoNodeException("Invalid resource uploaded, plase select one of the available")
+                else:
+                    self.resource = resource
 
-            if upload_session.base_file and self.resource and self.resource.title:
+            if upload_session.base_file and len(self.resource.files) == 0:
                 uploaded_files = upload_session.base_file[0]
                 aux_files = uploaded_files.auxillary_files
                 sld_files = uploaded_files.sld_files

--- a/geonode/upload/upload.py
+++ b/geonode/upload/upload.py
@@ -871,20 +871,16 @@ def final_step(upload_session, user, charset="UTF-8", dataset_id=None):
                     else:
                         raise GeneralUploadException(detail=f"There's an incosistent number of Datasets on the DB for {task.layer.name}")
 
-                assert _upload
                 assert saved_dataset
 
-                _upload.resource = saved_dataset
-                _upload.save()
+                # Update the state from session...
+                upload_session = Upload.objects.update_from_session(upload_session, resource=saved_dataset)
 
                 if not created:
                     return saved_dataset
 
                 # Hide the dataset until the upload process finishes...
                 saved_dataset.set_dirty_state()
-
-                # Update the state from session...
-                upload_session = Upload.objects.update_from_session(upload_session, resource=saved_dataset)
 
                 # Finalize the upload...
                 # Set default permissions on the newly created layer and send notifications


### PR DESCRIPTION
References: #9092

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [ ] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [ ] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
