### PR TITLE
[Fixes #9202] PEP-440 compliant version

### DIFF
--- a/geonode/version.py
+++ b/geonode/version.py
@@ -23,30 +23,27 @@ import subprocess
 
 
 def get_version(version=None):
-    "Returns a PEP 386-compliant version number from VERSION."
+    "Returns a PEP 440 compliant version number from VERSION."
     if version is None or not isinstance(version, list):
         from geonode import __version__ as version
     else:
         assert len(version) == 5
-        assert version[3] in ('unstable', 'beta', 'rc', 'final', 'post')
+        assert version[3] in ('rc', 'post', 'dev')
 
-    # Now build the two parts of the version number:
-    # main = X.Y[.Z]
-    # sub = .devN - for pre-alpha releases
-    #     | {a|b|c}N - for alpha, beta and rc releases
-    git_changeset = get_git_changeset()
+    # [N!]N(.N)*[{a|b|rc}N][.postN][.devN]
+    # Epoch segment: N!
+    # Release segment: N(.N)*
+    # Pre-release segment: {a|b|rc}N
+    # Post-release segment: .postN
+    # Development release segment: .devN
     main = '.'.join(str(x) for x in version[:3])
-    sub = ''
-    if version[3] not in ('unstable', 'final', 'post'):
-        mapping = {'beta': 'b', 'rc': 'rc'}
-        sub = mapping[version[3]] + str(version[4])
-    if git_changeset:
-        if version[3] == 'unstable':
-            sub += f'.dev{git_changeset}'
-        elif version[3] == 'post':
-            sub += f'.post{version[4]}'
-        elif version[3] != 'final':
-            sub += f'.build{git_changeset}'
+    sub = version[3]
+    sub_version = str(version[4])
+    print(f'sub: {sub}')
+    if sub == 'rc':
+        sub += sub_version
+    else:
+        sub = '.' + sub + sub_version
     return main + sub
 
 

--- a/geonode/version.py
+++ b/geonode/version.py
@@ -39,7 +39,6 @@ def get_version(version=None):
     main = '.'.join(str(x) for x in version[:3])
     sub = version[3]
     sub_version = str(version[4])
-    print(f'sub: {sub}')
     if sub == 'rc':
         sub += sub_version
     else:

--- a/geonode/version.py
+++ b/geonode/version.py
@@ -28,7 +28,7 @@ def get_version(version=None):
         from geonode import __version__ as version
     else:
         assert len(version) == 5
-        assert version[3] in ('rc', 'post', 'dev')
+        assert version[3] in ('final', 'rc', 'post', 'dev')
 
     # [N!]N(.N)*[{a|b|rc}N][.postN][.devN]
     # Epoch segment: N!
@@ -41,8 +41,10 @@ def get_version(version=None):
     sub_version = str(version[4])
     if sub == 'rc':
         sub += sub_version
-    else:
+    elif sub in ['post', 'dev']:
         sub = '.' + sub + sub_version
+    else:
+        sub = ''
     return main + sub
 
 


### PR DESCRIPTION
ref #9202 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
