### PR TITLE
[BACKPORT][Fixes #9799] Thesaurus selectbox performance in metadata editor is v…

### DIFF
--- a/geonode/base/forms.py
+++ b/geonode/base/forms.py
@@ -40,17 +40,18 @@ from modeltranslation.forms import TranslationModelForm
 from taggit.forms import TagField
 from tinymce.widgets import TinyMCE
 from django.contrib.admin.utils import flatten
+from django.utils.translation import get_language
+
 from geonode.base.enumerations import ALL_LANGUAGES
 from geonode.base.models import (HierarchicalKeyword,
                                  License, Region, ResourceBase, Thesaurus,
                                  ThesaurusKeyword, ThesaurusKeywordLabel, ThesaurusLabel,
                                  TopicCategory)
 from geonode.base.widgets import TaggitSelect2Custom
+from geonode.base.fields import MultiThesauriField
 from geonode.documents.models import Document
 from geonode.layers.models import Dataset
-from django.utils.translation import get_language
-from .fields import MultiThesauriField
-from geonode.base.utils import validate_extra_metadata
+from geonode.base.utils import validate_extra_metadata, remove_country_from_lanugecode
 
 logger = logging.getLogger(__name__)
 
@@ -290,7 +291,14 @@ class TKeywordForm(forms.ModelForm):
     )
 
 
+THESAURUS_RESULT_LIST_SEPERATOR = ("", "-------")
+
+
 class ThesaurusAvailableForm(forms.Form):
+
+    # seperator at beginning of thesaurus search result and between
+    # results found in local language and alt label
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         lang = get_language()
@@ -337,16 +345,21 @@ class ThesaurusAvailableForm(forms.Form):
 
     @staticmethod
     def _get_thesauro_keyword_label(item, lang):
-        qs_local = []
-        qs_non_local = [("", "------")]
-        for key in ThesaurusKeyword.objects.filter(thesaurus_id=item.id):
-            label = ThesaurusKeywordLabel.objects.filter(keyword=key).filter(lang=lang)
-            if label.exists():
-                qs_local.append((label.get().keyword.id, label.get().label))
-            else:
-                qs_non_local.append((key.id, key.alt_label))
 
-        return qs_non_local + qs_local
+        keyword_id_for_given_thesaurus = ThesaurusKeyword.objects.filter(thesaurus_id=item)
+
+        # try find results found for given language e.g. (en-us) if no results found remove country code from language to (en) and try again
+        qs_keyword_ids = ThesaurusKeywordLabel.objects.filter(lang=lang, keyword_id__in=keyword_id_for_given_thesaurus).values("keyword_id")
+        if len(qs_keyword_ids) == 0:
+            lang = remove_country_from_lanugecode(lang)
+            qs_keyword_ids = ThesaurusKeywordLabel.objects.filter(lang=lang, keyword_id__in=keyword_id_for_given_thesaurus).values("keyword_id")
+
+        not_qs_ids = ThesaurusKeywordLabel.objects.exclude(keyword_id__in=qs_keyword_ids).order_by("keyword_id").distinct("keyword_id").values("keyword_id")
+
+        qs_local = list(ThesaurusKeywordLabel.objects.filter(lang=lang, keyword_id__in=keyword_id_for_given_thesaurus).values_list("keyword_id", "label"))
+        qs_non_local = list(keyword_id_for_given_thesaurus.filter(id__in=not_qs_ids).values_list("id", "alt_label"))
+
+        return [THESAURUS_RESULT_LIST_SEPERATOR] + qs_local + [THESAURUS_RESULT_LIST_SEPERATOR] + qs_non_local
 
     @staticmethod
     def _get_thesauro_title_label(item, lang):

--- a/geonode/base/tests.py
+++ b/geonode/base/tests.py
@@ -58,6 +58,7 @@ from django.contrib.auth import get_user_model
 from geonode.storage.manager import storage_manager
 from django.test import Client, TestCase, override_settings, SimpleTestCase
 from django.shortcuts import reverse
+from django.utils import translation
 
 from geonode.base.middleware import ReadOnlyMiddleware, MaintenanceMiddleware
 from geonode.base.templatetags.base_tags import get_visibile_resources, facets
@@ -73,7 +74,7 @@ from geonode.decorators import on_ogc_backend
 from django.core.files import File
 from django.core.management import call_command
 from django.core.management.base import CommandError
-from geonode.base.forms import ThesaurusAvailableForm
+from geonode.base.forms import ThesaurusAvailableForm, THESAURUS_RESULT_LIST_SEPERATOR
 
 
 test_image = Image.new('RGBA', size=(50, 50), color=(155, 0, 0))
@@ -922,6 +923,24 @@ class TestThesaurusAvailableForm(TestCase):
         self.assertEqual(fields[0][0], '1')
         #  will check if the second element of the tuple is the thesaurus_id = 1
         self.assertEqual(fields[1][0], '2')
