### PR TITLE
Faceting : #11226 key to filter - step 1 + #11233 configuration

### DIFF
--- a/geonode/facets/models.py
+++ b/geonode/facets/models.py
@@ -39,6 +39,9 @@ class FacetProvider:
     Provides access to the facet information and the related topics
     """
 
+    def __init__(self, **kwargs):
+        self.config = kwargs.get("config", {}).copy()
+
     def __str__(self):
         return f"{self.__class__.__name__}[{self.name}]"
 
@@ -51,7 +54,7 @@ class FacetProvider:
         """
         self.get_info()["name"]
 
-    def get_info(self, lang="en") -> dict:
+    def get_info(self, lang="en", **kwargs) -> dict:
         """
         Get the basic info for this provider, as a dict with these keys:
         - 'name': the name of the provider (the one returned by name())
@@ -127,10 +130,10 @@ class FacetsRegistry:
 
         logger.info("Initializing Facets")
 
-        if providers := getattr(settings, "FACET_PROVIDERS", []):
-            _providers = [import_string(module_path) for module_path in providers]
-            for provider in _providers:
-                provider.register(self)
+        for providerconf in getattr(settings, "FACET_PROVIDERS", []):
+            clz = providerconf["class"]
+            provider = import_string(clz)
+            provider.register(self, config=providerconf.get("config", {}))
 
     def register_facet_provider(self, provider: FacetProvider):
         logger.info(f"Registering {provider}")

--- a/geonode/facets/providers/baseinfo.py
+++ b/geonode/facets/providers/baseinfo.py
@@ -38,7 +38,8 @@ class ResourceTypeFacetProvider(FacetProvider):
     def get_info(self, lang="en") -> dict:
         return {
             "name": self.name,
-            "key": "filter{resource_type.in}",
+            "key": "filter{resource_type.in}",  # deprecated
+            "filter": "filter{resource_type.in}",
             "label": "Resource type",
             "type": FACET_TYPE_BASE,
             "hierarchical": True,

--- a/geonode/facets/providers/baseinfo.py
+++ b/geonode/facets/providers/baseinfo.py
@@ -35,7 +35,7 @@ class ResourceTypeFacetProvider(FacetProvider):
     def name(self) -> str:
         return "resourcetype"
 
-    def get_info(self, lang="en") -> dict:
+    def get_info(self, lang="en", **kwargs) -> dict:
         return {
             "name": self.name,
             "key": "filter{resource_type.in}",  # deprecated
@@ -43,7 +43,6 @@ class ResourceTypeFacetProvider(FacetProvider):
             "label": "Resource type",
             "type": FACET_TYPE_BASE,
             "hierarchical": True,
-            "order": 0,
         }
 
     def get_facet_items(
@@ -92,7 +91,7 @@ class ResourceTypeFacetProvider(FacetProvider):
 
     @classmethod
     def register(cls, registry, **kwargs) -> None:
-        registry.register_facet_provider(ResourceTypeFacetProvider())
+        registry.register_facet_provider(ResourceTypeFacetProvider(**kwargs))
 
 
 class FeaturedFacetProvider(FacetProvider):
@@ -104,7 +103,7 @@ class FeaturedFacetProvider(FacetProvider):
     def name(self) -> str:
         return "featured"
 
-    def get_info(self, lang="en") -> dict:
+    def get_info(self, lang="en", **kwargs) -> dict:
         return {
             "name": self.name,
             "key": "filter{featured}",
@@ -145,4 +144,4 @@ class FeaturedFacetProvider(FacetProvider):
 
     @classmethod
     def register(cls, registry, **kwargs) -> None:
-        registry.register_facet_provider(FeaturedFacetProvider())
+        registry.register_facet_provider(FeaturedFacetProvider(**kwargs))

--- a/geonode/facets/providers/category.py
+++ b/geonode/facets/providers/category.py
@@ -36,15 +36,13 @@ class CategoryFacetProvider(FacetProvider):
     def name(self) -> str:
         return "category"
 
-    def get_info(self, lang="en") -> dict:
+    def get_info(self, lang="en", **kwargs) -> dict:
         return {
             "name": self.name,
             "key": "filter{category.identifier}",  # deprecated
             "filter": "filter{category.identifier}",
             "label": "Category",
             "type": FACET_TYPE_CATEGORY,
-            "hierarchical": False,
-            "order": 2,
         }
 
     def get_facet_items(
@@ -99,4 +97,4 @@ class CategoryFacetProvider(FacetProvider):
 
     @classmethod
     def register(cls, registry, **kwargs) -> None:
-        registry.register_facet_provider(CategoryFacetProvider())
+        registry.register_facet_provider(CategoryFacetProvider(**kwargs))

--- a/geonode/facets/providers/category.py
+++ b/geonode/facets/providers/category.py
@@ -39,7 +39,8 @@ class CategoryFacetProvider(FacetProvider):
     def get_info(self, lang="en") -> dict:
         return {
             "name": self.name,
-            "key": "filter{category.identifier}",
+            "key": "filter{category.identifier}",  # deprecated
+            "filter": "filter{category.identifier}",
             "label": "Category",
             "type": FACET_TYPE_CATEGORY,
             "hierarchical": False,

--- a/geonode/facets/providers/keyword.py
+++ b/geonode/facets/providers/keyword.py
@@ -39,7 +39,8 @@ class KeywordFacetProvider(FacetProvider):
     def get_info(self, lang="en") -> dict:
         return {
             "name": self.name,
-            "key": "filter{keywords.slug.in}",
+            "key": "filter{keywords.slug.in}",  # deprecated
+            "filter": "filter{keywords.slug.in}",
             "label": "Keyword",
             "type": FACET_TYPE_KEYWORD,
             "order": 2,

--- a/geonode/facets/providers/keyword.py
+++ b/geonode/facets/providers/keyword.py
@@ -36,14 +36,13 @@ class KeywordFacetProvider(FacetProvider):
     def name(self) -> str:
         return "keyword"
 
-    def get_info(self, lang="en") -> dict:
+    def get_info(self, lang="en", **kwargs) -> dict:
         return {
             "name": self.name,
             "key": "filter{keywords.slug.in}",  # deprecated
             "filter": "filter{keywords.slug.in}",
             "label": "Keyword",
             "type": FACET_TYPE_KEYWORD,
-            "order": 2,
         }
 
     def get_facet_items(
@@ -94,4 +93,4 @@ class KeywordFacetProvider(FacetProvider):
 
     @classmethod
     def register(cls, registry, **kwargs) -> None:
-        registry.register_facet_provider(KeywordFacetProvider())
+        registry.register_facet_provider(KeywordFacetProvider(**kwargs))

--- a/geonode/facets/providers/region.py
+++ b/geonode/facets/providers/region.py
@@ -39,7 +39,8 @@ class RegionFacetProvider(FacetProvider):
     def get_info(self, lang="en") -> dict:
         return {
             "name": self.name,
-            "key": "filter{regions.code.in}",
+            "key": "filter{regions.code.in}",  # deprecated
+            "filter": "filter{regions.code.in}",
             "label": "Region",
             "type": FACET_TYPE_PLACE,
             "hierarchical": False,  # source data is hierarchical, but this implementation is flat

--- a/geonode/facets/providers/region.py
+++ b/geonode/facets/providers/region.py
@@ -36,15 +36,13 @@ class RegionFacetProvider(FacetProvider):
     def name(self) -> str:
         return "region"
 
-    def get_info(self, lang="en") -> dict:
+    def get_info(self, lang="en", **kwargs) -> dict:
         return {
             "name": self.name,
             "key": "filter{regions.code.in}",  # deprecated
             "filter": "filter{regions.code.in}",
             "label": "Region",
             "type": FACET_TYPE_PLACE,
-            "hierarchical": False,  # source data is hierarchical, but this implementation is flat
-            "order": 2,
         }
 
     def get_facet_items(
@@ -95,4 +93,4 @@ class RegionFacetProvider(FacetProvider):
 
     @classmethod
     def register(cls, registry, **kwargs) -> None:
-        registry.register_facet_provider(RegionFacetProvider())
+        registry.register_facet_provider(RegionFacetProvider(**kwargs))

--- a/geonode/facets/providers/thesaurus.py
+++ b/geonode/facets/providers/thesaurus.py
@@ -32,17 +32,20 @@ class ThesaurusFacetProvider(FacetProvider):
     Implements faceting for a given Thesaurus
     """
 
