### PR TITLE
hide resources from search and catalogue listing

### DIFF
--- a/geonode/base/api/mixins.py
+++ b/geonode/base/api/mixins.py
@@ -1,0 +1,57 @@
+#########################################################################
+#
+# Copyright (C) 2024 OSGeo
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#########################################################################
+from distutils.util import strtobool
+from rest_framework.mixins import ListModelMixin
+from rest_framework.response import Response
+
+
+class AdvertisedListMixin(ListModelMixin):
+
+    def list(self, request, *args, **kwargs):
+        queryset = self.filter_queryset(self.get_queryset())
+
+        # advertised
+        # if superuser, all resources will be visible, otherwise only the advertised one and
+        # the resource which the user is owner will be returned
+        user = request.user
+        try:
+            _filter = request.query_params.get("advertised", "None")
+            advertised = strtobool(_filter) if _filter.lower() != "all" else "all"
+        except Exception:
+            advertised = None
+
+        if advertised is not None and advertised != "all":
+            queryset = queryset.filter(advertised=advertised)
+        else:
+            is_admin = user.is_superuser if user and user.is_authenticated else False
+
+            if advertised == "all":
+                pass
+            elif not is_admin and user and not user.is_anonymous:
+                queryset = (queryset.filter(advertised=True) | queryset.filter(owner=user)).distinct()
+            elif not user or user.is_anonymous:
+                queryset = queryset.filter(advertised=True)
+
+        page = self.paginate_queryset(queryset)
+        if page is not None:
+            serializer = self.get_serializer(page, many=True)
+            return self.get_paginated_response(serializer.data)
+
+        serializer = self.get_serializer(queryset, many=True)
+        return Response(serializer.data)

--- a/geonode/base/api/views.py
+++ b/geonode/base/api/views.py
@@ -17,7 +17,6 @@
 #
 #########################################################################
 import ast
-from distutils.util import strtobool
 import json
 import re
 
@@ -81,6 +80,7 @@ from geonode.resource.manager import resource_manager
 
 from guardian.shortcuts import get_objects_for_user
 
