### PR TITLE
bump django-markdownify to 0.9.1 fixes #9263

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -39,7 +39,7 @@ django-filter==2.4.0
 django-imagekit==4.0.2
 django-jsonfield-backport>=1.0.2
 django-taggit==1.4.0
-django-markdownify==0.9.0
+django-markdownify==0.9.1
 django-mptt==0.12.0
 django-modeltranslation>=0.11,<0.18.0
 django-treebeard==4.5.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -65,7 +65,7 @@ install_requires =
     django-imagekit==4.0.2
     django-jsonfield-backport>=1.0.2
     django-taggit==1.4.0
-    django-markdownify==0.9.0
+    django-markdownify==0.9.1
     django-mptt==0.12.0
     django-modeltranslation>=0.11,<0.18.0
     django-treebeard==4.5.1


### PR DESCRIPTION
Updates django-markdownify to version 0.9.1  which solves #9263 
## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

