### PR TITLE
#10995 Faceting

### DIFF
--- a/geonode/base/api/filters.py
+++ b/geonode/base/api/filters.py
@@ -17,13 +17,17 @@
 #
 #########################################################################
 import ast
-from geonode.favorite.models import Favorite
 import logging
+from distutils.util import strtobool
+from itertools import groupby
+
 from rest_framework.filters import SearchFilter, BaseFilterBackend
 
-from geonode.base.bbox_utils import filter_bbox
 from django.db.models import Subquery
-from distutils.util import strtobool
+
+from geonode.base.models import ThesaurusKeyword
+from geonode.favorite.models import Favorite
+from geonode.base.bbox_utils import filter_bbox
 
 logger = logging.getLogger(__name__)
 
@@ -47,17 +51,43 @@ class ExtentFilter(BaseFilterBackend):
 class TKeywordsFilter(BaseFilterBackend):
     """
     TKeywords are a ManyToMany relation but DREST can't handle AND filtering the way we need.
-    We'll be using "filter{tkeywords}" to have Resources having all of the  tkeywords
-
+    When the filter has more than one tkeyword, DREST by default will return Resources associated at least to one
+    of the keywords.
     """
 
     def filter_queryset(self, request, queryset, view):
-        f = request.GET.pop("filter{tkeywords}", None)
-        if f:
-            if not isinstance(f, list):
-                f = [f]
-            for v in f:
-                queryset = queryset.filter(tkeywords__id=v)
+        return (
+            self.filter_queryset_GROUP(request, queryset, view)
+            if "force_and" not in request.GET
+            else self.filter_queryset_AND(request, queryset, view)
+        )
+
+    def filter_queryset_AND(self, request, queryset, view):
+        """
+        This implementation requires all the tkeywords to be assigned to the Resource
+        """
+        for v in request.GET.pop("filter{tkeywords}", []):
+            queryset = queryset.filter(tkeywords__id=v)
+        return queryset
+
+    def filter_queryset_GROUP(self, request, queryset, view):
+        """
+        This implementation requires that at least one tkeyword for each thesaurus is assigned to the Resource
+        """
+        if tklist := request.GET.pop("filter{tkeywords}", None):
+            if len(tklist) == 1:
+                # if there's only one filtering keyword we don't need to tell to which thesaurus it belongs to
+                return queryset.filter(tkeywords__id=tklist[0])
+
+            tkinfo = (
+                ThesaurusKeyword.objects.filter(id__in=tklist).values("id", "thesaurus__id").order_by("thesaurus__id")
+            )
+
+            for t, tk in groupby(tkinfo, lambda r: r["thesaurus__id"]):
+                tklist_by_t = [x["id"] for x in tk]
+                logger.info("Filtering by %s - %r keywords", t, tklist_by_t)
+                queryset = queryset.filter(tkeywords__id__in=tklist_by_t)
+
         return queryset
 
 

--- a/geonode/base/api/filters.py
+++ b/geonode/base/api/filters.py
@@ -44,6 +44,23 @@ class ExtentFilter(BaseFilterBackend):
         return queryset
 
 
