### PR TITLE
[Fixes #9196] Fix storage manager copy function

### DIFF
--- a/.clabot
+++ b/.clabot
@@ -62,6 +62,7 @@
     "luorlandini",
     "minardimarcello",
     "mikesname",
-    "DavidQuartz"
+    "DavidQuartz",
+    "jkariukidev"
   ]
 }

--- a/geonode/storage/manager.py
+++ b/geonode/storage/manager.py
@@ -191,7 +191,6 @@ class StorageManager(StorageManagerInterface):
         new_path = mkdtemp()
         for f in files:
             with self.open(f, 'rb+') as open_file:
-                old_path = str(os.path.basename(Path(f).parent.absolute()))
                 old_file_name, _ = os.path.splitext(os.path.basename(f))
                 _, ext = os.path.splitext(open_file.name)
                 # path = os.path.join(old_path, random_suffix)

--- a/geonode/storage/manager.py
+++ b/geonode/storage/manager.py
@@ -195,7 +195,6 @@ class StorageManager(StorageManagerInterface):
                 old_file_name, _ = os.path.splitext(os.path.basename(f))
                 _, ext = os.path.splitext(open_file.name)
                 # path = os.path.join(old_path, random_suffix)
-                path = old_path
                 if re.match(r'.*_\w{7}$', old_file_name):
                     suffixed_name = re.sub(r'_\w{7}$', f'_{random_suffix}', old_file_name)
                     new_file = f"{new_path}/{suffixed_name}{ext}"

--- a/geonode/storage/manager.py
+++ b/geonode/storage/manager.py
@@ -185,8 +185,10 @@ class StorageManager(StorageManagerInterface):
         return updated_files
 
     def copy_files_list(self, files: List[str]):
+        from geonode.utils import mkdtemp
         out = []
         random_suffix = f'{uuid1().hex[:8]}'
+        new_path = mkdtemp()
         for f in files:
             with self.open(f, 'rb+') as open_file:
                 old_path = str(os.path.basename(Path(f).parent.absolute()))
@@ -198,7 +200,7 @@ class StorageManager(StorageManagerInterface):
                     suffixed_name = re.sub(r'_\w{7}$', f'_{random_suffix}', old_file_name)
                     new_file = f"{path}/{suffixed_name}{ext}"
                 else:
-                    new_file = f"{path}/{old_file_name}_{random_suffix}{ext}"
+                    new_file = f"{new_path}/{old_file_name}_{random_suffix}{ext}"
                 out.append(self.copy_single_file(open_file, new_file))
         return out
 

--- a/geonode/storage/manager.py
+++ b/geonode/storage/manager.py
@@ -198,7 +198,7 @@ class StorageManager(StorageManagerInterface):
                 path = old_path
                 if re.match(r'.*_\w{7}$', old_file_name):
                     suffixed_name = re.sub(r'_\w{7}$', f'_{random_suffix}', old_file_name)
-                    new_file = f"{path}/{suffixed_name}{ext}"
+                    new_file = f"{new_path}/{suffixed_name}{ext}"
                 else:
                     new_file = f"{new_path}/{old_file_name}_{random_suffix}{ext}"
                 out.append(self.copy_single_file(open_file, new_file))


### PR DESCRIPTION
ref #9196

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
