### PR TITLE
[Fixes #10214] metadata_only filter not working properly

### DIFF
--- a/geonode/documents/views.py
+++ b/geonode/documents/views.py
@@ -141,6 +141,7 @@ def document_embed(request, docid):
 class DocumentUploadView(CreateView):
     http_method_names = ['post']
     form_class = DocumentCreateForm
+    from django.views.decorators.csrf import csrf_exempt
 
     def post(self, request, *args, **kwargs):
         self.object = None

--- a/geonode/documents/views.py
+++ b/geonode/documents/views.py
@@ -141,7 +141,6 @@ def document_embed(request, docid):
 class DocumentUploadView(CreateView):
     http_method_names = ['post']
     form_class = DocumentCreateForm
-    from django.views.decorators.csrf import csrf_exempt
 
     def post(self, request, *args, **kwargs):
         self.object = None

--- a/geonode/security/tests.py
+++ b/geonode/security/tests.py
@@ -1505,6 +1505,38 @@ class SecurityTests(ResourceTestCaseMixin, GeoNodeBaseTestSupport):
         actual = get_visible_resources(queryset=layers, user=get_user_model().objects.get(username=self.user))
         self.assertEqual(layers.filter(dirty_state=False).count(), len(actual))
 
+    def test_get_visible_resources_should_return_resource_with_metadata_only_true(self):
+        '''
+        If metadata only is provided, it should return only the metadata resources
+        '''
+        try:
+            dataset = create_single_dataset("dataset_with_metadata_only_True")
+            dataset.metadata_only = True
+            dataset.save()
+
+            layers = Dataset.objects.all()
+            actual = get_visible_resources(queryset=layers, metadata_only=True, user=get_user_model().objects.get(username=self.user))
+            self.assertEqual(1, actual.count())
+        finally:
+            if dataset:
+                dataset.delete()
+
+    def test_get_visible_resources_should_return_resource_with_metadata_only_none(self):
+        '''
+        If metadata only is provided, it should return only the metadata resources
+        '''
+        try:
+            dataset = create_single_dataset("dataset_with_metadata_only_True")
+            dataset.metadata_only = True
+            dataset.save()
+
+            layers = Dataset.objects.all()
+            actual = get_visible_resources(queryset=layers, metadata_only=None, user=get_user_model().objects.get(username=self.user))
+            self.assertEqual(layers.count(), actual.count())
+        finally:
+            if dataset:
+                dataset.delete()
+
     @override_settings(
         ADMIN_MODERATE_UPLOADS=True,
         RESOURCE_PUBLISHING=True,

--- a/geonode/security/utils.py
+++ b/geonode/security/utils.py
@@ -78,9 +78,11 @@ def get_visible_resources(queryset,
     except Exception:
         pass
 
-    # Hide Dirty State Resources
-    filter_set = queryset.filter(
-        Q(dirty_state=False) & Q(metadata_only=metadata_only))
+    filter_set = queryset.filter(dirty_state=False)
+
+    if metadata_only is not None:
+        # Hide Dirty State Resources
+        filter_set = filter_set.filter(metadata_only=metadata_only)
 
     if not is_admin:
         if user:


### PR DESCRIPTION
ref #10214 
## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
