### PR TITLE
[4.0.x][Fixes #10208] Add a custom hook at the end of the permissions assign

### DIFF
--- a/geonode/geoserver/manager.py
+++ b/geonode/geoserver/manager.py
@@ -46,7 +46,7 @@ from geonode.security.permissions import (
 from geonode.resource.manager import (
     ResourceManager,
     ResourceManagerInterface)
-from geonode.geoserver.signals import geofence_rule_assign
+from geonode.geoserver.signals import post_set_permissions
 from .tasks import (
     geoserver_set_style,
     geoserver_delete_map,
@@ -473,7 +473,7 @@ class GeoServerResourceManager(ResourceManagerInterface):
             logger.exception(e)
             return False
 
-        geofence_rule_assign.send_robust(sender=instance, instance=instance)
+        post_set_permissions.send_robust(sender=instance, instance=instance)
 
         return True
 

--- a/geonode/geoserver/manager.py
+++ b/geonode/geoserver/manager.py
@@ -46,7 +46,7 @@ from geonode.security.permissions import (
 from geonode.resource.manager import (
     ResourceManager,
     ResourceManagerInterface)
-
+from geonode.geoserver.signals import geofence_rule_assign
 from .tasks import (
     geoserver_set_style,
     geoserver_delete_map,
@@ -472,6 +472,9 @@ class GeoServerResourceManager(ResourceManagerInterface):
         except Exception as e:
             logger.exception(e)
             return False
+
+        geofence_rule_assign.send_robust(sender=instance, instance=instance)
+
         return True
 
     def set_thumbnail(self, uuid: str, /, instance: ResourceBase = None, overwrite: bool = True, check_bbox: bool = True) -> bool:

--- a/geonode/geoserver/signals.py
+++ b/geonode/geoserver/signals.py
@@ -42,7 +42,7 @@ logger = logging.getLogger("geonode.geoserver.signals")
 
 geoserver_automatic_default_style_set = Signal(providing_args=['instance'])
 
-geofence_rule_assign = Signal(providing_args=['instance'])
+post_set_permissions = Signal(providing_args=['instance'])
 
 
 def geoserver_delete(typename):

--- a/geonode/geoserver/signals.py
+++ b/geonode/geoserver/signals.py
@@ -42,6 +42,8 @@ logger = logging.getLogger("geonode.geoserver.signals")
 
 geoserver_automatic_default_style_set = Signal(providing_args=['instance'])
 
+geofence_rule_assign = Signal(providing_args=['instance'])
+
 
 def geoserver_delete(typename):
     # cascading_delete should only be called if


### PR DESCRIPTION
ref #10208

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
