### PR TITLE
[Fixes #9370] "catalogue_post_save" fails on retrieving the self resource

### DIFF
--- a/geonode/base/api/tests.py
+++ b/geonode/base/api/tests.py
@@ -623,27 +623,28 @@ class BaseApiTests(APITestCase):
         """
         url = reverse('base-resources-list')
         # Check user permissions
-        resource = ResourceBase.objects.filter(owner__username='bobby').first()
-        self.assertEqual(resource.owner.username, 'bobby')
-        self.assertTrue(self.client.login(username='bobby', password='bob'))
-        response = self.client.get(f"{url}/{resource.id}/", format='json')
-        self.assertTrue('change_resourcebase' in list(response.data['resource']['perms']))
-        self.assertEqual(True, response.data['resource']['is_published'], response.data['resource']['is_published'])
-        data = {
-            "title": "Foo Title",
-            "abstract": "Foo Abstract",
-            "attribution": "Foo Attribution",
-            "doi": "321-12345-987654321",
-            "is_published": False
-        }
-        response = self.client.patch(f"{url}/{resource.id}/", data=data, format='json')
-        self.assertEqual(response.status_code, 200, response.status_code)
-        response = self.client.get(f"{url}/{resource.id}/", format='json')
-        self.assertEqual('Foo Title', response.data['resource']['title'], response.data['resource']['title'])
-        self.assertEqual('Foo Abstract', response.data['resource']['abstract'], response.data['resource']['abstract'])
-        self.assertEqual('Foo Attribution', response.data['resource']['attribution'], response.data['resource']['attribution'])
-        self.assertEqual('321-12345-987654321', response.data['resource']['doi'], response.data['resource']['doi'])
-        self.assertEqual(False, response.data['resource']['is_published'], response.data['resource']['is_published'])
+        for resource_type in ['dataset', 'document', 'map']:
+            resource = ResourceBase.objects.filter(owner__username='bobby', resource_type=resource_type).first()
+            self.assertEqual(resource.owner.username, 'bobby')
+            self.assertTrue(self.client.login(username='bobby', password='bob'))
+            response = self.client.get(f"{url}/{resource.id}/", format='json')
+            self.assertTrue('change_resourcebase' in list(response.data['resource']['perms']))
+            self.assertEqual(True, response.data['resource']['is_published'], response.data['resource']['is_published'])
+            data = {
+                "title": "Foo Title",
+                "abstract": "Foo Abstract",
+                "attribution": "Foo Attribution",
+                "doi": "321-12345-987654321",
+                "is_published": False
+            }
+            response = self.client.patch(f"{url}/{resource.id}/", data=data, format='json')
+            self.assertEqual(response.status_code, 200, response.status_code)
+            response = self.client.get(f"{url}/{resource.id}/", format='json')
+            self.assertEqual('Foo Title', response.data['resource']['title'], response.data['resource']['title'])
+            self.assertEqual('Foo Abstract', response.data['resource']['abstract'], response.data['resource']['abstract'])
+            self.assertEqual('Foo Attribution', response.data['resource']['attribution'], response.data['resource']['attribution'])
+            self.assertEqual('321-12345-987654321', response.data['resource']['doi'], response.data['resource']['doi'])
+            self.assertEqual(False, response.data['resource']['is_published'], response.data['resource']['is_published'])
 
     def test_delete_user_with_resource(self):
         owner, created = get_user_model().objects.get_or_create(username='delet-owner')

--- a/geonode/base/api/tests.py
+++ b/geonode/base/api/tests.py
@@ -617,6 +617,34 @@ class BaseApiTests(APITestCase):
             resource.tkeywords.set(ThesaurusKeyword.objects.none())
             self.assertEqual(0, resource.tkeywords.count())
 
+    def test_write_resources(self):
+        """
+        Ensure we can perform write oprtation afainst the Resource Bases.
+        """
+        url = reverse('base-resources-list')
+        # Check user permissions
+        resource = ResourceBase.objects.filter(owner__username='bobby').first()
+        self.assertEqual(resource.owner.username, 'bobby')
+        self.assertTrue(self.client.login(username='bobby', password='bob'))
+        response = self.client.get(f"{url}/{resource.id}/", format='json')
+        self.assertTrue('change_resourcebase' in list(response.data['resource']['perms']))
+        self.assertEqual(True, response.data['resource']['is_published'], response.data['resource']['is_published'])
+        data = {
+            "title": "Foo Title",
+            "abstract": "Foo Abstract",
+            "attribution": "Foo Attribution",
+            "doi": "321-12345-987654321",
+            "is_published": False
+        }
+        response = self.client.patch(f"{url}/{resource.id}/", data=data, format='json')
+        self.assertEqual(response.status_code, 200, response.status_code)
+        response = self.client.get(f"{url}/{resource.id}/", format='json')
+        self.assertEqual('Foo Title', response.data['resource']['title'], response.data['resource']['title'])
+        self.assertEqual('Foo Abstract', response.data['resource']['abstract'], response.data['resource']['abstract'])
+        self.assertEqual('Foo Attribution', response.data['resource']['attribution'], response.data['resource']['attribution'])
+        self.assertEqual('321-12345-987654321', response.data['resource']['doi'], response.data['resource']['doi'])
+        self.assertEqual(False, response.data['resource']['is_published'], response.data['resource']['is_published'])
+
     def test_delete_user_with_resource(self):
         owner, created = get_user_model().objects.get_or_create(username='delet-owner')
         Dataset(

--- a/geonode/catalogue/models.py
+++ b/geonode/catalogue/models.py
@@ -81,9 +81,9 @@ def catalogue_post_save(instance, sender, **kwargs):
                 )
             except Exception:
                 _d = dict(name=name,
-                        extension='xml',
-                        mime=mime,
-                        link_type='metadata')
+                          extension='xml',
+                          mime=mime,
+                          link_type='metadata')
                 Link.objects.filter(
                     resource=resources.get(),
                     url=metadata_url,

--- a/geonode/catalogue/models.py
+++ b/geonode/catalogue/models.py
@@ -40,7 +40,8 @@ def catalogue_pre_delete(instance, sender, **kwargs):
 
 def catalogue_post_save(instance, sender, **kwargs):
     """Get information from catalogue"""
-    resources = ResourceBase.objects.filter(id=instance.resourcebase_ptr.id)
+    _id = instance.resourcebase_ptr.id if hasattr(instance, 'resourcebase_ptr') else instance.id
+    resources = ResourceBase.objects.filter(id=_id)
 
     # Update the Catalog
     try:
@@ -65,28 +66,29 @@ def catalogue_post_save(instance, sender, **kwargs):
         raise Exception(msg)
 
     # Create the different metadata links with the available formats
-    for mime, name, metadata_url in record.links['metadata']:
-        try:
-            Link.objects.get_or_create(
-                resource=instance.resourcebase_ptr,
-                url=metadata_url,
-                defaults=dict(
-                    name=name,
-                    extension='xml',
-                    mime=mime,
-                    link_type='metadata'
+    if resources.exists():
+        for mime, name, metadata_url in record.links['metadata']:
+            try:
+                Link.objects.get_or_create(
+                    resource=resources.get(),
+                    url=metadata_url,
+                    defaults=dict(
+                        name=name,
+                        extension='xml',
+                        mime=mime,
+                        link_type='metadata'
+                    )
                 )
-            )
-        except Exception:
-            _d = dict(name=name,
-                      extension='xml',
-                      mime=mime,
-                      link_type='metadata')
-            Link.objects.filter(
-                resource=instance.resourcebase_ptr,
-                url=metadata_url,
-                extension='xml',
-                link_type='metadata').update(**_d)
+            except Exception:
+                _d = dict(name=name,
+                        extension='xml',
+                        mime=mime,
+                        link_type='metadata')
+                Link.objects.filter(
+                    resource=resources.get(),
+                    url=metadata_url,
+                    extension='xml',
+                    link_type='metadata').update(**_d)
 
     # generate an XML document (GeoNode's default is ISO)
     if instance.metadata_uploaded and instance.metadata_uploaded_preserve:


### PR DESCRIPTION
References: #9370

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [ ] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [ ] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
