### PR TITLE
Fixes AttributeError: module 'lib' has no attribute 'OpenSSL_add_all_algorithms' 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -97,6 +97,7 @@ geonode-announcements==2.0.2
 geonode-django-activity-stream==0.10.0
 gn-arcrest==10.5.5
 geoserver-restconfig==2.0.8
+cryptography==38.0.4
 gn-gsimporter==2.0.4
 gisdata==0.5.4
 


### PR DESCRIPTION
Version 39.0.0 contains a bug on latest OpenSSL,
34.0.8 needs to be enforced for now

![image](https://user-images.githubusercontent.com/34919/211856325-f1d377bf-e1e6-480f-ac40-2add7fb833e8.png)
![image](https://user-images.githubusercontent.com/34919/211856377-a60b7067-2a80-4332-aa56-c6850cf01b51.png)

