### PR TITLE
[Fixes #11643] Thesaurus topics should only return its own keys

### DIFF
--- a/geonode/facets/providers/thesaurus.py
+++ b/geonode/facets/providers/thesaurus.py
@@ -111,7 +111,7 @@ class ThesaurusFacetProvider(FacetProvider):
 
     def get_topics(self, keys: list, lang="en", **kwargs) -> list:
         q = (
-            ThesaurusKeyword.objects.filter(id__in=keys)
+            ThesaurusKeyword.objects.filter(id__in=keys, thesaurus__identifier=self.name)
             .values("id", "alt_label")
             .annotate(
                 localized_label=Subquery(

--- a/geonode/facets/tests.py
+++ b/geonode/facets/tests.py
@@ -498,6 +498,7 @@ class TestFacets(GeoNodeBaseTestSupport):
                 {regfilter: "R0", t0filter: t("0_1"), "key": [t("1_1"), t("1_0")]},
                 {t("1_0"): None, t("1_1"): None},
             ),
+            ("t_1", {"key": [t("0_1")]}, {}),
             # regions
             (regname, {t1filter: t("1_1")}, {"R1": 1}),
             (regname, {t1filter: t("1_1"), "key": ["R0", "R1"]}, {"R1": 1, "R0": None}),


### PR DESCRIPTION
## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: black geonode && flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