+class TKeywordsFilter(BaseFilterBackend):
+    """
+    TKeywords are a ManyToMany relation but DREST can't handle AND filtering the way we need.
+    We'll be using "filter{tkeywords}" to have Resources having all of the  tkeywords
+
+    """
+
+    def filter_queryset(self, request, queryset, view):
+        f = request.GET.pop("filter{tkeywords}", None)
+        if f:
+            if not isinstance(f, list):
+                f = [f]
+            for v in f:
+                queryset = queryset.filter(tkeywords__id=v)
+        return queryset
+
+
 class FavoriteFilter(BaseFilterBackend):
     """
     Filter that only allows users to see their own objects.

--- a/geonode/base/api/views.py
+++ b/geonode/base/api/views.py
@@ -67,7 +67,13 @@ from geonode.thumbs.thumbnails import create_thumbnail
 from geonode.thumbs.utils import _decode_base64, BASE64_PATTERN
 from geonode.groups.conf import settings as groups_settings
 from geonode.base.models import HierarchicalKeyword, Region, ResourceBase, TopicCategory, ThesaurusKeyword
-from geonode.base.api.filters import DynamicSearchFilter, ExtentFilter, FacetVisibleResourceFilter, FavoriteFilter
+from geonode.base.api.filters import (
+    DynamicSearchFilter,
+    ExtentFilter,
+    FacetVisibleResourceFilter,
+    FavoriteFilter,
+    TKeywordsFilter,
+)
 from geonode.groups.models import GroupProfile, GroupMember
 from geonode.people.utils import get_available_users
 from geonode.security.permissions import get_compact_perms_list, PermSpec, PermSpecCompact
@@ -346,6 +352,7 @@ class ResourceBaseViewSet(DynamicModelViewSet):
     authentication_classes = [SessionAuthentication, BasicAuthentication, OAuth2Authentication]
     permission_classes = [IsAuthenticatedOrReadOnly, UserHasPerms]
     filter_backends = [
+        TKeywordsFilter,
         DynamicFilterBackend,
         DynamicSortingFilter,
         DynamicSearchFilter,

--- a/geonode/base/models.py
+++ b/geonode/base/models.py
@@ -1349,7 +1349,7 @@ class ResourceBase(PolymorphicModel, PermissionLevelMixin, ItemBase):
 
     def get_absolute_url(self):
         try:
-            return self.get_real_instance().get_absolute_url()
+            return self.get_real_instance().get_absolute_url() if self != self.get_real_instance() else None
         except Exception as e:
             logger.exception(e)
             return None
@@ -1463,7 +1463,7 @@ class ResourceBase(PolymorphicModel, PermissionLevelMixin, ItemBase):
 
     @property
     def embed_url(self):
-        return self.get_real_instance().embed_url
+        return self.get_real_instance().embed_url if self != self.get_real_instance() else None
 
     def get_tiles_url(self):
         """Return URL for Z/Y/X mapping clients or None if it does not exist."""

--- a/geonode/facets/__init__.py
+++ b/geonode/facets/__init__.py
@@ -1,0 +1,20 @@
+#########################################################################
+#
+# Copyright (C) 2023 OSGeo
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#########################################################################
+
+default_app_config = "geonode.facets.apps.GeoNodeFacetsConfig"

--- a/geonode/facets/apps.py
+++ b/geonode/facets/apps.py
@@ -20,8 +20,6 @@ import logging
 
 from django.apps import AppConfig
 
-from geonode.facets.models import FacetProvider
-from geonode.facets.providers.category import CategoryFacetProvider
 
 logger = logging.getLogger(__name__)
 
@@ -36,44 +34,4 @@ class GeoNodeFacetsConfig(AppConfig):
 
         urlpatterns += urls.urlpatterns
 
-
-class FacetsRegistry:
-    def __init__(self):
-        self.facet_providers = None
-
-    def _load_facets_configuration(self) -> None:
-        """
-        Facet loading is done lazily because some FacetProvider may need to access the DB, which may not have been
-        initialized/created yet
-        """
-        self.facet_providers = dict()
-
-        from geonode.facets.providers.thesaurus import create_thesaurus_providers
-        from geonode.facets.providers.users import OwnerFacetProvider
-
-        logger.info("Initializing Facets")
-
-        self.register_facet_provider(CategoryFacetProvider())
-        self.register_facet_provider(OwnerFacetProvider())
-
-        # Thesaurus providers initialization should be called at startup and
-        # whenever records in Thesaurus or ThesaurusLabel change
-        for provider in create_thesaurus_providers():
-            self.register_facet_provider(provider)
-
-    def register_facet_provider(self, provider: FacetProvider):
-        logger.info(f"Registering {provider}")
-        self.facet_providers[provider.get_info()["name"]] = provider
-
-    def get_providers(self):
-        if self.facet_providers is None:
-            self._load_facets_configuration()
-        return self.facet_providers.values()
-
-    def get_provider(self, name):
-        if self.facet_providers is None:
-            self._load_facets_configuration()
-        return self.facet_providers.get(name, None)
-
-
-facet_registry = FacetsRegistry()
+        super(GeoNodeFacetsConfig, self).ready()

--- a/geonode/facets/apps.py
+++ b/geonode/facets/apps.py
@@ -21,6 +21,7 @@ import logging
 from django.apps import AppConfig
 
 from geonode.facets.models import FacetProvider
+from geonode.facets.providers.category import CategoryFacetProvider
 
 logger = logging.getLogger(__name__)
 
@@ -44,6 +45,7 @@ def init_providers():
     from geonode.facets.providers.thesaurus import create_thesaurus_providers
     from geonode.facets.providers.users import OwnerFacetProvider
 
+    register_facet_provider(CategoryFacetProvider())
     register_facet_provider(OwnerFacetProvider())
 
     # Thesaurus providers initialiazion should be called at startup and whenever records in Thesaurus or ThesaurusLabel change

--- a/geonode/facets/apps.py
+++ b/geonode/facets/apps.py
@@ -38,6 +38,16 @@ class GeoNodeFacetsConfig(AppConfig):
 
         urlpatterns += urls.urlpatterns
 
+        init_thesaurus_providers()
+
+
+def init_thesaurus_providers():
+    # should be called at startup and whenever records in Thesaurus or ThesaurusLabel change
+    from geonode.facets.providers.thesaurus import create_thesaurus_providers
+
+    for provider in create_thesaurus_providers():
+        register_facet_provider(provider)
+
 
 def register_facet_provider(provider: FacetProvider):
     logging.info(f"Registering {provider}")

--- a/geonode/facets/apps.py
+++ b/geonode/facets/apps.py
@@ -51,7 +51,7 @@ class FacetsRegistry:
         from geonode.facets.providers.thesaurus import create_thesaurus_providers
         from geonode.facets.providers.users import OwnerFacetProvider
 
-        logger.info(f"Initializing Facets")
+        logger.info("Initializing Facets")
 
         self.register_facet_provider(CategoryFacetProvider())
         self.register_facet_provider(OwnerFacetProvider())

--- a/geonode/facets/apps.py
+++ b/geonode/facets/apps.py
@@ -1,0 +1,44 @@
+#########################################################################
+#
+# Copyright (C) 2023 OSGeo
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#########################################################################
+import logging
+
+from django.apps import AppConfig
+
+from geonode.facets.models import FacetProvider
+
+
+logger = logging.getLogger(__name__)
+
+registered_facets = dict()
+
+
+class GeoNodeFacetsConfig(AppConfig):
+    name = "geonode.facets"
+    verbose_name = "GeoNode Facets endpoints"
+
+    def ready(self):
+        from geonode.urls import urlpatterns
+        from . import urls
+
+        urlpatterns += urls.urlpatterns
+
+
+def register_facet_provider(provider: FacetProvider):
+    logging.info(f"Registering {provider}")
+    registered_facets[provider.get_info()["name"]] = provider

--- a/geonode/facets/apps.py
+++ b/geonode/facets/apps.py
@@ -22,7 +22,6 @@ from django.apps import AppConfig
 
 from geonode.facets.models import FacetProvider
 
-
 logger = logging.getLogger(__name__)
 
 registered_facets = dict()
@@ -38,13 +37,16 @@ class GeoNodeFacetsConfig(AppConfig):
 
         urlpatterns += urls.urlpatterns
 
-        init_thesaurus_providers()
+        init_providers()
 
 
-def init_thesaurus_providers():
-    # should be called at startup and whenever records in Thesaurus or ThesaurusLabel change
+def init_providers():
     from geonode.facets.providers.thesaurus import create_thesaurus_providers
+    from geonode.facets.providers.users import OwnerFacetProvider
 
+    register_facet_provider(OwnerFacetProvider())
+
+    # Thesaurus providers initialiazion should be called at startup and whenever records in Thesaurus or ThesaurusLabel change
     for provider in create_thesaurus_providers():
         register_facet_provider(provider)
 

--- a/geonode/facets/apps.py
+++ b/geonode/facets/apps.py
@@ -29,9 +29,4 @@ class GeoNodeFacetsConfig(AppConfig):
     verbose_name = "GeoNode Facets endpoints"
 
     def ready(self):
-        from geonode.urls import urlpatterns
-        from . import urls
-
-        urlpatterns += urls.urlpatterns
-
         super(GeoNodeFacetsConfig, self).ready()

--- a/geonode/facets/models.py
+++ b/geonode/facets/models.py
@@ -1,4 +1,4 @@
-DEFAULT_FACET_TOPICS_LIMIT = 10
+DEFAULT_FACET_PAGE_SIZE = 10
 
 
 class FacetProvider:
@@ -33,21 +33,18 @@ class FacetProvider:
         """
         pass
 
