### PR TITLE
[Fixes #9363] Split thumbnail creation method

### DIFF
--- a/geonode/thumbs/thumbnails.py
+++ b/geonode/thumbs/thumbnails.py
@@ -118,19 +118,20 @@ def create_thumbnail(
 
     return create_thumbnail_from_locations(instance, locations, layers_bbox, default_thumbnail_name, compute_bbox_from_layers, is_map_with_datasets, bbox, wms_version, styles, background_zoom)
 
+
 def create_thumbnail_from_locations(
-        instance, 
-        locations, 
+        instance,
+        locations,
         layers_bbox,
         default_thumbnail_name,
         compute_bbox_from_layers,
         is_map_with_datasets,
         bbox,
-        wms_version = settings.OGC_SERVER["default"].get("WMS_VERSION", "1.1.1"), 
-        styles = None, 
-        background_zoom = None
+        wms_version=settings.OGC_SERVER["default"].get("WMS_VERSION", "1.1.1"),
+        styles=None,
+        background_zoom=None
         ):
-    
+
     mime_type = "image/png"
     width = settings.THUMBNAIL_SIZE["width"]
     height = settings.THUMBNAIL_SIZE["height"]

--- a/geonode/thumbs/thumbnails.py
+++ b/geonode/thumbs/thumbnails.py
@@ -116,7 +116,7 @@ def create_thumbnail(
     # --- define layer locations ---
     locations, layers_bbox = _layers_locations(instance, compute_bbox=compute_bbox_from_layers, target_crs=target_crs)
 
-    return create_thumbnail_from_locations(instance, locations, layers_bbox, default_thumbnail_name, compute_bbox_from_layers, is_map_with_datasets, wms_version, styles, background_zoom)
+    return create_thumbnail_from_locations(instance, locations, layers_bbox, default_thumbnail_name, compute_bbox_from_layers, is_map_with_datasets, bbox, wms_version, styles, background_zoom)
 
 def create_thumbnail_from_locations(
         instance, 
@@ -125,6 +125,7 @@ def create_thumbnail_from_locations(
         default_thumbnail_name,
         compute_bbox_from_layers,
         is_map_with_datasets,
+        bbox,
         wms_version = settings.OGC_SERVER["default"].get("WMS_VERSION", "1.1.1"), 
         styles = None, 
         background_zoom = None

--- a/geonode/thumbs/thumbnails.py
+++ b/geonode/thumbs/thumbnails.py
@@ -83,9 +83,6 @@ def create_thumbnail(
     instance.refresh_from_db()
 
     default_thumbnail_name = _generate_thumbnail_name(instance)
-    mime_type = "image/png"
-    width = settings.THUMBNAIL_SIZE["width"]
-    height = settings.THUMBNAIL_SIZE["height"]
 
     if default_thumbnail_name is None:
         # instance is Map and has no layers defined
@@ -119,6 +116,23 @@ def create_thumbnail(
     # --- define layer locations ---
     locations, layers_bbox = _layers_locations(instance, compute_bbox=compute_bbox_from_layers, target_crs=target_crs)
 
+    return create_thumbnail_from_locations(instance, locations, layers_bbox, default_thumbnail_name, compute_bbox_from_layers, is_map_with_datasets, wms_version, styles, background_zoom)
+
+def create_thumbnail_from_locations(
+        instance, 
+        locations, 
+        layers_bbox,
+        default_thumbnail_name,
+        compute_bbox_from_layers,
+        is_map_with_datasets,
+        wms_version = settings.OGC_SERVER["default"].get("WMS_VERSION", "1.1.1"), 
+        styles = None, 
+        background_zoom = None
+        ):
+    
+    mime_type = "image/png"
+    width = settings.THUMBNAIL_SIZE["width"]
+    height = settings.THUMBNAIL_SIZE["height"]
     if compute_bbox_from_layers and is_map_with_datasets:
         if not layers_bbox:
             raise ThumbnailError(f"Thumbnail generation couldn't determine a BBOX for: {instance}.")


### PR DESCRIPTION
ref #9363 
## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
