### PR TITLE
[Fixes #12235] Retrieve the ows_url for ArcGIS resources from the harvester url

### DIFF
--- a/geonode/harvesting/harvesters/arcgis.py
+++ b/geonode/harvesting/harvesters/arcgis.py
@@ -203,7 +203,7 @@ class ArcgisMapServiceResourceExtractor(ArcgisServiceResourceExtractor):
             resource_uuid = uuid.UUID(harvestable_resource.geonode_resource.uuid)
         _, service_name, service_type = parse_remote_url(harvestable_resource.unique_identifier)
         epsg_code, spatial_extent = _parse_spatial_extent(layer_representation["extent"])
-        ows_url = harvestable_resource.unique_identifier.rpartition("/")[0]
+        ows_url = harvestable_resource.harvester.remote_url
         store = slugify(ows_url)
         name = layer_representation.get("id", layer_representation.get("name", "Undefined"))
         title = layer_representation.get("name", layer_representation.get("title", "Undefined"))
@@ -305,7 +305,7 @@ class ArcgisImageServiceResourceExtractor(ArcgisServiceResourceExtractor):
             resource_uuid = uuid.UUID(harvestable_resource.geonode_resource.uuid)
         _, service_name, service_type = parse_remote_url(harvestable_resource.unique_identifier)
         epsg_code, spatial_extent = _parse_spatial_extent(layer_representation["extent"])
-        ows_url = harvestable_resource.unique_identifier.rpartition("/")[0]
+        ows_url = harvestable_resource.harvester.remote_url
         store = slugify(ows_url)
         name = layer_representation.get("id", layer_representation.get("name", "Undefined"))
         title = layer_representation.get("name", layer_representation.get("title", "Undefined"))


### PR DESCRIPTION
## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: black geonode && flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
