### PR TITLE
[Fixes 10521]  Make metadata wizard more flexible for custom metadata

### DIFF
--- a/geonode/base/api/serializers.py
+++ b/geonode/base/api/serializers.py
@@ -254,7 +254,6 @@ class ExtraMetadataSerializer(DynamicModelSerializer):
         fields = ("pk", "metadata")
 
     def to_representation(self, obj):
-
         if isinstance(obj, QuerySet):
             out = []
             for el in obj:
@@ -485,7 +484,12 @@ class ResourceBaseSerializer(
 
         self.fields["favorite"] = FavoriteField(read_only=True)
 
-    metadata = DynamicRelationField(ExtraMetadataSerializer, embed=False, many=True, deferred=True)
+    # Load metadata_records for contrib apps
+    if getattr(settings, "EXTRA_METADATA_ENABLED", False):
+        deferred = False
+    else:
+        deferred = True
+    metadata = DynamicRelationField(ExtraMetadataSerializer, embed=False, many=True, deferred=deferred)
 
     class Meta:
         model = ResourceBase

--- a/geonode/catalogue/models.py
+++ b/geonode/catalogue/models.py
@@ -80,6 +80,14 @@ def catalogue_post_save(instance, sender, **kwargs):
                     resource=resources.get(), url=metadata_url, extension="xml", link_type="metadata"
                 ).update(**_d)
 
+    # Load metadata_records for contrib apps
+    if getattr(settings, "EXTRA_METADATA_ENABLED", False):
+        if hasattr(instance, 'extra_metadata'):
+            del instance.extra_metadata
+        instance.extra_metadata = [
+            {extra.metadata.get("name", ""): extra.metadata.get("value", "")} for extra in instance.metadata.all()
+        ]
+
     # generate an XML document (GeoNode's default is ISO)
     if instance.metadata_uploaded and instance.metadata_uploaded_preserve:
         md_doc = etree.tostring(dlxml.fromstring(instance.metadata_xml))

--- a/geonode/documents/api/serializers.py
+++ b/geonode/documents/api/serializers.py
@@ -21,6 +21,7 @@ import logging
 from dynamic_rest.fields.fields import DynamicComputedField
 from geonode.base.api.serializers import ResourceBaseSerializer
 from geonode.documents.models import Document
+from django.conf import settings
 
 logger = logging.getLogger(__name__)
 
@@ -59,3 +60,7 @@ class DocumentSerializer(ResourceBaseSerializer):
             "file_path",
             "doc_file",
         )
+
+        # Load metadata_records for contrib apps
+        if getattr(settings, "EXTRA_METADATA_ENABLED", False):
+            fields += ("metadata",)

--- a/geonode/documents/templates/documents/document_metadata.html
+++ b/geonode/documents/templates/documents/document_metadata.html
@@ -56,7 +56,7 @@
 
       {% csrf_token %}
         <div id="mdeditor_form" class="col-md-12 form-controls">
