### PR TITLE
[Fixes #10374] UUID resolver endpoint

### DIFF
--- a/geonode/catalogue/urls.py
+++ b/geonode/catalogue/urls.py
@@ -18,6 +18,7 @@
 #########################################################################
 
 from django.conf.urls import url
+from django.urls import path
 from . import views
 
 urlpatterns = [
@@ -26,5 +27,6 @@ urlpatterns = [
     url(r'^csw_to_extra_format/(?P<layeruuid>[^/]*)/(?P<resname>[^/]*).txt$',
         views.csw_render_extra_format_txt, name="csw_render_extra_format_txt"),
     url(r'^csw_to_extra_format/(?P<layeruuid>[^/]*)/(?P<resname>[^/]*).html$',
-        views.csw_render_extra_format_html, name="csw_render_extra_format_html")
+        views.csw_render_extra_format_html, name="csw_render_extra_format_html"),
+    path(r'uuid/<uuid:uuid>', views.resolve_uuid, name="resolve_uuid")
 ]

--- a/geonode/catalogue/views.py
+++ b/geonode/catalogue/views.py
@@ -20,7 +20,7 @@ import os
 import logging
 from django.conf import settings
 from django.http import HttpResponse, HttpResponseRedirect
-from django.shortcuts import render
+from django.shortcuts import render, redirect
 from django.contrib.auth import get_user_model
 from django.views.decorators.csrf import csrf_exempt
 from pycsw import server
@@ -31,6 +31,7 @@ from geonode.layers.models import Dataset
 from geonode.base.auth import get_or_create_token
 from geonode.base.models import ContactRole, SpatialRepresentationType
 from geonode.groups.models import GroupProfile
+from geonode.utils import resolve_object
 from django.db import connection
 from django.core.exceptions import ObjectDoesNotExist
 
@@ -330,3 +331,8 @@ def csw_render_extra_format_html(request, layeruuid, resname):
     extra_res_md['poc_email'] = pocp.email
     return render(request, "geonode_metadata_full.html", context={"resource": resource,
                                                                   "extra_res_md": extra_res_md})
+
+
+def resolve_uuid(request, uuid):
+    resource = resolve_object(request, ResourceBase, {"uuid": uuid})
+    return redirect(resource)


### PR DESCRIPTION
References: #10374

A new UI route (`/catalogue/:uuid`) has been defined that takes a UUID as a parameter. In the backend, a corresponding database query is triggered which, based on the available metadata of the layer, allows the user to be redirected to the actual URL.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