-    def get_facet_items(self, queryset=None, lang="en", page: int = 0, limit: int = DEFAULT_FACET_TOPICS_LIMIT):
+    def get_facet_items(self, queryset, start: int = 0, end: int = DEFAULT_FACET_PAGE_SIZE, lang="en") -> (int, list):
         """
-        Return the items of the facets, as a dict:
-        - total: int, number of items matched
-        - start: int: the index of the initial returned items
-        - page: int: the returned page (should be the same as the `page` param)
-        - limit: int: the page size  (should be the same as the `limit` param)
-        - items: list of topic record. A topic record is a dict having these keys:
+        Return the items of the facets, in a tuple:
+        - int, total number of items matched
+        - list, topic records. A topic record is a dict having these keys:
           - key: the key of the items that should be used for filtering
           - label: a possibly localized label for the item
           - count: the count of such topic in the current facet
         :param queryset: the prefiltered queryset (may be filtered for authorization or other filters)
+        :param start: int: pagination, the index of the initial returned item
+        :param end: int: pagination, the index of the last returned item
         :param lang: the preferred language for the labels
-        :param page: page pagination param
-        :param limit: limit pagination param
-        :return: a dict
+        :return: a tuple int:total count of record, list of items
         """
         pass

--- a/geonode/facets/models.py
+++ b/geonode/facets/models.py
@@ -23,7 +23,8 @@ class FacetProvider:
         Get the basic info for this provider, as a dict with these keys:
         - 'name': the name of the provider (the one returned by name())
         - 'key': the filtering key to be used in a filter query
-        - 'label': a possibly localized label for this provider (localized according to the `lang` param
+        - 'label': a generic label for the facet; the client should try and localize it whenever possible
+        - 'localized_label': a localized label for the facet (localized according to the `lang` param)
         - 'type': the facet type (e.g. user, region, thesaurus, ...)
         - 'hierarchical': boolean value telling if the facet items are hierarchically organized
         - "order": an optional integer suggesting the relative ordering of the facets
@@ -39,7 +40,8 @@ class FacetProvider:
         - int, total number of items matched
         - list, topic records. A topic record is a dict having these keys:
           - key: the key of the items that should be used for filtering
-          - label: a possibly localized label for the item
+          - label: a generic label for the item; the client should try and localize it whenever possible
+          - localized_label: a localized label for the item
           - count: the count of such topic in the current facet
         :param queryset: the prefiltered queryset (may be filtered for authorization or other filters)
         :param start: int: pagination, the index of the initial returned item

--- a/geonode/facets/models.py
+++ b/geonode/facets/models.py
@@ -34,7 +34,9 @@ class FacetProvider:
         """
         pass
 
-    def get_facet_items(self, queryset, start: int = 0, end: int = DEFAULT_FACET_PAGE_SIZE, lang="en") -> (int, list):
+    def get_facet_items(
+        self, queryset, start: int = 0, end: int = DEFAULT_FACET_PAGE_SIZE, lang="en", topic_contains: str = None
+    ) -> (int, list):
         """
         Return the items of the facets, in a tuple:
         - int, total number of items matched
@@ -43,10 +45,12 @@ class FacetProvider:
           - label: a generic label for the item; the client should try and localize it whenever possible
           - localized_label: a localized label for the item
           - count: the count of such topic in the current facet
+          - other facet specific keys
         :param queryset: the prefiltered queryset (may be filtered for authorization or other filters)
         :param start: int: pagination, the index of the initial returned item
         :param end: int: pagination, the index of the last returned item
         :param lang: the preferred language for the labels
+        :param topic_contains: only returns matching topics
         :return: a tuple int:total count of record, list of items
         """
         pass

--- a/geonode/facets/models.py
+++ b/geonode/facets/models.py
@@ -1,3 +1,22 @@
+#########################################################################
+#
+# Copyright (C) 2023 Open Source Geospatial Foundation - all rights reserved
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#########################################################################
+
 import logging
 
 from django.conf import settings

--- a/geonode/facets/models.py
+++ b/geonode/facets/models.py
@@ -1,5 +1,11 @@
 DEFAULT_FACET_PAGE_SIZE = 10
 
+# Well known types of facet - not an enum bc it needs to be extensible
+FACET_TYPE_PLACE = "place"
+FACET_TYPE_USER = "user"
+FACET_TYPE_THESAURUS = "thesaurus"
+FACET_TYPE_CATEGORY = "category"
+
 
 class FacetProvider:
     """

--- a/geonode/facets/models.py
+++ b/geonode/facets/models.py
@@ -1,0 +1,53 @@
+DEFAULT_FACET_TOPICS_LIMIT = 10
+
+
+class FacetProvider:
+    """
+    Provides access to the facet information and the related topics
+    """
+
+    def __str__(self):
+        return f"{self.__class__.__name__}[{self.name}]"
+
+    @property
+    def name(self) -> str:
+        """
+        Get the name of the facet, to be used as a key for this provider.
+        You may want to override this method in order to have an optimized logic
+        :return: The name of the provider as a str
+        """
+        self.get_info()["name"]
+
+    def get_info(self, lang="en") -> dict:
+        """
+        Get the basic info for this provider, as a dict with these keys:
+        - 'name': the name of the provider (the one returned by name())
+        - 'key': the filtering key to be used in a filter query
+        - 'label': a possibly localized label for this provider (localized according to the `lang` param
+        - 'type': the facet type (e.g. user, region, thesaurus, ...)
+        - 'hierarchical': boolean value telling if the facet items are hierarchically organized
+        - "order": an optional integer suggesting the relative ordering of the facets
+
+        :param lang: lanuage for label localization
+        :return: a dict
+        """
+        pass
+
+    def get_facet_items(self, queryset=None, lang="en", page: int = 0, limit: int = DEFAULT_FACET_TOPICS_LIMIT):
+        """
+        Return the items of the facets, as a dict:
+        - total: int, number of items matched
+        - start: int: the index of the initial returned items
+        - page: int: the returned page (should be the same as the `page` param)
+        - limit: int: the page size  (should be the same as the `limit` param)
+        - items: list of topic record. A topic record is a dict having these keys:
+          - key: the key of the items that should be used for filtering
+          - label: a possibly localized label for the item
+          - count: the count of such topic in the current facet
+        :param queryset: the prefiltered queryset (may be filtered for authorization or other filters)
+        :param lang: the preferred language for the labels
+        :param page: page pagination param
+        :param limit: limit pagination param
+        :return: a dict
+        """
+        pass

--- a/geonode/facets/providers/category.py
+++ b/geonode/facets/providers/category.py
@@ -59,3 +59,7 @@ class CategoryFacetProvider(FacetProvider):
         ]
 
         return cnt, topics
