### PR TITLE
Upgrade Remote Docker version for CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
       - checkout
       - setup_remote_docker:
           docker_layer_caching: false
-          version: 20.10.12
+          version: docker24
 
       - run:
           name: Build the stack


### PR DESCRIPTION
CircleCI was failing because 20.10.12 is [deprecated](https://discuss.circleci.com/t/remote-docker-image-deprecations-and-eol-for-2024/50176)