### PR TITLE
[Backport 3.3.x][Fixes #9332][Test Cases] A/W: owner should not have any modification permission on published resource

### DIFF
--- a/geonode/security/tests.py
+++ b/geonode/security/tests.py
@@ -2566,6 +2566,7 @@ class TestPermissionChanges(GeoNodeBaseTestSupport):
             group=self.resource_group.group)
 
         self.owner_perms = [
+            'delete_resourcebase',
             'view_resourcebase',
             'download_resourcebase'
         ]
@@ -2574,7 +2575,7 @@ class TestPermissionChanges(GeoNodeBaseTestSupport):
             'change_resourcebase_metadata'
         ]
         self.layer_perms = ['change_layer_style', 'change_layer_data']
-        self.adv_owner_limit = ["delete_resourcebase", "change_resourcebase_permissions", "publish_resourcebase"]
+        self.adv_owner_limit = ["change_resourcebase_permissions", "publish_resourcebase"]
         self.safe_perms = ["download_resourcebase", "view_resourcebase"]
         self.data = {
             'resource-title': self.resource.title,
@@ -2669,7 +2670,7 @@ class TestPermissionChanges(GeoNodeBaseTestSupport):
         resource_perm_specs = self.resource.get_all_level_info()
         self.assertSetEqual(
             set(resource_perm_specs['users'][self.author]),
-            set(self.owner_perms))
+            set(self.safe_perms))
         self.assertSetEqual(
             set(resource_perm_specs['users'][self.member_with_perms]),
             set(self.owner_perms + self.layer_perms))

--- a/geonode/security/tests.py
+++ b/geonode/security/tests.py
@@ -2270,7 +2270,6 @@ class SetPermissionsTestCase(GeoNodeBaseTestSupport):
                 {"users": {}, "groups": {}},
                 {
                     self.author: [
-                        "delete_resourcebase",
                         "download_resourcebase",
                         "view_resourcebase",
                     ],
@@ -2292,7 +2291,6 @@ class SetPermissionsTestCase(GeoNodeBaseTestSupport):
                 {"users": {}, "groups": {"second_custom_group": ["view_resourcebase"]}},
                 {
                     self.author: [
-                        "delete_resourcebase",
                         "download_resourcebase",
                         "view_resourcebase",
                     ],
@@ -2392,7 +2390,6 @@ class SetPermissionsTestCase(GeoNodeBaseTestSupport):
             .first()
         expected = {
             self.author: [
-                "delete_resourcebase",
                 "download_resourcebase",
                 "view_resourcebase",
             ],
@@ -2449,7 +2446,6 @@ class SetPermissionsTestCase(GeoNodeBaseTestSupport):
         self.assertEqual(sut.role, "member")
         expected = {
             self.author: [
-                "delete_resourcebase",
                 "download_resourcebase",
                 "view_resourcebase",
             ],
@@ -2570,7 +2566,6 @@ class TestPermissionChanges(GeoNodeBaseTestSupport):
             group=self.resource_group.group)
 
         self.owner_perms = [
-            'delete_resourcebase',
             'view_resourcebase',
             'download_resourcebase'
         ]
@@ -2579,7 +2574,7 @@ class TestPermissionChanges(GeoNodeBaseTestSupport):
             'change_resourcebase_metadata'
         ]
         self.layer_perms = ['change_layer_style', 'change_layer_data']
-        self.adv_owner_limit = ["change_resourcebase_permissions", "publish_resourcebase"]
+        self.adv_owner_limit = ["delete_resourcebase", "change_resourcebase_permissions", "publish_resourcebase"]
         self.safe_perms = ["download_resourcebase", "view_resourcebase"]
         self.data = {
             'resource-title': self.resource.title,


### PR DESCRIPTION
References: #9332

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [ ] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [ ] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
