### PR TITLE
Test fix CircleCi test

### DIFF
--- a/geonode/upload/api/tests.py
+++ b/geonode/upload/api/tests.py
@@ -235,6 +235,7 @@ class UploadApiTests(GeoNodeLiveTestSupport, APITestCase):
         """
         Ensure we can access the Local Server Uploads list.
         """
+        resp = None
         layer_name = "relief_san_andres"
         try:
             self._cleanup_layer(layer_name=layer_name)
@@ -264,6 +265,7 @@ class UploadApiTests(GeoNodeLiveTestSupport, APITestCase):
         """
         Ensure we can access the Local Server Uploads list.
         """
+        resp = None
         layer_name = "relief_san_andres"
         try:
             self._cleanup_layer(layer_name=layer_name)
@@ -289,11 +291,11 @@ class UploadApiTests(GeoNodeLiveTestSupport, APITestCase):
         # removing the layer from geoserver
         dataset = gs_catalog.get_layer(layer_name)
         if dataset:
-            gs_catalog.delete(dataset)
+            gs_catalog.delete(dataset, purge="all", recurse=True)
         # removing the layer from geoserver
         store = gs_catalog.get_store(layer_name, workspace="geonode")
         if store:
-            gs_catalog.delete(store)
+            gs_catalog.delete(store, purge="all", recurse=True)
 
     @mock.patch("geonode.upload.uploadhandler.SimpleUploadedFile")
     def test_rest_uploads_with_size_limit(self, mocked_uploaded_file):


### PR DESCRIPTION
Fix broken test in circleCi

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: black geonode && flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
