### PR TITLE
Revert "[Fixes #9212] Login with basic auth or token headers or apikey GET parameter"

### DIFF
--- a/geonode/security/tests.py
+++ b/geonode/security/tests.py
@@ -295,60 +295,6 @@ class SecurityTests(ResourceTestCaseMixin, GeoNodeBaseTestSupport):
         self.assertEqual(response.status_code, 302)
 
     @on_ogc_backend(geoserver.BACKEND_PACKAGE)
-    def test_login_with_headers_middleware(self):
-        """
-        Tests the Geonode login with auth headers and apikey parameter
-        """
-        from django.contrib.sessions.middleware import SessionMiddleware
-        from geonode.security.middleware import LoginWithHeaderOrKeyMiddleware
-        from geonode.base.auth import create_auth_token
-        session_middleware = SessionMiddleware(None)
-        middleware = LoginWithHeaderOrKeyMiddleware(None)
-
-        standard_user = get_user_model().objects.get(username="bobby")
-        access_token = create_auth_token(standard_user)
-
-        request = HttpRequest()
-        request.user = get_anonymous_user()
-
-        request.path = reverse('maps_browse')
-        session_middleware.process_request(request)
-        middleware.process_request(request)
-        self.assertEqual(request.user, get_anonymous_user())
-
-        request = HttpRequest()
-        request.path = reverse('maps_browse')
-        request.user = get_anonymous_user()
-        request.META["HTTP_AUTHORIZATION"] = f'Basic {base64.b64encode(b"fake:fake").decode("utf-8")}'
-        session_middleware.process_request(request)
-        middleware.process_request(request)
-        self.assertEqual(request.user, get_anonymous_user())
-
-        request = HttpRequest()
-        request.path = reverse('maps_browse')
-        request.user = get_anonymous_user()
-        request.META["HTTP_AUTHORIZATION"] = f'Basic {base64.b64encode(b"bobby:bob").decode("utf-8")}'
-        session_middleware.process_request(request)
-        middleware.process_request(request)
-        self.assertEqual(request.user, standard_user)
-
-        request = HttpRequest()
-        request.path = reverse('maps_browse')
-        request.user = get_anonymous_user()
-        request.META["HTTP_AUTHORIZATION"] = f'Bearer {access_token.token}'
-        session_middleware.process_request(request)
-        middleware.process_request(request)
-        self.assertEqual(request.user, standard_user)
-
-        request = HttpRequest()
-        request.path = reverse('maps_browse')
-        request.user = get_anonymous_user()
-        request.GET['apikey'] = access_token.token
-        session_middleware.process_request(request)
-        middleware.process_request(request)
-        self.assertEqual(request.user, standard_user)
-
-    @on_ogc_backend(geoserver.BACKEND_PACKAGE)
     def test_attributes_sats_refresh(self):
         layers = Layer.objects.all()[:2].values_list('id', flat=True)
         test_layer = Layer.objects.get(id=layers[0])

--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -863,8 +863,6 @@ ACCESS_TOKEN_EXPIRE_SECONDS = int(os.getenv('ACCESS_TOKEN_EXPIRE_SECONDS', '8640
 # Require users to authenticate before using Geonode
 LOCKDOWN_GEONODE = ast.literal_eval(os.getenv('LOCKDOWN_GEONODE', 'False'))
 
-LOGIN_WITH_HEADER_OR_KEY = ast.literal_eval(os.getenv('LOGIN_WITH_HEADER_OR_KEY', 'False'))
-
 # Add additional paths (as regular expressions) that don't require
 # authentication.
 # - authorized exempt urls needed for oauth when GeoNode is set to lockdown
@@ -1936,11 +1934,6 @@ if NOTIFICATIONS_MODULE and NOTIFICATIONS_MODULE not in INSTALLED_APPS:
 # ########################################################################### #
 # SECURITY SETTINGS
 # ########################################################################### #
-
-# Creates a session from valid authentication headers (Basic Auth or Bearer Token) or apikey parameter (token)
-if LOGIN_WITH_HEADER_OR_KEY:
-    MIDDLEWARE += \
-        ('geonode.security.middleware.LoginWithHeaderOrKeyMiddleware',)
 
 # Require users to authenticate before using Geonode
 if LOCKDOWN_GEONODE:


### PR DESCRIPTION
This solution has several security implications. It will be kept on hold until a better approach will be found.