### PR TITLE
need to remove call to command rebuild_index in tasks.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -86,8 +86,7 @@ Markdown==3.5.2
 git+https://github.com/GeoNode/pinax-notifications.git@django_upgrade#egg=pinax-notifications
 
 # GeoNode org maintained apps.
-# django-geonode-mapstore-client==4.0.5
-git+https://github.com/GeoNode/geonode-mapstore-client.git@master#egg=django_geonode_mapstore_client
+git+https://github.com/gobiernodigitalmonterrey/geonode-mapstore-client#egg=django_geonode_mapstore_client
 git+https://github.com/GeoNode/geonode-importer.git@master#egg=geonode-importer
 django-avatar==8.0.0
 geonode-oauth-toolkit==2.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -86,7 +86,7 @@ Markdown==3.5.2
 git+https://github.com/GeoNode/pinax-notifications.git@django_upgrade#egg=pinax-notifications
 
 # GeoNode org maintained apps.
-git+https://github.com/gobiernodigitalmonterrey/geonode-mapstore-client#egg=django_geonode_mapstore_client
+git+https://github.com/gobiernodigitalmonterrey/geonode-mapstore-client@master#egg=django_geonode_mapstore_client
 git+https://github.com/GeoNode/geonode-importer.git@master#egg=geonode-importer
 django-avatar==8.0.0
 geonode-oauth-toolkit==2.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -86,7 +86,8 @@ Markdown==3.5.2
 git+https://github.com/GeoNode/pinax-notifications.git@django_upgrade#egg=pinax-notifications
 
 # GeoNode org maintained apps.
-git+https://github.com/gobiernodigitalmonterrey/geonode-mapstore-client@master#egg=django_geonode_mapstore_client
+# django-geonode-mapstore-client==4.0.5
+git+https://github.com/GeoNode/geonode-mapstore-client.git@master#egg=django_geonode_mapstore_client
 git+https://github.com/GeoNode/geonode-importer.git@master#egg=geonode-importer
 django-avatar==8.0.0
 geonode-oauth-toolkit==2.2.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -112,7 +112,8 @@ install_requires =
     pinax-notifications @ git+https://github.com/GeoNode/pinax-notifications.git@django_upgrade#egg=pinax-notifications
 
     # GeoNode org maintained apps.
-    django-geonode-mapstore-client>=4.0.5,<5.0.0
+    # django-geonode-mapstore-client==4.0.5
+    django-geonode-mapstore-client @ git+https://github.com/GeoNode/geonode-mapstore-client.git@master#egg=django_geonode_mapstore_client
     geonode-importer>=1.0.2
     django-avatar==8.0.0
     geonode-oauth-toolkit==2.2.2

--- a/tasks.py
+++ b/tasks.py
@@ -325,13 +325,6 @@ def migrations(ctx):
         f"python manage.py migrate --noinput --settings={_localsettings()} --database=datastore",
         pty=True,
     )
-    try:
-        ctx.run(
-            f"python manage.py rebuild_index --noinput --settings={_localsettings()}",
-            pty=True,
-        )
-    except Exception:
-        pass
 
 
 @task


### PR DESCRIPTION
when tasks.py is called, after the execution of manage.py in function migrations() there is a try block that use command rebuild_index, this returns the message 'Type "manage.py help' for usage.", i found that this is a haystack command, but haystack was removed after the add of django 4.2 support

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [ ] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [ ] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: black geonode && flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
