### PR TITLE
[Fixes #9722] dump_thesaurus management script not working properly

### DIFF
--- a/geonode/base/management/commands/dump_thesaurus.py
+++ b/geonode/base/management/commands/dump_thesaurus.py
@@ -83,8 +83,13 @@ class Command(BaseCommand):
 
     def list_thesauri(self):
         self.stderr.write(self.style.SUCCESS('LISTING THESAURI'))
-        max_id_len = len(max(Thesaurus.objects.values_list('identifier', flat=True), key=len))
-
+        
+        thesaurus_entries = Thesaurus.objects.values_list('identifier', flat=True)
+        if len(thesaurus_entries) == 0:
+          self.stderr.write(self.style.SUCCESS('NO ENTRIES FOUND ...'))
+          return
+        max_id_len = len(max(thesaurus_entries, key=len))
+        
         for t in Thesaurus.objects.order_by('order').all():
             if t.card_max == 0:
                 card = 'DISABLED'


### PR DESCRIPTION
ref #9722 9722
## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