+
+    @classmethod
+    def register(cls, registry, **kwargs) -> None:
+        registry.register_facet_provider(CategoryFacetProvider())

--- a/geonode/facets/providers/category.py
+++ b/geonode/facets/providers/category.py
@@ -1,0 +1,61 @@
+import logging
+
+from django.db.models import Count
+
+from geonode.facets.models import FacetProvider, DEFAULT_FACET_PAGE_SIZE, FACET_TYPE_CATEGORY
+
+logger = logging.getLogger(__name__)
+
+
+class CategoryFacetProvider(FacetProvider):
+    """
+    Implements faceting for resource's topicCategory
+    """
+
+    @property
+    def name(self) -> str:
+        return "category"
+
+    def get_info(self, lang="en") -> dict:
+        return {
+            "name": self.name,
+            "key": "filter{category__identifier}",
+            "label": "Category",
+            "type": FACET_TYPE_CATEGORY,
+            "hierarchical": False,
+            "order": 2,
+        }
+
+    def get_facet_items(
+        self,
+        queryset=None,
+        start: int = 0,
+        end: int = DEFAULT_FACET_PAGE_SIZE,
+        lang="en",
+        topic_contains: str = None,
+    ) -> (int, list):
+        logger.debug("Retrieving facets for %s", self.name)
+
+        q = queryset.values("category__identifier", "category__gn_description", "category__fa_class")
+        if topic_contains:
+            q = q.filter(category__gn_description=topic_contains)
+        q = q.annotate(count=Count("owner")).order_by("-count")
+
+        cnt = q.count()
+
+        logger.info("Found %d facets for %s", cnt, self.name)
+        logger.debug(" ---> %s\n\n", q.query)
+        logger.debug(" ---> %r\n\n", q.all())
+
+        topics = [
+            {
+                "key": r["category__identifier"],
+                "label": r["category__gn_description"],
+                "localized_label": r["category__gn_description"],
+                "count": r["count"],
+                "fa_class": r["category__fa_class"],
+            }
+            for r in q[start:end].all()
+        ]
+
+        return cnt, topics

--- a/geonode/facets/providers/category.py
+++ b/geonode/facets/providers/category.py
@@ -1,3 +1,22 @@
+#########################################################################
+#
+# Copyright (C) 2023 Open Source Geospatial Foundation - all rights reserved
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#########################################################################
+
 import logging
 
 from django.db.models import Count

--- a/geonode/facets/providers/category.py
+++ b/geonode/facets/providers/category.py
@@ -51,7 +51,6 @@ class CategoryFacetProvider(FacetProvider):
             {
                 "key": r["category__identifier"],
                 "label": r["category__gn_description"],
-                "localized_label": r["category__gn_description"],
                 "count": r["count"],
                 "fa_class": r["category__fa_class"],
             }

--- a/geonode/facets/providers/thesaurus.py
+++ b/geonode/facets/providers/thesaurus.py
@@ -1,0 +1,95 @@
+import logging
+
+from django.db.models import Count
+
+from geonode.base.models import Thesaurus, ResourceBase
+from geonode.facets.models import FacetProvider, DEFAULT_FACET_TOPICS_LIMIT
+
+logger = logging.getLogger(__name__)
+
+
+class ThesaurusFacetProvider(FacetProvider):
+    """
+    Implements faceting for a given Thesaurus
+    """
+
+    def __init__(self, identifier, title, order, labels: dict):
+        self._name = identifier
+        self.label = title
+        self.order = order
+        self.labels = labels
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def get_info(self, lang="en") -> dict:
+        return {
+            "name": self._name,
+            "key": "tkeyword",
+            "label": self.labels.get(lang, self.label),
+            "type": "thesaurus",
+            "hierarchical": False,
+            "order": self.order,
+        }
+
+    def get_facet_items(self, queryset=None, lang="en", page: int = 0, limit: int = DEFAULT_FACET_TOPICS_LIMIT) -> dict:
+        logging.debug("Retrieving facets for %s", self._name)
+
+        if not queryset:
+            queryset = ResourceBase.objects
+
+        q = (
+            queryset.filter(tkeywords__thesaurus__identifier=self._name, tkeywords__keyword__lang=lang)
+            .values("tkeywords", "tkeywords__keyword__label")
+            .annotate(count=Count("tkeywords"))
+            .order_by("-count")
+        )
+
+        cnt = q.count()
+        start = page * limit
+        end = start + limit
+
+        ret = {
+            "total": cnt,
+            "start": start,
+            "page": page,
+            "limit": limit,
+        }
+
+        logging.debug("Found %d facets for %s", cnt, self._name)
+        logging.debug(" ---> %s\n\n", q.query)
+        logging.debug(" ---> %r\n\n", q.all())
+
+        topics = [
+            {"key": r["tkeywords"], "label": r["tkeywords__keyword__label"], "count": r["count"]}
+            for r in q[start:end].all()
+        ]
+
+        ret["items"] = topics
+
+        return ret
+
+
+def create_thesaurus_providers() -> list:
+    # this query return the list of thesaurus X the list of localized titles
+    q = (
+        Thesaurus.objects.filter(facet=True)
+        .values("identifier", "title", "order", "rel_thesaurus__label", "rel_thesaurus__lang")
+        .order_by("order")
+    )
+
+    # coalesce the localized labels
+    ret = {}
+    for r in q.all():
+        identifier = r["identifier"]
+        t = ret.get(identifier, None)
+        if not t:
+            t = {k: r[k] for k in ("identifier", "title", "order")}
+            t["labels"] = {}
+        if r["rel_thesaurus__lang"] and r["rel_thesaurus__label"]:
+            t["labels"][r["rel_thesaurus__lang"]] = r["rel_thesaurus__label"]
+        ret[identifier] = t
+
+    logging.info("Creating providers for %r", ret)
+    return [ThesaurusFacetProvider(t["identifier"], t["title"], t["order"], t["labels"]) for t in ret.values()]

