### PR TITLE
[Fixes #9332] A/W: owner should not have any modification permission on published resource

### DIFF
--- a/geonode/security/utils.py
+++ b/geonode/security/utils.py
@@ -35,11 +35,13 @@ from geonode.groups.conf import settings as groups_settings
 from geonode.groups.models import GroupProfile
 from geonode.security.permissions import (
     PermSpecCompact,
+    EDIT_PERMISSIONS,
     VIEW_PERMISSIONS,
     ADMIN_PERMISSIONS,
     SERVICE_PERMISSIONS,
     DOWNLOAD_PERMISSIONS,
     DOWNLOADABLE_RESOURCES,
+    BASIC_MANAGE_PERMISSIONS,
     DATASET_ADMIN_PERMISSIONS,
     DATASET_EDIT_DATA_PERMISSIONS,
     DATASET_EDIT_STYLE_PERMISSIONS,
@@ -521,13 +523,14 @@ class AdvancedSecurityWorkflowManager:
                 if _resource.owner not in ResourceGroupsAndMembersSet.managers:
                     safe_remove(prev_perms, 'publish_resourcebase')
                     if not AdvancedSecurityWorkflowManager.is_simple_publishing_workflow() and (_resource.is_approved or _resource.is_published):
-                        safe_remove(prev_perms, 'change_resourcebase')
-                        safe_remove(prev_perms, 'change_resourcebase_metadata')
-                        if _resource.polymorphic_ctype.model == "dataset":
-                            safe_remove(prev_perms, 'change_dataset_style')
-                            safe_remove(prev_perms, 'change_dataset_data')
+                        for _perm in EDIT_PERMISSIONS:
+                            safe_remove(prev_perms, _perm)
+                        if _resource.resource_type == "dataset":
+                            for _perm in DATASET_ADMIN_PERMISSIONS:
+                                safe_remove(prev_perms, _perm)
                     if AdvancedSecurityWorkflowManager.is_advanced_workflow():
-                        safe_remove(prev_perms, 'change_resourcebase_permissions')
+                        for _perm in BASIC_MANAGE_PERMISSIONS:
+                            safe_remove(prev_perms, _perm)
             _perm_spec['users'][_resource.owner] = list(set(prev_perms))
 
             # Computing the MANAGERs and MEMBERs Permissions
@@ -580,8 +583,8 @@ class AdvancedSecurityWorkflowManager:
                 if not AdvancedSecurityWorkflowManager.is_auto_publishing_workflow():
                     if ((AdvancedSecurityWorkflowManager.is_simple_publishing_workflow() or AdvancedSecurityWorkflowManager.is_advanced_workflow()) and not _resource.is_published) or (
                             AdvancedSecurityWorkflowManager.is_simplified_workflow() and not (_resource.is_approved or _resource.is_published)):
-                        safe_remove(prev_perms, 'view_resourcebase')
-                        safe_remove(prev_perms, 'download_resourcebase')
+                        for _perm in VIEW_PERMISSIONS + DOWNLOAD_PERMISSIONS:
+                            safe_remove(prev_perms, _perm)
             _perm_spec['groups'][ResourceGroupsAndMembersSet.anonymous_group] = list(set(prev_perms))
 
             if ResourceGroupsAndMembersSet.registered_members_group and getattr(groups_settings, 'AUTO_ASSIGN_REGISTERED_MEMBERS_TO_REGISTERED_MEMBERS_GROUP_NAME', False):
@@ -590,8 +593,8 @@ class AdvancedSecurityWorkflowManager:
                     prev_perms += AdminViewPermissionsSet.view_perms.copy()
                     prev_perms = list(set(prev_perms))
                 if not AdvancedSecurityWorkflowManager.is_auto_publishing_workflow() and not _resource.is_approved:
-                    safe_remove(prev_perms, 'view_resourcebase')
-                    safe_remove(prev_perms, 'download_resourcebase')
+                    for _perm in VIEW_PERMISSIONS + DOWNLOAD_PERMISSIONS:
+                        safe_remove(prev_perms, _perm)
                 _perm_spec['groups'][ResourceGroupsAndMembersSet.registered_members_group] = list(set(prev_perms))
 
         return _perm_spec


### PR DESCRIPTION
References: #9332

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [ ] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [ ] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
