### PR TITLE
[Fixes #10936] Implement a generic API endpoint for linked resources

### DIFF
--- a/geonode/base/api/serializers.py
+++ b/geonode/base/api/serializers.py
@@ -705,3 +705,10 @@ class OwnerSerializer(BaseResourceCountSerializer):
         fields = ("pk", "username", "first_name", "last_name", "avatar", "perms")
 
     avatar = AvatarUrlField(240, read_only=True)
+
+
+class SimpleResourceSerializer(DynamicModelSerializer):
+    class Meta:
+        name = "linked_resources"
+        model = ResourceBase
+        fields = ("pk", "title", "resource_type", "detail_url", "thumbnail_url")

--- a/geonode/base/api/tests.py
+++ b/geonode/base/api/tests.py
@@ -22,6 +22,7 @@ import re
 import sys
 import json
 import logging
+from django.contrib.contenttypes.models import ContentType
 from django.test import override_settings
 import gisdata
 
@@ -41,7 +42,7 @@ from django.contrib.auth import get_user_model
 from rest_framework.test import APITestCase
 
 from guardian.shortcuts import get_anonymous_user
-from geonode.maps.models import Map
+from geonode.maps.models import Map, MapLayer
 from geonode.tests.base import GeoNodeBaseTestSupport
 
 from geonode.base import enumerations
@@ -59,11 +60,11 @@ from geonode.base.models import (
 
 from geonode.layers.models import Dataset
 from geonode.favorite.models import Favorite
-from geonode.documents.models import Document
+from geonode.documents.models import Document, DocumentResourceLink
 from geonode.geoapps.models import GeoApp
 from geonode.utils import build_absolute_uri
 from geonode.resource.api.tasks import ExecutionRequest
-from geonode.base.populate_test_data import create_models, create_single_dataset
+from geonode.base.populate_test_data import create_models, create_single_dataset, create_single_doc, create_single_map
 from geonode.resource.api.tasks import resouce_service_dispatcher
 
 logger = logging.getLogger(__name__)
@@ -2461,3 +2462,208 @@ class TestExtraMetadataBaseApi(GeoNodeBaseTestSupport):
         url = reverse("base-resources-extra-metadata", args=[self.layer.id])
         response = self.client.get(url, content_type="application/json")
         self.assertTrue(200, response.status_code)
+
+
+class TestApiLinkedResources(GeoNodeBaseTestSupport):
+    @classmethod
+    def setUpClass(cls) -> None:
+        super().setUpClass()
+        cls.dataset = create_single_dataset("single_layer")
+        cls.map = create_single_map("single_map")
+        cls.doc = create_single_doc("single_doc")
+
+    def test_only_get_method_is_available(self):
+        url = reverse("base-resources-linked_resources", args=[self.dataset.id])
+
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, 403)
+
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 403)
+
+        response = self.client.patch(url)
+        self.assertEqual(response.status_code, 403)
+
+        response = self.client.put(url)
+        self.assertEqual(response.status_code, 403)
+
+    def test_linked_resource_raise_error_for_geoapps(self):
+        geo_app = GeoApp.objects.create(
+            title="Test GeoApp",
+            owner=get_user_model().objects.first(),
+            resource_type="geostory",
+            blob='{"test_data": {"test": ["test_1","test_2","test_3"]}}',
+        )
+        geo_app.set_default_permissions()
+        url = reverse("base-resources-linked_resources", args=[geo_app.id])
+
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 501)
+
+    def test_linked_resource_for_document_should_return_the_expected_ouput(self):
+        try:
+            # data preparation
+            ctype = ContentType.objects.get_for_model(self.map)
+            ctype_dataset = ContentType.objects.get_for_model(self.dataset)
+            _d = DocumentResourceLink.objects.create(document_id=self.doc.id, content_type=ctype, object_id=self.map.id)
+            _d = DocumentResourceLink.objects.create(
+                document_id=self.doc.id, content_type=ctype_dataset, object_id=self.dataset.id
+            )
+
+            # expected output from api
+            expected_payload = {
+                "links": {"next": None, "previous": None},
+                "total": 2,
+                "page": 1,
+                "page_size": 10,
+                "resources": [
+                    {
+                        "detail_url": self.map.detail_url,
+                        "pk": self.map.id,
+                        "resource_type": self.map.resource_type,
+                        "thumbnail_url": self.map.thumbnail_url,
+                        "title": self.map.title,
+                    },
+                    {
+                        "detail_url": self.dataset.detail_url,
+                        "pk": self.dataset.id,
+                        "resource_type": self.dataset.resource_type,
+                        "thumbnail_url": self.dataset.thumbnail_url,
+                        "title": self.dataset.title,
+                    },
+                ],
+            }
+
+            # call the API
+            url = reverse("base-resources-linked_resources", args=[self.doc.id])
+            response = self.client.get(url)
+
+            # validation
+            self.assertEqual(response.status_code, 200)
+            self.assertDictEqual(expected_payload, response.json())
+        finally:
+            if _d:
+                _d.delete()
+
+    def test_linked_resources_maps_should_return_the_expected_ouput(self):
+        try:
+            # data preparation
+            _m = MapLayer(
+                map=self.map,
+                dataset=self.dataset,
+                name=self.dataset.name,
+                current_style="test_style",
+                ows_url="https://maps.geosolutionsgroup.com/geoserver/wms",
+            ).save()
+
+            # expected output from api
+            expected_payload = {
+                "links": {"next": None, "previous": None},
+                "total": 1,
+                "page": 1,
+                "page_size": 10,
+                "resources": [
+                    {
+                        "detail_url": self.dataset.detail_url,
+                        "pk": self.dataset.id,
+                        "resource_type": self.dataset.resource_type,
+                        "thumbnail_url": self.dataset.thumbnail_url,
+                        "title": self.dataset.title,
+                    }
+                ],
+            }
+
+            # call the API
+            url = reverse("base-resources-linked_resources", args=[self.map.id])
+            response = self.client.get(url)
+
+            # validation
+            self.assertEqual(response.status_code, 200)
+            self.assertDictEqual(expected_payload, response.json())
+        finally:
+            if _m:
+                _m.delete()
+
+    def test_linked_resource_dataset_should_return_the_expected_ouput(self):
+        try:
+            # data preparation
+            _m = MapLayer(
+                map=self.map,
+                dataset=self.dataset,
+                name=self.dataset.name,
+                current_style="test_style",
+                ows_url="https://maps.geosolutionsgroup.com/geoserver/wms",
+            ).save()
+
+            # expected output from api
+            expected_payload = {
+                "links": {"next": None, "previous": None},
+                "total": 1,
+                "page": 1,
+                "page_size": 10,
+                "resources": [
+                    {
+                        "detail_url": self.map.detail_url,
+                        "pk": self.map.id,
+                        "resource_type": self.map.resource_type,
+                        "thumbnail_url": self.map.thumbnail_url,
+                        "title": self.map.title,
+                    }
+                ],
+            }
+
+            # call the API
+            url = reverse("base-resources-linked_resources", args=[self.dataset.id])
+            response = self.client.get(url)
+
+            # validation
+            self.assertEqual(response.status_code, 200)
+            self.assertDictEqual(expected_payload, response.json())
+        finally:
+            if _m:
+                _m.delete()
+
+    def test_linked_resource_filter_should_work(self):
+        try:
+            # data preparation
+            ctype = ContentType.objects.get_for_model(self.map)
+            ctype_dataset = ContentType.objects.get_for_model(self.dataset)
+            _d = DocumentResourceLink.objects.create(document_id=self.doc.id, content_type=ctype, object_id=self.map.id)
+            _d = DocumentResourceLink.objects.create(
+                document_id=self.doc.id, content_type=ctype_dataset, object_id=self.dataset.id
+            )
+
+            # call the API
+            url = reverse("base-resources-linked_resources", args=[self.doc.id])
+            response = self.client.get(url)
+            # validation
+            self.assertEqual(response.status_code, 200, msg="no_filter_validation")
+            self.assertEqual(2, response.json().get("total", 0), msg="no_filter_validation")
+
+            response = self.client.get(url + "?resource_type=map")
+            # validation
+            self.assertEqual(response.status_code, 200, msg="map_filter_validation")
+            self.assertEqual(1, response.json().get("total", 0), msg="map_filter_validation")
+
+            response = self.client.get(url + "?title=single_layer")
+            # validation
+            self.assertEqual(response.status_code, 200, msg="dataset_filter_validation")
+            self.assertEqual(1, response.json().get("total", 0), msg="dataset_filter_validation")
+
+            response = self.client.get(url + "?resource_type=geoapp")
+            # validation
+            self.assertEqual(response.status_code, 200, msg="geoapp_filter_validation")
+            self.assertEqual(0, response.json().get("total", 0), msg="geoapp_filter_validation")
+
+            response = self.client.get(url + "?invalid_filter=invalid")
+            # validation
+            self.assertEqual(response.status_code, 500, msg="invalid_filter_validation")
+            self.assertEqual(0, response.json().get("total", 0), msg="invalid_filter_validation")
+
+        finally:
+            if _d:
+                _d.delete()


### PR DESCRIPTION
ref #10936 

The API is filterable:
- If the filter is related to the resource which we are asking the linked_resource we can use the dynamic filter example:


With the below URL, the filter will refer to the information of the resource PK and not to the linked resource. This is due to the behavior of the dynamic filter that geonode uses. We cannot change this
```python
URL: /api/v2/{PK}/linked_resources?filter{resource_type}=map
```

With the below URL, the filter will refer to the linked resource. The filter accepts the default django queryset filtering
```python
URL: /api/v2/{PK}/linked_resources?resource_type=map
URL: /api/v2/{PK}/linked_resources?title__icontains=title
URL: /api/v2/{PK}/linked_resources?resource_type=map
```

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: black geonode && flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
