### PR TITLE
[Backport to 3.3.x][Fixes #9186] Upload marks as PROCESSED a resource not ready yet

### DIFF
--- a/geonode/base/models.py
+++ b/geonode/base/models.py
@@ -1384,7 +1384,7 @@ class ResourceBase(PolymorphicModel, PermissionLevelMixin, ItemBase):
     def set_processing_state(self, state):
         if state == "PROCESSED":
             self.clear_dirty_state()
-        else:
+        elif state == "INVALID":
             self.set_dirty_state()
 
     @property

--- a/geonode/upload/models.py
+++ b/geonode/upload/models.py
@@ -209,7 +209,9 @@ class Upload(models.Model):
         elif self.state == Upload.STATE_WAITING:
             return 50.0
         elif self.state == Upload.STATE_PROCESSED:
-            return 100.0
+            if self.layer and self.layer.processed:
+                return 100.0
+            return 80.0
         elif self.state in (Upload.STATE_COMPLETE, Upload.STATE_RUNNING):
             if self.layer and self.layer.processed and self.layer.instance_is_processed:
                 self.state = Upload.STATE_PROCESSED
@@ -249,7 +251,7 @@ class Upload(models.Model):
             return None
 
     def get_detail_url(self):
-        if self.layer and self.state == Upload.STATE_PROCESSED:
+        if self.layer and self.layer.processed:
             return getattr(self.layer, 'detail_url', None)
         else:
             return None

--- a/geonode/upload/tasks.py
+++ b/geonode/upload/tasks.py
@@ -206,20 +206,9 @@ def _update_upload_session_state(self, upload_session_id: int):
                                 _response = final_step_view(None, _upload.get_session)
                                 if _response:
                                     _upload.refresh_from_db()
-                                    _content = _response.content
-                                    if isinstance(_content, bytes):
-                                        _content = _content.decode('UTF-8')
-                                    _response_json = json.loads(_content)
-                                    _success = _response_json.get('success', False)
-                                    if _upload.state != Upload.STATE_PROCESSED:
-                                        if _upload.layer and _upload.layer.processed:
-                                            # GeoNode Layer successfully processed...
-                                            _upload.set_processing_state(Upload.STATE_PROCESSED)
-                                        else:
-                                            # GeoNode Layer updating...
-                                            _upload.set_processing_state(Upload.STATE_RUNNING)
-                            elif _upload.layer and _upload.layer.processed:
-                                _upload.set_processing_state(Upload.STATE_PROCESSED)
+                                    if _upload.state not in (Upload.STATE_PROCESSED, Upload.STATE_RUNNING) and not _upload.layer:
+                                        # GeoNode Layer still updating...
+                                        _upload.set_processing_state(Upload.STATE_RUNNING)
                         logger.debug(f"Upload {upload_session_id} updated with state {_upload.state}.")
                 except (NotFound, Exception) as e:
                     logger.exception(e)


### PR DESCRIPTION
References: #9186

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [ ] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [ ] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
