### PR TITLE
[Fixes #11338] Drop spatial extent widget from Django admin

### DIFF
--- a/geonode/documents/admin.py
+++ b/geonode/documents/admin.py
@@ -36,6 +36,7 @@ class DocumentAdminForm(ResourceBaseAdminForm):
 
 
 class DocumentAdmin(TabbedTranslationAdmin):
+    exclude = ("ll_bbox_polygon", "bbox_polygon", "srid")
     list_display = ("id", "title", "date", "category", "group", "is_approved", "is_published", "metadata_completeness")
     list_display_links = ("id",)
     list_editable = ("title", "category", "group", "is_approved", "is_published")
@@ -55,6 +56,7 @@ class DocumentAdmin(TabbedTranslationAdmin):
         "is_approved",
         "is_published",
     )
+    readonly_fields = ("geographic_bounding_box",)
     date_hierarchy = "date"
     form = DocumentAdminForm
     actions = [metadata_batch_edit]

--- a/geonode/geoapps/admin.py
+++ b/geonode/geoapps/admin.py
@@ -32,6 +32,7 @@ class GeoAppAdminForm(ResourceBaseAdminForm):
 
 
 class GeoAppAdmin(TabbedTranslationAdmin):
+    exclude = ("ll_bbox_polygon", "bbox_polygon", "srid")
     list_display_links = ("title",)
     list_display = (
         "id",
@@ -65,6 +66,7 @@ class GeoAppAdmin(TabbedTranslationAdmin):
         "is_approved",
         "is_published",
     )
+    readonly_fields = ("geographic_bounding_box",)
     form = GeoAppAdminForm
 
     def delete_queryset(self, request, queryset):

--- a/geonode/layers/admin.py
+++ b/geonode/layers/admin.py
@@ -55,6 +55,7 @@ class DatasetAdminForm(ResourceBaseAdminForm):
 
 
 class DatasetAdmin(TabbedTranslationAdmin):
+    exclude = ("ll_bbox_polygon", "bbox_polygon", "srid")
     list_display = (
         "id",
         "alternate",
@@ -86,7 +87,7 @@ class DatasetAdmin(TabbedTranslationAdmin):
     search_fields = ("alternate", "title", "abstract", "purpose", "is_approved", "is_published", "state")
     filter_horizontal = ("contacts",)
     date_hierarchy = "date"
-    readonly_fields = ("uuid", "alternate", "workspace")
+    readonly_fields = ("uuid", "alternate", "workspace", "geographic_bounding_box")
     inlines = [AttributeInline]
     form = DatasetAdminForm
     actions = [metadata_batch_edit]

--- a/geonode/maps/admin.py
+++ b/geonode/maps/admin.py
@@ -44,6 +44,7 @@ class MapAdmin(TabbedTranslationAdmin):
     inlines = [
         MapLayerInline,
     ]
+    exclude = ("ll_bbox_polygon", "bbox_polygon", "srid")
     list_display_links = ("title",)
     list_display = (
         "id",
@@ -78,6 +79,7 @@ class MapAdmin(TabbedTranslationAdmin):
         "is_approved",
         "is_published",
     )
+    readonly_fields = ("geographic_bounding_box",)
     form = MapAdminForm
     actions = [metadata_batch_edit]
 

--- a/geonode/services/admin.py
+++ b/geonode/services/admin.py
@@ -31,6 +31,7 @@ class ServiceAdminForm(ResourceBaseAdminForm):
 
 
 class ServiceAdmin(admin.ModelAdmin):
+    exclude = ("ll_bbox_polygon", "bbox_polygon", "srid")
     list_display = ("id", "name", "base_url", "type", "method")
     list_display_links = ("id", "name")
     list_filter = ("id", "name", "type", "method")


### PR DESCRIPTION
ref #11338 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [ ] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [ ] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: black geonode && flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
