### PR TITLE
Upgrade Geoserver with fix for oauth2

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -79,7 +79,7 @@ services:
 
   # Geoserver backend
   geoserver:
-    image: geonode/geoserver:2.23.3-v1
+    image: geonode/geoserver:2.23.3-v2
     container_name: geoserver4${COMPOSE_PROJECT_NAME}
     healthcheck:
       test: "curl -m 10 --fail --silent --write-out 'HTTP CODE : %{http_code}\n' --output /dev/null http://geoserver:8080/geoserver/ows"

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -92,7 +92,7 @@ services:
 
   # Geoserver backend
   geoserver:
-    image: geonode/geoserver:2.23.3-v1
+    image: geonode/geoserver:2.23.3-v2
     container_name: geoserver4${COMPOSE_PROJECT_NAME}
     healthcheck:
       test: "curl -m 10 --fail --silent --write-out 'HTTP CODE : %{http_code}\n' --output /dev/null http://geoserver:8080/geoserver/ows"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,7 +91,7 @@ services:
 
   # Geoserver backend
   geoserver:
-    image: geonode/geoserver:2.23.3-v1
+    image: geonode/geoserver:2.23.3-v2
     container_name: geoserver4${COMPOSE_PROJECT_NAME}
     healthcheck:
       test: "curl -m 10 --fail --silent --write-out 'HTTP CODE : %{http_code}\n' --output /dev/null http://geoserver:8080/geoserver/ows"

--- a/geonode/base/api/tests.py
+++ b/geonode/base/api/tests.py
@@ -1951,10 +1951,10 @@ class BaseApiTests(APITestCase):
         self.assertEqual(response.json(), "The url must be of an image with format (png, jpeg or jpg)")
 
         # using Base64 data as an ASCII byte string
-        data["file"] = (
-            "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAABHNCSVQICAgI\
+        data[
+            "file"
+        ] = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAABHNCSVQICAgI\
         fAhkiAAAABl0RVh0U29mdHdhcmUAZ25vbWUtc2NyZWVuc2hvdO8Dvz4AAAANSURBVAiZYzAxMfkPAALYAZzx61+bAAAAAElFTkSuQmCC"
-        )
         with patch("geonode.base.models.is_monochromatic_image") as _mck:
             _mck.return_value = False
             response = self.client.put(url, data=data, format="json")

--- a/geonode/harvesting/harvesters/geonodeharvester.py
+++ b/geonode/harvesting/harvesters/geonodeharvester.py
@@ -433,14 +433,14 @@ class GeonodeCurrentHarvester(base.BaseHarvesterWorker):
             result["filter{title.icontains}"] = self.resource_title_filter
         if self.start_date_filter is not None:
             start_date = dateutil.parser.parse(self.start_date_filter)
-            result["filter{date.gte}"] = (
-                f"{start_date.astimezone(dt.timezone.utc).replace(microsecond=0).isoformat().split('+')[0]}Z"
-            )
+            result[
+                "filter{date.gte}"
+            ] = f"{start_date.astimezone(dt.timezone.utc).replace(microsecond=0).isoformat().split('+')[0]}Z"
         if self.end_date_filter is not None:
             end_date = dateutil.parser.parse(self.end_date_filter)
-            result["filter{date.lte}"] = (
-                f"{end_date.astimezone(dt.timezone.utc).replace(microsecond=0).isoformat().split('+')[0]}Z"
-            )
+            result[
+                "filter{date.lte}"
+            ] = f"{end_date.astimezone(dt.timezone.utc).replace(microsecond=0).isoformat().split('+')[0]}Z"
         if self.keywords_filter is not None:
             result["filter{keywords.slug.in}"] = self.keywords_filter
         if self.categories_filter is not None:
@@ -738,14 +738,14 @@ class GeonodeLegacyHarvester(base.BaseHarvesterWorker):
             result["title__icontains"] = self.resource_title_filter
         if self.start_date_filter is not None:
             start_date = dateutil.parser.parse(self.start_date_filter)
-            result["date__gte"] = (
-                f"{start_date.astimezone(dt.timezone.utc).replace(microsecond=0).isoformat().split('+')[0]}Z"
-            )
+            result[
+                "date__gte"
+            ] = f"{start_date.astimezone(dt.timezone.utc).replace(microsecond=0).isoformat().split('+')[0]}Z"
         if self.end_date_filter is not None:
             end_date = dateutil.parser.parse(self.end_date_filter)
-            result["date__lte"] = (
-                f"{end_date.astimezone(dt.timezone.utc).replace(microsecond=0).isoformat().split('+')[0]}Z"
-            )
+            result[
+                "date__lte"
+            ] = f"{end_date.astimezone(dt.timezone.utc).replace(microsecond=0).isoformat().split('+')[0]}Z"
         if self.keywords_filter is not None:
             result["keywords__slug__in"] = ",".join(self.keywords_filter)
         if self.categories_filter is not None:


### PR DESCRIPTION
## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: black geonode && flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
