### PR TITLE
[CLA] add 52North staff to .clabot

### DIFF
--- a/.clabot
+++ b/.clabot
@@ -66,6 +66,13 @@
     "jkariukidev",
     "mwallschlaeger",
     "edsonflavio",
-    "MalteIwanicki"
+    "MalteIwanicki",
+    "autermann",
+    "ridoo",
+    "MarkusKonk",
+    "MatthesRieke",
+    "JohannesSchnell",
+    "EHJ-52n",
+    "MartinPontius"
   ]
 }


### PR DESCRIPTION
PR for adding 52°North staff to the CLA bot config