### PR TITLE
[Fixes #11034] Drop AnonymousUser from perm spec

### DIFF
--- a/geonode/security/models.py
+++ b/geonode/security/models.py
@@ -114,6 +114,7 @@ class PermissionLevelMixin:
             for _kk in list(_v):
                 # Remove AnonymousUser if set for some reason (legacy code)
                 if _kk == get_anonymous_user():
+                    logger.warning("Guardian permisions for AnonymouUser on resource {resource.id} were found in the DB, which is unexpected")
                     del info[_k][_kk]
                     continue
                 _vv = _v[_kk]

--- a/geonode/security/models.py
+++ b/geonode/security/models.py
@@ -31,7 +31,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.contrib.auth.models import Group, Permission
 from django.contrib.contenttypes.models import ContentType
 
-from guardian.shortcuts import get_perms, get_groups_with_perms
+from guardian.shortcuts import get_perms, get_groups_with_perms, get_anonymous_user
 
 from geonode.groups.models import GroupProfile
 from geonode.groups.conf import settings as groups_settings
@@ -109,12 +109,17 @@ class PermissionLevelMixin:
         except Exception:
             tb = traceback.format_exc()
             logger.debug(tb)
-        # Remove duplicated perms if any
-        if info:
-            for _k, _v in info.items():
-                for _kk, _vv in info[_k].items():
-                    if _vv and isinstance(_vv, list):
-                        info[_k][_kk] = list(set(_vv))
+
+        for _k, _v in info.items():
+            for _kk in list(_v):
+                # Remove AnonymousUser if set for some reason (legacy code)
+                if _kk == get_anonymous_user():
+                    del info[_k][_kk]
+                    continue
+                _vv = _v[_kk]
+                if _vv and isinstance(_vv, list):
+                    # Remove duplicated perms
+                    info[_k][_kk] = list(set(_vv))
         return info
 
     def get_self_resource(self):

--- a/geonode/security/models.py
+++ b/geonode/security/models.py
@@ -114,7 +114,9 @@ class PermissionLevelMixin:
             for _kk in list(_v):
                 # Remove AnonymousUser if set for some reason (legacy code)
                 if _kk == get_anonymous_user():
-                    logger.warning("Guardian permisions for AnonymouUser on resource {resource.id} were found in the DB, which is unexpected")
+                    logger.warning(
+                        "Guardian permisions for AnonymouUser on resource {resource.id} were found in the DB, which is unexpected"
+                    )
                     del info[_k][_kk]
                     continue
                 _vv = _v[_kk]

--- a/geonode/security/tests.py
+++ b/geonode/security/tests.py
@@ -2773,3 +2773,16 @@ class TestUserHasPerms(GeoNodeBaseTestSupport):
             result = self.client.patch(url)
             # checking that the user cannot call the url in patch due the lack of permissions
             self.assertEqual(403, result.status_code, _case)
+
+    def test_anonymous_user_is_stripped_off(self):
+        from geonode.base.models import ResourceBase
+
+        perms = ["base.view_resourcebase", "base.download_resourcebase"]
+        resource = ResourceBase.objects.get(id=self.dataset.id)
+        for perm in perms:
+            assign_perm(perm, get_anonymous_user(), resource)
+            assign_perm(perm, Group.objects.get(name="anonymous"), resource)
+
+        perm_spec = resource.get_all_level_info()
+        anonymous_user_perm = perm_spec["users"].get(get_anonymous_user())
+        self.assertEqual(anonymous_user_perm, None, "Anynmous user wasn't removed")


### PR DESCRIPTION
#11034 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [ ] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [ ] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: black geonode && flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
