### PR TITLE
[Fixes #10462] GeoNode is vulnerable to an XML External Entity (XXE) injection

### DIFF
--- a/geonode/geoserver/helpers.py
+++ b/geonode/geoserver/helpers.py
@@ -238,7 +238,7 @@ def extract_name_from_sld(gs_catalog, sld, sld_file=None):
                     sld = sld_file.read()
             if isinstance(sld, str):
                 sld = sld.encode('utf-8')
-            dom = etree.XML(sld)
+            dom = etree.XML(sld, parser=etree.XMLParser(resolve_entities=False))
         elif sld_file and isfile(sld_file):
             with open(sld_file, "rb") as sld_file:
                 sld = sld_file.read()
@@ -378,7 +378,7 @@ def set_dataset_style(saved_dataset, title, sld, base_file=None):
             elif isinstance(sld, str):
                 sld = sld.strip('b\'\n')
                 sld = re.sub(r'(\\r)|(\\n)', '', sld).encode("UTF-8")
-            etree.XML(sld)
+            etree.XML(sld, parser=etree.XMLParser(resolve_entities=False))
         elif base_file and isfile(base_file):
             with open(base_file, "rb") as sld_file:
                 sld = sld_file.read()

--- a/geonode/geoserver/tests/test_helpers.py
+++ b/geonode/geoserver/tests/test_helpers.py
@@ -28,7 +28,10 @@ from geonode import geoserver
 from geonode.decorators import on_ogc_backend
 from geonode.tests.base import GeoNodeBaseTestSupport
 from geonode.geoserver.views import _response_callback
-from geonode.geoserver.helpers import get_dataset_storetype
+from geonode.geoserver.helpers import (
+    gs_catalog,
+    get_dataset_storetype,
+    extract_name_from_sld)
 from geonode.layers.populate_datasets_data import create_dataset_data
 
 from geonode.geoserver.ows import (
@@ -70,6 +73,19 @@ class HelperTest(GeoNodeBaseTestSupport):
         self.user = 'admin'
         self.passwd = 'admin'
         create_dataset_data()
+
+    @on_ogc_backend(geoserver.BACKEND_PACKAGE)
+    def test_extract_name_from_sld(self):
+        content = """<?xml version="1.0" standalone="yes"?>
+<!DOCTYPE foo [ <!ENTITY ent SYSTEM "/etc/passwd" > ]>
+<foo xmlns="http://www.opengis.net/sld">
+<NamedLayer>
+    <UserStyle>
+        <Name>&ent;</Name>
+    </UserStyle>
+</NamedLayer>
+</foo>"""
+        self.assertIsNone(extract_name_from_sld(gs_catalog, content))
 
     @on_ogc_backend(geoserver.BACKEND_PACKAGE)
     def test_replace_callback(self):

--- a/geonode/geoserver/views.py
+++ b/geonode/geoserver/views.py
@@ -179,7 +179,7 @@ def dataset_style_upload(request, layername):
                 if isfile(sld):
                     with open(sld) as sld_file:
                         sld = sld_file.read()
-                etree.XML(sld)
+                etree.XML(sld, parser=etree.XMLParser(resolve_entities=False))
         except Exception:
             logger.exception("The uploaded SLD file is not valid XML")
             raise Exception(
@@ -799,7 +799,7 @@ def get_capabilities(request, layerid=None, user=None,
                     }
                     gc_str = tpl.render(ctx)
                     gc_str = gc_str.encode("utf-8", "replace")
-                    layerelem = etree.XML(gc_str)
+                    layerelem = etree.XML(gc_str, parser=etree.XMLParser(resolve_entities=False))
                     rootdoc = etree.ElementTree(layerelem)
             except Exception as e:
                 import traceback


### PR DESCRIPTION
References: #10462

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
