### PR TITLE
[Fixes #10138] Render pdf thumbnails from top margin

### DIFF
--- a/geonode/base/models.py
+++ b/geonode/base/models.py
@@ -1721,7 +1721,7 @@ class ResourceBase(PolymorphicModel, PermissionLevelMixin, ItemBase):
 
     # Note - you should probably broadcast layer#post_save() events to ensure
     # that indexing (or other listeners) are notified
-    def save_thumbnail(self, filename, image):
+    def save_thumbnail(self, filename, image, **kwargs):
         upload_path = get_unique_upload_path(filename)
         # force convertion to JPEG output file
         upload_path = f'{os.path.splitext(upload_path)[0]}.jpg'
@@ -1745,7 +1745,8 @@ class ResourceBase(PolymorphicModel, PermissionLevelMixin, ItemBase):
                     # Optimize the Thumbnail size and resolution
                     _default_thumb_size = settings.THUMBNAIL_SIZE
                     im = Image.open(storage_manager.open(actual_name))
-                    cover = ImageOps.fit(im, (_default_thumb_size['width'], _default_thumb_size['height'])).convert("RGB")
+                    centering = kwargs.get("centering",(0.5,0.5))
+                    cover = ImageOps.fit(im, (_default_thumb_size['width'], _default_thumb_size['height']), centering=centering).convert("RGB")
 
                     # Saving the thumb into a temporary directory on file system
                     tmp_location = os.path.abspath(f"{settings.MEDIA_ROOT}/{upload_path}")

--- a/geonode/base/models.py
+++ b/geonode/base/models.py
@@ -1745,7 +1745,7 @@ class ResourceBase(PolymorphicModel, PermissionLevelMixin, ItemBase):
                     # Optimize the Thumbnail size and resolution
                     _default_thumb_size = settings.THUMBNAIL_SIZE
                     im = Image.open(storage_manager.open(actual_name))
-                    centering = kwargs.get("centering",(0.5,0.5))
+                    centering = kwargs.get("centering", (0.5, 0.5))
                     cover = ImageOps.fit(im, (_default_thumb_size['width'], _default_thumb_size['height']), centering=centering).convert("RGB")
 
                     # Saving the thumb into a temporary directory on file system

--- a/geonode/documents/management/commands/sync_geonode_documents.py
+++ b/geonode/documents/management/commands/sync_geonode_documents.py
@@ -35,13 +35,21 @@ class Command(BaseCommand):
             action='store_true',
             dest="updatethumbnails",
             default=False,
-            help="Update the document thumbnails.")
+            help="Generate thumbnails for documents. Only documents without a thumbnail will be considered, unless --force is used.")
+
+        parser.add_argument(
+            '--force',
+            action='store_true',
+            dest="force",
+            default=False,
+            help="Force the update of thumbnails for all documents.")
 
     def handle(self, *args, **options):
         updatethumbnails = options.get('updatethumbnails')
+        force = options.get('force')
         for doc in Document.objects.all():
             if updatethumbnails:
-                if doc.thumbnail_url is None or doc.thumbnail_url == '':
+                if (doc.thumbnail_url is None or doc.thumbnail_url == '') or force:
                     try:
                         create_document_thumbnail(doc.id)
                     except Exception:


### PR DESCRIPTION
ref #10138 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
