### PR TITLE
[Fixes #11249] Mark remote documents with sourcetype REMOTE

### DIFF
--- a/geonode/documents/api/tests.py
+++ b/geonode/documents/api/tests.py
@@ -28,6 +28,7 @@ from guardian.shortcuts import assign_perm, get_anonymous_user
 from geonode import settings
 
 from geonode.base.populate_test_data import create_models
+from geonode.base.enumerations import SOURCE_TYPE_REMOTE
 from geonode.documents.models import Document
 
 logger = logging.getLogger(__name__)
@@ -171,6 +172,22 @@ class DocumentsApiTests(APITestCase):
         self.assertEqual(201, actual.status_code)
         created_doc_url = actual.json().get("document", {}).get("doc_url", "")
         self.assertEqual(created_doc_url, doc_url)
+
+    def test_remote_document_is_marked_remote(self):
+        """Tests creating an external document set its sourcetype to REMOTE."""
+        self.client.force_login(self.admin)
+        doc_url = "https://example.com/image"
+        payload = {
+            "document": {
+                "title": "A remote document is remote",
+                "doc_url": doc_url,
+                "extension": "jpeg",
+            }
+        }
+        actual = self.client.post(self.url, data=payload, format="json")
+        self.assertEqual(201, actual.status_code)
+        created_sourcetype = actual.json().get("document", {}).get("sourcetype", "")
+        self.assertEqual(created_sourcetype, SOURCE_TYPE_REMOTE)
 
     def test_either_path_or_url_doc(self):
         """

--- a/geonode/documents/api/views.py
+++ b/geonode/documents/api/views.py
@@ -31,6 +31,7 @@ from geonode import settings
 from geonode.base.api.filters import DynamicSearchFilter, ExtentFilter
 from geonode.base.api.pagination import GeoNodeApiPagination
 from geonode.base.api.permissions import UserHasPerms
+from geonode.base import enumerations
 from geonode.documents.api.exceptions import DocumentException
 from geonode.documents.models import Document
 
@@ -123,6 +124,7 @@ class DocumentViewSet(DynamicModelViewSet):
                 payload["files"] = [manager.get_retrieved_paths().get("base_file")]
             if doc_url:
                 payload["doc_url"] = doc_url
+                payload["sourcetype"] = enumerations.SOURCE_TYPE_REMOTE
 
             resource = serializer.save(**payload)
 

--- a/geonode/documents/tests.py
+++ b/geonode/documents/tests.py
@@ -47,6 +47,7 @@ from geonode.maps.models import Map
 from geonode.layers.models import Dataset
 from geonode.compat import ensure_string
 from geonode.base.models import License, Region
+from geonode.base.enumerations import SOURCE_TYPE_REMOTE
 from geonode.documents import DocumentsAppConfig
 from geonode.resource.manager import resource_manager
 from geonode.documents.forms import DocumentFormMixin
@@ -136,6 +137,21 @@ class DocumentsTest(GeoNodeBaseTestSupport):
 
         self.assertEqual(Document.objects.get(pk=c.id).title, "theimg")
         self.assertEqual(DocumentResourceLink.objects.get(pk=_d.id).object_id, m.id)
+
+    def test_remote_document_is_marked_remote(self):
+        """Tests creating an external document set its sourcetype to REMOTE."""
+        self.client.login(username="admin", password="admin")
+        form_data = {
+            "title": "A remote document through form is remote",
+            "doc_url": "http://www.geonode.org/map.pdf",
+        }
+
+        response = self.client.post(reverse("document_upload"), data=form_data)
+
+        self.assertEqual(response.status_code, 302)
+
+        d = Document.objects.get(title="A remote document is remote")
+        self.assertEqual(d.sourcetype, SOURCE_TYPE_REMOTE)
 
     def test_create_document_url(self):
         """Tests creating an external document instead of a file."""

--- a/geonode/documents/tests.py
+++ b/geonode/documents/tests.py
@@ -150,7 +150,7 @@ class DocumentsTest(GeoNodeBaseTestSupport):
 
         self.assertEqual(response.status_code, 302)
 
-        d = Document.objects.get(title="A remote document is remote")
+        d = Document.objects.get(title="A remote document through form is remote")
         self.assertEqual(d.sourcetype, SOURCE_TYPE_REMOTE)
 
     def test_create_document_url(self):

--- a/geonode/documents/views.py
+++ b/geonode/documents/views.py
@@ -51,6 +51,7 @@ from geonode.decorators import check_keyword_write_perms
 from geonode.security.utils import get_user_visible_groups, AdvancedSecurityWorkflowManager
 from geonode.base.forms import CategoryForm, TKeywordForm, ThesaurusAvailableForm
 from geonode.base.models import Thesaurus, TopicCategory
+from geonode.base import enumerations
 
 from .utils import get_download_response
 
@@ -184,7 +185,10 @@ class DocumentUploadView(CreateView):
                 None,
                 resource_type=Document,
                 defaults=dict(
-                    owner=self.request.user, doc_url=doc_form.pop("doc_url", None), title=doc_form.pop("title", None)
+                    owner=self.request.user,
+                    doc_url=doc_form.pop("doc_url", None),
+                    title=doc_form.pop("title", None),
+                    sourcetype=enumerations.SOURCE_TYPE_REMOTE,
                 ),
             )
 


### PR DESCRIPTION
ref #11249 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: black geonode && flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