-          {% form document_form using "layouts/doc_panels.html" %}
+          {% form document_form using panel_template %}
           {# document_form|as_bootstrap #}
         </div>
 

--- a/geonode/documents/templates/layouts/doc_panels.html
+++ b/geonode/documents/templates/layouts/doc_panels.html
@@ -266,6 +266,8 @@ span.grippy::after {
             <a>{% trans "Optional Metadata" %}</a>
         {% endif %}
       </li>
+      {% block extra_metadata_steps%}
+      {% endblock %}
   </ul>
   {% block mandatory %}
     <div id="mandatory" class="tab-pane fade in active">
@@ -580,6 +582,8 @@ span.grippy::after {
         </div>
       </div></div></div>
     </div>
+    {% block extra_metadata_content %}
+    {% endblock %}
   </div>
   {% endblock ownership %}
 

--- a/geonode/documents/templates/layouts/doc_panels.html
+++ b/geonode/documents/templates/layouts/doc_panels.html
@@ -266,7 +266,7 @@ span.grippy::after {
             <a>{% trans "Optional Metadata" %}</a>
         {% endif %}
       </li>
-      {% block extra_metadata_steps%}
+      {% block extra_metadata_steps %}
       {% endblock %}
   </ul>
   {% block mandatory %}

--- a/geonode/geoapps/api/serializers.py
+++ b/geonode/geoapps/api/serializers.py
@@ -19,6 +19,7 @@
 import logging
 
 from django.contrib.auth import get_user_model
+from django.conf import settings
 from geonode.geoapps.api.exceptions import DuplicateGeoAppException, InvalidGeoAppException, GeneralGeoAppException
 
 from geonode.geoapps.models import GeoApp
@@ -38,6 +39,9 @@ class GeoAppSerializer(ResourceBaseSerializer):
         name = "geoapp"
         view_name = "geoapps-list"
         fields = ("pk", "uuid", "data", "name", "executions")
+        # Load metadata_records for contrib apps
+        if getattr(settings, "EXTRA_METADATA_ENABLED", False):
+            fields += ("metadata",)
 
     def extra_update_checks(self, validated_data):
         _user_profiles = {}

--- a/geonode/geoapps/templates/apps/app_metadata.html
+++ b/geonode/geoapps/templates/apps/app_metadata.html
@@ -55,7 +55,7 @@
 
       {% csrf_token %}
         <div id="mdeditor_form" class="col-md-12 form-controls">
-          {% form geoapp_form using "layouts/app_panels.html" %}
+          {% form geoapp_form using panel_template %}
           {# geoapp_form|as_bootstrap #}
         </div>
 

--- a/geonode/geoapps/templates/layouts/app_panels.html
+++ b/geonode/geoapps/templates/layouts/app_panels.html
@@ -256,6 +256,8 @@ span.grippy::after {
       <li data-step="3" data-toggle="tab" href="#ownership">
           <a>{% trans "Optional Metadata" %}</a>
       </li>
+      {% block extra_metadata_steps %}
+      {% endblock %}
   </ul>
     <div id="mandatory" class="tab-pane fade in active">
         <!--<br />-->
@@ -510,6 +512,8 @@ span.grippy::after {
         </div>
       </div></div></div>
     </div>
+    {% block extra_metadata_content %}
+    {% endblock %}
 </div>
 <div id="settings" class="tab-pane fade" style="overflow: hidden;">
   <!--<br />-->

--- a/geonode/layers/api/serializers.py
+++ b/geonode/layers/api/serializers.py
@@ -179,6 +179,9 @@ class DatasetSerializer(ResourceBaseSerializer):
             "attribute_set",
             "executions",
         )
+        # Load metadata_records for contrib apps
+        if getattr(settings, "EXTRA_METADATA_ENABLED", False):
+            fields += ("metadata",)
 
     name = serializers.CharField(read_only=True)
     workspace = serializers.CharField(read_only=True)

--- a/geonode/layers/templates/datasets/dataset_metadata.html
+++ b/geonode/layers/templates/datasets/dataset_metadata.html
@@ -78,7 +78,7 @@
 
         {% csrf_token %}
         <div id="mdeditor_form" class="col-md-12 form-controls">
-          {% form dataset_form using "layouts/panels.html" %}
+          {% form dataset_form using panel_template %}
           {# dataset_form|as_bootstrap #}
         </div>
 

--- a/geonode/layers/templates/layouts/panels.html
+++ b/geonode/layers/templates/layouts/panels.html
@@ -280,6 +280,8 @@ span.grippy::after {
       <li data-step="4"  data-toggle="tab" href="#dataset">
           <a>{% trans "Dataset Attributes" %}</a>
       </li>
+      {% block extra_metadata_steps%}
+      {% endblock %}
   </ul>
   {% endblock breadcrumbs %}
   {% block mandatory %}
@@ -644,6 +646,8 @@ span.grippy::after {
     </div>
     {% endblock %}
   </div>
+    {% block extra_metadata_content %}
+    {% endblock %}
 </div>
 <div id="preview" class="tab-pane fade" style="overflow: hidden;">
     <!-- <iframe id="preview_encoder_iframe" height="100%" width="100%" style="width:0;height:0;border:0;border:none;" src="{% url 'dataset_metadata_detail' resource.alternate %}"></iframe> -->

--- a/geonode/maps/api/serializers.py
+++ b/geonode/maps/api/serializers.py
@@ -19,6 +19,7 @@
 import ast
 import logging
 
+from django.conf import settings
 from dynamic_rest.fields.fields import DynamicField, DynamicRelationField
 from dynamic_rest.serializers import DynamicModelSerializer
 from rest_framework import serializers
@@ -161,6 +162,9 @@ class MapSerializer(ResourceBaseSerializer):
         name = "map"
         view_name = "maps-list"
         fields = ("pk", "uuid", "urlsuffix", "featuredurl", "data", "maplayers", "executions")
+        # Load metadata_records for contrib apps
+        if getattr(settings, "EXTRA_METADATA_ENABLED", False):
+            fields += ("metadata",)
 
 
 class SimpleMapSerializer(BaseDynamicModelSerializer):

--- a/geonode/maps/templates/layouts/map_panels.html
+++ b/geonode/maps/templates/layouts/map_panels.html
@@ -269,6 +269,8 @@ span.grippy::after {
             <a>{% trans "Optional Metadata" %}</a>
         {% endif %}
       </li>
+      {% block extra_metadata_steps %}
+      {% endblock %}
   </ul>
     <div id="mandatory" class="tab-pane fade in active">
         <!--<br />-->
@@ -568,6 +570,8 @@ span.grippy::after {
         </div>
       </div></div></div>
     </div>
+    {% block extra_metadata_content %}
+    {% endblock %}
 </div>
 <div id="settings" class="tab-pane fade" style="overflow: hidden;">
   <!--<br />-->

--- a/geonode/maps/templates/maps/map_metadata.html
+++ b/geonode/maps/templates/maps/map_metadata.html
@@ -57,7 +57,7 @@
 
       {% csrf_token %}
         <div id="mdeditor_form" class="col-md-12 form-controls">
-          {% form map_form using "layouts/map_panels.html" %}
+          {% form map_form using panel_template %}
           {# map_form|as_bootstrap #}
         </div>
 

--- a/geonode/maps/views.py
+++ b/geonode/maps/views.py
@@ -77,7 +77,14 @@ def _resolve_map(request, id, permission="base.change_resourcebase", msg=_PERMIS
 
 @login_required
 @check_keyword_write_perms
-def map_metadata(request, mapid, template="maps/map_metadata.html", ajax=True):
+def map_metadata(
+    request,
+    mapid,
+    template="maps/map_metadata.html",
+    ajax=True,
+    panel_template="layouts/map_panels.html",
+    custom_metadata=None,
+):
     try:
         map_obj = _resolve_map(request, mapid, "base.change_resourcebase_metadata", _PERMISSION_MSG_VIEW)
     except PermissionDenied:
@@ -285,6 +292,8 @@ def map_metadata(request, mapid, template="maps/map_metadata.html", ajax=True):
             "resource": map_obj,
             "map": map_obj,
             "config": json.dumps(map_obj.blob),
+            "panel_template": panel_template,
+            "custom_metadata": custom_metadata,
             "map_form": map_form,
             "poc_form": poc_form,
             "author_form": author_form,
@@ -572,6 +581,15 @@ def map_metadata_detail(request, mapid, template="maps/map_metadata_detail.html"
             group = None
     site_url = settings.SITEURL.rstrip("/") if settings.SITEURL.startswith("http") else settings.SITEURL
     register_event(request, EventType.EVENT_VIEW_METADATA, map_obj)
+
+    # Load metadata_records for contrib apps
+    if getattr(settings, "EXTRA_METADATA_ENABLED", False):
+        if hasattr(map_obj, 'extra_metadata'):
+            del map_obj.extra_metadata
+        map_obj.extra_metadata = [
+            {extra.metadata.get("name", ""): extra.metadata.get("value", "")} for extra in map_obj.metadata.all()
+        ]
+
     return render(request, template, context={"resource": map_obj, "group": group, "SITEURL": site_url})
 
 

--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -504,6 +504,8 @@ INSTALLED_APPS = (
     "allauth.socialaccount",
     # GeoNode
     "geonode",
+    # custom metadata
+    "custom_metadata.apps.CustomMetadataConfig",
 )
 
 markdown_white_listed_tags = [
@@ -2186,6 +2188,9 @@ EXTRA_METADATA_SCHEMA = {
     },
     **CUSTOM_METADATA_SCHEMA,
 }
+
+EXTRA_METADATA_ENABLED = os.getenv("EXTRA_METADATA_ENABLED", True)
+EXTRA_METADATA_APP_URL_PATTERNS = os.getenv("EXTRA_METADATA_APP_URL_PATTERNS", False)
 
 
 """

--- a/geonode/templates/metadata_detail.html
+++ b/geonode/templates/metadata_detail.html
@@ -348,6 +348,9 @@
         {% endif %}
         {% endblock supplemental_information %}
 
+        {% block extra_metadata %}
+        {% endblock extra_metadata %}
+
         {% block spatial_representation_type %}
         {% if resource.spatial_representation_type %}
         <dt>{% trans "Spatial Representation Type" %}</dt>

--- a/geonode/urls.py
+++ b/geonode/urls.py
@@ -65,6 +65,23 @@ urlpatterns = [
     url(r"^messages/", include(msg_urls)),
 ]
 
+# custom_metadata
+if settings.EXTRA_METADATA_ENABLED:
+    custom_metadata_app = getattr(settings, "CUSTOM_METADATA_APP", "custom_metadata")
+    default_url_patterns = [
+        "datasets",
+        "maps",
+        "documents",
+        "apps",
+    ]
+    url_patterns = getattr(settings, "EXTRA_METADATA_APP_URL_PATTERNS", None) or default_url_patterns
+    for pattern in url_patterns:
+        try:
+            module = __import__(f"{custom_metadata_app}.urls.{pattern}_urls")
+            urlpatterns += [url(f"^{pattern}/", include(f"{custom_metadata_app}.urls.{pattern}_urls"))]
+        except ModuleNotFoundError as e:
+            pass
+
 urlpatterns += [
     # ResourceBase views
     url(r"^base/", include("geonode.base.urls")),


### PR DESCRIPTION
The aim of this PR is **not** to implement extra metadata but rather to allow contrib apps to implement their own requirements of extrametadata forms_. (Every contrib app is then responsible for generating a metadata form and handling validation._) The foundation for implementation of extra metadata is the m2m relation from BaseResource Model to ExtaMetdata

**You can see my ongoing work of a contrib app here**
_* Please note that the app is still under development and some things can still change._

- [Repo](https://github.com/csgis/custom_metadata)
- [Docs](https://geonode-custom-metadata-app.readthedocs.io/en/latest/)

**To make things more flexible I'd like to suggest these 5 steps.** 

1. Allow apps to override URLs to decorate views
1. Allow apps to pass their version of panels.html and form context to the wizard
1. Render extra metadata if present in metadata_details template
1. Enrich extra metadata to XML context if needed
1. Provide extra_metadata as api response for mapstore's detail panel

### Overview of changed files

The amount of changed files looks overwhelming. But the following table shows the changes just repeat for core apps
datasets, maps, documents and geoapps.

#### Allow apps to override URLs to decorate views
| filename            | Intention                                                     |
|---------------------|---------------------------------------------------------------|
| geonode/urls.py     | Allow apps to ovveride core apps for custom metadata          |
| geonode/settings.py | Introduce a new Variable if custom metadata should be enabled |

#### Allow apps to pass their version of panels.html and form context to the wizard

| filename                                              | Intention                                                                                                                                                         |
|-------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| documents/templates/documents/document_metadata.html  | Make used html panel dynamic by variable panel_template                                                                                                           |
| documents/templates/layouts/doc_panels.html           | Add extra metadata menu step and content to wizard                                                                                                                |
| geoapps/templates/apps/app_metadata.html              | Make used html panel dynamic by variable panel_template                                                                                                           |
| geoapps/templates/layouts/app_panels.html             | Add extra metadata menu step and content to wizard                                                                                                                |
| layers/templates/datasets/dataset_metadata.html       | Make used html panel dynamic by variable panel_template                                                                                                           |
| layers/templates/layouts/panels.html                  | Add extra metadata menu step and content to wizard                                                                                                                |
| maps/templates/layouts/map_panels.html                | Add extra metadata menu step and content to wizard                                                                                                                |
| maps/templates/maps/map_metadata.html                 | Make used html panel dynamic by variable panel_template                                                                                                           |
| documents/views.py                                    | Allow decorator to pass panel_template and custom_metadata form  context in function signature. Update resource object with m2m relation from ExtraMetadata Model |
| geoapps/views.py                                      | Allow decorator to pass panel_template and custom_metadata form  context in function signature. Update resource object with m2m relation from ExtraMetadata Model |
| layers/views.py                                       | Allow decorator to pass panel_template and custom_metadata form  context in function signature. Update resource object with m2m relation from ExtraMetadata Model |
| maps/views.py                                         | Allow decorator to pass panel_template and custom_metadata form  context in function signature. Update resource object with m2m relation from ExtraMetadata Model |

#### Render extra metadata if present in metadata_details views

| filename                       | Intention                                      |
|--------------------------------|------------------------------------------------|
| templates/metadata_detail.html | Add metadata rendering to html representation  |

#### Add metadata to XML export of datasets

| filename                    | Intention                                                         |
|-----------------------------|-------------------------------------------------------------------|
| geonode/catalogue/models.py | Update resource object with m2m relation from ExtraMetadata Model |


#### Provide extra_metadata as api response for mapstore's detail panel

| filename                      | Intention                                                   |
|-------------------------------|-------------------------------------------------------------|
| documents/api/serializers.py  | Serialize object with m2m relation from ExtraMetadata Model |
| base/api/serializers.py       | Serialize object with m2m relation from ExtraMetadata Model |
| geoapps/api/serializers.py    | Serialize object with m2m relation from ExtraMetadata Model |
| layers/api/serializers.py     | Serialize object with m2m relation from ExtraMetadata Model |
| maps/api/serializers.py       | Serialize object with m2m relation from ExtraMetadata Model |


## 2 Not yet considered

Even though this PR has already updated the serializer to make the metadata object available to the Details Panel of mapstore2, the display of the metadata has not yet been considered. Through the conversation with Giovanni and Stefano, I would hope that users will be able to view the data without having to create their own build. After that PR I will start to have a lookk at the React component.

---

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [x] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [x] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
