### PR TITLE
[Fixes #10287] The "set_layer_permissions" management command does not behave correctly with "AnonyousUser"

### DIFF
--- a/geonode/base/views.py
+++ b/geonode/base/views.py
@@ -124,14 +124,27 @@ def user_and_group_permission(request, model):
             permissions_names = form.cleaned_data.get('permission_type')
 
             if permissions_names:
-                set_permissions.apply_async(
-                    ([permissions_names], resources_names, users_usernames, groups_names, delete_flag))
+                if 'edit' in permissions_names and 'AnonymousUser' in users_usernames:
+                    messages.add_message(
+                        request,
+                        messages.ERROR,
+                        '"EDIT" permissions not allowed for the "AnonymousUser".'
+                    )
+                else:
+                    set_permissions.apply_async(
+                        ([permissions_names], resources_names, users_usernames, groups_names, delete_flag))
 
-            messages.add_message(
-                request,
-                messages.INFO,
-                f'The asyncronous permissions {form.cleaned_data.get("mode")} request for {", ".join(users_usernames or groups_names)} has been sent'
-            )
+                    messages.add_message(
+                        request,
+                        messages.INFO,
+                        f'The asyncronous permissions {form.cleaned_data.get("mode")} request for {", ".join(users_usernames or groups_names)} has been sent'
+                    )
+            else:
+                messages.add_message(
+                    request,
+                    messages.ERROR,
+                    'No permissions have been set.'
+                )
         else:
             messages.add_message(
                 request,

--- a/geonode/base/views.py
+++ b/geonode/base/views.py
@@ -123,34 +123,31 @@ def user_and_group_permission(request, model):
             delete_flag = form.cleaned_data.get('mode') == 'unset'
             permissions_names = form.cleaned_data.get('permission_type')
 
+            _message = ''
+            _errors = False
             if permissions_names:
                 if 'edit' in permissions_names and 'AnonymousUser' in users_usernames:
-                    messages.add_message(
-                        request,
-                        messages.ERROR,
-                        '"EDIT" permissions not allowed for the "AnonymousUser".'
-                    )
+                    if not _errors:
+                        _message = '"EDIT" permissions not allowed for the "AnonymousUser".'
+                        _errors = True
                 else:
                     set_permissions.apply_async(
                         ([permissions_names], resources_names, users_usernames, groups_names, delete_flag))
-
-                    messages.add_message(
-                        request,
-                        messages.INFO,
-                        f'The asyncronous permissions {form.cleaned_data.get("mode")} request for {", ".join(users_usernames or groups_names)} has been sent'
-                    )
+                    if not _errors:
+                        _message = f'The asyncronous permissions {form.cleaned_data.get("mode")} request for {", ".join(users_usernames or groups_names)} has been sent'
             else:
-                messages.add_message(
-                    request,
-                    messages.ERROR,
-                    'No permissions have been set.'
-                )
+                if not _errors:
+                    _message = 'No permissions have been set.'
+                    _errors = True
         else:
-            messages.add_message(
-                request,
-                messages.ERROR,
-                f'Some error has occured {form.errors}'
-            )
+            if not _errors:
+                _message = f'Some error has occured {form.errors}'
+                _errors = True
+        messages.add_message(
+            request,
+            (messages.INFO if not _errors else messages.ERROR),
+            _message
+        )
         return HttpResponseRedirect(
             get_url_for_app_model(model, model_class))
 

--- a/geonode/base/views.py
+++ b/geonode/base/views.py
@@ -102,6 +102,8 @@ def user_and_group_permission(request, model):
     if request.method == 'POST':
         form = UserAndGroupPermissionsForm(request.POST)
         ids = ids.split(",")
+        _message = ''
+        _errors = False
         if form.is_valid():
             resources_names = form.cleaned_data.get('layers')
             users_usernames = [user.username for user in model_class.objects.filter(
@@ -123,8 +125,6 @@ def user_and_group_permission(request, model):
             delete_flag = form.cleaned_data.get('mode') == 'unset'
             permissions_names = form.cleaned_data.get('permission_type')
 
-            _message = ''
-            _errors = False
             if permissions_names:
                 if 'edit' in permissions_names and 'AnonymousUser' in users_usernames:
                     if not _errors:

--- a/geonode/layers/tests.py
+++ b/geonode/layers/tests.py
@@ -2117,15 +2117,6 @@ class SetLayersPermissionsCommand(GeoNodeBaseTestSupport):
         '''
         try:
             expected_perms = {
-                'delete_resourcebase',
-                'change_resourcebase',
-                'view_resourcebase',
-                'change_resourcebase_permissions',
-                'change_dataset_style',
-                'change_resourcebase_metadata',
-                'publish_resourcebase',
-                'change_dataset_data',
-                'download_resourcebase'
             }
 
             dataset, args, username, opts = self._create_arguments(perms_type='edit')

--- a/geonode/layers/utils.py
+++ b/geonode/layers/utils.py
@@ -496,6 +496,8 @@ def set_datasets_permissions(permissions_name, resources_names=None, users_usern
                     for _group, _perms in perms_spec_compact_resource.extended["groups"].items()
                     if _user not in copy_compact_perms.extended["groups"]
                 }
+                if final_perms_payload["users"].get("AnonymousUser") is None and final_perms_payload["groups"].get("anonymous"):
+                    final_perms_payload["groups"].pop("anonymous")
 
             # calling the resource manager to set the permissions
             resource_manager.set_permissions(resource.uuid, instance=resource, permissions=final_perms_payload)


### PR DESCRIPTION
References: #10287

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [ ] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [ ] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