--- a/geonode/facets/providers/thesaurus.py
+++ b/geonode/facets/providers/thesaurus.py
@@ -3,7 +3,7 @@ import logging
 from django.db.models import Count
 
 from geonode.base.models import Thesaurus
-from geonode.facets.models import FacetProvider, DEFAULT_FACET_PAGE_SIZE
+from geonode.facets.models import FacetProvider, DEFAULT_FACET_PAGE_SIZE, FACET_TYPE_THESAURUS
 
 logger = logging.getLogger(__name__)
 
@@ -29,7 +29,7 @@ class ThesaurusFacetProvider(FacetProvider):
             "key": "filter{tkeyword}",
             "label": self.label,
             "localized_label": self.labels.get(lang, None),
-            "type": "thesaurus",
+            "type": FACET_TYPE_THESAURUS,
             "hierarchical": False,
             "order": self.order,
         }

--- a/geonode/facets/providers/thesaurus.py
+++ b/geonode/facets/providers/thesaurus.py
@@ -1,3 +1,22 @@
+#########################################################################
+#
+# Copyright (C) 2023 Open Source Geospatial Foundation - all rights reserved
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#########################################################################
+
 import logging
 
 from django.db.models import Count

--- a/geonode/facets/providers/thesaurus.py
+++ b/geonode/facets/providers/thesaurus.py
@@ -26,8 +26,8 @@ class ThesaurusFacetProvider(FacetProvider):
         return {
             "name": self._name,
             "key": "filter{tkeyword}",
-            "label": self.label,
-            "localized_label": self.labels.get(lang, None),
+            "label": self.labels.get(lang, self.label),
+            "is_localized": self.labels.get(lang, None) is not None,
             "type": FACET_TYPE_THESAURUS,
             "hierarchical": False,
             "order": self.order,
@@ -68,8 +68,8 @@ class ThesaurusFacetProvider(FacetProvider):
         topics = [
             {
                 "key": r["tkeywords"],
-                "localized_label": r["tkeywords__keyword__label"],
-                "label": r["tkeywords__alt_label"],
+                "label": r["tkeywords__keyword__label"] or r["tkeywords__alt_label"],
+                "is_localized": r["tkeywords__keyword__label"] is not None,
                 "count": r["count"],
             }
             for r in q[start:end].all()

--- a/geonode/facets/providers/thesaurus.py
+++ b/geonode/facets/providers/thesaurus.py
@@ -25,7 +25,7 @@ class ThesaurusFacetProvider(FacetProvider):
     def get_info(self, lang="en") -> dict:
         return {
             "name": self._name,
-            "key": "filter{tkeyword}",
+            "key": "filter{tkeywords}",
             "label": self.labels.get(lang, self.label),
             "is_localized": self.labels.get(lang, None) is not None,
             "type": FACET_TYPE_THESAURUS,

--- a/geonode/facets/providers/users.py
+++ b/geonode/facets/providers/users.py
@@ -1,0 +1,44 @@
+import logging
+
+from django.db.models import Count
+
+from geonode.facets.models import FacetProvider, DEFAULT_FACET_PAGE_SIZE
+
+logger = logging.getLogger(__name__)
+
+
+class OwnerFacetProvider(FacetProvider):
+    """
+    Implements faceting for users owner of the resources
+    """
+
+    @property
+    def name(self) -> str:
+        return "owner"
+
+    def get_info(self, lang="en") -> dict:
+        return {
+            "name": "owner",
+            "key": "owner",
+            "label": "Owner",
+            "type": "users",
+            "hierarchical": False,
+            "order": 5,
+        }
+
+    def get_facet_items(
+        self, queryset=None, start: int = 0, end: int = DEFAULT_FACET_PAGE_SIZE, lang="en"
+    ) -> (int, list):
+        logging.debug("Retrieving facets for OWNER")
+
+        q = queryset.values("owner", "owner__username").annotate(count=Count("owner")).order_by("-count")
+
+        cnt = q.count()
+
+        logging.info("Found %d facets for %s", cnt, self.name)
+        logging.debug(" ---> %s\n\n", q.query)
+        logging.debug(" ---> %r\n\n", q.all())
+
+        topics = [{"key": r["owner"], "label": r["owner__username"], "count": r["count"]} for r in q[start:end].all()]
+
+        return cnt, topics

--- a/geonode/facets/providers/users.py
+++ b/geonode/facets/providers/users.py
@@ -58,3 +58,7 @@ class OwnerFacetProvider(FacetProvider):
         ]
 
         return cnt, topics
+
+    @classmethod
+    def register(cls, registry, **kwargs) -> None:
+        registry.register_facet_provider(OwnerFacetProvider())

--- a/geonode/facets/providers/users.py
+++ b/geonode/facets/providers/users.py
@@ -27,17 +27,25 @@ class OwnerFacetProvider(FacetProvider):
         }
 
     def get_facet_items(
-        self, queryset=None, start: int = 0, end: int = DEFAULT_FACET_PAGE_SIZE, lang="en"
+        self,
+        queryset=None,
+        start: int = 0,
+        end: int = DEFAULT_FACET_PAGE_SIZE,
+        lang="en",
+        topic_contains: str = None,
     ) -> (int, list):
-        logging.debug("Retrieving facets for OWNER")
+        logger.debug("Retrieving facets for OWNER")
 
-        q = queryset.values("owner", "owner__username").annotate(count=Count("owner")).order_by("-count")
+        q = queryset.values("owner", "owner__username")
+        if topic_contains:
+            q = q.filter(owner__username__icontains=topic_contains)
+        q = q.annotate(count=Count("owner")).order_by("-count")
 
         cnt = q.count()
 
-        logging.info("Found %d facets for %s", cnt, self.name)
-        logging.debug(" ---> %s\n\n", q.query)
-        logging.debug(" ---> %r\n\n", q.all())
+        logger.info("Found %d facets for %s", cnt, self.name)
+        logger.debug(" ---> %s\n\n", q.query)
+        logger.debug(" ---> %r\n\n", q.all())
 
         topics = [
             {

--- a/geonode/facets/providers/users.py
+++ b/geonode/facets/providers/users.py
@@ -54,7 +54,7 @@ class OwnerFacetProvider(FacetProvider):
                 "localized_label": r["owner__username"],
                 "count": r["count"],
             }
-            for r in q[start:end].all()
+            for r in q[start:end]
         ]
 
         return cnt, topics

--- a/geonode/facets/providers/users.py
+++ b/geonode/facets/providers/users.py
@@ -1,3 +1,22 @@
+#########################################################################
+#
+# Copyright (C) 2023 Open Source Geospatial Foundation - all rights reserved
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#########################################################################
+
 import logging
 
 from django.db.models import Count

--- a/geonode/facets/providers/users.py
+++ b/geonode/facets/providers/users.py
@@ -2,7 +2,7 @@ import logging
 
 from django.db.models import Count
 
-from geonode.facets.models import FacetProvider, DEFAULT_FACET_PAGE_SIZE
+from geonode.facets.models import FacetProvider, DEFAULT_FACET_PAGE_SIZE, FACET_TYPE_USER
 
 logger = logging.getLogger(__name__)
 
@@ -21,7 +21,7 @@ class OwnerFacetProvider(FacetProvider):
             "name": "owner",
             "key": "owner",
             "label": "Owner",
-            "type": "users",
+            "type": FACET_TYPE_USER,
             "hierarchical": False,
             "order": 5,
         }

