### PR TITLE
[Fixes #9637] Performance scalability issues with Thumbnail generation

### DIFF
--- a/geonode/geoserver/helpers.py
+++ b/geonode/geoserver/helpers.py
@@ -61,7 +61,6 @@ from gsimporter import Client
 from lxml import etree, objectify
 from owslib.etree import etree as dlxml
 from owslib.wcs import WebCoverageService
-from owslib.wms import WebMapService
 
 from geonode import GeoNodeException
 from geonode.base.models import Link
@@ -1559,13 +1558,6 @@ def fetch_gs_resource(instance, values, tries):
             return (values, None)
         gs_resource = None
     return (values, gs_resource)
-
-
-def get_wms():
-    wms_url = f"{ogc_server_settings.internal_ows}?service=WMS&request=GetCapabilities&version=1.1.0"
-    req, body = http_client.get(wms_url, user=_user)
-    _wms = WebMapService(wms_url, xml=body)
-    return _wms
 
 
 def wps_execute_dataset_attribute_statistics(dataset_name, field):

--- a/geonode/thumbs/tests/test_unit.py
+++ b/geonode/thumbs/tests/test_unit.py
@@ -41,7 +41,7 @@ FIXTURES_DIR = "geonode/thumbs/tests/fixtures/"
 class ThumbnailsUtilsUnitTest(GeoNodeBaseSimpleTestSupport):
 
     def test_create_getmap_request(self):
-        request = utils.__build_getmap_request(layers=["geonode:Foo"], size=[512, 512], srs="epsg:4326", bbox=[-180, -90, 180, 90], bgcolor="fff")
+        request = utils._build_getmap_request(layers=["geonode:Foo"], size=[512, 512], srs="epsg:4326", bbox=[-180, -90, 180, 90], bgcolor="fff")
         self.assertDictEqual(
             request,
             {

--- a/geonode/thumbs/tests/test_unit.py
+++ b/geonode/thumbs/tests/test_unit.py
@@ -40,6 +40,27 @@ FIXTURES_DIR = "geonode/thumbs/tests/fixtures/"
 
 class ThumbnailsUtilsUnitTest(GeoNodeBaseSimpleTestSupport):
 
+    def test_create_getmap_request(self):
+        request = utils.__build_getmap_request(layers=["geonode:Foo"], size=[512, 512], srs="epsg:4326", bbox=[-180, -90, 180, 90], bgcolor="fff")
+        self.assertDictEqual(
+            request,
+            {
+                'service': 'WMS',
+                'version': '1.3.0',
+                'request': 'GetMap',
+                'layers': 'geonode:Foo',
+                'styles': '',
+                'width': '512',
+                'height': '512',
+                'crs': 'epsg:4326',
+                'bbox': '-90,-180,90,180',
+                'format': 'None',
+                'transparent': 'FALSE',
+                'bgcolor': '0xff',
+                'exceptions': 'None'
+            }
+        )
+
     def test_make_bbox_to_pixels_transf_same(self):
 
         src_bbox = [0, 0, 1, 1]

--- a/geonode/thumbs/utils.py
+++ b/geonode/thumbs/utils.py
@@ -247,10 +247,10 @@ def get_map(
     return image.read()
 
 
-def __build_getmap_request(version='1.3.0', layers=None, styles=None, srs=None, bbox=None,
-                           format=None, size=None, time=None, dimensions={},
-                           elevation=None, transparent=False,
-                           bgcolor=None, exceptions=None, **kwargs):
+def _build_getmap_request(version='1.3.0', layers=None, styles=None, srs=None, bbox=None,
+                          format=None, size=None, time=None, dimensions={},
+                          elevation=None, transparent=False,
+                          bgcolor=None, exceptions=None, **kwargs):
     from owslib.crs import Crs
 
     request = {'service': 'WMS', 'version': version, 'request': 'GetMap'}
@@ -384,7 +384,7 @@ def getmap(base_url,
 
     n = Namespaces()
 
-    request = __build_getmap_request(
+    request = _build_getmap_request(
         version=version,
         layers=layers,
         styles=styles,

--- a/geonode/thumbs/utils.py
+++ b/geonode/thumbs/utils.py
@@ -402,8 +402,6 @@ def getmap(base_url,
 
     data = urlencode(request)
 
-    request = bind_url(base_url) + data
-
     u = openURL(base_url, data, method, timeout=timeout, auth=None, headers=headers)
 
     # need to handle casing in the header keys

--- a/geonode/thumbs/utils.py
+++ b/geonode/thumbs/utils.py
@@ -271,7 +271,7 @@ def __build_getmap_request(version='1.3.0', layers=None, styles=None, srs=None, 
     # remap srs to crs for the actual request
     if srs.upper() == 'EPSG:0':
         # if it's esri's unknown spatial ref code, bail
-        raise Exception('Undefined spatial reference (%s).' % srs)
+        raise Exception(f'Undefined spatial reference ({srs}).')
 
     sref = Crs(srs)
     if sref.axisorder == 'yx':
@@ -283,7 +283,7 @@ def __build_getmap_request(version='1.3.0', layers=None, styles=None, srs=None, 
     request['bbox'] = ','.join([repr(x) for x in bbox])
     request['format'] = str(format)
     request['transparent'] = str(transparent).upper()
-    request['bgcolor'] = '0x' + bgcolor[1:7]
+    request['bgcolor'] = f"0x{bgcolor[1:7]}"
     request['exceptions'] = str(exceptions)
 
     if time is not None:
@@ -294,7 +294,7 @@ def __build_getmap_request(version='1.3.0', layers=None, styles=None, srs=None, 
 
     # any other specified dimension, prefixed with "dim_"
     for k, v in list(dimensions.items()):
-        request['dim_' + k] = str(v)
+        request[f"dim_{k}"] = str(v)
 
     if kwargs:
         for kw in kwargs:

--- a/geonode/thumbs/utils.py
+++ b/geonode/thumbs/utils.py
@@ -380,7 +380,7 @@ def getmap(base_url,
     """
     from owslib.etree import etree
     from owslib.namespaces import Namespaces
-    from owslib.util import openURL, ServiceException, bind_url, nspath
+    from owslib.util import openURL, ServiceException, nspath
 
     n = Namespaces()
 

--- a/geonode/thumbs/utils.py
+++ b/geonode/thumbs/utils.py
@@ -23,9 +23,9 @@ import base64
 import logging
 
 from pyproj import CRS
-from owslib.wms import WebMapService
 from typing import List, Tuple, Callable, Union
 from uuid import uuid4
+from urllib.parse import urlencode
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -211,16 +211,14 @@ def get_map(
         else:
             headers["Authorization"] = f"Bearer {additional_kwargs['access_token']}"
 
-    wms = WebMapService(
-        f"{thumbnail_url}{wms_endpoint}",
-        version=wms_version,
-        headers=headers)
-
     image = None
     for retry in range(max_retries):
         try:
             # fetch data
-            image = wms.getmap(
+            image = getmap(
+                f"{thumbnail_url}{wms_endpoint}",
+                version=wms_version,
+                headers=headers,
                 layers=layers,
                 styles=styles,
                 srs=bbox[-1] if bbox else None,
@@ -247,6 +245,179 @@ def get_map(
             break
 
     return image.read()
+
+
+def __build_getmap_request(version='1.3.0', layers=None, styles=None, srs=None, bbox=None,
+                           format=None, size=None, time=None, dimensions={},
+                           elevation=None, transparent=False,
+                           bgcolor=None, exceptions=None, **kwargs):
+    from owslib.crs import Crs
+
+    request = {'service': 'WMS', 'version': version, 'request': 'GetMap'}
+
+    # check layers and styles
+    assert len(layers) > 0
+    request['layers'] = ','.join(layers)
+    if styles:
+        assert len(styles) == len(layers)
+        request['styles'] = ','.join(styles)
+    else:
+        request['styles'] = ''
+
+    # size
+    request['width'] = str(size[0])
+    request['height'] = str(size[1])
+
+    # remap srs to crs for the actual request
+    if srs.upper() == 'EPSG:0':
+        # if it's esri's unknown spatial ref code, bail
+        raise Exception('Undefined spatial reference (%s).' % srs)
+
+    sref = Crs(srs)
+    if sref.axisorder == 'yx':
+        # remap the given bbox
+        bbox = (bbox[1], bbox[0], bbox[3], bbox[2])
+
+    # remapping the srs to crs for the request
+    request['crs'] = str(srs)
+    request['bbox'] = ','.join([repr(x) for x in bbox])
+    request['format'] = str(format)
+    request['transparent'] = str(transparent).upper()
+    request['bgcolor'] = '0x' + bgcolor[1:7]
+    request['exceptions'] = str(exceptions)
+
+    if time is not None:
+        request['time'] = str(time)
+
+    if elevation is not None:
+        request['elevation'] = str(elevation)
+
+    # any other specified dimension, prefixed with "dim_"
+    for k, v in list(dimensions.items()):
+        request['dim_' + k] = str(v)
+
+    if kwargs:
+        for kw in kwargs:
+            request[kw] = kwargs[kw]
+    return request
+
+
+def getmap(base_url,
+           version='1.3.0',
+           headers={},
+           layers=None,
+           styles=None,
+           srs=None,
+           bbox=None,
+           format=None,
+           size=None,
+           time=None,
+           elevation=None,
+           dimensions={},
+           transparent=False,
+           bgcolor='#FFFFFF',
+           exceptions='XML',
+           method='Get',
+           timeout=None,
+           **kwargs):
+    """Request and return an image from the WMS as a file-like object.
+
+    Parameters
+    ----------
+    layers : list
+        List of content layer names.
+    styles : list
+        Optional list of named styles, must be the same length as the
+        layers list.
+    srs : string
+        A spatial reference system identifier.
+        Note: this is an invalid query parameter key for 1.3.0 but is being
+                retained for standardization with 1.1.1.
+        Note: throws exception if the spatial ref is ESRI's "no reference"
+                code (EPSG:0)
+    bbox : tuple
+        (left, bottom, right, top) in srs units (note, this order does not
+            change depending on axis order of the crs).
+
+        CRS:84: (long, lat)
+        EPSG:4326: (lat, long)
+    format : string
+        Output image format such as 'image/jpeg'.
+    size : tuple
+        (width, height) in pixels.
+
+    time : string or list or range
+        Optional. Time value of the specified layer as ISO-8601 (per value)
+    elevation : string or list or range
+        Optional. Elevation value of the specified layer.
+    dimensions: dict (dimension : string or list or range)
+        Optional. Any other Dimension option, as specified in the GetCapabilities
+
+    transparent : bool
+        Optional. Transparent background if True.
+    bgcolor : string
+        Optional. Image background color.
+    method : string
+        Optional. HTTP DCP method name: Get or Post.
+    **kwargs : extra arguments
+        anything else e.g. vendor specific parameters
+
+    Example
+    -------
+        wms = WebMapService('http://webservices.nationalatlas.gov/wms/1million',\
+                                version='1.3.0')
+        img = wms.getmap(layers=['airports1m'],\
+                                styles=['default'],\
+                                srs='EPSG:4326',\
+                                bbox=(-176.646, 17.7016, -64.8017, 71.2854),\
+                                size=(300, 300),\
+                                format='image/jpeg',\
+                                transparent=True)
+        out = open('example.jpg.jpg', 'wb')
+        out.write(img.read())
+        out.close()
+
+    """
+    from owslib.etree import etree
+    from owslib.namespaces import Namespaces
+    from owslib.util import openURL, ServiceException, bind_url, nspath
+
+    n = Namespaces()
+
+    request = __build_getmap_request(
+        version=version,
+        layers=layers,
+        styles=styles,
+        srs=srs,
+        bbox=bbox,
+        dimensions=dimensions,
+        elevation=elevation,
+        format=format,
+        size=size,
+        time=time,
+        transparent=transparent,
+        bgcolor=bgcolor,
+        exceptions=exceptions,
+        **kwargs)
+
+    data = urlencode(request)
+
+    request = bind_url(base_url) + data
+
+    u = openURL(base_url, data, method, timeout=timeout, auth=None, headers=headers)
+
+    # need to handle casing in the header keys
+    headers = {}
+    for k, v in list(u.info().items()):
+        headers[k.lower()] = v
+
+    # handle the potential charset def
+    if headers.get('content-type', '').split(';')[0] in ['application/vnd.ogc.se_xml', 'text/xml']:
+        se_xml = u.read()
+        se_tree = etree.fromstring(se_xml)
+        err_message = str(se_tree.find(nspath('ServiceException', n.get_namespace('ogc'))).text).strip()
+        raise ServiceException(err_message)
+    return u
 
 
 def epsg_3857_area_of_use():


### PR DESCRIPTION
References: #9637

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [ ] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [ ] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
