### PR TITLE
[fixes #11734] standing up docker compose stack on a port different than 80

### DIFF
--- a/scripts/docker/nginx/geonode.conf.envsubst
+++ b/scripts/docker/nginx/geonode.conf.envsubst
@@ -105,7 +105,7 @@ location / {
   add_header Access-Control-Allow-Methods "GET, POST, PUT, PATCH, OPTIONS";
   
   proxy_redirect              off;
-  proxy_set_header            Host $host;
+  proxy_set_header            Host $http_host;
   proxy_set_header            Origin $HTTP_SCHEME://$host;
   proxy_set_header            X-Real-IP $remote_addr;
   proxy_set_header            X-Forwarded-Host $server_name;


### PR DESCRIPTION
This PR includes a small change to the nginx-related `geonode.conf.envsubst` file. It replaces usage of NGINX's `$host` variable with `$http_host`. 

As mentioned in #11734, the `$host` variable does not preserve port information, which means that the current configuration does not allow the django service to know what was the original port from which outside requests came from - and therefore the GeoNode API is not able to generate correct URLs, which in turn means the UI is not functional. 

This is really only a problem if the system maintainer wants to have GeoNode running on a port different from `80`.


- Fixes #11734 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- ~~[ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented~~
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: black geonode && flake8 geonode
- ~~[ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates~~
- ~~[ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)~~

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
