### PR TITLE
[Fixes #12063] Cannot clone map/geoapp with linked resources

### DIFF
--- a/geonode/resource/manager.py
+++ b/geonode/resource/manager.py
@@ -503,11 +503,11 @@ class ResourceManager(ResourceManagerInterface):
                             defaults.pop("name")
                     _resource.save()
                     for lr in LinkedResource.get_linked_resources(source=instance.pk, is_internal=False):
-                        LinkedResource.object.get_or_create(
+                        LinkedResource.objects.get_or_create(
                             source_id=_resource.pk, target_id=lr.target.pk, internal=False
                         )
                     for lr in LinkedResource.get_linked_resources(target=instance.pk, is_internal=False):
-                        LinkedResource.object.get_or_create(
+                        LinkedResource.objects.get_or_create(
                             source_id=lr.source.pk, target_id=_resource.pk, internal=False
                         )
 

--- a/geonode/resource/tests.py
+++ b/geonode/resource/tests.py
@@ -28,7 +28,7 @@ from geonode.groups.models import GroupProfile
 from geonode.base.populate_test_data import create_models
 from geonode.tests.base import GeoNodeBaseTestSupport
 from geonode.resource.manager import ResourceManager
-from geonode.base.models import ResourceBase
+from geonode.base.models import LinkedResource, ResourceBase
 from geonode.layers.models import Dataset
 from geonode.services.models import Service
 from geonode.documents.models import Document
@@ -164,6 +164,26 @@ class TestResourceManager(GeoNodeBaseTestSupport):
 
         # copy with maps
         res = create_single_map("A Test Map")
+        self.assertTrue(isinstance(res, Map))
+        _copy_assert_resource(res, "A Test Map 2")
+
+    def test_resource_copy_with_linked_resources(self):
+        def _copy_assert_resource(res, title):
+            dataset_copy = None
+            try:
+                dataset_copy = self.rm.copy(res, defaults=dict(title=title))
+                self.assertIsNotNone(dataset_copy)
+                self.assertEqual(dataset_copy.title, title)
+            finally:
+                if dataset_copy:
+                    dataset_copy.delete()
+                self.assertIsNotNone(res)
+                res.delete()
+
+        # copy with maps
+        res = create_single_map("A Test Map")
+        target = ResourceBase.objects.first()
+        LinkedResource.objects.get_or_create(source_id=res.id, target_id=target.id)
         self.assertTrue(isinstance(res, Map))
         _copy_assert_resource(res, "A Test Map 2")
 


### PR DESCRIPTION
<Include a few sentences describing the overall goals for this Pull Request>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [ ] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [ ] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: black geonode && flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