-    def __init__(self, identifier, title, order, labels: dict):
+    def __init__(self, identifier, title, order, labels: dict, **kwargs):
+        super().__init__(**kwargs)
+
         self._name = identifier
         self.label = title
-        self.order = order
         self.labels = labels
+
+        self.config["order"] = order
 
     @property
     def name(self) -> str:
         return self._name
 
-    def get_info(self, lang="en") -> dict:
+    def get_info(self, lang="en", **kwargs) -> dict:
         return {
             "name": self._name,
             "key": "filter{tkeywords}",  # deprecated
@@ -50,8 +53,6 @@ class ThesaurusFacetProvider(FacetProvider):
             "label": self.labels.get(lang, self.label),
             "is_localized": self.labels.get(lang, None) is not None,
             "type": FACET_TYPE_THESAURUS,
-            "hierarchical": False,
-            "order": self.order,
         }
 
     def get_facet_items(
@@ -153,5 +154,5 @@ class ThesaurusFacetProvider(FacetProvider):
         logger.info("Creating providers for %r", ret)
         for t in ret.values():
             registry.register_facet_provider(
-                ThesaurusFacetProvider(t["identifier"], t["title"], t["order"], t["labels"])
+                ThesaurusFacetProvider(t["identifier"], t["title"], t["order"], t["labels"], **kwargs)
             )

--- a/geonode/facets/providers/thesaurus.py
+++ b/geonode/facets/providers/thesaurus.py
@@ -45,7 +45,8 @@ class ThesaurusFacetProvider(FacetProvider):
     def get_info(self, lang="en") -> dict:
         return {
             "name": self._name,
-            "key": "filter{tkeywords}",
+            "key": "filter{tkeywords}",  # deprecated
+            "filter": "filter{tkeywords}",
             "label": self.labels.get(lang, self.label),
             "is_localized": self.labels.get(lang, None) is not None,
             "type": FACET_TYPE_THESAURUS,

--- a/geonode/facets/providers/users.py
+++ b/geonode/facets/providers/users.py
@@ -36,15 +36,13 @@ class OwnerFacetProvider(FacetProvider):
     def name(self) -> str:
         return "owner"
 
-    def get_info(self, lang="en") -> dict:
+    def get_info(self, lang="en", **kwargs) -> dict:
         return {
             "name": "owner",
             "key": "owner",  # deprecated
             "filter": "owner",
             "label": "Owner",
             "type": FACET_TYPE_USER,
-            "hierarchical": False,
-            "order": 5,
         }
 
     def get_facet_items(
@@ -95,4 +93,4 @@ class OwnerFacetProvider(FacetProvider):
 
     @classmethod
     def register(cls, registry, **kwargs) -> None:
-        registry.register_facet_provider(OwnerFacetProvider())
+        registry.register_facet_provider(OwnerFacetProvider(**kwargs))

--- a/geonode/facets/providers/users.py
+++ b/geonode/facets/providers/users.py
@@ -39,7 +39,8 @@ class OwnerFacetProvider(FacetProvider):
     def get_info(self, lang="en") -> dict:
         return {
             "name": "owner",
-            "key": "owner",
+            "key": "owner",  # deprecated
+            "filter": "owner",
             "label": "Owner",
             "type": FACET_TYPE_USER,
             "hierarchical": False,

--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -2335,12 +2335,12 @@ IMPORTER_HANDLERS = ast.literal_eval(
 INSTALLED_APPS += ("geonode.facets",)
 GEONODE_APPS += ("geonode.facets",)
 
-FACET_PROVIDERS = (
-    "geonode.facets.providers.baseinfo.ResourceTypeFacetProvider",
-    "geonode.facets.providers.baseinfo.FeaturedFacetProvider",
-    "geonode.facets.providers.category.CategoryFacetProvider",
-    "geonode.facets.providers.keyword.KeywordFacetProvider",
-    "geonode.facets.providers.users.OwnerFacetProvider",
-    "geonode.facets.providers.thesaurus.ThesaurusFacetProvider",
-    "geonode.facets.providers.region.RegionFacetProvider",
-)
+FACET_PROVIDERS = [
+    {"class": "geonode.facets.providers.baseinfo.ResourceTypeFacetProvider"},
+    {"class": "geonode.facets.providers.baseinfo.FeaturedFacetProvider"},
+    {"class": "geonode.facets.providers.category.CategoryFacetProvider", "config": {"order": 5, "type": "select"}},
+    {"class": "geonode.facets.providers.keyword.KeywordFacetProvider", "config": {"order": 6, "type": "select"}},
+    {"class": "geonode.facets.providers.region.RegionFacetProvider", "config": {"order": 7, "type": "select"}},
+    {"class": "geonode.facets.providers.users.OwnerFacetProvider", "config": {"order": 8, "type": "select"}},
+    {"class": "geonode.facets.providers.thesaurus.ThesaurusFacetProvider", "config": {"type": "select"}},
+]


### PR DESCRIPTION
2 commits for 2 issues:

- #11226 : Rename facet entry key to filter.
  First step (see related issue)
  The commit msg does not include the "fixes" because issue should not be closed right now.
- #11233: Faceting: improvement: facet configuration



## Checklist

For all pull requests:

- [ ] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [ ] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: black geonode && flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
