### PR TITLE
[Fixes #11312] Expose dataset ows url

### DIFF
--- a/geonode/geoserver/helpers.py
+++ b/geonode/geoserver/helpers.py
@@ -2296,6 +2296,22 @@ def get_dataset_capabilities_url(layer, version="1.3.0", access_token=None):
     return wms_url
 
 
+def get_layer_ows_url(layer, access_token=None):
+    """
+    Generate the layer-specific GetCapabilities URL
+    """
+    workspace_layername = layer.alternate.split(":") if ":" in layer.alternate else ("", layer.alternate)
+    ows_url = settings.GEOSERVER_PUBLIC_LOCATION
+    if not layer.remote_service:
+        ows_url = f"{ows_url}{'/'.join(workspace_layername)}/ows"  # noqa
+        if access_token:
+            ows_url += f"?access_token={access_token}"
+    else:
+        ows_url = f"{layer.remote_service.service_url}"
+
+    return ows_url
+
+
 def wps_format_is_supported(_format, dataset_type):
     return (_format, dataset_type) in WPS_ACCEPTABLE_FORMATS
 

--- a/geonode/geoserver/tests/test_helpers.py
+++ b/geonode/geoserver/tests/test_helpers.py
@@ -40,6 +40,7 @@ from geonode.geoserver.helpers import (
     get_dataset_storetype,
     extract_name_from_sld,
     get_dataset_capabilities_url,
+    get_layer_ows_url,
 )
 from geonode.geoserver.ows import _wcs_link, _wfs_link, _wms_link
 
@@ -294,4 +295,15 @@ xlink:href="{settings.GEOSERVER_LOCATION}ows?service=WMS&amp;request=GetLegendGr
         dataset = Dataset.objects.get(alternate=identifier)
         expected_url = f"{ows_url}geonode/CA/ows?service=wms&version=1.3.0&request=GetCapabilities"
         capabilities_url = get_dataset_capabilities_url(dataset)
+        self.assertEqual(capabilities_url, expected_url, capabilities_url)
+        
+    @on_ogc_backend(geoserver.BACKEND_PACKAGE)
+    def test_layer_ows_url(self):
+        from geonode.layers.models import Dataset
+
+        ows_url = settings.GEOSERVER_PUBLIC_LOCATION
+        identifier = "geonode:CA"
+        dataset = Dataset.objects.get(alternate=identifier)
+        expected_url = f"{ows_url}geonode/CA/ows"
+        capabilities_url = get_layer_ows_url(dataset)
         self.assertEqual(capabilities_url, expected_url, capabilities_url)

--- a/geonode/geoserver/tests/test_helpers.py
+++ b/geonode/geoserver/tests/test_helpers.py
@@ -296,7 +296,7 @@ xlink:href="{settings.GEOSERVER_LOCATION}ows?service=WMS&amp;request=GetLegendGr
         expected_url = f"{ows_url}geonode/CA/ows?service=wms&version=1.3.0&request=GetCapabilities"
         capabilities_url = get_dataset_capabilities_url(dataset)
         self.assertEqual(capabilities_url, expected_url, capabilities_url)
-        
+
     @on_ogc_backend(geoserver.BACKEND_PACKAGE)
     def test_layer_ows_url(self):
         from geonode.layers.models import Dataset

--- a/geonode/layers/api/serializers.py
+++ b/geonode/layers/api/serializers.py
@@ -173,6 +173,7 @@ class DatasetSerializer(ResourceBaseSerializer):
             "featureinfo_custom_template",
             "ows_url",
             "capabilities_url",
+            "dataset_ows_url",
             "workspace",
             "default_style",
             "styles",

--- a/geonode/layers/models.py
+++ b/geonode/layers/models.py
@@ -260,6 +260,12 @@ class Dataset(ResourceBase):
         from geonode.geoserver.helpers import get_dataset_capabilities_url
 
         return get_dataset_capabilities_url(self)
+    
+    @property
+    def dataset_ows_url(self):
+        from geonode.geoserver.helpers import get_layer_ows_url
+
+        return get_layer_ows_url(self)
 
     @property
     def embed_url(self):

--- a/geonode/layers/models.py
+++ b/geonode/layers/models.py
@@ -260,7 +260,7 @@ class Dataset(ResourceBase):
         from geonode.geoserver.helpers import get_dataset_capabilities_url
 
         return get_dataset_capabilities_url(self)
-    
+
     @property
     def dataset_ows_url(self):
         from geonode.geoserver.helpers import get_layer_ows_url


### PR DESCRIPTION
ref #11312 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: black geonode && flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