--- a/geonode/facets/providers/users.py
+++ b/geonode/facets/providers/users.py
@@ -39,6 +39,14 @@ class OwnerFacetProvider(FacetProvider):
         logging.debug(" ---> %s\n\n", q.query)
         logging.debug(" ---> %r\n\n", q.all())
 
-        topics = [{"key": r["owner"], "label": r["owner__username"], "count": r["count"]} for r in q[start:end].all()]
+        topics = [
+            {
+                "key": r["owner"],
+                "label": r["owner__username"],
+                "localized_label": r["owner__username"],
+                "count": r["count"],
+            }
+            for r in q[start:end].all()
+        ]
 
         return cnt, topics

--- a/geonode/facets/tests.py
+++ b/geonode/facets/tests.py
@@ -1,3 +1,22 @@
+#########################################################################
+#
+# Copyright (C) 2023 Open Source Geospatial Foundation - all rights reserved
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#########################################################################
+
 import logging
 import json
 from tastypie.test import TestApiClient

--- a/geonode/facets/tests.py
+++ b/geonode/facets/tests.py
@@ -1,0 +1,224 @@
+import logging
+from uuid import uuid4
+import json
+
+from django.http import JsonResponse
+from django.test import RequestFactory
+from django.urls import reverse
+
+from geonode.base.models import Thesaurus, ThesaurusLabel, ThesaurusKeyword, ThesaurusKeywordLabel, ResourceBase
+from django.contrib.auth import get_user_model
+from geonode.tests.base import GeoNodeBaseTestSupport
+import geonode.facets.views as views
+
+
+logger = logging.getLogger(__name__)
+
+
+class FacetsTest(GeoNodeBaseTestSupport):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.user = get_user_model().objects.create(username="user_00")
+        cls.admin = get_user_model().objects.get(username="admin")
+
+        cls._create_thesauri()
+        cls._create_resources()
+        cls.rf = RequestFactory()
+
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+        # remove_models(cls.get_obj_ids, type=cls.get_type, integration=cls.get_integration)
+
+    def setUp(self):
+        super().setUp()
+
+        # self.user = get_user_model().objects.create(username="user_00")
+        # self.admin = get_user_model().objects.get(username="admin")
+        #
+        # self.assertEqual(self.admin.username, "admin")
+        # self.assertEqual(self.admin.is_superuser, True)
+        #
+        # self._create_thesauri()
+        # self._create_resources()
+        # self.rf = RequestFactory()
+
+    @classmethod
+    def _create_thesauri(cls):
+        cls.thesauri = {}
+        cls.thesauri_k = {}
+
+        for tn in range(2):
+            t = Thesaurus.objects.create(identifier=f"t_{tn}", title=f"Thesaurus {tn}")
+            cls.thesauri[tn] = t
+            for tl in (
+                "en",
+                "it",
+            ):
+                ThesaurusLabel.objects.create(thesaurus=t, lang=tl, label=f"TLabel {tn} {tl}")
+
+            for tkn in range(10):
+                tk = ThesaurusKeyword.objects.create(thesaurus=t, alt_label=f"alt_tkn{tkn}_t{tn}")
+                cls.thesauri_k[f"{tn}_{tkn}"] = tk
+                for tkl in (
+                    "en",
+                    "it",
+                ):
+                    ThesaurusKeywordLabel.objects.create(keyword=tk, lang=tkl, label=f"T{tn}_K{tkn}_{tkl}")
+
+    @classmethod
+    def _create_resources(self):
+        public_perm_spec = {"users": {"AnonymousUser": ["view_resourcebase"]}, "groups": []}
+
+        for x in range(20):
+            d: ResourceBase = ResourceBase.objects.create(
+                title=f"dataset_{x:02}",
+                uuid=str(uuid4()),
+                owner=self.user,
+                abstract=f"Abstract for dataset {x:02}",
+                subtype="vector",
+                is_approved=True,
+                is_published=True,
+            )
+
+            # These are the assigned keywords to the Resources
+
+            # RB00 ->            T1K0
+            # RB01 ->  T0K0      T1K0
+            # RB02 ->            T1K0
+            # RB03 ->  T0K0      T1K0
+            # RB04 ->            T1K0
+            # RB05 ->  T0K0      T1K0
+            # RB06 ->            T1K0
+            # RB07 ->  T0K0      T1K0
+            # RB08 ->            T1K0
+            # RB09 ->  T0K0      T1K0
+            # RB10 ->
+            # RB11 ->  T0K0 T0K1
+            # RB12 ->
+            # RB13 ->  T0K0 T0K1
+            # RB14 ->
+            # RB15 ->  T0K0 T0K1
+            # RB16 ->
+            # RB17 ->  T0K0 T0K1
+            # RB18 ->
+            # RB19 ->  T0K0 T0K1
+
+            if x % 2 == 1:
+                print(f"ADDING KEYWORDS {self.thesauri_k['0_0']} to RB {d}")
+                d.tkeywords.add(self.thesauri_k["0_0"])
+                d.save()
+            if x % 2 == 1 and x > 10:
+                print(f"ADDING KEYWORDS {self.thesauri_k['0_1']} to RB {d}")
+                d.tkeywords.add(self.thesauri_k["0_1"])
+                d.save()
+            if x < 10:
+                print(f"ADDING KEYWORDS {self.thesauri_k['1_0']} to RB {d}")
+                d.tkeywords.add(self.thesauri_k["1_0"])
+                d.save()
+
+            d.set_permissions(public_perm_spec)
+
+    @staticmethod
+    def _facets_to_map(facets):
+        return {f["name"]: f for f in facets}
+
+    def test_facets_base(self):
+        req = self.rf.get(reverse("list_facets"), data={"lang": "en"})
+        res: JsonResponse = views.list_facets(req)
+        obj = json.loads(res.content)
+        self.assertIn("facets", obj)
+        facets_list = obj["facets"]
+        self.assertEqual(4, len(facets_list))
+        fmap = self._facets_to_map(facets_list)
+        for name in ("category", "owner", "t_0", "t_1"):
+            self.assertIn(name, fmap)
+
+    def test_facets_rich(self):
+        # make sure the resources are in
+        c = ResourceBase.objects.count()
+        self.assertEqual(20, c)
+
+        # make sure tkeywords have been assigned by checking a sample resource
+        rb = ResourceBase.objects.get(title="dataset_01")
+        self.assertEqual(2, rb.tkeywords.count())
+
+        # run the request
+        req = self.rf.get(reverse("list_facets"), data={"include_topics": 1, "lang": "en"})
+        res: JsonResponse = views.list_facets(req)
+        obj = json.loads(res.content)
+
+        facets_list = obj["facets"]
+        self.assertEqual(4, len(facets_list))
+        fmap = self._facets_to_map(facets_list)
+        for expected in (
+            {
+                "name": "category",
+                "topics": {
+                    "total": 1,
+                },
+            },
+            {
+                "name": "owner",
+                "topics": {
+                    "total": 1,
+                },
+            },
+            {
+                "name": "t_0",
+                "topics": {
+                    "total": 2,
+                    "items": {
+                        "T0_K0_en": {"label": "T0_K0_en", "count": 10},
+                        "T0_K1_en": {"label": "T0_K1_en", "count": 5},
+                    },
+                },
+            },
+            {
+                "name": "t_1",
+                "topics": {
+                    "total": 1,
+                    "items": {
+                        "T1_K0_en": {"count": 10},
+                    },
+                },
+            },
+        ):
+            name = expected["name"]
+            self.assertIn(name, fmap)
+            facet = fmap[name]
+            expected_topics = expected["topics"]
+            for topic_key in expected_topics:
+                if topic_key != "items":
+                    self.assertEqual(
+                        expected_topics[topic_key], facet["topics"][topic_key], f"Mismatching '{topic_key}'"
+                    )
+                else:
+                    items = facet["topics"]["items"]
+                    expected_items = expected_topics["items"]
+                    for item in items:
+                        self.assertIn(item["label"], expected_items, f"topic not found '{item['label']}'")
+                        x_item = expected_items[item["label"]]
+                        for _k, _v in x_item.items():
+                            self.assertEqual(_v, item[_k], f"Mismatch item key:{_k}")
+
+        # print(json.dumps(json.loads(res.content), indent=True))
+
+    def test_bad_lang(self):
+        # for thesauri, make sure that by requesting a non-existent language the faceting is still working,
+        # using the default labels
+        # TODO impl+test
+        pass
+
+    def test_user_auth(self):
+        # make sure the user authorization pre-filters the visible resources
+        # TODO test
+        pass
+
+    def test_thesauri_reloading(self):
+        # Thesauri facets are cached.
+        # Make sure that when Thesauri or ThesauriLabel change the facets cache is invalidated
+        # TODO impl+test
+        pass

