### PR TITLE
[Fixes #9413] Adopt DRF exceptions inside geoapps APIv2 4.0.x API v2

### DIFF
--- a/geonode/geoapps/api/exceptions.py
+++ b/geonode/geoapps/api/exceptions.py
@@ -1,0 +1,40 @@
+#########################################################################
+#
+# Copyright (C) 2022 OSGeo
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#########################################################################
+from rest_framework.exceptions import APIException
+
+
+class DuplicateGeoAppException(APIException):
+    status_code = 409
+    default_detail = "GeoApp already exists"
+    default_code = "geoapp_exception"
+    category = "geoapp_api"
+
+
+class InvalidGeoAppException(APIException):
+    status_code = 400
+    default_detail = "The provided data is not valid"
+    default_code = "geoapp_exception"
+    category = "geoapp_api"
+
+
+class GeneralGeoAppException(APIException):
+    status_code = 500
+    default_detail = "An error has occurred while processing your request"
+    default_code = "geoapp_exception"
+    category = "geoapp_api"

--- a/geonode/geoapps/api/serializers.py
+++ b/geonode/geoapps/api/serializers.py
@@ -19,7 +19,7 @@
 import logging
 
 from django.contrib.auth import get_user_model
-from geonode.geoapps.api.exceptions import DuplicateGeoAppException, InvalidGeoAppException
+from geonode.geoapps.api.exceptions import DuplicateGeoAppException, InvalidGeoAppException, GeneralGeoAppException
 
 from geonode.geoapps.models import GeoApp
 from geonode.resource.manager import resource_manager

--- a/geonode/geoapps/api/serializers.py
+++ b/geonode/geoapps/api/serializers.py
@@ -18,9 +18,8 @@
 #########################################################################
 import logging
 
-from rest_framework.serializers import ValidationError
-
 from django.contrib.auth import get_user_model
+from geonode.geoapps.api.exceptions import DuplicateGeoAppException, InvalidGeoAppException
 
 from geonode.geoapps.models import GeoApp
 from geonode.resource.manager import resource_manager
@@ -54,15 +53,15 @@ class GeoAppSerializer(ResourceBaseSerializer):
             if _u:
                 validated_data[_key] = _u
             else:
-                raise ValidationError(f"The specified '{_key}' does not exist!")
+                raise InvalidGeoAppException(f"The specified '{_key}' does not exist!")
 
     def extra_create_checks(self, validated_data):
         if 'name' not in validated_data or \
                 'owner' not in validated_data:
-            raise ValidationError("No valid data: 'name' and 'owner' are mandatory fields!")
+            raise InvalidGeoAppException("No valid data: 'name' and 'owner' are mandatory fields!")
 
         if self.Meta.model.objects.filter(name=validated_data['name']).count():
-            raise ValidationError("A GeoApp with the same 'name' already exists!")
+            raise DuplicateGeoAppException("A GeoApp with the same 'name' already exists!")
 
         self.extra_update_checks(validated_data)
 
@@ -84,7 +83,7 @@ class GeoAppSerializer(ResourceBaseSerializer):
             if _u:
                 validated_data[_key] = _u
             else:
-                raise ValidationError(f"The specified '{_key}' does not exist!")
+                raise InvalidGeoAppException(f"The specified '{_key}' does not exist!")
 
         return validated_data
 
@@ -108,7 +107,7 @@ class GeoAppSerializer(ResourceBaseSerializer):
             self.Meta.model.objects.filter(pk=_instance.id).update(**validated_data)
             _instance.refresh_from_db()
         except Exception as e:
-            raise ValidationError(e)
+            raise GeneralGeoAppException(e)
 
         # Let's finalize the instance and notify the users
         validated_data['blob'] = _data
@@ -122,10 +121,10 @@ class GeoAppSerializer(ResourceBaseSerializer):
         # Sanity checks
         _mandatory_fields = ['name', 'owner', 'resource_type']
         if not all([_x in validated_data for _x in _mandatory_fields]):
-            raise ValidationError(f"No valid data: {_mandatory_fields} are mandatory fields!")
+            raise InvalidGeoAppException(f"No valid data: {_mandatory_fields} are mandatory fields!")
 
         if self.Meta.model.objects.filter(name=validated_data['name']).count():
-            raise ValidationError("A GeoApp with the same 'name' already exists!")
+            raise DuplicateGeoAppException("A GeoApp with the same 'name' already exists!")
 
         return self._create_and_update(self._sanitize_validated_data(validated_data))
 
@@ -135,6 +134,6 @@ class GeoAppSerializer(ResourceBaseSerializer):
         # Sanity checks
         _mandatory_fields = ['resource_type', ]
         if not all([_x in validated_data for _x in _mandatory_fields]):
-            raise ValidationError(f"No valid data: {_mandatory_fields} are mandatory fields!")
+            raise InvalidGeoAppException(f"No valid data: {_mandatory_fields} are mandatory fields!")
 
         return self._create_and_update(self._sanitize_validated_data(validated_data), instance=instance)


### PR DESCRIPTION
ref #9413 
## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
