### PR TITLE
[Fixes #10091] improve thumbnails quality

### DIFF
--- a/geonode/base/api/tests.py
+++ b/geonode/base/api/tests.py
@@ -2014,7 +2014,7 @@ class BaseApiTests(APITestCase):
             _mck.return_value = False
             response = self.client.put(url, data=data, format="json")
             self.assertEqual(response.status_code, 200)
-            self.assertIsNotNone(re.search(f"dataset-{re_uuid}-thumb-{re_uuid}.png", Dataset.objects.get(pk=resource.pk).thumbnail_url, re.I))
+            self.assertIsNotNone(re.search(f"dataset-{re_uuid}-thumb-{re_uuid}.jpg", Dataset.objects.get(pk=resource.pk).thumbnail_url, re.I))
             # File upload
             with patch('PIL.Image.open') as _mck:
                 _mck.return_value = test_image
@@ -2024,7 +2024,7 @@ class BaseApiTests(APITestCase):
                 self.assertEqual(Dataset.objects.get(pk=resource.pk).thumbnail_url, None)
                 f = SimpleUploadedFile('test_image.png', BytesIO(test_image.tobytes()).read(), 'image/png')
                 response = self.client.put(url, data={"file": f})
-                self.assertIsNotNone(re.search(f"dataset-{re_uuid}-thumb-{re_uuid}.png", Dataset.objects.get(pk=resource.pk).thumbnail_url, re.I))
+                self.assertIsNotNone(re.search(f"dataset-{re_uuid}-thumb-{re_uuid}.jpg", Dataset.objects.get(pk=resource.pk).thumbnail_url, re.I))
                 self.assertEqual(response.status_code, 200)
 
     def test_set_thumbnail_from_bbox_from_Anonymous_user_raise_permission_error(self):

--- a/geonode/base/models.py
+++ b/geonode/base/models.py
@@ -1743,14 +1743,11 @@ class ResourceBase(PolymorphicModel, PermissionLevelMixin, ItemBase):
                     # Optimize the Thumbnail size and resolution
                     _default_thumb_size = settings.THUMBNAIL_SIZE
                     im = Image.open(storage_manager.open(actual_name))
-                    im.thumbnail(
-                        (_default_thumb_size['width'], _default_thumb_size['height']),
-                        resample=Image.ANTIALIAS)
                     cover = ImageOps.fit(im, (_default_thumb_size['width'], _default_thumb_size['height']))
 
                     # Saving the thumb into a temporary directory on file system
                     tmp_location = os.path.abspath(f"{settings.MEDIA_ROOT}/{upload_path}")
-                    cover.save(tmp_location, format='PNG')
+                    cover.save(tmp_location, quality="high")
 
                     with open(tmp_location, 'rb+') as img:
                         # Saving the img via storage manager

--- a/geonode/base/models.py
+++ b/geonode/base/models.py
@@ -1723,6 +1723,8 @@ class ResourceBase(PolymorphicModel, PermissionLevelMixin, ItemBase):
     # that indexing (or other listeners) are notified
     def save_thumbnail(self, filename, image):
         upload_path = get_unique_upload_path(filename)
+        # force convertion to JPEG output file
+        upload_path = f'{os.path.splitext(upload_path)[0]}.jpg'
         try:
             # Check that the image is valid
             if is_monochromatic_image(None, image):
@@ -1743,7 +1745,7 @@ class ResourceBase(PolymorphicModel, PermissionLevelMixin, ItemBase):
                     # Optimize the Thumbnail size and resolution
                     _default_thumb_size = settings.THUMBNAIL_SIZE
                     im = Image.open(storage_manager.open(actual_name))
-                    cover = ImageOps.fit(im, (_default_thumb_size['width'], _default_thumb_size['height']))
+                    cover = ImageOps.fit(im, (_default_thumb_size['width'], _default_thumb_size['height'])).convert("RGB")
 
                     # Saving the thumb into a temporary directory on file system
                     tmp_location = os.path.abspath(f"{settings.MEDIA_ROOT}/{upload_path}")

--- a/geonode/documents/tasks.py
+++ b/geonode/documents/tasks.py
@@ -79,7 +79,7 @@ def create_document_thumbnail(self, object_id):
         logger.warning(f"Thumbnail for document #{object_id} empty.")
         ResourceBase.objects.filter(id=document.id).update(thumbnail_url=None)
     else:
-        filename = f'document-{document.uuid}-thumb.png'
+        filename = f'document-{document.uuid}-thumb.jpg'
         document.save_thumbnail(filename, thumbnail_content)
         logger.debug(f"Thumbnail for document #{object_id} created.")
 

--- a/geonode/documents/tests.py
+++ b/geonode/documents/tests.py
@@ -301,6 +301,8 @@ class DocumentsTest(GeoNodeBaseTestSupport):
                     )
                     file = Image.open(thumb_file)
                     self.assertEqual(file.size, (400, 200))
+                    # check thumbnail qualty and extention
+                    self.assertEqual(file.format, 'JPEG')
         finally:
             Document.objects.filter(title='img File Doc').delete()
 

