### PR TITLE
[Fixes #11337] wait-for-databases.sh does not support other port than 5432

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -38,7 +38,8 @@ logger = logging.getLogger(__name__)
 def waitfordbs(ctx):
     print("**************************databases*******************************")
     db_host = os.getenv("DATABASE_HOST", "db")
-    ctx.run(f"/usr/bin/wait-for-databases {db_host}", pty=True)
+    db_port = os.getenv("DATABASE_PORT", "5432")
+    ctx.run(f"/usr/bin/wait-for-databases {db_host} {db_port}", pty=True)
 
 
 @task

--- a/wait-for-databases.sh
+++ b/wait-for-databases.sh
@@ -3,19 +3,20 @@
 set -e
 
 host="$1"
+port="$2"
 shift
 
-until PGPASSWORD=${POSTGRES_PASSWORD} psql -h "$host" -U ${POSTGRES_USER} -P "pager=off" -c '\l'; do
+until PGPASSWORD=${POSTGRES_PASSWORD} psql -h "$host" -U ${POSTGRES_USER} -p ${port}-P "pager=off" -c '\l'; do
   >&2 echo "Postgres is unavailable - sleeping"
   sleep 1
 done
 
-until PGPASSWORD=${GEONODE_DATABASE_PASSWORD} psql -h "$host" -U ${GEONODE_DATABASE} -d ${GEONODE_DATABASE} -P "pager=off" -c '\l'; do
+until PGPASSWORD=${GEONODE_DATABASE_PASSWORD} psql -h "$host" -U ${GEONODE_DATABASE} -d ${GEONODE_DATABASE} -p ${port} -P "pager=off" -c '\l'; do
   >&2 echo "${GEONODE_DATABASE} is unavailable - sleeping"
   sleep 1
 done
 
-until PGPASSWORD=${GEONODE_GEODATABASE_PASSWORD} psql -h "$host" -U ${GEONODE_GEODATABASE} -d ${GEONODE_GEODATABASE} -P "pager=off" -c '\l'; do
+until PGPASSWORD=${GEONODE_GEODATABASE_PASSWORD} psql -h "$host" -U ${GEONODE_GEODATABASE} -d ${GEONODE_GEODATABASE} -p ${port} -P "pager=off" -c '\l'; do
   >&2 echo "${GEONODE_GEODATABASE} is unavailable - sleeping"
   sleep 1
 done


### PR DESCRIPTION
mini bugfix allows wait-for-db.sh to receive DB_PORT env var to connect to a database using a different port.

closes #11337 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [ ] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: black geonode && flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
