### PR TITLE
[GHSA-r4vm-9c9v-x572] Inefficient Regular Expression Complexity in Geonode

### DIFF
--- a/geonode/upload/upload_validators.py
+++ b/geonode/upload/upload_validators.py
@@ -121,8 +121,8 @@ def _validate_shapefile_components(possible_filenames):
         shape_component = shp_files[0]
     except IndexError:
         return None
-    base_name, base_extension = os.path.splitext(os.path.basename(shape_component))
-    components = [base_extension[1:]]
+    base_name = os.path.splitext(os.path.basename(shape_component))[0].lower()
+    components = [os.path.splitext(shape_component)[1][1:].lower()]
     shapefile_additional = [
         ShapefileAux(extension="dbf", mandatory=aux_mandatory),
         ShapefileAux(extension="shx", mandatory=aux_mandatory),
@@ -132,17 +132,19 @@ def _validate_shapefile_components(possible_filenames):
     ]
     for additional_component in shapefile_additional:
         for path in possible_filenames:
-            additional_name = os.path.splitext(os.path.basename(path))[0]
-            matches_main_name = bool(re.match(base_name, additional_name, re.I))
+            additional_name = os.path.splitext(os.path.basename(path))[0].lower()
             extension = os.path.splitext(path)[1][1:].lower()
             found_component = extension == additional_component.extension
+            matches_main_name = base_name == additional_name
             if found_component and matches_main_name:
                 components.append(additional_component.extension)
                 break
         else:
             if additional_component.mandatory:
                 raise forms.ValidationError(
-                    f"Could not find {additional_component.extension} file, which is mandatory for " "shapefile uploads"
+                    _("Could not find {extension} file, which is mandatory for shapefile uploads").format(
+                        extension=additional_component.extension
+                    )
                 )
     logger.debug(f"shapefile components: {components}")
     return components

--- a/geonode/upload/upload_validators.py
+++ b/geonode/upload/upload_validators.py
@@ -18,7 +18,6 @@
 #########################################################################
 
 """Tools for performing validation of uploaded spatial files."""
-import re
 import os.path
 import logging
 import zipfile


### PR DESCRIPTION
This PR reworks the upload validator:
- introduces .lower() for name checking
- adds translation for error message
- uses string comparation instead of re (https://github.com/GeoNode/geonode/security/advisories/GHSA-r4vm-9c9v-x572)

caution. from what I see this part is not covered by a test:
https://app.codecov.io/gh/GeoNode/geonode/blob/master/geonode%2Fupload%2Fupload_validators.py#L102

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: black geonode && flake8 geonode
- [x] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
