### PR TITLE
[Fixes #10525] set/unset batch permissions on groups raise an error

### DIFF
--- a/geonode/layers/tests.py
+++ b/geonode/layers/tests.py
@@ -67,6 +67,7 @@ from geonode.layers.populate_datasets_data import create_dataset_data
 from geonode.base.models import TopicCategory, License, Region, Link
 from geonode.utils import check_ogc_backend, set_resource_default_links
 from geonode.layers.metadata import convert_keyword, set_metadata, parse_metadata
+from geonode.groups.models import GroupProfile
 
 from geonode.layers.utils import (
     is_sld_upload_only,
@@ -924,6 +925,50 @@ class DatasetsTest(GeoNodeBaseTestSupport):
                     _c += 1
         # "norman" has no permissions
         self.assertEqual(_c, 0)
+
+    @on_ogc_backend(geoserver.BACKEND_PACKAGE)
+    def test_assign_remove_permissions_for_groups(self):
+        # Assing
+        layer = Dataset.objects.all().first()
+        perm_spec = layer.get_all_level_info()
+        group_profile = GroupProfile.objects.create(slug="group1", title="group1", access="public")
+        self.assertNotIn(group_profile, perm_spec["groups"])
+
+        # giving manage permissions to the group
+        utils.set_datasets_permissions("manage", resources_names=[layer.name], groups_names=["group1"], delete_flag=False, verbose=True)
+        perm_spec = layer.get_all_level_info()
+        expected = {
+            'change_dataset_data', 'change_dataset_style', 'change_resourcebase',
+            'change_resourcebase_metadata', 'change_resourcebase_permissions',
+            'delete_resourcebase', 'download_resourcebase', 'publish_resourcebase',
+            'view_resourcebase'
+        }
+        # checking the perms list
+        self.assertSetEqual(
+            expected,
+            set(perm_spec['groups'][group_profile.group])
+        )
+
+        # Chaning perms to the group from manage to read
+        utils.set_datasets_permissions("view", resources_names=[layer.name], groups_names=["group1"], delete_flag=False, verbose=True)
+        perm_spec = layer.get_all_level_info()
+        expected = {
+            'view_resourcebase'
+        }
+        # checking the perms list
+        self.assertSetEqual(
+            expected,
+            set(perm_spec['groups'][group_profile.group])
+        )
+
+        # Chaning perms to the group from manage to read
+        utils.set_datasets_permissions("view", resources_names=[layer.name], groups_names=["group1"], delete_flag=True, verbose=True)
+        perm_spec = layer.get_all_level_info()
+        # checking the perms list
+        self.assertTrue(group_profile.group not in perm_spec['groups'])
+
+        if group_profile:
+            group_profile.delete()
 
     def test_xml_form_without_files_should_raise_500(self):
         files = dict()

--- a/geonode/layers/utils.py
+++ b/geonode/layers/utils.py
@@ -494,7 +494,7 @@ def set_datasets_permissions(permissions_name, resources_names=None, users_usern
                 final_perms_payload["groups"] = {
                     _group: _perms
                     for _group, _perms in perms_spec_compact_resource.extended["groups"].items()
-                    if _user not in copy_compact_perms.extended["groups"]
+                    if _group not in copy_compact_perms.extended["groups"]
                 }
                 if final_perms_payload["users"].get("AnonymousUser") is None and final_perms_payload["groups"].get("anonymous"):
                     final_perms_payload["groups"].pop("anonymous")


### PR DESCRIPTION
ref #10525

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
