### PR TITLE
[Fixes #9210] Owner is still able to edit data and style after a resource has been approved and A/W is active

### DIFF
--- a/geonode/base/api/serializers.py
+++ b/geonode/base/api/serializers.py
@@ -84,7 +84,9 @@ class ResourceBaseToRepresentationSerializerMixin(DynamicModelSerializer):
         if request:
             data['perms'] = instance.get_user_perms(request.user).union(
                 instance.get_self_resource().get_user_perms(request.user)
-            )
+            ).union(
+                instance.get_real_instance().get_user_perms(request.user)
+            ).distinct()
             if not request.user.is_anonymous and getattr(settings, "FAVORITE_ENABLED", False):
                 favorite = Favorite.objects.filter(user=request.user, object_id=instance.pk).count()
                 data['favorite'] = favorite > 0

--- a/geonode/security/tests.py
+++ b/geonode/security/tests.py
@@ -2674,7 +2674,7 @@ class TestPermissionChanges(GeoNodeBaseTestSupport):
         resource_perm_specs = self.resource.get_all_level_info()
         self.assertSetEqual(
             set(resource_perm_specs['users'][self.author]),
-            set(self.owner_perms + self.layer_perms))
+            set(self.owner_perms))
         self.assertSetEqual(
             set(resource_perm_specs['users'][self.member_with_perms]),
             set(self.owner_perms + self.layer_perms))

--- a/geonode/security/utils.py
+++ b/geonode/security/utils.py
@@ -538,6 +538,8 @@ class AdvancedSecurityWorkflowManager:
                     if not AdvancedSecurityWorkflowManager.is_simple_publishing_workflow() and (_resource.is_approved or _resource.is_published):
                         safe_remove(prev_perms, 'change_resourcebase')
                         safe_remove(prev_perms, 'change_resourcebase_metadata')
+                        safe_remove(prev_perms, 'change_layer_style')
+                        safe_remove(prev_perms, 'change_layer_data')
                     if AdvancedSecurityWorkflowManager.is_advanced_workflow():
                         safe_remove(prev_perms, 'change_resourcebase_permissions')
             _perm_spec['users'][_resource.owner] = list(set(prev_perms))

--- a/geonode/security/utils.py
+++ b/geonode/security/utils.py
@@ -538,8 +538,9 @@ class AdvancedSecurityWorkflowManager:
                     if not AdvancedSecurityWorkflowManager.is_simple_publishing_workflow() and (_resource.is_approved or _resource.is_published):
                         safe_remove(prev_perms, 'change_resourcebase')
                         safe_remove(prev_perms, 'change_resourcebase_metadata')
-                        safe_remove(prev_perms, 'change_layer_style')
-                        safe_remove(prev_perms, 'change_layer_data')
+                        if _resource.polymorphic_ctype.model == "layer":
+                            safe_remove(prev_perms, 'change_layer_style')
+                            safe_remove(prev_perms, 'change_layer_data')
                     if AdvancedSecurityWorkflowManager.is_advanced_workflow():
                         safe_remove(prev_perms, 'change_resourcebase_permissions')
             _perm_spec['users'][_resource.owner] = list(set(prev_perms))


### PR DESCRIPTION
ref #9210 
## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
