### PR TITLE
[#12110] Clean up some deprecation messages

### DIFF
--- a/geonode/people/api/serializers.py
+++ b/geonode/people/api/serializers.py
@@ -12,7 +12,7 @@ import geonode.base.api.serializers as base_serializers
 logger = logging.getLogger(__name__)
 
 
-class UserSerializer(base_serializers.BaseDynamicModelSerializer):
+class UserSerializer(base_serializers.DynamicModelSerializer):
 
     link = base_serializers.AutoLinkField(read_only=True)
 

--- a/geonode/resource/api/serializer.py
+++ b/geonode/resource/api/serializer.py
@@ -16,11 +16,16 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 #########################################################################
-from geonode.base.api.serializers import BaseDynamicModelSerializer
+from dynamic_rest.serializers import DynamicModelSerializer
+
+from geonode.base.api.serializers import AutoLinkField
 from geonode.resource.models import ExecutionRequest
 
 
-class ExecutionRequestSerializer(BaseDynamicModelSerializer):
+class ExecutionRequestSerializer(DynamicModelSerializer):
+
+    link = AutoLinkField(read_only=True)
+
     class Meta:
         model = ExecutionRequest
         name = "request"


### PR DESCRIPTION
As an improvement of #12110, uses the new link serialization for a couple more Serializers, removing the related deprecation messages in the log.

Improved Serializers are:
- `ExecutionRequestSerializer`: using new `AutoLinkField`
- `UserSerializer`: `AutoLinkField` was already there, but the class still inherited from `BaseDynamicModelSerializer`. Fixed.

Also fixed the selection of the target view_name.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [ ] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [ ] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: black geonode && flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
