### PR TITLE
[Fixes #9426][Remote Services] Errors on creating WMS Cascade stores and layers

### DIFF
--- a/geonode/services/serviceprocessors/wms.py
+++ b/geonode/services/serviceprocessors/wms.py
@@ -477,7 +477,6 @@ class WmsServiceHandler(base.ServiceHandlerBase,
             layer_resource = layer_resource.resource
         else:
             logger.debug(f"Layer {layer_meta.id} is already present. Skipping...")
-        layer_resource.refresh()
         return layer_resource
 
     def _offers_geonode_projection(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -101,7 +101,7 @@ geonode-announcements==2.0.2
 geonode-django-activity-stream==0.10.0
 gn-arcrest==10.5.4
 geonode-dialogos==3.0.1
-geoserver-restconfig==2.0.5
+geoserver-restconfig==2.0.6
 gn-gsimporter==2.0.1
 gisdata==0.5.4
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -127,7 +127,7 @@ install_requires =
     geonode-django-activity-stream==0.10.0
     gn-arcrest==10.5.4
     geonode-dialogos==3.0.1
-    geoserver-restconfig==2.0.5
+    geoserver-restconfig==2.0.6
     gn-gsimporter==2.0.1
     gisdata==0.5.4
 


### PR DESCRIPTION
References: #9426

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [ ] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [ ] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
