### PR TITLE
[Fixes  #9591] Expose supported upload file formats as configurations

### DIFF
--- a/geonode/br/management/commands/restore.py
+++ b/geonode/br/management/commands/restore.py
@@ -323,7 +323,7 @@ class Command(BaseCommand):
                 # Prepare Target DB
                 try:
                     call_command('makemigrations', interactive=False)
-                    call_command('migrate', interactive=False, load_initial_data=False)
+                    call_command('migrate', interactive=False)
 
                     db_name = settings.DATABASES['default']['NAME']
                     db_user = settings.DATABASES['default']['USER']

--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -1584,56 +1584,6 @@ if GEONODE_CLIENT_LAYER_PREVIEW_LIBRARY == 'mapstore':
     MAPSTORE_EXTENSIONS_FOLDER_PATH = '/static/mapstore/extensions/'
 
     # Supported Dataset file types for uploading Datasets. This setting is being from from the client
-    MAPSTORE_SUPPORTED_DATASET_FILE_TYPES = [
-        {
-            "id": "shp",
-            "label": "ESRI Shapefile",
-            "format": "vector",
-            "ext": ["shp"],
-            "requires": ["shp", "prj", "dbf", "shx"],
-            "optional": ["xml", "sld"]
-        },
-        {
-            "id": "tiff",
-            "label": "GeoTIFF",
-            "format": "raster",
-            "ext": ["tiff", "tif"],
-            "mimeType": ["image/tiff"],
-            "optional": ["xml", "sld"]
-        },
-        {
-            "id": "csv",
-            "label": "Comma Separated Value (CSV)",
-            "format": "vector",
-            "ext": ["csv"],
-            "mimeType": ["text/csv"],
-            "optional": ["xml", "sld"]
-        },
-        {
-            "id": "zip",
-            "label": "Zip Archive",
-            "format": "archive",
-            "ext": ["zip"],
-            "mimeType": ["application/zip"],
-            "optional": ["xml", "sld"]
-        },
-        {
-            "id": "xml",
-            "label": "XML Metadata File",
-            "format": "metadata",
-            "ext": ["xml"],
-            "mimeType": ["application/json"],
-            "needsFiles": ["shp", "prj", "dbf", "shx", "csv", "tiff", "zip", "sld"]
-        },
-        {
-            "id": "sld",
-            "label": "Styled Layer Descriptor (SLD)",
-            "format": "metadata",
-            "ext": ["sld"],
-            "mimeType": ["application/json"],
-            "needsFiles": ["shp", "prj", "dbf", "shx", "csv", "tiff", "zip", "xml"]
-        }
-    ]
 
 # -- END Client Hooksets Setup
 
@@ -2204,3 +2154,54 @@ to evaluate if the file is greater than the limit size defined
 '''
 
 SIZE_RESTRICTED_FILE_UPLOAD_ELEGIBLE_URL_NAMES = ("data_upload", "uploads-upload", "document_upload",)
+
+SUPPORTED_DATASET_FILE_TYPES = [
+        {
+            "id": "shp",
+            "label": "ESRI Shapefile",
+            "format": "vector",
+            "ext": ["shp"],
+            "requires": ["shp", "prj", "dbf", "shx"],
+            "optional": ["xml", "sld"]
+        },
+        {
+            "id": "tiff",
+            "label": "GeoTIFF",
+            "format": "raster",
+            "ext": ["tiff", "tif"],
+            "mimeType": ["image/tiff"],
+            "optional": ["xml", "sld"]
+        },
+        {
+            "id": "csv",
+            "label": "Comma Separated Value (CSV)",
+            "format": "vector",
+            "ext": ["csv"],
+            "mimeType": ["text/csv"],
+            "optional": ["xml", "sld"]
+        },
+        {
+            "id": "zip",
+            "label": "Zip Archive",
+            "format": "archive",
+            "ext": ["zip"],
+            "mimeType": ["application/zip"],
+            "optional": ["xml", "sld"]
+        },
+        {
+            "id": "xml",
+            "label": "XML Metadata File",
+            "format": "metadata",
+            "ext": ["xml"],
+            "mimeType": ["application/json"],
+            "needsFiles": ["shp", "prj", "dbf", "shx", "csv", "tiff", "zip", "sld"]
+        },
+        {
+            "id": "sld",
+            "label": "Styled Layer Descriptor (SLD)",
+            "format": "metadata",
+            "ext": ["sld"],
+            "mimeType": ["application/json"],
+            "needsFiles": ["shp", "prj", "dbf", "shx", "csv", "tiff", "zip", "xml"]
+        }
+    ]

--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -1583,6 +1583,58 @@ if GEONODE_CLIENT_LAYER_PREVIEW_LIBRARY == 'mapstore':
     # Extensions path to use in importing custom extensions into geonode
     MAPSTORE_EXTENSIONS_FOLDER_PATH = '/static/mapstore/extensions/'
 
+    # Supported Dataset file types for uploading Datasets. This setting is being from from the client
+    MAPSTORE_SUPPORTED_DATASET_FILE_TYPES = [
+        {
+            "id": "shp",
+            "label": "ESRI Shapefile",
+            "format": "vector",
+            "ext": ["shp"],
+            "requires": ["shp", "prj", "dbf", "shx"],
+            "optional": ["xml", "sld"]
+        },
+        {
+            "id": "tiff",
+            "label": "GeoTIFF",
+            "format": "raster",
+            "ext": ["tiff", "tif"],
+            "mimeType": ["image/tiff"],
+            "optional": ["xml", "sld"]
+        },
+        {
+            "id": "csv",
+            "label": "Comma Separated Value (CSV)",
+            "format": "vector",
+            "ext": ["csv"],
+            "mimeType": ["text/csv"],
+            "optional": ["xml", "sld"]
+        },
+        {
+            "id": "zip",
+            "label": "Zip Archive",
+            "format": "archive",
+            "ext": ["zip"],
+            "mimeType": ["application/zip"],
+            "optional": ["xml", "sld"]
+        },
+        {
+            "id": "xml",
+            "label": "XML Metadata File",
+            "format": "metadata",
+            "ext": ["xml"],
+            "mimeType": ["application/json"],
+            "needsFiles": ["shp", "prj", "dbf", "shx", "csv", "tiff", "zip", "sld"]
+        },
+        {
+            "id": "sld",
+            "label": "Styled Layer Descriptor (SLD)",
+            "format": "metadata",
+            "ext": ["sld"],
+            "mimeType": ["application/json"],
+            "needsFiles": ["shp", "prj", "dbf", "shx", "csv", "tiff", "zip", "xml"]
+        }
+    ]
+
 # -- END Client Hooksets Setup
 
 SERVICE_UPDATE_INTERVAL = 0

--- a/geonode/tests/test_utils.py
+++ b/geonode/tests/test_utils.py
@@ -19,8 +19,10 @@
 import os
 import copy
 import shutil
+from unittest import TestCase
 import zipfile
 import tempfile
+from django.test import override_settings
 
 from osgeo import ogr
 from unittest.mock import patch
@@ -35,7 +37,8 @@ from geonode.layers.models import Attribute
 from geonode.geoserver.helpers import set_attributes
 from geonode.tests.base import GeoNodeBaseTestSupport
 from geonode.br.management.commands.utils.utils import ignore_time
-from geonode.utils import copy_tree, fixup_shp_columnnames, unzip_file
+from geonode.utils import copy_tree, fixup_shp_columnnames, get_supported_file_types, unzip_file
+from geonode import settings
 
 
 class TestCopyTree(GeoNodeBaseTestSupport):
@@ -219,3 +222,52 @@ class TestSetAttributes(GeoNodeBaseTestSupport):
         # The name and type should be set as provided by attribute map
         for a in _l.attributes:
             self.assertIn([a.attribute, a.attribute_type], expected_results)
+
+
+class TestSupportedTypes(TestCase):
+
+    def setUp(self):
+        self.replaced = [
+            {
+                "id": "shp",
+                "label": "Replaced type",
+                "format": "vector",
+                "ext": ["shp"],
+                "requires": ["shp", "prj", "dbf", "shx"],
+                "optional": ["xml", "sld"]
+            },
+        ]
+
+    @override_settings(ADDITIONAL_DATASET_FILE_TYPES=[
+            {
+                "id": "dummy_type",
+                "label": "Dummy Type",
+                "format": "dummy",
+                "ext": ["dummy"]
+            },
+        ])
+    def test_should_append_additional_type_if_config_is_provided(self):
+        prev_count = len(settings.SUPPORTED_DATASET_FILE_TYPES)
+        supported_types = get_supported_file_types()
+        supported_keys = [t.get('id') for t in supported_types]
+        self.assertIn('dummy_type', supported_keys)
+        self.assertEqual(len(supported_keys), prev_count + 1)
+
+    @override_settings(ADDITIONAL_DATASET_FILE_TYPES=[
+            {
+                "id": "shp",
+                "label": "Replaced type",
+                "format": "vector",
+                "ext": ["shp"],
+                "requires": ["shp", "prj", "dbf", "shx"],
+                "optional": ["xml", "sld"]
+            },
+        ])
+    def test_should_replace_the_type_id_if_already_exists(self):
+        prev_count = len(settings.SUPPORTED_DATASET_FILE_TYPES)
+        supported_types = get_supported_file_types()
+        supported_keys = [t.get('id') for t in supported_types]
+        self.assertIn('shp', supported_keys)
+        self.assertEqual(len(supported_keys), prev_count)
+        shp_type = [t for t in supported_types if t['id'] == "shp"][0]
+        self.assertEqual(shp_type['label'], "Replaced type")

--- a/geonode/utils.py
+++ b/geonode/utils.py
@@ -1876,3 +1876,26 @@ def get_xpath_value(
 def get_geonode_app_types():
     from geonode.geoapps.models import GeoApp
     return list(set(GeoApp.objects.values_list('resource_type', flat=True)))
+
+
+def get_supported_file_types():
+    from django.conf import settings as gn_settings
+    '''
+    Return a list of all supported file type in geonode
+    If one of the type provided in the custom type exists in the default
+    is going to override it
+    '''
+    default_types = settings.SUPPORTED_DATASET_FILE_TYPES
+    types_module = (
+        gn_settings.ADDITIONAL_DATASET_FILE_TYPES
+        if hasattr(gn_settings, "ADDITIONAL_DATASET_FILE_TYPES")
+        else []
+    )
+    supported_types = default_types.copy()
+    default_types_id = [t.get('id') for t in default_types]
+    for _type in types_module:
+        if _type.get("id") in default_types_id:
+            supported_types[default_types_id.index(_type.get("id"))] = _type
+        else:
+            supported_types.extend([_type])
+    return supported_types


### PR DESCRIPTION
References: #9591

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [x] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**

ref #9591 