### PR TITLE
Control read only mode with environmental variable #11710

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -253,3 +253,5 @@ RESTART_POLICY_WINDOW=120s
 
 DEFAULT_MAX_UPLOAD_SIZE=5368709120
 DEFAULT_MAX_PARALLEL_UPLOADS_PER_USER=5
+
+# FORCE_READ_ONLY_MODE=False Set to TRUE to force the read-only mode. If true, override even the value saved in the database. If false, the DB value wins

--- a/.env.sample
+++ b/.env.sample
@@ -254,4 +254,4 @@ RESTART_POLICY_WINDOW=120s
 DEFAULT_MAX_UPLOAD_SIZE=5368709120
 DEFAULT_MAX_PARALLEL_UPLOADS_PER_USER=5
 
-# FORCE_READ_ONLY_MODE=False Set to TRUE to force the read-only mode. If true, override even the value saved in the database. If false, the DB value wins
+# FORCE_READ_ONLY_MODE=False Override the read-only value saved in the configuration

--- a/geonode/base/tests.py
+++ b/geonode/base/tests.py
@@ -17,6 +17,7 @@
 #
 #########################################################################
 
+import django.test.utils
 import json
 import logging
 import os
@@ -666,6 +667,16 @@ class ConfigurationTest(GeoNodeBaseTestSupport):
 
         self.assertEqual(response.status_code, 503, "User is allowed to get index page")
 
+    @patch.dict(os.environ, {"FORCE_READ_ONLY_MODE": "True"})
+    def test_readonly_overwrite_by_env(self):
+        config = Configuration.load()
+        self.assertTrue(config.read_only)
+
+    @patch.dict(os.environ, {"FORCE_READ_ONLY_MODE": "False"})
+    def test_readonly_is_not_overwrite_by_env(self):
+        # will take the value from the db
+        config = Configuration.load()
+        self.assertFalse(config.read_only)
 
 class TestOwnerRightsRequestUtils(TestCase):
     def setUp(self):

--- a/geonode/base/tests.py
+++ b/geonode/base/tests.py
@@ -17,7 +17,6 @@
 #
 #########################################################################
 
-import django.test.utils
 import json
 import logging
 import os
@@ -677,6 +676,7 @@ class ConfigurationTest(GeoNodeBaseTestSupport):
         # will take the value from the db
         config = Configuration.load()
         self.assertFalse(config.read_only)
+
 
 class TestOwnerRightsRequestUtils(TestCase):
     def setUp(self):

--- a/geonode/context_processors.py
+++ b/geonode/context_processors.py
@@ -17,6 +17,8 @@
 #
 #########################################################################
 
+import ast
+import os
 import warnings
 
 from django.conf import settings

--- a/geonode/context_processors.py
+++ b/geonode/context_processors.py
@@ -17,8 +17,6 @@
 #
 #########################################################################
 
-import ast
-import os
 import warnings
 
 from django.conf import settings

--- a/geonode/singleton.py
+++ b/geonode/singleton.py
@@ -21,6 +21,7 @@
 # Geonode functionality
 
 import os
+import ast
 from django.db import models
 
 
@@ -41,7 +42,7 @@ class SingletonModel(models.Model):
         obj, _ = cls.objects.get_or_create(pk=1)
         val = os.getenv("FORCE_READ_ONLY_MODE", None)
         if val is not None:
-            setattr(obj, "read_only", val)
+            setattr(obj, "read_only", ast.literal_eval(val))
         return obj
 
     def save(self, *args, **kwargs):

--- a/geonode/singleton.py
+++ b/geonode/singleton.py
@@ -20,7 +20,6 @@
 
 # Geonode functionality
 
-import ast
 import os
 from django.db import models
 

--- a/geonode/singleton.py
+++ b/geonode/singleton.py
@@ -40,8 +40,9 @@ class SingletonModel(models.Model):
     @classmethod
     def load(cls):
         obj, _ = cls.objects.get_or_create(pk=1)
-        if ast.literal_eval(os.getenv("FORCE_READ_ONLY_MODE", "False")):
-            setattr(obj, "read_only", True)
+        val = os.getenv("FORCE_READ_ONLY_MODE", None)
+        if val is not None:
+            setattr(obj, "read_only", val)
         return obj
 
     def save(self, *args, **kwargs):

--- a/geonode/singleton.py
+++ b/geonode/singleton.py
@@ -20,6 +20,8 @@
 
 # Geonode functionality
 
+import ast
+import os
 from django.db import models
 
 
@@ -38,6 +40,8 @@ class SingletonModel(models.Model):
     @classmethod
     def load(cls):
         obj, _ = cls.objects.get_or_create(pk=1)
+        if ast.literal_eval(os.getenv("FORCE_READ_ONLY_MODE", "False")):
+            setattr(obj, "read_only", True)
         return obj
 
     def save(self, *args, **kwargs):


### PR DESCRIPTION
Add environment variable to Force the "READ_ONLY" mode.

- If `TRUE`, set the application in `read_only` even if is not set in the configuration. 
- If `FALSE`, set the application will not be in `read_only` even if is set in the configuration
- 
## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: black geonode && flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
