### PR TITLE
Fix region intersection test

### DIFF
--- a/geonode/base/fixtures/regions.json
+++ b/geonode/base/fixtures/regions.json
@@ -4335,23 +4335,6 @@
     }
   },
   {
-    "pk": 256,
-    "model": "base.region",
-    "fields": {
-      "rght": 515,
-      "code": "PAC",
-      "name": "Pacific",
-      "parent": null,
-      "level": 1,
-      "lft": 464,
-      "tree_id": 90,
-      "bbox_x0": 139.572356,
-      "bbox_x1": -74.531208,
-      "bbox_y0": -56.267241,
-      "bbox_y1": 62.0215969
-    }
-  },
-  {
     "pk": 257,
     "model": "base.region",
     "fields": {

--- a/geonode/resource/utils.py
+++ b/geonode/resource/utils.py
@@ -489,7 +489,7 @@ def metadata_post_save(instance, *args, **kwargs):
                     poly2 = GEOSGeometry(wkt2, srid=int(srid2[0]))
                     poly2.transform(4326)
 
-                    if poly2.intersection(poly1):
+                    if not poly2.intersection(poly1).empty:
                         regions_to_add.append(region)
                     if region.level == 0 and region.parent is None:
                         global_regions.append(region)


### PR DESCRIPTION
ref #11166

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: black geonode && flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
