### PR TITLE
[Fixes #12167] providing multiple openid_connect django.allauth socialproviders fails when loading login page

### DIFF
--- a/geonode/people/adapters.py
+++ b/geonode/people/adapters.py
@@ -267,12 +267,7 @@ class GenericOpenIDConnectAdapter(OAuth2Adapter, SocialAccountAdapter):
         provider = provider or self.provider_id
         provider_class = registry.get_class(provider)
         if provider_class is None or provider_class.uses_apps:
-            # check if first app provider contains client_id, mutiple apps in a single provider
-            # get seperated into multiple providers, an this function gets called multiple times
-            # https://github.com/pennersr/django-allauth/blob/main/docs/socialaccount/providers/openid_connect.rst
-            if not self.list_apps(request)[0].client_id:
-                raise (ImproperlyConfigured(f"Missing client_id parameter in provider: {provider} configuration"))
-            app = self.get_app(request, provider=provider, client_id=self.list_apps(request)[0].client_id)
+            app = self.get_app(request, provider=provider)
             if not provider_class:
                 # In this case, the `provider` argument passed was a
                 # `provider_id`.

--- a/geonode/people/templatetags/socialaccount_extra.py
+++ b/geonode/people/templatetags/socialaccount_extra.py
@@ -15,10 +15,10 @@ def get_user_social_providers(user):
 @register.simple_tag
 def get_other_social_providers(user):
     user_providers = get_user_social_providers(user)
-    user_provider_names = [p.name.lower() for p in user_providers]
+    user_provider_names = [p.id.lower() for p in user_providers]
     other_providers = []
-    for provider in providers.registry.get_list():
-        if provider.name.lower() not in user_provider_names:
+    for provider in providers.registry.get_class_list():
+        if provider.id.lower() not in user_provider_names:
             other_providers.append(provider)
     return other_providers
 

--- a/geonode/templates/socialaccount/snippets/provider_list.html
+++ b/geonode/templates/socialaccount/snippets/provider_list.html
@@ -5,7 +5,7 @@
 {% get_providers as socialaccount_providers %}
 
 {% for provider in socialaccount_providers %}
-        {% if provider.id == "openid" %}
+        {% if provider.id == "openid_connect" %}
             {% for brand in provider.get_brands %}
                 <a class="list-group-item" title="{{brand.name}}" href="{% provider_login_url provider openid=brand.openid_url process=process %}">
                     {{brand.name}}

--- a/geonode/templates/socialaccount/snippets/provider_list.html
+++ b/geonode/templates/socialaccount/snippets/provider_list.html
@@ -7,13 +7,13 @@
 {% for provider in socialaccount_providers %}
         {% if provider.id == "openid" %}
             {% for brand in provider.get_brands %}
-                <a class="list-group-item" title="{{brand.name}}" href="{% provider_login_url provider.id openid=brand.openid_url process=process %}">
+                <a class="list-group-item" title="{{brand.name}}" href="{% provider_login_url provider openid=brand.openid_url process=process %}">
                     {{brand.name}}
                 </a>
             {% endfor %}
         {% endif %}
         <div class="form-group">
-            <a class="btn btn-default btn-block" title="{{provider.name}}" href="{% provider_login_url provider.id process=process scope=scope auth_params=auth_params %}">
+            <a class="btn btn-default btn-block" title="{{provider.name}}" href="{% provider_login_url provider process=process scope=scope auth_params=auth_params %}">
                 <i class="fa fa-{{ provider.name|lower }}-square fa-2x" aria-hidden="true"></i>
                 {% if process == "login" %}
                     {% trans "Sign in with" %}

--- a/geonode/templates/socialaccount/snippets/remaining_providers_list.html
+++ b/geonode/templates/socialaccount/snippets/remaining_providers_list.html
@@ -5,7 +5,7 @@
 {% get_other_social_providers user as other_providers %}
 
 {% for provider in other_providers %}
-    {% if provider.id == "openid" %}
+    {% if provider.id == "openid_connect" %}
         {% for brand in provider.get_brands %}
             <a class="list-group-item" title="{{brand.name}}" href="{% provider_login_url provider openid=brand.openid_url process=process %}">
                 {{brand.name}}

--- a/geonode/templates/socialaccount/snippets/remaining_providers_list.html
+++ b/geonode/templates/socialaccount/snippets/remaining_providers_list.html
@@ -7,13 +7,13 @@
 {% for provider in other_providers %}
     {% if provider.id == "openid" %}
         {% for brand in provider.get_brands %}
-            <a class="list-group-item" title="{{brand.name}}" href="{% provider_login_url provider.id openid=brand.openid_url process=process %}">
+            <a class="list-group-item" title="{{brand.name}}" href="{% provider_login_url provider openid=brand.openid_url process=process %}">
                 {{brand.name}}
             </a>
         {% endfor %}
     {% endif %}
     <div class="form-group">
-        <a class="btn btn-default btn-block" title="{{provider.name}}" href="{% provider_login_url provider.id process=process scope=scope auth_params=auth_params %}">
+        <a class="btn btn-default btn-block" title="{{provider.name}}" href="{% provider_login_url provider process=process scope=scope auth_params=auth_params %}">
             <i class="fa fa-{{ provider.name|lower }}-square fa-2x" aria-hidden="true"></i>
             {% if process == "login" %}
                 {% trans "Sign in with" %}


### PR DESCRIPTION
<Include a few sentences describing the overall goals for this Pull Request>

ref #12167, #12180

minor fix to allow mutiple APPS defined in an  `openid_connect` , `SOCIALACCOUNT_PROVIDERS`. Further it includes check that client_id must be set.

closes #12167
closes #12180

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [ ] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: black geonode && flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
