### PR TITLE
[Fixes #9673] Proxy must use OGC_REQUEST_TIMEOUT instead of an hardcoded one

### DIFF
--- a/geonode/proxy/views.py
+++ b/geonode/proxy/views.py
@@ -70,8 +70,9 @@ def proxy(request, url=None, response_callback=None,
           sec_chk_hosts=True, sec_chk_rules=True, timeout=None,
           allowed_hosts=[], headers=None, access_token=None, **kwargs):
     # Request default timeout
+    from geonode.geoserver.helpers import ogc_server_settings
     if not timeout:
-        timeout = TIMEOUT
+        timeout = getattr(ogc_server_settings, "TIMEOUT", TIMEOUT)
 
     # Security rules and settings
     PROXY_ALLOWED_HOSTS = getattr(settings, 'PROXY_ALLOWED_HOSTS', ())
@@ -104,13 +105,11 @@ def proxy(request, url=None, response_callback=None,
             PROXY_ALLOWED_HOSTS += (site_url.hostname, )
 
         # Attach current hostname
-        if check_ogc_backend(geoserver.BACKEND_PACKAGE):
-            from geonode.geoserver.helpers import ogc_server_settings
-            hostname = (
-                ogc_server_settings.hostname,
-            ) if ogc_server_settings else ()
-            if hostname not in PROXY_ALLOWED_HOSTS:
-                PROXY_ALLOWED_HOSTS += hostname
+        hostname = (
+            ogc_server_settings.hostname,
+        ) if ogc_server_settings else ()
+        if hostname not in PROXY_ALLOWED_HOSTS:
+            PROXY_ALLOWED_HOSTS += hostname
 
         # Check OWS regexp
         if url.query and ows_regexp.match(url.query):


### PR DESCRIPTION
References: #9673

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [ ] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [ ] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
