### PR TITLE
[Fixes #9101] Keywords filter only returns the root nodes of the tree

### DIFF
--- a/geonode/base/api/tests.py
+++ b/geonode/base/api/tests.py
@@ -1636,6 +1636,80 @@ class BaseApiTests(APITestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data['total'], 0)
 
+        # Testing Hierarchical Keywords tree
+        try:
+            HierarchicalKeyword.objects.filter(slug__in=['a', 'a1', 'a2', 'b', 'b1']).delete()
+            HierarchicalKeyword.add_root(name='a')
+            HierarchicalKeyword.add_root(name='b')
+            a = HierarchicalKeyword.objects.get(slug='a')
+            b = HierarchicalKeyword.objects.get(slug='b')
+            a.add_child(name='a1')
+            a.add_child(name='a2')
+            b.add_child(name='b1')
+            resources = ResourceBase.objects.filter(owner__username='bobby')
+            res1 = resources.first()
+            res2 = resources.last()
+            self.assertNotEqual(res1, res2)
+            res1.keywords.add(HierarchicalKeyword.objects.get(slug='a1'))
+            res1.keywords.add(HierarchicalKeyword.objects.get(slug='a2'))
+            res2.keywords.add(HierarchicalKeyword.objects.get(slug='b1'))
+            resource_keywords = HierarchicalKeyword.resource_keywords_tree(bobby)
+            logger.error(resource_keywords)
+
+            """
+            Final api outcome will be something like
+            [
+                {
+                    'id': 116,
+                    'text': 'a',
+                    'href': 'a',
+                    'tags': [],
+                    'nodes': [
+                        {
+                            'id': 118,
+                            'text': 'a1',
+                            'href': 'a1',
+                            'tags': [1]
+                        },
+                        {
+                            'id': 119,
+                            'text': 'a2',
+                            'href': 'a2',
+                            'tags': [1]
+                        }
+                    ]
+                },
+                {
+                    'id': 117,
+                    'text': 'b',
+                    'href': 'b',
+                    'tags': [],
+                    'nodes': [
+                        {
+                            'id': 120,
+                            'text': 'b1',
+                            'href': 'b1',
+                            'tags': [1]
+                        }
+                    ]
+                },
+                ...
+            ]
+            """
+            url = reverse('keywords-list')
+            # Authenticated user
+            self.assertTrue(self.client.login(username='bobby', password='bob'))
+            response = self.client.get(url, format='json')
+            self.assertEqual(response.status_code, 200)
+            for _kw in response.data["keywords"]:
+                if _kw.get('href') in ['a', 'b']:
+                    self.assertListEqual(_kw.get('tags'), [], _kw.get('tags'))
+                    self.assertEqual(len(_kw.get('nodes')), 2)
+                    for _kw_child in _kw.get('nodes'):
+                        self.assertEqual(_kw_child.get('tags')[0], 1)
+        finally:
+            HierarchicalKeyword.objects.filter(slug__in=['a', 'a1', 'a2', 'b', 'b1']).delete()
+
     def test_tkeywords_list(self):
         """
         Ensure we can access the list of thasaurus keywords.

--- a/geonode/base/api/views.py
+++ b/geonode/base/api/views.py
@@ -228,7 +228,15 @@ class HierarchicalKeywordViewSet(WithDynamicViewSetMixin, ListModelMixin, Retrie
 
     def get_queryset(self):
         resource_keywords = HierarchicalKeyword.resource_keywords_tree(self.request.user)
-        slugs = [obj.get('href') for obj in resource_keywords]
+
+        def _get_kw_hrefs(keywords, slugs: list = []):
+            for obj in keywords:
+                if obj.get('tags', []):
+                    slugs.append(obj.get('href'))
+                _get_kw_hrefs(obj.get('nodes', []), slugs)
+            return slugs
+
+        slugs = _get_kw_hrefs(resource_keywords)
         return HierarchicalKeyword.objects.filter(slug__in=slugs)
 
     permission_classes = [AllowAny, ]

--- a/geonode/base/models.py
+++ b/geonode/base/models.py
@@ -421,6 +421,7 @@ class HierarchicalKeyword(TagBase, MP_Node):
                         node = node["nodes"][-1]
                     else:
                         node = item_found
+                        node["nodes"] = getattr(node, "nodes", [])
 
         # All leaves appended but a child which is not a leaf may not be added
         # again, as a leaf, but only its tag count be updated


### PR DESCRIPTION
References: #9101

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [ ] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [ ] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