--- a/geonode/facets/urls.py
+++ b/geonode/facets/urls.py
@@ -1,0 +1,26 @@
+#########################################################################
+#
+# Copyright (C) 2023 OSGeo
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#########################################################################
+
+from django.urls import path
+from . import views
+
+urlpatterns = [
+    path("facets", views.list_facets, name="list_facets"),
+    path("facets/<facet>", views.get_facet, name="get_facet"),
+]

--- a/geonode/facets/views.py
+++ b/geonode/facets/views.py
@@ -1,3 +1,22 @@
+#########################################################################
+#
+# Copyright (C) 2023 Open Source Geospatial Foundation - all rights reserved
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#########################################################################
+
 import logging
 from urllib.parse import urlencode
 

--- a/geonode/facets/views.py
+++ b/geonode/facets/views.py
@@ -137,7 +137,7 @@ def _resolve_language(request) -> (str, bool):
     try:
         return request.LANGUAGE_CODE.split("-")[0], False
     except AttributeError:
-        return settings.LANGUAGE_CODE
+        return settings.LANGUAGE_CODE, False
 
 
 def _resolve_boolean(request, name, fallback=None):

--- a/geonode/facets/views.py
+++ b/geonode/facets/views.py
@@ -8,7 +8,7 @@ from django.http import HttpResponseNotFound, JsonResponse
 from django.urls import reverse
 
 from geonode.base.models import ResourceBase
-from geonode.facets.apps import registered_facets
+from geonode.facets.apps import facet_registry
 from geonode.facets.models import FacetProvider, DEFAULT_FACET_PAGE_SIZE
 from geonode.security.utils import get_visible_resources
 
@@ -31,7 +31,7 @@ def list_facets(request, **kwargs):
 
     facets = []
 
-    for provider in registered_facets.values():
+    for provider in facet_registry.get_providers():
         logger.debug("Fetching data from provider %r", provider)
         info = provider.get_info(lang=lang)
         if add_links:
@@ -55,7 +55,7 @@ def get_facet(request, facet):
     logger.debug("get_facet -> %r for user '%r'", facet, request.user.username)
 
     # retrieve provider for the requested facet
-    provider: FacetProvider = registered_facets.get(facet)
+    provider: FacetProvider = facet_registry.get_provider(facet)
     if not provider:
         return HttpResponseNotFound()
 

