### PR TITLE
[Fixes #11533] Remote resources created by harvesters do not have remote subtype

### DIFF
--- a/geonode/harvesting/harvesters/base.py
+++ b/geonode/harvesting/harvesters/base.py
@@ -247,6 +247,7 @@ class BaseHarvesterWorker(abc.ABC):
         if self.should_copy_resource(harvestable_resource):
             defaults["sourcetype"] = enumerations.SOURCE_TYPE_COPYREMOTE
         else:
+            defaults["subtype"] = 'remote'
             defaults["sourcetype"] = enumerations.SOURCE_TYPE_REMOTE
         return {key: value for key, value in defaults.items() if value is not None}
 

--- a/geonode/harvesting/harvesters/base.py
+++ b/geonode/harvesting/harvesters/base.py
@@ -247,7 +247,7 @@ class BaseHarvesterWorker(abc.ABC):
         if self.should_copy_resource(harvestable_resource):
             defaults["sourcetype"] = enumerations.SOURCE_TYPE_COPYREMOTE
         else:
-            defaults["subtype"] = 'remote'
+            defaults["subtype"] = "remote"
             defaults["sourcetype"] = enumerations.SOURCE_TYPE_REMOTE
         return {key: value for key, value in defaults.items() if value is not None}
 

--- a/geonode/harvesting/harvesters/geonodeharvester.py
+++ b/geonode/harvesting/harvesters/geonodeharvester.py
@@ -261,6 +261,7 @@ class GeonodeCurrentHarvester(base.BaseHarvesterWorker):
                         "thumbnail_url": harvested_info.resource_descriptor.distribution.thumbnail_url,
                         "srid": srid,
                         "ptype": GXP_PTYPES["GN_WMS"],
+                        "subtype": "remote"
                     }
                 )
         return defaults

--- a/geonode/harvesting/harvesters/geonodeharvester.py
+++ b/geonode/harvesting/harvesters/geonodeharvester.py
@@ -261,7 +261,7 @@ class GeonodeCurrentHarvester(base.BaseHarvesterWorker):
                         "thumbnail_url": harvested_info.resource_descriptor.distribution.thumbnail_url,
                         "srid": srid,
                         "ptype": GXP_PTYPES["GN_WMS"],
-                        "subtype": "remote"
+                        "subtype": "remote",
                     }
                 )
         return defaults

--- a/geonode/harvesting/tests/test_integrations.py
+++ b/geonode/harvesting/tests/test_integrations.py
@@ -1,0 +1,96 @@
+##############################################
+#
+# Copyright (C) 2021 OSGeo
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#########################################################################
+from unittest import mock
+import uuid
+
+from django.test.utils import override_settings
+from django.contrib.auth import get_user_model
+from geonode.tests.base import GeoNodeBaseTestSupport
+from geonode.layers.models import Dataset
+
+from geonode.harvesting.resourcedescriptor import *
+from geonode.harvesting.models import *
+from geonode.harvesting.harvesters.base import HarvestedResourceInfo
+from geonode.harvesting.harvesters.geonodeharvester import GeonodeUnifiedHarvesterWorker
+
+from geonode.harvesting.tasks import _harvest_resource
+
+
+class HarvesterIntegrationsTestCase(GeoNodeBaseTestSupport):
+    unique_identifier = "id"
+    title = "Test"
+    remote_url = "test.com"
+    name = "This is a geonode harvester"
+    user = get_user_model().objects.get(username="AnonymousUser")
+    harvester_type = "geonode.harvesting.harvesters.geonodeharvester.GeonodeLegacyHarvester"
+
+    @override_settings(ASYNC_SIGNALS=False)
+    def setUp(self):
+        super().setUp()
+
+        self.record_description_contact = mock.MagicMock(RecordDescriptionContact)
+        self.record_distribution = mock.MagicMock(RecordDistribution)
+        self.record_distribution.thumbnail_url.return_value = "thumb.png"
+        self.record_distribution.wms_url.return_value = "http://test.com/geoserver"
+        self.record_identification = RecordIdentification(name=self.name, title=self.title, other_keywords=[])
+
+        self.harvester = Harvester.objects.create(
+            remote_url=self.remote_url, name=self.name, default_owner=self.user, harvester_type=self.harvester_type
+        )
+        self.harvestable_resource = HarvestableResource.objects.create(
+            unique_identifier=self.unique_identifier,
+            title=self.title,
+            harvester=self.harvester,
+            last_refreshed=dt.datetime.now(),
+            remote_resource_type="dataset",
+        )
+
+        self.session = AsynchronousHarvestingSession.objects.create(
+            harvester=self.harvester, session_type=AsynchronousHarvestingSession.TYPE_HARVESTING
+        )
+
+        self.record_description = RecordDescription(
+            uuid=uuid.uuid4(),
+            author=self.record_description_contact,
+            date_stamp=dt.datetime.now(),
+            distribution=self.record_distribution,
+            identification=self.record_identification,
+            point_of_contact=self.record_description_contact,
+            reference_systems=["EPSG:3857"],
+            additional_parameters={
+                "alternate": "geonode:test",
+                "workspace": "geonode",
+                "subtype": "vector",
+                "resource_type": "",
+            },
+        )
+
+        self.harvested_info = HarvestedResourceInfo(
+            resource_descriptor=self.record_description, copied_resources=[], additional_information=None
+        )
+
+    @mock.patch(
+        "geonode.harvesting.harvesters.geonodeharvester.GeonodeCurrentHarvester.check_availability",
+        mock.Mock(return_value=True),
+    )
+    def test_remote_subtype_is_set_for_harvested_dataset(self):
+        worker = GeonodeUnifiedHarvesterWorker(remote_url=self.remote_url, harvester_id=self.harvester.id)
+        worker.update_geonode_resource(self.harvested_info, self.harvestable_resource)
+        dataset = Dataset.objects.get(alternate="geonode:test")
+        self.assertEqual(dataset.subtype, "remote")

