### PR TITLE
[Fixes #9041] Docker NGINX listen on ports 80/443

### DIFF
--- a/scripts/docker/nginx/docker-entrypoint.sh
+++ b/scripts/docker/nginx/docker-entrypoint.sh
@@ -33,20 +33,14 @@ else
 fi
 
 echo "Sanity checks on http/s ports configuration"
-if [ -z "${HTTP_PORT}" ]; then
-        HTTP_PORT=80
-fi
-if [ -z "${HTTPS_PORT}" ]; then
-        HTTPS_PORT=443
-fi
 if [ -z "${JENKINS_HTTP_PORT}" ]; then
         JENKINS_HTTP_PORT=9080
 fi
 
 echo "Replacing environement variables"
-envsubst '\$HTTP_PORT \$HTTPS_PORT \$HTTP_HOST \$HTTPS_HOST \$RESOLVER' < /etc/nginx/nginx.conf.envsubst > /etc/nginx/nginx.conf
-envsubst '\$HTTP_PORT \$HTTPS_PORT \$HTTP_HOST \$HTTPS_HOST \$RESOLVER' < /etc/nginx/nginx.https.available.conf.envsubst > /etc/nginx/nginx.https.available.conf
-envsubst '\$HTTP_PORT \$HTTPS_PORT \$HTTP_HOST \$HTTPS_HOST \$JENKINS_HTTP_PORT' < /etc/nginx/sites-enabled/geonode.conf.envsubst > /etc/nginx/sites-enabled/geonode.conf
+envsubst '\$HTTP_HOST \$HTTPS_HOST \$RESOLVER' < /etc/nginx/nginx.conf.envsubst > /etc/nginx/nginx.conf
+envsubst '\$HTTP_HOST \$HTTPS_HOST \$RESOLVER' < /etc/nginx/nginx.https.available.conf.envsubst > /etc/nginx/nginx.https.available.conf
+envsubst '\$HTTP_HOST \$HTTPS_HOST \$JENKINS_HTTP_PORT' < /etc/nginx/sites-enabled/geonode.conf.envsubst > /etc/nginx/sites-enabled/geonode.conf
 
 echo "Enabling or not https configuration"
 if [ -z "${HTTPS_HOST}" ]; then 

--- a/scripts/docker/nginx/nginx.conf.envsubst
+++ b/scripts/docker/nginx/nginx.conf.envsubst
@@ -22,7 +22,7 @@ http {
     # even if not used (HTTP_HOST empty), we must keep it as it's used for internal API calls between django and geoserver
     # TODO : do not use unencrypted connection even on LAN, but is it possible to have browser not complaining about unknown authority ?
     server {
-        listen              $HTTP_PORT;
+        listen              80;
         server_name         $HTTP_HOST 127.0.0.1 geonode;
 
         include sites-enabled/*.conf;
@@ -30,8 +30,8 @@ http {
 
     # Default server closes the connection (we can connect only using HTTP_HOST and HTTPS_HOST)
     server {
-        listen          $HTTP_PORT default_server;
-        listen          $HTTPS_PORT;
+        listen          80 default_server;
+        listen          443;
         server_name     _;
         return          444;
     }

--- a/scripts/docker/nginx/nginx.https.available.conf.envsubst
+++ b/scripts/docker/nginx/nginx.https.available.conf.envsubst
@@ -7,7 +7,7 @@ ssl_session_timeout 10m;
 
 # this is the actual HTTPS host
 server {
-    listen              $HTTPS_PORT ssl;
+    listen              443 ssl;
     server_name         $HTTPS_HOST;
     keepalive_timeout   70;
 


### PR DESCRIPTION
Containers should always listen on some fixed ports. Only remapped externally exposed ports should change.

This PR removes all references to `HTTP_PORT` and `HTTPS_PORT` inside `scripts/docker/nginx` and fixes issue #9041.

Such change should be propagated to geonode-project. I tested it successfully on geonode-project, so I believe it should work here too, since it is a rather small change and both compose files are the same with respect to how ports are remapped and exposed.

Users could still experience this issue after applying the patch, if they do not delete the `nginx-confd` volume. I would actually suggest keeping that volume disabled by default, so that the configuration is created each time, by looking at the environment variables.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [X] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [X] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [X] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [X] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [X] The issue connected to the PR must have Labels and Milestone assigned
- [X] PR for bug fixes and small new features are presented as a single commit
- [X] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**