### PR TITLE
[Fixes #10976] Fix thesaurus labels translations

### DIFF
--- a/geonode/base/templatetags/thesaurus.py
+++ b/geonode/base/templatetags/thesaurus.py
@@ -2,6 +2,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from django import template
 from django.utils.translation import get_language
 from geonode.base.models import Thesaurus, ThesaurusKeywordLabel, ThesaurusLabel
+from geonode.base.utils import remove_country_from_languagecode
 
 register = template.Library()
 
@@ -24,6 +25,7 @@ def get_thesaurus_date(thesaurus_id):
 @register.filter
 def get_name_translation(tidentifier):
     lang = get_language()
+    lang = remove_country_from_languagecode(lang)
     available = Thesaurus.objects.filter(identifier=tidentifier)
     if not available.exists():
         raise ObjectDoesNotExist("Selected idenfifier does not exists")
@@ -48,6 +50,7 @@ def get_thesaurus_translation_by_id(id):
 @register.filter
 def get_thesaurus_localized_label(tkeyword):
     lang = get_language()
+    lang = remove_country_from_languagecode(lang)
     translation = (
         ThesaurusKeywordLabel.objects.values_list("label", flat=True).filter(keyword__id=tkeyword.id).filter(lang=lang)
     )


### PR DESCRIPTION
ref #10976 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: black geonode && flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
