### PR TITLE
[Fixes #9531] Provide priority to _update_geofence_rule method

### DIFF
--- a/geonode/geoserver/security.py
+++ b/geonode/geoserver/security.py
@@ -46,8 +46,8 @@ logger = logging.getLogger(__name__)
 
 
 def _get_geofence_payload(layer, layer_name, workspace, access, user=None, group=None,
-                          service=None, request=None, geo_limit=None):
-    highest_priority = get_highest_priority()
+                          service=None, request=None, geo_limit=None, priority=None):
+    highest_priority = priority if priority is not None else get_highest_priority()
     root_el = etree.Element("Rule")
     username_el = etree.SubElement(root_el, "userName")
     if user is not None:
@@ -86,7 +86,7 @@ def _get_geofence_payload(layer, layer_name, workspace, access, user=None, group
 def _update_geofence_rule(layer, layer_name, workspace,
                           service, request=None,
                           user=None, group=None,
-                          geo_limit=None, allow=True):
+                          geo_limit=None, allow=True, priority=None):
     payload = _get_geofence_payload(
         layer=layer,
         layer_name=layer_name,
@@ -96,7 +96,8 @@ def _update_geofence_rule(layer, layer_name, workspace,
         group=group,
         service=service,
         request=request,
-        geo_limit=geo_limit
+        geo_limit=geo_limit,
+        priority=priority
     )
     logger.debug(f"request data: {payload}")
     response = requests.post(


### PR DESCRIPTION
ref #9531 
## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
