### PR TITLE
[Fixes #9500] OWS Url wrong for INDEXED Remote Services

### DIFF
--- a/geonode/utils.py
+++ b/geonode/utils.py
@@ -2021,11 +2021,15 @@ def set_resource_default_links(instance, layer, prune=False, **kwargs):
         logger.debug(" -- Resource Links[Thumbnail link]...done!")
 
         logger.debug(" -- Resource Links[OWS Links]...")
-        # ogc_wms_path = '%s/ows' % instance.workspace
-        ogc_wms_path = 'ows'
-        ogc_wms_url = urljoin(ogc_server_settings.public_url, ogc_wms_path)
+        try:
+            ogc_wms_url = instance.ows_url
+        except Exception:
+            ogc_wms_url = None
+        if not ogc_wms_url:
+            ogc_wms_path = 'ows'
+            ogc_wms_url = urljoin(ogc_server_settings.public_url, ogc_wms_path)
         ogc_wms_name = f'OGC WMS: {instance.workspace} Service'
-        if Link.objects.filter(resource=instance.resourcebase_ptr, name=ogc_wms_name, url=ogc_wms_url).count() < 2:
+        if not Link.objects.filter(resource=instance.resourcebase_ptr, link_type='OGC:WMS').exists():
             Link.objects.get_or_create(
                 resource=instance.resourcebase_ptr,
                 url=ogc_wms_url,
@@ -2039,11 +2043,15 @@ def set_resource_default_links(instance, layer, prune=False, **kwargs):
             )
 
         if instance.storeType == "dataStore":
-            # ogc_wfs_path = '%s/wfs' % instance.workspace
-            ogc_wfs_path = 'ows'
-            ogc_wfs_url = urljoin(ogc_server_settings.public_url, ogc_wfs_path)
+            try:
+                ogc_wfs_url = instance.ows_url
+            except Exception:
+                ogc_wfs_url = None
+            if not ogc_wfs_url:
+                ogc_wfs_path = 'ows'
+                ogc_wfs_url = urljoin(ogc_server_settings.public_url, ogc_wfs_path)
             ogc_wfs_name = f'OGC WFS: {instance.workspace} Service'
-            if Link.objects.filter(resource=instance.resourcebase_ptr, name=ogc_wfs_name, url=ogc_wfs_url).count() < 2:
+            if not Link.objects.filter(resource=instance.resourcebase_ptr, link_type='OGC:WFS').exists():
                 Link.objects.get_or_create(
                     resource=instance.resourcebase_ptr,
                     url=ogc_wfs_url,
@@ -2057,11 +2065,15 @@ def set_resource_default_links(instance, layer, prune=False, **kwargs):
                 )
 
         if instance.storeType == "coverageStore":
-            # ogc_wcs_path = '%s/wcs' % instance.workspace
-            ogc_wcs_path = 'ows'
-            ogc_wcs_url = urljoin(ogc_server_settings.public_url, ogc_wcs_path)
+            try:
+                ogc_wcs_url = instance.ows_url
+            except Exception:
+                ogc_wcs_url = None
+            if not ogc_wcs_url:
+                ogc_wcs_path = 'ows'
+                ogc_wcs_url = urljoin(ogc_server_settings.public_url, ogc_wcs_path)
             ogc_wcs_name = f'OGC WCS: {instance.workspace} Service'
-            if Link.objects.filter(resource=instance.resourcebase_ptr, name=ogc_wcs_name, url=ogc_wcs_url).count() < 2:
+            if not Link.objects.filter(resource=instance.resourcebase_ptr, link_type='OGC:WCS').exists():
                 Link.objects.get_or_create(
                     resource=instance.resourcebase_ptr,
                     url=ogc_wcs_url,


### PR DESCRIPTION
References: #9500

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [ ] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [ ] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
