### PR TITLE
[Fixes #9148] switch from wikimedia to osm for thumbnail basemap

### DIFF
--- a/geonode/base/api/views.py
+++ b/geonode/base/api/views.py
@@ -228,7 +228,15 @@ class HierarchicalKeywordViewSet(WithDynamicViewSetMixin, ListModelMixin, Retrie
 
     def get_queryset(self):
         resource_keywords = HierarchicalKeyword.resource_keywords_tree(self.request.user)
-        slugs = [obj.get('href') for obj in resource_keywords]
+
+        def _get_kw_hrefs(keywords, slugs: list = []):
+            for obj in keywords:
+                if obj.get('tags', []):
+                    slugs.append(obj.get('href'))
+                _get_kw_hrefs(obj.get('nodes', []), slugs)
+            return slugs
+
+        slugs = _get_kw_hrefs(resource_keywords)
         return HierarchicalKeyword.objects.filter(slug__in=slugs)
 
     permission_classes = [AllowAny, ]

--- a/geonode/base/models.py
+++ b/geonode/base/models.py
@@ -421,6 +421,7 @@ class HierarchicalKeyword(TagBase, MP_Node):
                         node = node["nodes"][-1]
                     else:
                         node = item_found
+                        node["nodes"] = getattr(node, "nodes", [])
 
         # All leaves appended but a child which is not a leaf may not be added
         # again, as a leaf, but only its tag count be updated

--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -1977,8 +1977,8 @@ THUMBNAIL_SIZE = {
 
 THUMBNAIL_BACKGROUND = {
     # class generating thumbnail's background
-    'class': 'geonode.thumbs.background.WikiMediaTileBackground',
-    # 'class': 'geonode.thumbs.background.OSMTileBackground',
+    #'class': 'geonode.thumbs.background.WikiMediaTileBackground',
+    'class': 'geonode.thumbs.background.OSMTileBackground',
     # 'class': 'geonode.thumbs.background.GenericXYZBackground',
     # initialization parameters for generator instance, valid only for generic classes
     'options': {


### PR DESCRIPTION
ref #9148 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
