### PR TITLE
lxml 5.2.1 fixes ABI compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # native dependencies
 Pillow==10.2.0
-lxml==5.2.0
+lxml==5.2.1
 psycopg2==2.9.9
 Django==4.2.9
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ setup_requires =
 install_requires =
     # native dependencies
     Pillow==10.2.0
-    lxml==5.2.0
+    lxml==5.2.1
     psycopg2==2.9.9
     Django==4.2.9
 


### PR DESCRIPTION
From lxml 5.2.1 changelog:

>LP#2059910: The minimum CPU architecture for the Linux x86 binary wheels was set back to “core2”, but with SSE 4.2 enabled

This fix solves core dump caused by lxml on some KVM virtualized machines