--- a/geonode/harvesting/tests/test_integrations.py
+++ b/geonode/harvesting/tests/test_integrations.py
@@ -35,8 +35,6 @@ from geonode.harvesting.models import Harvester, HarvestableResource, Asynchrono
 from geonode.harvesting.harvesters.base import HarvestedResourceInfo
 from geonode.harvesting.harvesters.geonodeharvester import GeonodeUnifiedHarvesterWorker
 
-from geonode.harvesting.tasks import _harvest_resource
-
 
 class HarvesterIntegrationsTestCase(GeoNodeBaseTestSupport):
     unique_identifier = "id"

--- a/geonode/harvesting/tests/test_integrations.py
+++ b/geonode/harvesting/tests/test_integrations.py
@@ -16,16 +16,22 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 #########################################################################
-from unittest import mock
 import uuid
+import datetime as dt
+from unittest import mock
 
 from django.test.utils import override_settings
 from django.contrib.auth import get_user_model
 from geonode.tests.base import GeoNodeBaseTestSupport
 from geonode.layers.models import Dataset
 
-from geonode.harvesting.resourcedescriptor import *
-from geonode.harvesting.models import *
+from geonode.harvesting.resourcedescriptor import (
+    RecordDescriptionContact,
+    RecordDistribution,
+    RecordIdentification,
+    RecordDescription,
+)
+from geonode.harvesting.models import Harvester, HarvestableResource, AsynchronousHarvestingSession
 from geonode.harvesting.harvesters.base import HarvestedResourceInfo
 from geonode.harvesting.harvesters.geonodeharvester import GeonodeUnifiedHarvesterWorker
 

--- a/geonode/resource/utils.py
+++ b/geonode/resource/utils.py
@@ -234,11 +234,6 @@ def update_resource(
 
     to_update.update(defaults)
     try:
-        ResourceBase.objects.filter(id=instance.resourcebase_ptr.id).update(**defaults)
-    except Exception as e:
-        logger.error(f"{e} - {defaults}")
-        raise
-    try:
         instance.get_real_concrete_instance_class().objects.filter(id=instance.id).update(**to_update)
     except Exception as e:
         logger.error(f"{e} - {to_update}")
@@ -254,8 +249,6 @@ def update_resource(
             _s = Service.objects.filter(harvester=_h).get()
             _to_update = {
                 "remote_typename": _s.name,
-                # "ows_url": _s.service_url,
-                "subtype": "remote",
             }
             if hasattr(instance, "remote_service"):
                 _to_update["remote_service"] = _s


### PR DESCRIPTION
## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: black geonode && flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
