### PR TITLE
fixes sync_security_rules

### DIFF
--- a/geonode/geoserver/management/commands/sync_security_rules.py
+++ b/geonode/geoserver/management/commands/sync_security_rules.py
@@ -18,7 +18,7 @@
 #########################################################################
 
 from django.core.management.base import BaseCommand
-from geonode.geoserver.security.utils import sync_resources_with_guardian
+from geonode.geoserver.security import sync_resources_with_guardian
 
 
 class Command(BaseCommand):
@@ -27,4 +27,4 @@ class Command(BaseCommand):
     """
 
     def handle(self, *args, **options):
-        sync_resources_with_guardian()
+        sync_resources_with_guardian(force=True)

--- a/geonode/geoserver/security.py
+++ b/geonode/geoserver/security.py
@@ -326,7 +326,7 @@ def create_geofence_rules(layer, perms, user=None, group=None, batch: Batch = No
     return batch
 
 
-def sync_resources_with_guardian(resource=None):
+def sync_resources_with_guardian(resource=None, force=False):
     """
     Sync resources with Guardian and clear their dirty state
     """
@@ -336,13 +336,16 @@ def sync_resources_with_guardian(resource=None):
     if resource:
         dirty_resources = ResourceBase.objects.filter(id=resource.id)
     else:
-        dirty_resources = ResourceBase.objects.filter(dirty_state=True)
-    if dirty_resources and dirty_resources.exists():
+        if force:
+            resources = ResourceBase.objects.all()
+        else:
+            resources = ResourceBase.objects.filter(dirty_state=True)
+    if resources and resources.exists():
         logger.debug(" --------------------------- synching with guardian!")
 
         rules_committed = False
 
-        for r in dirty_resources:
+        for r in resources:
             if r.polymorphic_ctype.name == "dataset":
                 layer = None
                 try:


### PR DESCRIPTION
ref #11015 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [ ] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [ ] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: black geonode && flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
