### PR TITLE
[Fixes #11061] Filtering by tkeywords

### DIFF
--- a/geonode/api/tests.py
+++ b/geonode/api/tests.py
@@ -36,7 +36,14 @@ from geonode.geoserver.manager import GeoServerResourceManager
 from geonode.maps.models import Map
 from geonode.layers.models import Dataset
 from geonode.documents.models import Document
-from geonode.base.models import ExtraMetadata, Thesaurus, ThesaurusLabel, ThesaurusKeyword, ThesaurusKeywordLabel, ResourceBase
+from geonode.base.models import (
+    ExtraMetadata,
+    Thesaurus,
+    ThesaurusLabel,
+    ThesaurusKeyword,
+    ThesaurusKeywordLabel,
+    ResourceBase,
+)
 from geonode.utils import check_ogc_backend
 from geonode.decorators import on_ogc_backend
 from geonode.groups.models import GroupProfile
@@ -882,8 +889,8 @@ class ThesauriApiTests(GeoNodeBaseTestSupport):
             t = Thesaurus.objects.create(identifier=f"t_{tn}", title=f"Thesaurus {tn}")
             cls.thesauri[tn] = t
             for tl in (
-                    "en",
-                    "it",
+                "en",
+                "it",
             ):
                 ThesaurusLabel.objects.create(thesaurus=t, lang=tl, label=f"TLabel {tn} {tl}")
 
@@ -891,8 +898,8 @@ class ThesauriApiTests(GeoNodeBaseTestSupport):
                 tk = ThesaurusKeyword.objects.create(thesaurus=t, alt_label=f"alt_tkn{tkn}_t{tn}")
                 cls.thesauri_k[f"{tn}_{tkn}"] = tk
                 for tkl in (
-                        "en",
-                        "it",
+                    "en",
+                    "it",
                 ):
                     ThesaurusKeywordLabel.objects.create(keyword=tk, lang=tkl, label=f"T{tn}_K{tkn}_{tkl}")
 
@@ -957,19 +964,19 @@ class ThesauriApiTests(GeoNodeBaseTestSupport):
         list_url = reverse("base-resources-list")
 
         for tks, exp, exp_and in (
-                # single filter
-                (("0_0",), 10, 10),
-                (("0_1",), 5, 5),
-                (("1_0",), 10, 10),
-                (("1_1",), 5, 5),
-                # same thesaurus: OR
-                (("0_0", "0_1"), 10, 5),
-                (("1_0", "1_1"), 13, 2),
-                # different thesauri: AND
-                (("0_0", "1_0"), 5, 5),
-                (("0_1", "1_0"), 0, 0),
-                (("0_1", "1_0", "1_1"), 1, 0),
-                (("0_0", "0_1", "1_0", "1_1"), 6, 0),
+            # single filter
+            (("0_0",), 10, 10),
+            (("0_1",), 5, 5),
+            (("1_0",), 10, 10),
+            (("1_1",), 5, 5),
+            # same thesaurus: OR
+            (("0_0", "0_1"), 10, 5),
+            (("1_0", "1_1"), 13, 2),
+            # different thesauri: AND
+            (("0_0", "1_0"), 5, 5),
+            (("0_1", "1_0"), 0, 0),
+            (("0_1", "1_0", "1_1"), 1, 0),
+            (("0_0", "0_1", "1_0", "1_1"), 6, 0),
         ):
             logger.debug(f"Testing filters for {tks}")
             filter = [("filter{tkeywords}", self.thesauri_k[tk].id) for tk in tks]
@@ -981,6 +988,3 @@ class ThesauriApiTests(GeoNodeBaseTestSupport):
             url = f"{list_url}?{urlencode(filter + [('force_and', True)])}"
             resp = self.api_client.get(url).json()
             self.assertEqual(exp_and, resp["total"], f"Unexpected number of resources for FORCE_AND filter {tks}")
-
-
-

--- a/geonode/api/tests.py
+++ b/geonode/api/tests.py
@@ -16,12 +16,14 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 #########################################################################
-from unittest.mock import patch
-from django.conf import settings
-
+import logging
 from datetime import datetime, timedelta
-from tastypie.test import ResourceTestCaseMixin
+from tastypie.test import ResourceTestCaseMixin, TestApiClient
+from unittest.mock import patch
+from urllib.parse import urlencode
+from uuid import uuid4
 
+from django.conf import settings
 from django.urls import reverse
 from django.contrib.auth.models import Group
 from django.contrib.auth import get_user_model
@@ -34,13 +36,16 @@ from geonode.geoserver.manager import GeoServerResourceManager
 from geonode.maps.models import Map
 from geonode.layers.models import Dataset
 from geonode.documents.models import Document
-from geonode.base.models import ExtraMetadata
+from geonode.base.models import ExtraMetadata, Thesaurus, ThesaurusLabel, ThesaurusKeyword, ThesaurusKeywordLabel, ResourceBase
 from geonode.utils import check_ogc_backend
 from geonode.decorators import on_ogc_backend
 from geonode.groups.models import GroupProfile
 from geonode.base.auth import get_or_create_token
 from geonode.tests.base import GeoNodeBaseTestSupport
 from geonode.base.populate_test_data import all_public, create_models, remove_models
+
+
+logger = logging.getLogger(__name__)
 
 
 class PermissionsApiTests(ResourceTestCaseMixin, GeoNodeBaseTestSupport):
@@ -842,3 +847,140 @@ class SearchApiTests(ResourceTestCaseMixin, GeoNodeBaseTestSupport):
         # by adding a new layer, the total should increase
         actual = sum([x["count"] for x in resp.json()["objects"]])
         self.assertEqual(0, actual)
+
+
+class ThesauriApiTests(GeoNodeBaseTestSupport):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.user = get_user_model().objects.create(username="user_00")
+        cls.admin = get_user_model().objects.get(username="admin")
+
+        cls._create_thesauri()
+        cls._create_resources()
+
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+        # remove_models(cls.get_obj_ids, type=cls.get_type, integration=cls.get_integration)
+
+    def setUp(self):
+        super().setUp()
+
+        self.api_client = TestApiClient()
+
+        self.assertEqual(self.admin.username, "admin")
+        self.assertEqual(self.admin.is_superuser, True)
+
+    @classmethod
+    def _create_thesauri(cls):
+        cls.thesauri = {}
+        cls.thesauri_k = {}
+
+        for tn in range(2):
+            t = Thesaurus.objects.create(identifier=f"t_{tn}", title=f"Thesaurus {tn}")
+            cls.thesauri[tn] = t
+            for tl in (
+                    "en",
+                    "it",
+            ):
+                ThesaurusLabel.objects.create(thesaurus=t, lang=tl, label=f"TLabel {tn} {tl}")
+
+            for tkn in range(10):
+                tk = ThesaurusKeyword.objects.create(thesaurus=t, alt_label=f"alt_tkn{tkn}_t{tn}")
+                cls.thesauri_k[f"{tn}_{tkn}"] = tk
+                for tkl in (
+                        "en",
+                        "it",
+                ):
+                    ThesaurusKeywordLabel.objects.create(keyword=tk, lang=tkl, label=f"T{tn}_K{tkn}_{tkl}")
+
+    @classmethod
+    def _create_resources(self):
+        public_perm_spec = {"users": {"AnonymousUser": ["view_resourcebase"]}, "groups": []}
+
+        for x in range(20):
+            d: ResourceBase = ResourceBase.objects.create(
+                title=f"dataset_{x:02}",
+                uuid=str(uuid4()),
+                owner=self.user,
+                abstract=f"Abstract for dataset {x:02}",
+                subtype="vector",
+                is_approved=True,
+                is_published=True,
+            )
+
+            # These are the assigned keywords to the Resources
+
+            # RB00 ->            T1K0
+            # RB01 ->  T0K0      T1K0
+            # RB02 ->            T1K0
+            # RB03 ->  T0K0      T1K0
+            # RB04 ->            T1K0
+            # RB05 ->  T0K0      T1K0
+            # RB06 ->            T1K0
+            # RB07 ->  T0K0      T1K0
+            # RB08 ->            T1K0 T1K1
+            # RB09 ->  T0K0      T1K0 T1K1
+            # RB10 ->                 T1K1
+            # RB11 ->  T0K0 T0K1      T1K1
+            # RB12 ->                 T1K1
+            # RB13 ->  T0K0 T0K1
+            # RB14 ->
+            # RB15 ->  T0K0 T0K1
+            # RB16 ->
+            # RB17 ->  T0K0 T0K1
+            # RB18 ->
+            # RB19 ->  T0K0 T0K1
+
+            if x % 2 == 1:
+                print(f"ADDING KEYWORDS {self.thesauri_k['0_0']} to RB {d}")
+                d.tkeywords.add(self.thesauri_k["0_0"])
+                d.save()
+            if x % 2 == 1 and x > 10:
+                print(f"ADDING KEYWORDS {self.thesauri_k['0_1']} to RB {d}")
+                d.tkeywords.add(self.thesauri_k["0_1"])
+                d.save()
+            if x < 10:
+                print(f"ADDING KEYWORDS {self.thesauri_k['1_0']} to RB {d}")
+                d.tkeywords.add(self.thesauri_k["1_0"])
+                d.save()
+            if 7 < x < 13:
+                d.tkeywords.add(self.thesauri_k["1_1"])
+                d.save()
+
+            d.set_permissions(public_perm_spec)
+
+    def test_resources_filtered(self):
+        # list_url = reverse("base-resources", kwargs={"api_name": "api", "resource_name": "base"})
+        list_url = reverse("base-resources-list")
+
+        for tks, exp, exp_and in (
+                # single filter
+                (("0_0",), 10, 10),
+                (("0_1",), 5, 5),
+                (("1_0",), 10, 10),
+                (("1_1",), 5, 5),
+                # same thesaurus: OR
+                (("0_0", "0_1"), 10, 5),
+                (("1_0", "1_1"), 13, 2),
+                # different thesauri: AND
+                (("0_0", "1_0"), 5, 5),
+                (("0_1", "1_0"), 0, 0),
+                (("0_1", "1_0", "1_1"), 1, 0),
+                (("0_0", "0_1", "1_0", "1_1"), 6, 0),
+        ):
+            logger.debug(f"Testing filters for {tks}")
+            filter = [("filter{tkeywords}", self.thesauri_k[tk].id) for tk in tks]
+            url = f"{list_url}?{urlencode(filter)}"
+            resp = self.api_client.get(url).json()
+            self.assertEqual(exp, resp["total"], f"Unexpected number of resources for default filter {tks}")
+
+            filter = [("filter{tkeywords}", self.thesauri_k[tk].id) for tk in tks]
+            url = f"{list_url}?{urlencode(filter + [('force_and', True)])}"
+            resp = self.api_client.get(url).json()
+            self.assertEqual(exp_and, resp["total"], f"Unexpected number of resources for FORCE_AND filter {tks}")
+
+
+

--- a/geonode/base/api/views.py
+++ b/geonode/base/api/views.py
@@ -67,7 +67,13 @@ from geonode.thumbs.thumbnails import create_thumbnail
 from geonode.thumbs.utils import _decode_base64, BASE64_PATTERN
 from geonode.groups.conf import settings as groups_settings
 from geonode.base.models import HierarchicalKeyword, Region, ResourceBase, TopicCategory, ThesaurusKeyword
-from geonode.base.api.filters import DynamicSearchFilter, ExtentFilter, FacetVisibleResourceFilter, FavoriteFilter
+from geonode.base.api.filters import (
+    DynamicSearchFilter,
+    ExtentFilter,
+    FacetVisibleResourceFilter,
+    FavoriteFilter,
+    TKeywordsFilter,
+)
 from geonode.groups.models import GroupProfile, GroupMember
 from geonode.people.utils import get_available_users
 from geonode.security.permissions import get_compact_perms_list, PermSpec, PermSpecCompact
@@ -346,6 +352,7 @@ class ResourceBaseViewSet(DynamicModelViewSet):
     authentication_classes = [SessionAuthentication, BasicAuthentication, OAuth2Authentication]
     permission_classes = [IsAuthenticatedOrReadOnly, UserHasPerms]
     filter_backends = [
+        TKeywordsFilter,
         DynamicFilterBackend,
         DynamicSortingFilter,
         DynamicSearchFilter,

--- a/geonode/base/models.py
+++ b/geonode/base/models.py
@@ -1349,7 +1349,7 @@ class ResourceBase(PolymorphicModel, PermissionLevelMixin, ItemBase):
 
     def get_absolute_url(self):
         try:
-            return self.get_real_instance().get_absolute_url()
+            return self.get_real_instance().get_absolute_url() if self != self.get_real_instance() else None
         except Exception as e:
             logger.exception(e)
             return None
@@ -1463,7 +1463,7 @@ class ResourceBase(PolymorphicModel, PermissionLevelMixin, ItemBase):
 
     @property
     def embed_url(self):
-        return self.get_real_instance().embed_url
+        return self.get_real_instance().embed_url if self != self.get_real_instance() else None
 
     def get_tiles_url(self):
         """Return URL for Z/Y/X mapping clients or None if it does not exist."""


### PR DESCRIPTION
#11061

Adds a new Filter that handles `filter{tkeywords}` and removes such queryparam from the request, so that DREST won't process the same params again.
A new `force_and param` has been added in order to provide a further on-demand behaviour. 
It will be documented and used in the forecoming 4.2 version.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [ ] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [ ] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: black geonode && flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
