### PR TITLE
[Fixes #9330] Upload randomly causing "java.lang.NullPointerException" during Import

### DIFF
--- a/geonode/geoserver/tests/test_server.py
+++ b/geonode/geoserver/tests/test_server.py
@@ -1245,8 +1245,7 @@ class LayerTests(GeoNodeBaseTestSupport):
                     self.assertIn(
                         _link_orig.url,
                         _lyr.csw_anytext,
-                        f"The link URL {_link_orig.url} is not present in the 'csw_anytext' \
-attribute of the layer '{_lyr.alternate}'"
+                        f"The link URL {_link_orig.url} is not present in the 'csw_anytext' attribute of the layer '{_lyr.alternate}'"
                     )
                 # Check catalogue
                 catalogue = get_catalogue()

--- a/geonode/upload/tests/test_utils.py
+++ b/geonode/upload/tests/test_utils.py
@@ -30,6 +30,7 @@ from geonode.upload.utils import get_max_upload_size, get_max_upload_parallelism
 
 
 class UtilsTestCase(GeoNodeBaseTestSupport):
+
     def test_pages(self):
         self.assertIn("kml-overlay", utils._pages)
 

--- a/geonode/upload/tests/utils.py
+++ b/geonode/upload/tests/utils.py
@@ -1,0 +1,84 @@
+#########################################################################
+#
+# Copyright (C) 2021 OSGeo
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#########################################################################
+
+import os
+import logging
+
+from io import IOBase
+from urllib.request import urljoin
+
+from django.urls import reverse
+from django.contrib.auth import authenticate
+
+logger = logging.getLogger(__name__)
+
+GEONODE_USER = 'admin'
+GEONODE_PASSWD = 'admin'
+
+
+def rest_upload_by_path(_file, client, username=GEONODE_USER, password=GEONODE_PASSWD, non_interactive=False):
+    """ function that uploads a file, or a collection of files, to
+    the GeoNode"""
+    assert authenticate(username=username, password=password)
+    client.login(username=username, password=password)
+    spatial_files = ("dbf_file", "shx_file", "prj_file")
+    base, ext = os.path.splitext(_file)
+    params = {
+        # make public since wms client doesn't do authentication
+        'permissions': '{ "users": {"AnonymousUser": ["view_resourcebase"]} , "groups":{}}',
+        'time': 'false',
+        'charset': 'UTF-8'
+    }
+
+    # deal with shapefiles
+    if ext.lower() == '.shp':
+        for spatial_file in spatial_files:
+            ext, _ = spatial_file.split('_')
+            file_path = f"{base}.{ext}"
+            # sometimes a shapefile is missing an extra file,
+            # allow for that
+            if os.path.exists(file_path):
+                params[spatial_file] = open(file_path, 'rb')
+
+    with open(_file, 'rb') as base_file:
+        params['base_file'] = base_file
+        for name, value in params.items():
+            if isinstance(value, IOBase):
+                params[name] = (os.path.basename(value.name), value)
+        url = urljoin(
+            f"{reverse('uploads-list')}/",
+            'upload/')
+        if non_interactive:
+            params["non_interactive"] = 'true'
+        logger.error(f" ---- UPLOAD URL: {url}")
+        response = client.post(url, data=params)
+
+    # Closes the files
+    for spatial_file in spatial_files:
+        if isinstance(params.get(spatial_file), IOBase):
+            params[spatial_file].close()
+
+    try:
+        logger.error(f" -- response: {response.status_code} / {response.json()}")
+        return response, response.json()
+    except (ValueError, TypeError):
+        logger.exception(
+            ValueError(
+                f"probably not json, status {response.status_code} / {response.content}"))
+        return response, response.content

--- a/geonode/upload/upload.py
+++ b/geonode/upload/upload.py
@@ -628,15 +628,13 @@ def final_step(upload_session, user, charset="UTF-8", dataset_id=None):
                     Upload.objects.invalidate_from_session(upload_session)
                     raise GeneralUploadException(detail=_("The GeoServer Import Session is no more available ") + str(e))
 
-                upload_session.import_session = import_session.reload()
-                upload_session = Upload.objects.update_from_session(upload_session, resource=saved_dataset)
-
                 if import_session.tasks is None or len(import_session.tasks) == 0:
                     return saved_dataset
 
                 task = import_session.tasks[0]
                 try:
-                    task.set_charset(charset)
+                    if charset:
+                        task.set_charset(charset)
                 except Exception as e:
                     logger.exception(e)
 
@@ -696,7 +694,8 @@ def final_step(upload_session, user, charset="UTF-8", dataset_id=None):
                     logger.exception(e)
                     Upload.objects.invalidate_from_session(upload_session)
                     raise GeneralUploadException(detail=_("The GeoServer Import Session is no more available ") + str(e))
-                upload_session.import_session = import_session
+
+                upload_session.import_session = import_session.reload()
                 upload_session = Upload.objects.update_from_session(upload_session, resource=saved_dataset)
 
                 _tasks_failed = any([_task.state in ["BAD_FORMAT", "ERROR", "CANCELED"] for _task in import_session.tasks])


### PR DESCRIPTION
References: #9330

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [ ] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [ ] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
