### PR TITLE
[Fixes #9386] Adopt DRF exceptions inside maps APIv2

### DIFF
--- a/geonode/maps/api/exception.py
+++ b/geonode/maps/api/exception.py
@@ -1,0 +1,26 @@
+#########################################################################
+#
+# Copyright (C) 2022 OSGeo
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#########################################################################
+from rest_framework.exceptions import APIException
+
+
+class GeneralMapsException(APIException):
+    status_code = 500
+    default_detail = "Error during maps operation"
+    default_code = "maps_exception"
+    category = "maps_api"

--- a/geonode/maps/api/tests.py
+++ b/geonode/maps/api/tests.py
@@ -162,7 +162,7 @@ class MapsApiTests(APITestCase):
         expected_error = {
             "success": False,
             "errors": [
-                "serializer instance and object found are different"
+                "serializer instance and object are different"
             ],
             "code": "maps_exception"
         }

--- a/geonode/maps/api/tests.py
+++ b/geonode/maps/api/tests.py
@@ -21,6 +21,7 @@ from urllib.parse import urljoin
 
 from django.conf import settings
 from django.urls import reverse
+from mock import patch
 from rest_framework.test import APITestCase
 
 from geonode.base.populate_test_data import create_models
@@ -136,6 +137,37 @@ class MapsApiTests(APITestCase):
         self.assertEqual(response_maplayer["extra_params"], {"msId": "Stamen.Watercolor__0"})
         self.assertEqual(response_maplayer["current_style"], "some-style-first-layer")
         self.assertIsNotNone(response_maplayer["dataset"])
+
+    @patch("geonode.maps.api.views.resolve_object")
+    def test_patch_map_raise_exception(self, mocked_obj):
+        """
+        Patch to maps/<pk>/
+        """
+        # Get Layers List (backgrounds)
+        resource = Map.objects.first()
+        mocked_obj.return_value = Map.objects.last()
+
+        url = reverse("maps-detail", kwargs={"pk": resource.pk})
+
+        data = {
+            "title": f"{resource.title}-edited",
+            "abstract": resource.abstract,
+            "data": DUMMY_MAPDATA,
+            "id": resource.id,
+            "maplayers": DUMMY_MAPLAYERS_DATA,
+        }
+        self.client.login(username="admin", password="admin")
+        response = self.client.patch(f"{url}?include[]=data", data=data, format="json")
+
+        expected_error = {
+            "success": False,
+            "errors": [
+                "serializer instance and object found are different"
+            ],
+            "code": "maps_exception"
+        }
+        self.assertEqual(response.status_code, 500)
+        self.assertEqual(expected_error, response.json())
 
     def test_create_map(self):
         """

--- a/geonode/maps/api/views.py
+++ b/geonode/maps/api/views.py
@@ -26,7 +26,6 @@ from dynamic_rest.viewsets import DynamicModelViewSet
 from oauth2_provider.contrib.rest_framework import OAuth2Authentication
 from rest_framework.authentication import BasicAuthentication, SessionAuthentication
 from rest_framework.decorators import action
-from rest_framework.exceptions import ValidationError
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
 from rest_framework.response import Response
 
@@ -35,6 +34,7 @@ from geonode.base.api.filters import DynamicSearchFilter, ExtentFilter
 from geonode.base.api.pagination import GeoNodeApiPagination
 from geonode.base.api.permissions import IsOwnerOrReadOnly
 from geonode.layers.api.serializers import DatasetSerializer
+from geonode.maps.api.exception import GeneralMapsException
 from geonode.maps.api.permissions import MapPermissionsFilter
 from geonode.maps.api.serializers import MapLayerSerializer, MapSerializer
 from geonode.maps.contants import _PERMISSION_MSG_SAVE
@@ -137,7 +137,7 @@ class MapViewSet(DynamicModelViewSet):
         )
         instance = serializer.instance
         if instance != map_obj:
-            raise ValidationError()
+            raise GeneralMapsException(detail="serializer instance and object found are different")
         # Thumbnail will be handled later
         post_change_data = {
             "thumbnail": serializer.validated_data.pop("thumbnail_url", ""),

--- a/geonode/maps/api/views.py
+++ b/geonode/maps/api/views.py
@@ -137,7 +137,7 @@ class MapViewSet(DynamicModelViewSet):
         )
         instance = serializer.instance
         if instance != map_obj:
-            raise GeneralMapsException(detail="serializer instance and object found are different")
+            raise GeneralMapsException(detail="serializer instance and object are different")
         # Thumbnail will be handled later
         post_change_data = {
             "thumbnail": serializer.validated_data.pop("thumbnail_url", ""),


### PR DESCRIPTION
ref #9386

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
