### PR TITLE
[Fixes #7535] Issues with .env GEOSERVER_ADMIN_PASSWORD

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -59,11 +59,11 @@ else
         invoke monitoringfixture
         invoke initialized
         invoke updateadmin
+        invoke geoserverfixture
     fi
 
     invoke statics
-    invoke waitforgeoserver
-    invoke geoserverfixture
+    invoke waitforgeoserver    
 
     echo "Executing UWSGI server $cmd for Production"
 fi

--- a/geonode/local_settings.py.geoserver.sample
+++ b/geonode/local_settings.py.geoserver.sample
@@ -106,11 +106,11 @@ GEOSERVER_PUBLIC_LOCATION = os.getenv(
     'GEOSERVER_PUBLIC_LOCATION', _default_public_location
 )
 
-OGC_SERVER_DEFAULT_USER = os.getenv(
+GEOSERVER_ADMIN_USER = os.getenv(
     'GEOSERVER_ADMIN_USER', 'admin'
 )
 
-OGC_SERVER_DEFAULT_PASSWORD = os.getenv(
+GEOSERVER_ADMIN_PASSWORD = os.getenv(
     'GEOSERVER_ADMIN_PASSWORD', 'geoserver'
 )
 
@@ -126,8 +126,8 @@ OGC_SERVER = {
         # the proxy won't work and the integration tests will fail
         # the entire block has to be overridden in the local_settings
         'PUBLIC_LOCATION': GEOSERVER_PUBLIC_LOCATION,
-        'USER': OGC_SERVER_DEFAULT_USER,
-        'PASSWORD': OGC_SERVER_DEFAULT_PASSWORD,
+        'USER': GEOSERVER_ADMIN_USER,
+        'PASSWORD': GEOSERVER_ADMIN_PASSWORD,
         'MAPFISH_PRINT_ENABLED': True,
         'PRINT_NG_ENABLED': True,
         'GEONODE_SECURITY_ENABLED': True,

--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -997,11 +997,11 @@ GEOSERVER_WEB_UI_LOCATION = os.getenv(
     'GEOSERVER_WEB_UI_LOCATION', GEOSERVER_PUBLIC_LOCATION
 )
 
-OGC_SERVER_DEFAULT_USER = os.getenv(
+GEOSERVER_ADMIN_USER = os.getenv(
     'GEOSERVER_ADMIN_USER', 'admin'
 )
 
-OGC_SERVER_DEFAULT_PASSWORD = os.getenv(
+GEOSERVER_ADMIN_PASSWORD = os.getenv(
     'GEOSERVER_ADMIN_PASSWORD', 'geoserver'
 )
 
@@ -1021,8 +1021,8 @@ OGC_SERVER = {
         # the proxy won't work and the integration tests will fail
         # the entire block has to be overridden in the local_settings
         'PUBLIC_LOCATION': GEOSERVER_PUBLIC_LOCATION,
-        'USER': OGC_SERVER_DEFAULT_USER,
-        'PASSWORD': OGC_SERVER_DEFAULT_PASSWORD,
+        'USER': GEOSERVER_ADMIN_USER,
+        'PASSWORD': GEOSERVER_ADMIN_PASSWORD,
         'MAPFISH_PRINT_ENABLED': ast.literal_eval(os.getenv('MAPFISH_PRINT_ENABLED', 'True')),
         'PRINT_NG_ENABLED': ast.literal_eval(os.getenv('PRINT_NG_ENABLED', 'True')),
         'GEONODE_SECURITY_ENABLED': ast.literal_eval(os.getenv('GEONODE_SECURITY_ENABLED', 'True')),

--- a/geonode/upload/tests/test_settings.py
+++ b/geonode/upload/tests/test_settings.py
@@ -117,11 +117,11 @@ GEOSERVER_PUBLIC_LOCATION = os.getenv(
     'GEOSERVER_PUBLIC_LOCATION', _default_public_location
 )
 
-OGC_SERVER_DEFAULT_USER = os.getenv(
+GEOSERVER_ADMIN_USER = os.getenv(
     'GEOSERVER_ADMIN_USER', 'admin'
 )
 
-OGC_SERVER_DEFAULT_PASSWORD = os.getenv(
+GEOSERVER_ADMIN_PASSWORD = os.getenv(
     'GEOSERVER_ADMIN_PASSWORD', 'geoserver'
 )
 
@@ -137,8 +137,8 @@ OGC_SERVER = {
         # the proxy won't work and the integration tests will fail
         # the entire block has to be overridden in the local_settings
         'PUBLIC_LOCATION': GEOSERVER_PUBLIC_LOCATION,
-        'USER': OGC_SERVER_DEFAULT_USER,
-        'PASSWORD': OGC_SERVER_DEFAULT_PASSWORD,
+        'USER': GEOSERVER_ADMIN_USER,
+        'PASSWORD': GEOSERVER_ADMIN_PASSWORD,
         'MAPFISH_PRINT_ENABLED': True,
         'PRINT_NG_ENABLED': True,
         'GEONODE_SECURITY_ENABLED': True,

--- a/package/support/geonode.local_settings
+++ b/package/support/geonode.local_settings
@@ -98,11 +98,11 @@ GEOSERVER_PUBLIC_LOCATION = os.getenv(
     'GEOSERVER_PUBLIC_LOCATION', '{}gs/'.format(SITEURL)
 )
 
-OGC_SERVER_DEFAULT_USER = os.getenv(
+GEOSERVER_ADMIN_USER = os.getenv(
     'GEOSERVER_ADMIN_USER', 'admin'
 )
 
-OGC_SERVER_DEFAULT_PASSWORD = os.getenv(
+GEOSERVER_ADMIN_PASSWORD = os.getenv(
     'GEOSERVER_ADMIN_PASSWORD', 'geoserver'
 )
 
@@ -117,8 +117,8 @@ OGC_SERVER = {
         # the proxy won't work and the integration tests will fail
         # the entire block has to be overridden in the local_settings
         'PUBLIC_LOCATION': GEOSERVER_PUBLIC_LOCATION,
-        'USER': OGC_SERVER_DEFAULT_USER,
-        'PASSWORD': OGC_SERVER_DEFAULT_PASSWORD,
+        'USER': GEOSERVER_ADMIN_USER,
+        'PASSWORD': GEOSERVER_ADMIN_PASSWORD,
         'MAPFISH_PRINT_ENABLED': True,
         'PRINT_NG_ENABLED': True,
         'GEONODE_SECURITY_ENABLED': True,

--- a/tasks.py
+++ b/tasks.py
@@ -43,10 +43,7 @@ def waitfordbs(ctx):
 
 @task
 def waitforgeoserver(ctx):
-    print("****************************geoserver********************************")
-    while not _rest_api_availability(f"{os.environ['GEOSERVER_LOCATION']}rest"):
-        print("Wait for GeoServer API availability...")
-    print("GeoServer is available for HTTP calls!")
+    _waitforgeoserver()
 
 
 @task
@@ -251,6 +248,7 @@ def collectstatic(ctx):
 
 @task
 def geoserverfixture(ctx):
+    _waitforgeoserver()
     print("********************geoserver fixture********************************")
     _geoserver_info_provision(f"{os.environ['GEOSERVER_LOCATION']}rest/")
 
@@ -404,8 +402,8 @@ def _geoserver_info_provision(url):
     print("Setting GeoServer Admin Password...")
     cat = Catalog(
         url,
-        username=settings.OGC_SERVER_DEFAULT_USER,
-        password=settings.OGC_SERVER_DEFAULT_PASSWORD
+        username="admin",
+        password="geoserver"
     )
     headers = {
         "Content-type": "application/xml",
@@ -596,3 +594,9 @@ def _prepare_admin_fixture(admin_password, admin_email):
     ]
     with open('/tmp/django_admin_docker.json', 'w') as fixturefile:
         json.dump(default_fixture, fixturefile)
+
+def _waitforgeoserver():
+    print("****************************geoserver********************************")
+    while not _rest_api_availability(f"{os.environ['GEOSERVER_LOCATION']}rest"):
+        print("Wait for GeoServer API availability...")
+    print("GeoServer is available for HTTP calls!")


### PR DESCRIPTION
When initializing the geonode stack with docker, the password for the geoserver admin user is changed from the default to the value of $GEOSERVER_ADMIN_PASSWORD. Subsequent password changes require manual intervention to update the password in geoserver (even if FORCE_REINIT=true).

OGC_SERVER_DEFAULT_PASSWORD and OGC_SERVER_DEFAULT_USER are redundant as they always took the value of GEOSERVER_ADMIN_PASSWORD/GEOSERVER_ADMIN_USER if defined, replaced with GEOSERVER_ADMIN_PASSWORD/GEOSERVER_ADMIN_USER to avoid confusion.

Corresponding issues in geonode-project:
* GeoNode/geonode-project#332
* GeoNode/geonode-project#172
* GeoNode/geonode-project#209

## Checklist

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
