### PR TITLE
[Fixes #19061] Time serie date field not recognized

### DIFF
--- a/geonode/geoserver/helpers.py
+++ b/geonode/geoserver/helpers.py
@@ -1814,14 +1814,17 @@ def set_time_info(layer, attribute, end_attribute, presentation, precision_value
     info = DimensionInfo(
         "time", enabled, presentation, resolution, "ISO8601", None, attribute=attribute, end_attribute=end_attribute
     )
-    if resource and resource.metadata:
+    if resource and hasattr(resource, "metadata") and resource.metadata:
         metadata = dict(resource.metadata or {})
     else:
         metadata = dict({})
     metadata["time"] = info
 
-    if resource and resource.metadata:
+    if resource and hasattr(resource, "metadata") and resource.metadata:
         resource.metadata = metadata
+    else:
+        setattr(resource, "metadata", metadata)
+
     if resource:
         gs_catalog.save(resource)
 

--- a/geonode/layers/forms.py
+++ b/geonode/layers/forms.py
@@ -274,7 +274,9 @@ class LayerStyleUploadForm(forms.Form):
 class DatasetTimeSerieForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         _choises = [(None, "-----")] + [
-            (_a.pk, _a.attribute) for _a in kwargs.get("instance").attributes if _a.attribute_type in ["xsd:dateTime"]
+            (_a.pk, _a.attribute)
+            for _a in kwargs.get("instance").attributes
+            if _a.attribute_type in ["xsd:dateTime", "xsd:date"]
         ]
         self.base_fields.get("attribute").choices = _choises
         self.base_fields.get("end_attribute").choices = _choises

--- a/geonode/layers/templates/layouts/panels.html
+++ b/geonode/layers/templates/layouts/panels.html
@@ -735,11 +735,11 @@ span.grippy::after {
                   </button></div>
                   <div class="panel-body">
                     <div>
-                      <span><label for="dataset_attribute">Attribute</label></span>
+                      <span><label for="timeserie_dataset_attribute">Attribute</label></span>
                       {{timeseries_form.attribute}}
                     </div>
                     <div>
-                    <span><label for="dataset_end_attribute">End attribute</label></span>
+                    <span><label for="timeserie_dataset_end_attribute">End attribute</label></span>
                       {{timeseries_form.end_attribute}}
                     </div>
                     <span><label for="dataset_presentation">Presentation</label></span>

--- a/geonode/layers/templates/layouts/panels.html
+++ b/geonode/layers/templates/layouts/panels.html
@@ -735,11 +735,11 @@ span.grippy::after {
                   </button></div>
                   <div class="panel-body">
                     <div>
-                      <span><label for="timeserie_dataset_attribute">Attribute</label></span>
+                      <span><label for="dataset_attribute">Attribute</label></span>
                       {{timeseries_form.attribute}}
                     </div>
                     <div>
-                    <span><label for="timeserie_dataset_end_attribute">End attribute</label></span>
+                    <span><label for="dataset_end_attribute">End attribute</label></span>
                       {{timeseries_form.end_attribute}}
                     </div>
                     <span><label for="dataset_presentation">Presentation</label></span>

--- a/geonode/layers/tests.py
+++ b/geonode/layers/tests.py
@@ -1992,7 +1992,7 @@ class TestDatasetForm(GeoNodeBaseTestSupport):
         )
         self.assertTrue(form.is_valid())
         self.assertDictEqual({}, form.errors)
-        expected_choises = [(None, '-----'), (self.dataset.attributes.first().id, 'field_date')]
+        expected_choises = [(None, "-----"), (self.dataset.attributes.first().id, "field_date")]
         actual_choices = form.fields.get("attribute").choices
         self.assertListEqual(expected_choises, actual_choices)
 
@@ -2015,9 +2015,9 @@ class TestDatasetForm(GeoNodeBaseTestSupport):
         self.assertFalse(form.is_valid())
         self.assertEqual(
             f"Select a valid choice. {self.dataset.attributes.first().id} is not one of the available choices.",
-            form.errors.get("attribute")[0]
+            form.errors.get("attribute")[0],
         )
-        expected_choises = [(None, '-----')]
+        expected_choises = [(None, "-----")]
         actual_choices = form.fields.get("attribute").choices
         self.assertListEqual(expected_choises, actual_choices)
 

--- a/geonode/layers/tests.py
+++ b/geonode/layers/tests.py
@@ -1974,6 +1974,53 @@ class TestDatasetForm(GeoNodeBaseTestSupport):
         self.assertTrue(form.is_valid())
         self.assertDictEqual({}, form.errors)
 
+    def test_dataset_time_form_should_work_with_date_attribute(self):
+        attr, _ = Attribute.objects.get_or_create(
+            dataset=self.dataset, attribute="field_date", attribute_type="xsd:date"
+        )
+        self.dataset.attribute_set.add(attr)
+        self.dataset.save()
+        form = self.time_form(
+            instance=self.dataset,
+            data={
+                "attribute": self.dataset.attributes.first().id,
+                "end_attribute": "",
+                "presentation": "DISCRETE_INTERVAL",
+                "precision_value": 12345,
+                "precision_step": "seconds",
+            },
+        )
+        self.assertTrue(form.is_valid())
+        self.assertDictEqual({}, form.errors)
+        expected_choises = [(None, '-----'), (self.dataset.attributes.first().id, 'field_date')]
+        actual_choices = form.fields.get("attribute").choices
+        self.assertListEqual(expected_choises, actual_choices)
+
+    def test_timeserie_raise_error_if_not_valid_attribute(self):
+        attr, _ = Attribute.objects.get_or_create(
+            dataset=self.dataset, attribute="field_date", attribute_type="xsd:string"
+        )
+        self.dataset.attribute_set.add(attr)
+        self.dataset.save()
+        form = self.time_form(
+            instance=self.dataset,
+            data={
+                "attribute": self.dataset.attributes.first().id,
+                "end_attribute": "",
+                "presentation": "DISCRETE_INTERVAL",
+                "precision_value": 12345,
+                "precision_step": "seconds",
+            },
+        )
+        self.assertFalse(form.is_valid())
+        self.assertEqual(
+            f"Select a valid choice. {self.dataset.attributes.first().id} is not one of the available choices.",
+            form.errors.get("attribute")[0]
+        )
+        expected_choises = [(None, '-----')]
+        actual_choices = form.fields.get("attribute").choices
+        self.assertListEqual(expected_choises, actual_choices)
+
     def test_dataset_time_form_should_raise_error_if_invalid_payload(self):
         attr, _ = Attribute.objects.get_or_create(
             dataset=self.dataset, attribute="field_date", attribute_type="xsd:dateTime"

--- a/geonode/layers/views.py
+++ b/geonode/layers/views.py
@@ -497,10 +497,6 @@ def dataset_metadata(
                     initial["precision_step"] = "seconds"
 
         timeseries_form = DatasetTimeSerieForm(instance=layer, prefix="timeseries", initial=initial)
-        timeseries_form.fields.get("attribute").queryset = layer.attributes.filter(attribute_type__in=["xsd:dateTime"])
-        timeseries_form.fields.get("end_attribute").queryset = layer.attributes.filter(
-            attribute_type__in=["xsd:dateTime"]
-        )
 
         # Create THESAURUS widgets
         lang = settings.THESAURUS_DEFAULT_LANG if hasattr(settings, "THESAURUS_DEFAULT_LANG") else "en"


### PR DESCRIPTION
ref #10961 
## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: black geonode && flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
