### PR TITLE
[Fixes #11097] Faceting: resource type

### DIFF
--- a/geonode/facets/models.py
+++ b/geonode/facets/models.py
@@ -28,7 +28,7 @@ FACET_TYPE_PLACE = "place"
 FACET_TYPE_USER = "user"
 FACET_TYPE_THESAURUS = "thesaurus"
 FACET_TYPE_CATEGORY = "category"
-FACET_TYPE_RESOURCETYPE = "resourcetype"
+FACET_TYPE_BASE = "base"
 
 logger = logging.getLogger(__name__)
 

--- a/geonode/facets/providers/baseinfo.py
+++ b/geonode/facets/providers/baseinfo.py
@@ -1,0 +1,147 @@
+#########################################################################
+#
+# Copyright (C) 2023 Open Source Geospatial Foundation - all rights reserved
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#########################################################################
+
+import logging
+
+from django.db.models import Count
+
+from geonode.facets.models import FacetProvider, DEFAULT_FACET_PAGE_SIZE, FACET_TYPE_BASE
+
+logger = logging.getLogger(__name__)
+
+
+class ResourceTypeFacetProvider(FacetProvider):
+    """
+    Implements faceting for resources' type and subtype
+    """
+
+    @property
+    def name(self) -> str:
+        return "resourcetype"
+
+    def get_info(self, lang="en") -> dict:
+        return {
+            "name": self.name,
+            "key": "filter{resource_type.in}",
+            "label": "Resource type",
+            "type": FACET_TYPE_BASE,
+            "hierarchical": True,
+            "order": 0,
+        }
+
+    def get_facet_items(
+        self,
+        queryset=None,
+        start: int = 0,
+        end: int = DEFAULT_FACET_PAGE_SIZE,
+        lang="en",
+        topic_contains: str = None,
+    ) -> (int, list):
+        logger.debug("Retrieving facets for %s", self.name)
+
+        if topic_contains:
+            logger.warning(f"Facet {self.name} does not support topic_contains filtering")
+
+        q = queryset.values("resource_type", "subtype")
+        q = q.annotate(ctype=Count("resource_type"), csub=Count("subtype"))
+        q = q.order_by()
+
+        # aggregate subtypes into rtypes
+        tree = {}
+        for r in q.all():
+            res_type = r["resource_type"]
+            t = tree.get(res_type, {"cnt": 0, "sub": {}})
+            t["cnt"] += r["ctype"]
+            if sub := r["subtype"]:
+                t["sub"][sub] = {"cnt": r["ctype"]}
+            tree[res_type] = t
+
+        logger.info("Found %d main facets for %s", len(tree), self.name)
+        logger.debug(" ---> %s\n\n", q.query)
+        logger.debug(" ---> %r\n\n", q.all())
+
+        topics = []
+        for rtype, info in tree.items():
+            t = {"key": rtype, "label": rtype, "count": info["cnt"]}
+            if sub := info["sub"]:
+                children = []
+                for stype, sinfo in sub.items():
+                    children.append({"key": stype, "label": stype, "count": sinfo["cnt"]})
+                t["filter"] = "filter{subtype.in}"
+                t["items"] = sorted(children, reverse=True, key=lambda x: x["count"])
+            topics.append(t)
+
+        return len(topics), sorted(topics, reverse=True, key=lambda x: x["count"])
+
+    @classmethod
+    def register(cls, registry, **kwargs) -> None:
+        registry.register_facet_provider(ResourceTypeFacetProvider())
+
+
+class FeaturedFacetProvider(FacetProvider):
+    """
+    Implements faceting for resources flagged as featured
+    """
+
+    @property
+    def name(self) -> str:
+        return "featured"
+
+    def get_info(self, lang="en") -> dict:
+        return {
+            "name": self.name,
+            "key": "filter{featured}",
+            "label": "Featured",
+            "type": FACET_TYPE_BASE,
+            "hierarchical": False,
+            "order": 0,
+        }
+
+    def get_facet_items(
+        self,
+        queryset=None,
+        start: int = 0,
+        end: int = DEFAULT_FACET_PAGE_SIZE,
+        lang="en",
+        topic_contains: str = None,
+    ) -> (int, list):
+        logger.debug("Retrieving facets for %s", self.name)
+
+        if topic_contains:
+            logger.warning(f"Facet {self.name} does not support topic_contains filtering")
+
+        q = queryset.values("featured").annotate(cnt=Count("featured")).order_by()
+
+        logger.debug(" ---> %s\n\n", q.query)
+        logger.debug(" ---> %r\n\n", q.all())
+
+        topics = [
+            {
+                "key": r["featured"],
+                "label": str(r["featured"]),
+                "count": r["cnt"],
+            }
+            for r in q[start:end]
+        ]
+
+        return 2, topics
+
+    @classmethod
+    def register(cls, registry, **kwargs) -> None:
+        registry.register_facet_provider(FeaturedFacetProvider())

--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -2320,6 +2320,8 @@ INSTALLED_APPS += ("geonode.facets",)
 GEONODE_APPS += ("geonode.facets",)
 
 FACET_PROVIDERS = (
+    "geonode.facets.providers.baseinfo.ResourceTypeFacetProvider",
+    "geonode.facets.providers.baseinfo.FeaturedFacetProvider",
     "geonode.facets.providers.category.CategoryFacetProvider",
     "geonode.facets.providers.users.OwnerFacetProvider",
     "geonode.facets.providers.thesaurus.ThesaurusFacetProvider",


### PR DESCRIPTION
Implements #11097

Creates 2 new FacetProviders, 
- `ResourceTypeFacetProvider`: provides faceting for resources types (dataset, maps, ..) and subtypes(raster, vector, ...)
- `FeaturedFacetProvider`: provides faceting for `featured` flag.

## Checklist

For all pull requests:

- [ ] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [ ] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: black geonode && flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