--- a/geonode/facets/views.py
+++ b/geonode/facets/views.py
@@ -1,0 +1,95 @@
+import logging
+from urllib.parse import urlencode
+from rest_framework.authentication import SessionAuthentication, BasicAuthentication
+from rest_framework.decorators import api_view, authentication_classes
+
+from django.http import HttpResponseNotFound, JsonResponse
+from django.urls import reverse
+
+from geonode.base.models import ResourceBase
+from geonode.facets.apps import registered_facets
+from geonode.facets.models import FacetProvider, DEFAULT_FACET_TOPICS_LIMIT
+from geonode.security.utils import get_visible_resources
+
+logger = logging.getLogger(__name__)
+
+
+def list_facets(request, **kwargs):
+    lang = _resolve_language(request)
+    add_links = _resolve_boolean(request, "add_links", False)
+    include_topics = _resolve_boolean(request, "include_topics", False)
+
+    facets = []
+
+    for provider in registered_facets.values():
+        logger.debug("Fetching data from provider %r", provider)
+        info = provider.get_info(lang=lang)
+        if add_links:
+            info["link"] = f"{reverse('get_facet', args=[info['name']])}?{urlencode({'add_links': True})}"
+
+        if include_topics:
+            content = provider.get_facet_items(queryset=_prefilter_topics(request))
+            info["topics"] = content
+
+        facets.append(info)
+
+    logger.debug("Returning facets %r", facets)
+    return JsonResponse({"facets": facets})
+
+
+@api_view(["GET"])
+@authentication_classes([SessionAuthentication, BasicAuthentication])
+def get_facet(request, facet):
+    logger.debug("get_facet -> %r", facet)
+    lang = _resolve_language(request)
+    add_link = _resolve_boolean(request, "add_links", False)
+
+    provider: FacetProvider = registered_facets.get(facet)
+    if not provider:
+        return HttpResponseNotFound()
+
+    page = int(request.GET.get("page", 0))
+    limit = int(request.GET.get("limit", DEFAULT_FACET_TOPICS_LIMIT))
+
+    info = provider.get_info(lang)
+    info["user"] = request.user.username
+
+    qs = _prefilter_topics(request)
+    content = provider.get_facet_items(queryset=qs, lang=lang, page=page, limit=limit)
+
+    if add_link:
+        exist_prev = page > 0
+        exist_next = content["total"] > (page + 1) * limit
+        link = reverse("get_facet", args=[info["name"]])
+        info["prev"] = f'{link}?{urlencode({"limit": limit, "page": page-1, "add_links":True})}' if exist_prev else None
+        info["next"] = f'{link}?{urlencode({"limit": limit, "page": page+1, "add_links":True})}' if exist_next else None
+
+    info["topics"] = content
+
+    return JsonResponse(info)
+
+
+def _prefilter_topics(request):
+    return get_visible_resources(ResourceBase.objects, request.user)
+
+
+def _resolve_language(request):
+    # first try with an explicit request using params
+    if lang := request.GET.get("lang", None):
+        return lang
+    # 2nd try: use LANGUAGE_CODE
+    return request.LANGUAGE_CODE.split("-")[0]
+
+
+def _resolve_boolean(request, name, fallback=None):
+    val = request.GET.get(name, None)
+    if val is None:
+        return fallback
+
+    val = val.lower()
+    if val.startswith("t") or val.startswith("y") or val == "1":
+        return True
+    elif val.startswith("f") or val.startswith("n") or val == "0":
+        return False
+    else:
+        return fallback

--- a/geonode/facets/views.py
+++ b/geonode/facets/views.py
@@ -7,6 +7,7 @@ from rest_framework.decorators import api_view, authentication_classes
 from django.http import HttpResponseNotFound, JsonResponse
 from django.urls import reverse
 
+from django.conf import settings
 from geonode.base.models import ResourceBase
 from geonode.facets.models import FacetProvider, DEFAULT_FACET_PAGE_SIZE, facet_registry
 from geonode.security.utils import get_visible_resources
@@ -120,6 +121,8 @@ def _prefilter_topics(request):
     :param request:
     :return: a QuerySet on ResourceBase
     """
+    logger.debug("Filtering by user '%s'", request.user)
+    # return ResourceBase.objects
     return get_visible_resources(ResourceBase.objects, request.user)
 
 
@@ -131,7 +134,10 @@ def _resolve_language(request) -> (str, bool):
     if lang := request.GET.get(PARAM_LANG, None):
         return lang, True
     # 2nd try: use LANGUAGE_CODE
-    return request.LANGUAGE_CODE.split("-")[0], False
+    try:
+        return request.LANGUAGE_CODE.split("-")[0], False
+    except AttributeError:
+        return settings.LANGUAGE_CODE
 
 
 def _resolve_boolean(request, name, fallback=None):

--- a/geonode/facets/views.py
+++ b/geonode/facets/views.py
@@ -8,8 +8,7 @@ from django.http import HttpResponseNotFound, JsonResponse
 from django.urls import reverse
 
 from geonode.base.models import ResourceBase
-from geonode.facets.apps import facet_registry
-from geonode.facets.models import FacetProvider, DEFAULT_FACET_PAGE_SIZE
+from geonode.facets.models import FacetProvider, DEFAULT_FACET_PAGE_SIZE, facet_registry
 from geonode.security.utils import get_visible_resources
 
 PARAM_PAGE = "page"

--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -434,6 +434,7 @@ GEONODE_INTERNAL_APPS = (
     "geonode.messaging",
     "geonode.favorite",
     "geonode.monitoring",
+    "geonode.facets",
 )
 
 GEONODE_CONTRIB_APPS = (

--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -2261,3 +2261,9 @@ SUPPORTED_DATASET_FILE_TYPES = [
         "needsFiles": ["shp", "prj", "dbf", "shx", "csv", "tiff", "zip", "xml"],
     },
 ]
+
+FACET_PROVIDERS = (
+    "geonode.facets.providers.category.CategoryFacetProvider",
+    "geonode.facets.providers.users.OwnerFacetProvider",
+    "geonode.facets.providers.thesaurus.ThesaurusFacetProvider",
+)

--- a/geonode/urls.py
+++ b/geonode/urls.py
@@ -120,6 +120,7 @@ urlpatterns += [
     url(r"^api/v2/", include("geonode.api.urls")),
     url(r"^api/v2/", include("geonode.management_commands_http.urls")),
     url(r"^api/v2/api-auth/", include("rest_framework.urls", namespace="geonode_rest_framework")),
+    url(r"^api/v2/", include("geonode.facets.urls")),
     url(r"", include(api.urls)),
 ]
 


### PR DESCRIPTION
Includes commits for #10995 (faceting)
- Base framework: initial app, urls and basic logic for extensible faceting through registering
- Facets provider for Thesaurus keywords, owner and category


This PR also includes a fix for #11061 "Filtering by keywords"

## Checklist


For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: black geonode && flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