--- a/geonode/thumbs/tests/test_integration.py
+++ b/geonode/thumbs/tests/test_integration.py
@@ -238,7 +238,7 @@ class GeoNodeThumbnailTileBackground(GeoNodeBaseTestSupport):
     )
     def test_tile_background_generic_fetch_zoom(self):
 
-        width = 240
+        width = 500
         height = 200
 
         bbox_3857 = [-8250483.072013094, -8221819.186406153, 4961221.562116772, 4985108.133455889, "EPSG:3857"]

--- a/geonode/thumbs/tests/test_unit.py
+++ b/geonode/thumbs/tests/test_unit.py
@@ -128,7 +128,7 @@ class ThumbnailsUnitTest(GeoNodeBaseTestSupport):
 
         dataset_name = thumbnails._generate_thumbnail_name(Dataset.objects.first())
         self.assertIsNotNone(
-            re.match(f"dataset-{self.re_uuid}-thumb.jpg", dataset_name, re.I), "Dataset name should meet a provided pattern"
+            re.match(f"dataset-{self.re_uuid}-thumb.png", dataset_name, re.I), "Dataset name should meet a provided pattern"
         )
 
     def test_get_unique_upload_path(self):
@@ -154,7 +154,7 @@ class ThumbnailsUnitTest(GeoNodeBaseTestSupport):
 
         map_name = thumbnails._generate_thumbnail_name(Map.objects.first())
         self.assertIsNotNone(
-            re.match(f"map-{self.re_uuid}-thumb.jpg", map_name, re.I), "Map name should meet a provided pattern"
+            re.match(f"map-{self.re_uuid}-thumb.png", map_name, re.I), "Map name should meet a provided pattern"
         )
 
     def test_generate_thumbnail_name_document(self):
@@ -168,7 +168,7 @@ class ThumbnailsUnitTest(GeoNodeBaseTestSupport):
             ))
         name = thumbnails._generate_thumbnail_name(doc)
         self.assertIsNotNone(
-            re.match(f"document-{self.re_uuid}-thumb.jpg", name, re.I), "Document name should meet a provided pattern"
+            re.match(f"document-{self.re_uuid}-thumb.png", name, re.I), "Document name should meet a provided pattern"
         )
 
     def test_generate_thumbnail_name_geoapp(self):
@@ -184,7 +184,7 @@ class ThumbnailsUnitTest(GeoNodeBaseTestSupport):
         )
         name = thumbnails._generate_thumbnail_name(geo_app)
         self.assertIsNotNone(
-            re.match(f"geoapp-{self.re_uuid}-thumb.jpg", name, re.I), "GeoApp name should meet a provided pattern"
+            re.match(f"geoapp-{self.re_uuid}-thumb.png", name, re.I), "GeoApp name should meet a provided pattern"
         )
 
     def test_datasets_locations_dataset(self):

--- a/geonode/thumbs/tests/test_unit.py
+++ b/geonode/thumbs/tests/test_unit.py
@@ -128,7 +128,7 @@ class ThumbnailsUnitTest(GeoNodeBaseTestSupport):
 
         dataset_name = thumbnails._generate_thumbnail_name(Dataset.objects.first())
         self.assertIsNotNone(
-            re.match(f"dataset-{self.re_uuid}-thumb.png", dataset_name, re.I), "Dataset name should meet a provided pattern"
+            re.match(f"dataset-{self.re_uuid}-thumb.jpg", dataset_name, re.I), "Dataset name should meet a provided pattern"
         )
 
     def test_get_unique_upload_path(self):
@@ -154,7 +154,7 @@ class ThumbnailsUnitTest(GeoNodeBaseTestSupport):
 
         map_name = thumbnails._generate_thumbnail_name(Map.objects.first())
         self.assertIsNotNone(
-            re.match(f"map-{self.re_uuid}-thumb.png", map_name, re.I), "Map name should meet a provided pattern"
+            re.match(f"map-{self.re_uuid}-thumb.jpg", map_name, re.I), "Map name should meet a provided pattern"
         )
 
     def test_generate_thumbnail_name_document(self):
@@ -168,7 +168,7 @@ class ThumbnailsUnitTest(GeoNodeBaseTestSupport):
             ))
         name = thumbnails._generate_thumbnail_name(doc)
         self.assertIsNotNone(
-            re.match(f"document-{self.re_uuid}-thumb.png", name, re.I), "Document name should meet a provided pattern"
+            re.match(f"document-{self.re_uuid}-thumb.jpg", name, re.I), "Document name should meet a provided pattern"
         )
 
     def test_generate_thumbnail_name_geoapp(self):
@@ -184,7 +184,7 @@ class ThumbnailsUnitTest(GeoNodeBaseTestSupport):
         )
         name = thumbnails._generate_thumbnail_name(geo_app)
         self.assertIsNotNone(
-            re.match(f"geoapp-{self.re_uuid}-thumb.png", name, re.I), "GeoApp name should meet a provided pattern"
+            re.match(f"geoapp-{self.re_uuid}-thumb.jpg", name, re.I), "GeoApp name should meet a provided pattern"
         )
 
     def test_datasets_locations_dataset(self):


### PR DESCRIPTION
ref #10091 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
