### PR TITLE
[Fixes #11072] Revert django-autocomplete-light upgrade

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -70,7 +70,7 @@ dj-pagination==2.5.0
 django-select2==8.1.1
 django-floppyforms<1.10.0
 django-forms-bootstrap<=3.1.0
-django-autocomplete-light==3.9.7
+django-autocomplete-light==3.5.1
 django-invitations<2.0.1
 django-recaptcha==3.0.0
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -96,7 +96,7 @@ install_requires =
     django-select2==8.1.1
     django-floppyforms<1.10.0
     django-forms-bootstrap<=3.1.0
-    django-autocomplete-light==3.9.7
+    django-autocomplete-light==3.5.1
     django-invitations<2.0.1
     django-recaptcha==3.0.0
 


### PR DESCRIPTION
ref #11072 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: black geonode && flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