+from geonode.base.api.mixins import AdvertisedListMixin
 from .permissions import (
     IsSelfOrAdminOrReadOnly,
     IsOwnerOrAdmin,
@@ -337,7 +337,7 @@ class OwnerViewSet(WithDynamicViewSetMixin, ListModelMixin, RetrieveModelMixin, 
         return queryset.order_by("username")
 
 
-class ResourceBaseViewSet(DynamicModelViewSet):
+class ResourceBaseViewSet(DynamicModelViewSet, AdvertisedListMixin):
     """
     API endpoint that allows base resources to be viewed or edited.
     """
@@ -364,41 +364,6 @@ class ResourceBaseViewSet(DynamicModelViewSet):
         result_page = paginator.paginate_queryset(resources, request)
         serializer = ResourceBaseSerializer(result_page, embed=True, many=True)
         return paginator.get_paginated_response({"resources": serializer.data})
-
-    def list(self, request, *args, **kwargs):
-        queryset = self.filter_queryset(self.get_queryset())
-
-        # advertised
-        # if superuser, all resources will be visible, otherwise only the advertised once and
-        # the resource which the user is owner will be returned
-        # if the filter{advertised} is sent, is going to be used after the list of the
-        # resources is generated
-        user = request.user
-        try:
-            _filter = request.query_params.get("advertised", "None")
-            advertised = strtobool(_filter) if _filter.lower() != "all" else "all"
-        except Exception:
-            advertised = None
-
-        if advertised is not None and advertised != "all":
-            queryset = queryset.filter(advertised=advertised)
-        else:
-            is_admin = user.is_superuser if user and user.is_authenticated else False
-
-            if advertised == "all":
-                pass
-            elif not is_admin and user and not user.is_anonymous:
-                queryset = (queryset.filter(advertised=True) | queryset.filter(owner=user)).distinct()
-            elif not user or user.is_anonymous:
-                queryset = queryset.filter(advertised=True)
-
-        page = self.paginate_queryset(queryset)
-        if page is not None:
-            serializer = self.get_serializer(page, many=True)
-            return self.get_paginated_response(serializer.data)
-
-        serializer = self.get_serializer(queryset, many=True)
-        return Response(serializer.data)
 
     @extend_schema(
         methods=["get"],

--- a/geonode/documents/api/views.py
+++ b/geonode/documents/api/views.py
@@ -29,6 +29,7 @@ from oauth2_provider.contrib.rest_framework import OAuth2Authentication
 from geonode import settings
 
 from geonode.base.api.filters import DynamicSearchFilter, ExtentFilter
+from geonode.base.api.mixins import AdvertisedListMixin
 from geonode.base.api.pagination import GeoNodeApiPagination
 from geonode.base.api.permissions import UserHasPerms
 from geonode.base.api.views import base_linked_resources
@@ -49,7 +50,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-class DocumentViewSet(DynamicModelViewSet):
+class DocumentViewSet(DynamicModelViewSet, AdvertisedListMixin):
     """
     API endpoint that allows documents to be viewed or edited.
     """

--- a/geonode/geoapps/api/views.py
+++ b/geonode/geoapps/api/views.py
@@ -24,6 +24,7 @@ from rest_framework.authentication import SessionAuthentication, BasicAuthentica
 from oauth2_provider.contrib.rest_framework import OAuth2Authentication
 
 from geonode.base.api.filters import DynamicSearchFilter, ExtentFilter
+from geonode.base.api.mixins import AdvertisedListMixin
 from geonode.base.api.pagination import GeoNodeApiPagination
 from geonode.base.api.permissions import UserHasPerms
 from geonode.geoapps.models import GeoApp
@@ -36,7 +37,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-class GeoAppViewSet(DynamicModelViewSet):
+class GeoAppViewSet(DynamicModelViewSet, AdvertisedListMixin):
     """
     API endpoint that allows geoapps to be viewed or edited.
     """

--- a/geonode/layers/api/views.py
+++ b/geonode/layers/api/views.py
@@ -30,6 +30,7 @@ from oauth2_provider.contrib.rest_framework import OAuth2Authentication
 from rest_framework.response import Response
 
 from geonode.base.api.filters import DynamicSearchFilter, ExtentFilter
+from geonode.base.api.mixins import AdvertisedListMixin
 from geonode.base.api.pagination import GeoNodeApiPagination
 from geonode.base.api.permissions import UserHasPerms
 from geonode.layers.api.exceptions import GeneralDatasetException, InvalidDatasetException, InvalidMetadataException
@@ -56,7 +57,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-class DatasetViewSet(DynamicModelViewSet):
+class DatasetViewSet(DynamicModelViewSet, AdvertisedListMixin):
     """
     API endpoint that allows layers to be viewed or edited.
     """

--- a/geonode/maps/api/tests.py
+++ b/geonode/maps/api/tests.py
@@ -213,6 +213,39 @@ class MapsApiTests(APITestCase):
         self.assertEqual(response.status_code, 500)
         self.assertEqual(expected_error, response.json())
 
+    def test_map_listing_advertised(self):
+        app = Map.objects.first()
+        app.advertised = False
+        app.save()
+
+        url = reverse("maps-list")
+
+        payload = self.client.get(url)
+
+        prev_count = payload.json().get("total")
+        # the user can see only the advertised resources
+        self.assertEqual(Map.objects.filter(advertised=True).count(), prev_count)
+
+        payload = self.client.get(f"{url}?advertised=True")
+        # so if advertised is True, we dont see the advertised=False resource
+        new_count = payload.json().get("total")
+        # recheck the count
+        self.assertEqual(new_count, prev_count)
+
+        payload = self.client.get(f"{url}?advertised=False")
+        # so if advertised is False, we see only the resource with advertised==False
+        new_count = payload.json().get("total")
+        # recheck the count
+        self.assertEqual(new_count, 1)
+
+        # if all is requested, we will see all the resources
+        payload = self.client.get(f"{url}?advertised=all")
+        new_count = payload.json().get("total")
+        # recheck the count
+        self.assertEqual(new_count, prev_count + 1)
+
+        Map.objects.update(advertised=True)
+
     def test_create_map(self):
         """
         Post to maps/

--- a/geonode/maps/api/tests.py
+++ b/geonode/maps/api/tests.py
@@ -224,7 +224,7 @@ class MapsApiTests(APITestCase):
 
         prev_count = payload.json().get("total")
         # the user can see only the advertised resources
-        self.assertEqual(Map.objects.filter(advertised=True).count(), prev_count)
+        self.assertTrue(Map.objects.filter(advertised=True).count() >= prev_count)
 
         payload = self.client.get(f"{url}?advertised=True")
         # so if advertised is True, we dont see the advertised=False resource

--- a/geonode/maps/api/views.py
+++ b/geonode/maps/api/views.py
@@ -31,6 +31,7 @@ from rest_framework.response import Response
 
 from geonode.base import register_event
 from geonode.base.api.filters import DynamicSearchFilter, ExtentFilter
+from geonode.base.api.mixins import AdvertisedListMixin
 from geonode.base.api.pagination import GeoNodeApiPagination
 from geonode.base.api.permissions import UserHasPerms
 from geonode.layers.api.serializers import DatasetSerializer
@@ -47,7 +48,7 @@ from geonode.utils import resolve_object
 logger = logging.getLogger(__name__)
 
 
-class MapViewSet(DynamicModelViewSet):
+class MapViewSet(DynamicModelViewSet, AdvertisedListMixin):
     """
     API endpoint that allows maps to be viewed or edited.
     """


### PR DESCRIPTION
ref #11993 
## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: black geonode && flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
