### PR TITLE
[Fixes #9269] Favorite tab shows Add to Favorites even when geoapp is…

### DIFF
--- a/geonode/favorite/models.py
+++ b/geonode/favorite/models.py
@@ -57,8 +57,11 @@ class FavoriteManager(models.Manager):
         if Favorite exists for input user and type and pk of the input
         content_object, return it.  else return None.
         impl note: can only be 0 or 1, per the class's unique_together.
+        For geoapp we need to get the real_instance type
         """
         content_type = ContentType.objects.get_for_model(type(content_object))
+        if content_type.model == 'geoapp':
+            content_type = ContentType.objects.get_for_model(type(content_object.get_real_instance()))
         result = self.filter(
             user=user,
             content_type=content_type,

--- a/geonode/favorite/tests.py
+++ b/geonode/favorite/tests.py
@@ -71,16 +71,21 @@ class FavoriteTest(GeoNodeBaseTestSupport):
     def test_favorite(self):
         # assume we created at least one User and two Documents in setUp.
         test_user = get_user_model().objects.first()
+        test_user2 = get_user_model().objects.last()
         test_document_1 = Document.objects.first()
         test_document_2 = Document.objects.last()
+        test_geoapp_1 = GeoApp.objects.first()
         self.assertIsNotNone(test_document_1)
         self.assertIsNotNone(test_document_2)
+        self.assertIsNotNone(test_geoapp_1)
 
         # test create favorite.
         Favorite.objects.create_favorite(test_document_1, test_user)
         Favorite.objects.create_favorite(test_document_2, test_user)
+        Favorite.objects.create_favorite(test_geoapp_1, test_user2)
+
         favorites = Favorite.objects.all()
-        self.assertEqual(favorites.count(), 2)
+        self.assertEqual(favorites.count(), 3)
         ct = ContentType.objects.get_for_model(test_document_1)
         self.assertEqual(favorites[0].content_type, ct)
 
@@ -107,6 +112,10 @@ class FavoriteTest(GeoNodeBaseTestSupport):
         # test favorite for user and a specific content object.
         user_content_favorite = Favorite.objects.favorite_for_user_and_content_object(test_user, test_document_1)
         self.assertEqual(user_content_favorite.object_id, test_document_1.id)
+
+        # test favorite for user and a specific content object for geoapp.
+        user_content_favorite = Favorite.objects.favorite_for_user_and_content_object(test_user2, test_geoapp_1)
+        self.assertEqual(user_content_favorite.object_id, test_geoapp_1.id)
 
         # test bulk favorites.
         bulk_favorites = Favorite.objects.bulk_favorite_objects(test_user)


### PR DESCRIPTION
… already in favorites

ref #9269 

<Include a few sentences describing the overall goals for this Pull Request>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [ ] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [ ] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
