### PR TITLE
[Fixes #9511] extrapolate FileUploadSizeLimit and UploadParallelismLi…

### DIFF
--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -2144,3 +2144,11 @@ EXTRA_METADATA_SCHEMA = {**{
     "document": os.getenv('DOCUMENT_EXTRA_METADATA_SCHEMA', DEFAULT_EXTRA_METADATA_SCHEMA),
     "geoapp": os.getenv('GEOAPP_EXTRA_METADATA_SCHEMA', DEFAULT_EXTRA_METADATA_SCHEMA)
 }, **CUSTOM_METADATA_SCHEMA}
+
+
+'''
+Define the URLs patterns used by the SizeRestrictedFileUploadHandler
+to evaluate if the file is greater than the limit size defined
+'''
+
+SIZE_RESTRICTED_FILE_UPLOAD_ELEGIBLE_URL_NAMES = ("data_upload", "uploads-upload", "document_upload",)

--- a/geonode/upload/api/tests.py
+++ b/geonode/upload/api/tests.py
@@ -751,7 +751,7 @@ class UploadApiTests(GeoNodeLiveTestSupport, APITestCase):
         # Try to upload and verify if it passed only by the form size validation
         fname = os.path.join(GOOD_DATA, 'raster', 'relief_san_andres.tif')
 
-        _get_parallel_uploads_count_path = "geonode.upload.forms.LayerUploadForm._get_parallel_uploads_count"
+        _get_parallel_uploads_count_path = "geonode.upload.forms.UploadLimitValidator._get_parallel_uploads_count"
         with mock.patch(_get_parallel_uploads_count_path, new_callable=mock.PropertyMock) as mocked_get_parallel_uploads_count:
             mocked_get_parallel_uploads_count.return_value = lambda: 200
 

--- a/geonode/upload/uploadhandler.py
+++ b/geonode/upload/uploadhandler.py
@@ -20,7 +20,7 @@ class SizeRestrictedFileUploadHandler(FileUploadHandler):
     The upload will be blocked afterwards by the Upload Form
     """
 
-    elegible_url_names = ("data_upload", "uploads-upload", "document_upload",)
+    elegible_url_names = settings.SIZE_RESTRICTED_FILE_UPLOAD_ELEGIBLE_URL_NAMES
 
     def handle_raw_input(self, input_data, META, content_length, boundary, encoding=None):
         """


### PR DESCRIPTION
…mit limit from upload form

ref #9511 
## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
