### PR TITLE
[Fixes #11977][Backport 4.1.x] B/R should only deal with data

### DIFF
--- a/geonode/br/management/commands/backup.py
+++ b/geonode/br/management/commands/backup.py
@@ -21,6 +21,8 @@ import json
 import os
 import time
 import shutil
+from typing import LiteralString
+
 import requests
 import re
 import logging
@@ -156,6 +158,9 @@ class Command(BaseCommand):
                 # Dump Fixtures
                 logger.info("*** Dumping GeoNode fixtures...")
 
+                fixtures_target = os.path.join(target_folder, "fixtures")
+                os.makedirs(fixtures_target, exist_ok=True)
+
                 for app_name, dump_name in zip(config.app_names, config.dump_names):
                     # prevent dumping BackupRestore application
                     if app_name == "br":
@@ -163,7 +168,7 @@ class Command(BaseCommand):
 
                     logger.info(f" - Dumping '{app_name}' into '{dump_name}.json'")
                     # Point stdout at a file for dumping data to.
-                    with open(os.path.join(target_folder, f"{dump_name}.json"), "w") as output:
+                    with open(os.path.join(fixtures_target, f"{dump_name}.json"), "w") as output:
                         call_command("dumpdata", app_name, format="json", indent=2, stdout=output)
 
                 # Store Media Root
@@ -180,126 +185,6 @@ class Command(BaseCommand):
                     ignore=utils.ignore_time(config.gs_data_dt_filter[0], config.gs_data_dt_filter[1]),
                 )
                 logger.info(f"Saved media files from '{media_root}'")
-
-                # Store Static Root
-                logger.info("*** Dumping GeoNode static folder...")
-
-                static_root = settings.STATIC_ROOT
-                static_folder = os.path.join(target_folder, utils.STATIC_ROOT)
-                if not os.path.exists(static_folder):
-                    os.makedirs(static_folder, exist_ok=True)
-
-                copy_tree(
-                    static_root,
-                    static_folder,
-                    ignore=utils.ignore_time(config.gs_data_dt_filter[0], config.gs_data_dt_filter[1]),
-                )
-                logger.info(f"Saved static root from '{static_root}'.")
-
-                # Store Static Folders
-                logger.info("*** Dumping GeoNode static files...")
-
-                static_folders = settings.STATICFILES_DIRS
-                static_files_folders = os.path.join(target_folder, utils.STATICFILES_DIRS)
-                if not os.path.exists(static_files_folders):
-                    os.makedirs(static_files_folders, exist_ok=True)
-
-                for static_files_folder in static_folders:
-                    # skip dumping of static files of apps not located under PROJECT_ROOT path
-                    # (check to prevent saving files from site-packages in project-template based GeoNode projects)
-                    if getattr(settings, "PROJECT_ROOT", None) and not static_files_folder.startswith(
-                        settings.PROJECT_ROOT
-                    ):
-                        logger.info(
-                            f"Skipping static directory: {static_files_folder}. "
-                            f"It's not located under PROJECT_ROOT path: {settings.PROJECT_ROOT}."
-                        )
-                        continue
-
-                    static_folder = os.path.join(
-                        static_files_folders, os.path.basename(os.path.normpath(static_files_folder))
-                    )
-                    if not os.path.exists(static_folder):
-                        os.makedirs(static_folder, exist_ok=True)
-
-                    copy_tree(
-                        static_files_folder,
-                        static_folder,
-                        ignore=utils.ignore_time(config.gs_data_dt_filter[0], config.gs_data_dt_filter[1]),
-                    )
-                    logger.info(f"Saved static files from '{static_files_folder}'.")
-
-                # Store Template Folders
-                logger.info("*** Dumping GeoNode template folders...")
-
-                template_folders = []
-                try:
-                    template_folders = settings.TEMPLATE_DIRS
-                except Exception:
-                    try:
-                        template_folders = settings.TEMPLATES[0]["DIRS"]
-                    except Exception:
-                        pass
-                template_files_folders = os.path.join(target_folder, utils.TEMPLATE_DIRS)
-                if not os.path.exists(template_files_folders):
-                    os.makedirs(template_files_folders, exist_ok=True)
-
-                for template_files_folder in template_folders:
-                    # skip dumping of template files of apps not located under PROJECT_ROOT path
-                    # (check to prevent saving files from site-packages in project-template based GeoNode projects)
-                    if getattr(settings, "PROJECT_ROOT", None) and not template_files_folder.startswith(
-                        settings.PROJECT_ROOT
-                    ):
-                        logger.info(
-                            f"Skipping template directory: {template_files_folder}. "
-                            f"It's not located under PROJECT_ROOT path: {settings.PROJECT_ROOT}."
-                        )
-                        continue
-
-                    template_folder = os.path.join(
-                        template_files_folders, os.path.basename(os.path.normpath(template_files_folder))
-                    )
-                    if not os.path.exists(template_folder):
-                        os.makedirs(template_folder, exist_ok=True)
-
-                    copy_tree(
-                        template_files_folder,
-                        template_folder,
-                        ignore=utils.ignore_time(config.gs_data_dt_filter[0], config.gs_data_dt_filter[1]),
-                    )
-                    logger.info(f"Saved template files from '{template_files_folder}'.")
-
-                # Store Locale Folders
-                logger.info("*** Dumping GeoNode locale folders...")
-                locale_folders = settings.LOCALE_PATHS
-                locale_files_folders = os.path.join(target_folder, utils.LOCALE_PATHS)
-                if not os.path.exists(locale_files_folders):
-                    os.makedirs(locale_files_folders, exist_ok=True)
-
-                for locale_files_folder in locale_folders:
-                    # skip dumping of locale files of apps not located under PROJECT_ROOT path
-                    # (check to prevent saving files from site-packages in project-template based GeoNode projects)
-                    if getattr(settings, "PROJECT_ROOT", None) and not locale_files_folder.startswith(
-                        settings.PROJECT_ROOT
-                    ):
-                        logger.info(
-                            f"Skipping locale directory: {locale_files_folder}. "
-                            f"It's not located under PROJECT_ROOT path: {settings.PROJECT_ROOT}."
-                        )
-                        continue
-
-                    locale_folder = os.path.join(
-                        locale_files_folders, os.path.basename(os.path.normpath(locale_files_folder))
-                    )
-                    if not os.path.exists(locale_folder):
-                        os.makedirs(locale_folder, exist_ok=True)
-
-                    copy_tree(
-                        locale_files_folder,
-                        locale_folder,
-                        ignore=utils.ignore_time(config.gs_data_dt_filter[0], config.gs_data_dt_filter[1]),
-                    )
-                    logger.info(f"Saved Locale Files from '{locale_files_folder}'.")
 
                 # Create Final ZIP Archive
                 logger.info("*** Creating final ZIP archive...")

--- a/geonode/br/management/commands/backup.py
+++ b/geonode/br/management/commands/backup.py
@@ -21,7 +21,6 @@ import json
 import os
 import time
 import shutil
-from typing import LiteralString
 
 import requests
 import re


### PR DESCRIPTION
According to #11977, removed the backup and restoring of
- templates
- static dirs
- static root

Also taking care of 
- #12002 
- #12003 

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [ ] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: black geonode && flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
