### PR TITLE
Fix ISO 19139 metadata validity

### DIFF
--- a/geonode/catalogue/templates/catalogue/full_metadata.xml
+++ b/geonode/catalogue/templates/catalogue/full_metadata.xml
@@ -186,14 +186,14 @@
      <gmd:MD_DataIdentification>
        <gmd:citation>
          <gmd:CI_Citation>
-           {% if layer.alternate %}
-           <gmd:name>
-             <gco:CharacterString>{{layer.alternate}}</gco:CharacterString>
-           </gmd:name>
-           {% endif %}
            <gmd:title>
              <gco:CharacterString>{{layer.title}}</gco:CharacterString>
            </gmd:title>
+           {% if layer.alternate %}
+           <gmd:alternateTitle>
+             <gco:CharacterString>{{layer.alternate}}</gco:CharacterString>
+           </gmd:alternateTitle>
+           {% endif %}
            <gmd:date>
              <gmd:CI_Date>
                <gmd:date>
@@ -501,10 +501,10 @@
        </gmd:contentType>
      </gmd:MD_CoverageDescription>
      {% elif layer.subtype == 'vector' %}
-     <gmd:includedWithDataset>
-       <gco:Boolean>0</gco:Boolean>
-     </gmd:includedWithDataset>
      <gmd:MD_FeatureCatalogueDescription>
+       <gmd:includedWithDataset>
+         <gco:Boolean>0</gco:Boolean>
+       </gmd:includedWithDataset>
        <gmd:featureCatalogueCitation uuidref="{{layer.uuid}}" xlink:href="{{ SITEURL }}{{ layer.get_absolute_url }}/feature_catalogue"/>
      </gmd:MD_FeatureCatalogueDescription>
      {% endif %}
@@ -583,3 +583,4 @@
      </gmd:DQ_DataQuality>
    </gmd:dataQualityInfo>
  </gmd:MD_Metadata>
+ 


### PR DESCRIPTION
This is a small fix for the ISO 19139 metadata template. Two validation problems are solved. Metadata served via pycsw should be valid after integrating the adjustments.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users): https://github.com/GeoNode/geonode/issues/7181
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