+
+    def test_get_thesuro_key_label_with_cmd_language_code(self):
+        # in python test language code look like 'en' this test checks if key label result function
+        # returns correct results
+        tid = 1
+        translation.activate("en")
+        t_available_form = ThesaurusAvailableForm(data={"1": tid})
+        results = t_available_form._get_thesauro_keyword_label(tid, translation.get_language())
+        self.assertNotEqual(results[1], THESAURUS_RESULT_LIST_SEPERATOR)
+
+    def test_get_thesuro_key_label_with_browser_language_code(self):
+        # in browser scenario language does not look like "it", but rather include coutry code
+        # like "it-it" this test checks if _get_thesauro_keyword_label can handle this
+        tid = 1
+        translation.activate("en-us")
+        t_available_form = ThesaurusAvailableForm(data={"1": tid})
+        results = t_available_form._get_thesauro_keyword_label(tid, translation.get_language())
+        self.assertNotEqual(results[1], THESAURUS_RESULT_LIST_SEPERATOR)
 
 
 class TestFacets(TestCase):

--- a/geonode/base/utils.py
+++ b/geonode/base/utils.py
@@ -189,3 +189,16 @@ def validate_extra_metadata(data, instance):
             raise ValidationError(f"{e} at index {_index} for input json: {json.dumps(_metadata)}")
     # conerted because in this case, we can store a well formated json instead of the user input
     return data
+
+
+@staticmethod
+def remove_country_from_lanugecode(language: str):
+    """ Remove country code (us) from language name (en-us)
+    >>> remove_country_from_lanugecode("en-us")
+    'en'
+    """
+    if "-" not in language:
+        return language
+
+    lang, _, _ = language.lower().partition("-")
+    return lang

--- a/geonode/base/views.py
+++ b/geonode/base/views.py
@@ -35,6 +35,7 @@ from django.core.exceptions import PermissionDenied
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.urls import reverse
+from django.utils.translation import get_language
 
 # Geonode dependencies
 from geonode.maps.models import Map
@@ -47,7 +48,7 @@ from geonode.tasks.tasks import set_permissions
 from geonode.resource.manager import resource_manager
 from geonode.security.utils import get_visible_resources
 from geonode.notifications_helper import send_notification
-from geonode.base.utils import OwnerRightsRequestViewUtils
+from geonode.base.utils import OwnerRightsRequestViewUtils, remove_country_from_lanugecode
 from geonode.base.forms import UserAndGroupPermissionsForm
 
 from geonode.base.forms import (
@@ -301,23 +302,25 @@ class ThesaurusKeywordLabelAutocomplete(autocomplete.Select2QuerySetView):
 
 class ThesaurusAvailable(autocomplete.Select2QuerySetView):
     def get_queryset(self):
-        tid = self.request.GET.get("sysid")
-        lang = self.request.GET.get("lang")
-        qs_local = []
-        qs_non_local = []
-        for key in ThesaurusKeyword.objects.filter(thesaurus_id=tid):
-            label = ThesaurusKeywordLabel.objects.filter(keyword=key).filter(lang=lang)
-            if self.q:
-                label = label.filter(label__icontains=self.q)
-            if label.exists():
-                qs_local.append(label.get())
-            else:
-                if self.q in key.alt_label:
-                    qs_non_local.append(key)
-                elif not self.q:
-                    qs_non_local.append(key)
 
-        return qs_non_local + qs_local
+        tid = self.request.GET.get("sysid")
+        lang = get_language()
+        keyword_id_for_given_thesaurus = ThesaurusKeyword.objects.filter(thesaurus_id=tid)
+
+        # try find results found for given language e.g. (en-us) if no results found remove country code from language to (en) and try again
+        qs_keyword_ids = ThesaurusKeywordLabel.objects.filter(lang=lang, keyword_id__in=keyword_id_for_given_thesaurus).values("keyword_id")
+        if len(qs_keyword_ids) == 0:
+            lang = remove_country_from_lanugecode(lang)
+            qs_keyword_ids = ThesaurusKeywordLabel.objects.filter(lang=lang, keyword_id__in=keyword_id_for_given_thesaurus).values("keyword_id")
+
+        not_qs_ids = ThesaurusKeywordLabel.objects.exclude(keyword_id__in=qs_keyword_ids).order_by("keyword_id").distinct("keyword_id").values("keyword_id")
+        qs = ThesaurusKeywordLabel.objects.filter(lang=lang, keyword_id__in=keyword_id_for_given_thesaurus)
+        if self.q:
+            qs = qs.filter(label__istartswith=self.q)
+
+        qs_local = list(qs)
+        qs_non_local = list(keyword_id_for_given_thesaurus.filter(id__in=not_qs_ids))
+        return qs_local + qs_non_local
 
     def get_results(self, context):
         return [


### PR DESCRIPTION
…ery slow (#9800)

* [Fixes #9799] Thesaurus selectbox performance in metadata editor is very slow

Co-authored-by: mattiagiupponi <51856725+mattiagiupponi@users.noreply.github.com>

<Include a few sentences describing the overall goals for this Pull Request>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [ ] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [ ] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
