### PR TITLE
[Fixes #12253] Improvements to the proxy view

### DIFF
--- a/geonode/proxy/apps.py
+++ b/geonode/proxy/apps.py
@@ -32,4 +32,8 @@ class GeoNodeProxyAppConfig(AppConfig):
 
     def ready(self):
         super().ready()
-        run_setup_hooks()
+        try:
+            run_setup_hooks()
+        except:
+            # This is in case the Service table doesn't exist yet
+            post_migrate.connect(run_setup_hooks, sender=self)

--- a/geonode/proxy/apps.py
+++ b/geonode/proxy/apps.py
@@ -17,8 +17,19 @@
 #
 #########################################################################
 from django.apps import AppConfig
+from django.db.models.signals import post_migrate
+
+from .utils import proxy_urls_registry
+
+
+def run_setup_hooks(*args, **kwargs):
+    proxy_urls_registry.initialize()
 
 
 class GeoNodeProxyAppConfig(AppConfig):
     name = "geonode.proxy"
     verbose_name = "GeoNode Proxy"
+
+    def ready(self):
+        super().ready()
+        run_setup_hooks()

--- a/geonode/proxy/apps.py
+++ b/geonode/proxy/apps.py
@@ -34,6 +34,6 @@ class GeoNodeProxyAppConfig(AppConfig):
         super().ready()
         try:
             run_setup_hooks()
-        except:
+        except Exception:
             # This is in case the Service table doesn't exist yet
             post_migrate.connect(run_setup_hooks, sender=self)

--- a/geonode/proxy/tests.py
+++ b/geonode/proxy/tests.py
@@ -52,6 +52,7 @@ from geonode.layers.models import Dataset
 from geonode.decorators import on_ogc_backend
 from geonode.tests.base import GeoNodeBaseTestSupport
 from geonode.base.populate_test_data import create_models, create_single_dataset
+from geonode.proxy.views import ProxyUrlsRegistry
 
 TEST_DOMAIN = ".github.com"
 TEST_URL = f"https://help{TEST_DOMAIN}/"
@@ -67,7 +68,7 @@ class ProxyTest(GeoNodeBaseTestSupport):
         self.proxy_url = "/proxy/"
         self.url = TEST_URL
 
-    @patch("geonode.proxy.views.PROXY_ALLOWED_HOSTS", set([TEST_DOMAIN]))
+    @patch("geonode.proxy.views.proxy_urls_registry", ProxyUrlsRegistry().set([TEST_DOMAIN]))
     def test_proxy_allowed_host(self):
         """If PROXY_ALLOWED_HOSTS is not empty and DEBUG is False requests should return no error."""
         self.client.login(username="admin", password="admin")
@@ -75,30 +76,30 @@ class ProxyTest(GeoNodeBaseTestSupport):
         self.assertEqual(response.status_code, 200, response.status_code)
 
     @override_settings(PROXY_ALLOWED_PARAMS_NEEDLES=("request=GetCapabilities",))
-    @patch("geonode.proxy.views.PROXY_ALLOWED_HOSTS", set())
+    @patch("geonode.proxy.views.proxy_urls_registry", ProxyUrlsRegistry().clear())
     def test_proxy_allowed_params(self):
         response = self.client.get(f"{self.proxy_url}?url=https://example.com?request=GetCapabilities")
         self.assertNotEqual(response.status_code, 404, response.status_code)
 
     @override_settings(PROXY_ALLOWED_PARAMS_NEEDLES=("request=GetCapabilities",))
-    @patch("geonode.proxy.views.PROXY_ALLOWED_HOSTS", set())
+    @patch("geonode.proxy.views.proxy_urls_registry", ProxyUrlsRegistry().clear())
     def test_proxy_not_allowed_params(self):
         response = self.client.get(f"{self.proxy_url}?url=http://example.com?param=any")
         self.assertEqual(response.status_code, 403, response.status_code)
 
-    @override_settings(PROXY_ALLOWED_HOSTS=(), PROXY_ALLOWED_PATH_NEEDLES=("tms",))
-    @patch("geonode.proxy.views.PROXY_ALLOWED_HOSTS", set())
+    @override_settings(PROXY_ALLOWED_PATH_NEEDLES=("tms",))
+    @patch("geonode.proxy.views.proxy_urls_registry", ProxyUrlsRegistry().clear())
     def test_proxy_allowed_path(self):
         response = self.client.get(f"{self.proxy_url}?url=https://example.com/tms/")
         self.assertNotEqual(response.status_code, 404, response.status_code)
 
-    @override_settings(PROXY_ALLOWED_HOSTS=(), PROXY_ALLOWED_PATH_NEEDLES=("tms",))
-    @patch("geonode.proxy.views.PROXY_ALLOWED_HOSTS", set())
+    @override_settings(PROXY_ALLOWED_PATH_NEEDLES=("tms",))
+    @patch("geonode.proxy.views.proxy_urls_registry", ProxyUrlsRegistry().clear())
     def test_proxy_not_allowed_path(self):
         response = self.client.get(f"{self.proxy_url}?url=http://example.com/xyz")
         self.assertEqual(response.status_code, 403, response.status_code)
 
-    @patch("geonode.proxy.views.PROXY_ALLOWED_HOSTS", set())
+    @patch("geonode.proxy.views.proxy_urls_registry", ProxyUrlsRegistry().clear())
     def test_validate_remote_services_hosts(self):
         """If PROXY_ALLOWED_HOSTS is empty and DEBUG is False requests should return 200
         for Remote Services hosts."""
@@ -117,7 +118,7 @@ class ProxyTest(GeoNodeBaseTestSupport):
         # 200 - FOUND
         self.assertTrue(response.status_code in (200, 301))
 
-    @patch("geonode.proxy.views.PROXY_ALLOWED_HOSTS", set([".example.org"]))
+    @patch("geonode.proxy.views.proxy_urls_registry", ProxyUrlsRegistry().set([".example.org"]))
     def test_relative_urls(self):
         """Proxying to a URL with a relative path element should normalise the path into
         an absolute path before calling the remote URL."""
@@ -137,6 +138,7 @@ class ProxyTest(GeoNodeBaseTestSupport):
         self.client.get(f"{self.proxy_url}?url={url}")
         assert request_mock.call_args[0][0] == "http://example.org/index.html"
 
+    @patch("geonode.proxy.views.proxy_urls_registry", ProxyUrlsRegistry().set([".example.org"]))
     def test_proxy_preserve_headers(self):
         """The GeoNode Proxy should preserve the original request headers."""
         import geonode.proxy.views
@@ -173,23 +175,22 @@ class ProxyTest(GeoNodeBaseTestSupport):
 
         response = self.client.get(f"{self.proxy_url}?url={url}")
         self.assertDictContainsSubset(
-            dict(response.headers.copy()),
             {
-                "Content-Type": "text/plain",
+                "Content-Type": "image/tiff",
                 "Vary": "Authorization, Accept-Language, Cookie, origin",
                 "X-Content-Type-Options": "nosniff",
                 "X-XSS-Protection": "1; mode=block",
                 "Referrer-Policy": "same-origin",
                 "Cross-Origin-Opener-Policy": "same-origin",
                 "X-Frame-Options": "SAMEORIGIN",
-                "Content-Language": "en-us",
-                "Content-Length": "119",
+                "Content-Language": "en",
+                "Content-Length": "11",
                 "Content-Disposition": 'attachment; filename="filename.tif"',
             },
+            dict(response.headers.copy()),
         )
 
     def test_proxy_url_forgery(self):
-        """The GeoNode Proxy should preserve the original request headers."""
         import geonode.proxy.views
         from urllib.parse import urlsplit
 

--- a/geonode/proxy/tests.py
+++ b/geonode/proxy/tests.py
@@ -54,8 +54,8 @@ from geonode.tests.base import GeoNodeBaseTestSupport
 from geonode.base.populate_test_data import create_models, create_single_dataset
 from geonode.proxy.utils import ProxyUrlsRegistry
 
-TEST_DOMAIN = ".github.com"
-TEST_URL = f"https://help{TEST_DOMAIN}/"
+TEST_DOMAIN = "help.github.com"
+TEST_URL = f"https://{TEST_DOMAIN}/"
 
 
 class ProxyTest(GeoNodeBaseTestSupport):
@@ -118,7 +118,7 @@ class ProxyTest(GeoNodeBaseTestSupport):
         # 200 - FOUND
         self.assertTrue(response.status_code in (200, 301))
 
-    @patch("geonode.proxy.views.proxy_urls_registry", ProxyUrlsRegistry().set([".example.org"]))
+    @patch("geonode.proxy.views.proxy_urls_registry", ProxyUrlsRegistry().set(["example.org"]))
     def test_relative_urls(self):
         """Proxying to a URL with a relative path element should normalise the path into
         an absolute path before calling the remote URL."""
@@ -138,7 +138,7 @@ class ProxyTest(GeoNodeBaseTestSupport):
         self.client.get(f"{self.proxy_url}?url={url}")
         assert request_mock.call_args[0][0] == "http://example.org/index.html"
 
-    @patch("geonode.proxy.views.proxy_urls_registry", ProxyUrlsRegistry().set([".example.org"]))
+    @patch("geonode.proxy.views.proxy_urls_registry", ProxyUrlsRegistry().set(["example.org"]))
     def test_proxy_preserve_headers(self):
         """The GeoNode Proxy should preserve the original request headers."""
         import geonode.proxy.views

--- a/geonode/proxy/tests.py
+++ b/geonode/proxy/tests.py
@@ -54,8 +54,8 @@ from geonode.tests.base import GeoNodeBaseTestSupport
 from geonode.base.populate_test_data import create_models, create_single_dataset
 from geonode.proxy.utils import ProxyUrlsRegistry
 
-TEST_DOMAIN = "help.github.com"
-TEST_URL = f"https://{TEST_DOMAIN}/"
+TEST_DOMAIN = ".github.com"
+TEST_URL = f"https://help{TEST_DOMAIN}/"
 
 
 class ProxyTest(GeoNodeBaseTestSupport):
@@ -152,7 +152,7 @@ class ProxyTest(GeoNodeBaseTestSupport):
         response = self.client.get(f"{self.proxy_url}?url=http://bogus.pocus.com/wcs")
         self.assertNotEqual(response.status_code, 403, response.status_code)
 
-    @patch("geonode.proxy.views.proxy_urls_registry", ProxyUrlsRegistry().set(["example.org"]))
+    @patch("geonode.proxy.views.proxy_urls_registry", ProxyUrlsRegistry().set([".example.org"]))
     def test_relative_urls(self):
         """Proxying to a URL with a relative path element should normalise the path into
         an absolute path before calling the remote URL."""

--- a/geonode/proxy/tests.py
+++ b/geonode/proxy/tests.py
@@ -52,7 +52,7 @@ from geonode.layers.models import Dataset
 from geonode.decorators import on_ogc_backend
 from geonode.tests.base import GeoNodeBaseTestSupport
 from geonode.base.populate_test_data import create_models, create_single_dataset
-from geonode.proxy.views import ProxyUrlsRegistry
+from geonode.proxy.utils import ProxyUrlsRegistry
 
 TEST_DOMAIN = ".github.com"
 TEST_URL = f"https://help{TEST_DOMAIN}/"

--- a/geonode/proxy/utils.py
+++ b/geonode/proxy/utils.py
@@ -13,9 +13,8 @@ class ProxyUrlsRegistry:
 
         self.proxy_allowed_hosts = set([site_url.hostname])
 
-        hostname = ogc_server_settings.hostname if ogc_server_settings else None
-        if hostname:
-            self.proxy_allowed_hosts.add(hostname)
+        if ogc_server_settings:
+            self.proxy_allowed_hosts.add(ogc_server_settings.hostname)
 
         for _s in Service.objects.all():
             _remote_host = urlsplit(_s.base_url).hostname

--- a/geonode/proxy/utils.py
+++ b/geonode/proxy/utils.py
@@ -1,0 +1,44 @@
+from urllib.parse import urlsplit
+
+from django.conf import settings
+
+
+site_url = urlsplit(settings.SITEURL)
+
+
+class ProxyUrlsRegistry:
+    def initialize(self):
+        from geonode.geoserver.helpers import ogc_server_settings
+        from geonode.services.models import Service
+
+        self.proxy_alloed_hosts = set()
+
+        self.proxy_alloed_hosts.add(site_url.hostname)
+
+        hostname = ogc_server_settings.hostname if ogc_server_settings else None
+        if hostname:
+            self.proxy_alloed_hosts.add(hostname)
+
+        for _s in Service.objects.all():
+            _remote_host = urlsplit(_s.base_url).hostname
+            self.proxy_alloed_hosts.add(_remote_host)
+
+    def set(self, hosts):
+        self.proxy_alloed_hosts = set(hosts)
+        return self
+
+    def clear(self):
+        self.proxy_alloed_hosts = set()
+        return self
+
+    def register_host(self, host):
+        self.proxy_alloed_hosts.add(host)
+
+    def unregister_host(self, host):
+        self.proxy_alloed_hosts.remove(host)
+
+    def get_proxy_alloed_hosts(self):
+        return self.proxy_alloed_hosts
+
+
+proxy_urls_registry = ProxyUrlsRegistry()

--- a/geonode/proxy/utils.py
+++ b/geonode/proxy/utils.py
@@ -11,34 +11,32 @@ class ProxyUrlsRegistry:
         from geonode.geoserver.helpers import ogc_server_settings
         from geonode.services.models import Service
 
-        self.proxy_alloed_hosts = set()
-
-        self.proxy_alloed_hosts.add(site_url.hostname)
+        self.proxy_allowed_hosts = set([site_url.hostname])
 
         hostname = ogc_server_settings.hostname if ogc_server_settings else None
         if hostname:
-            self.proxy_alloed_hosts.add(hostname)
+            self.proxy_allowed_hosts.add(hostname)
 
         for _s in Service.objects.all():
             _remote_host = urlsplit(_s.base_url).hostname
-            self.proxy_alloed_hosts.add(_remote_host)
+            self.proxy_allowed_hosts.add(_remote_host)
 
     def set(self, hosts):
-        self.proxy_alloed_hosts = set(hosts)
+        self.proxy_allowed_hosts = set(hosts)
         return self
 
     def clear(self):
-        self.proxy_alloed_hosts = set()
+        self.proxy_allowed_hosts = set()
         return self
 
     def register_host(self, host):
-        self.proxy_alloed_hosts.add(host)
+        self.proxy_allowed_hosts.add(host)
 
     def unregister_host(self, host):
-        self.proxy_alloed_hosts.remove(host)
+        self.proxy_allowed_hosts.remove(host)
 
-    def get_proxy_alloed_hosts(self):
-        return self.proxy_alloed_hosts
+    def get_proxy_allowed_hosts(self):
+        return self.proxy_allowed_hosts
 
 
 proxy_urls_registry = ProxyUrlsRegistry()

--- a/geonode/proxy/utils.py
+++ b/geonode/proxy/utils.py
@@ -11,7 +11,7 @@ class ProxyUrlsRegistry:
         from geonode.geoserver.helpers import ogc_server_settings
         from geonode.services.models import Service
 
-        self.proxy_allowed_hosts = set([site_url.hostname])
+        self.proxy_allowed_hosts = set([site_url.hostname] + list(getattr(settings, "PROXY_ALLOWED_HOSTS", ())))
 
         if ogc_server_settings:
             self.proxy_allowed_hosts.add(ogc_server_settings.hostname)

--- a/geonode/proxy/views.py
+++ b/geonode/proxy/views.py
@@ -73,7 +73,6 @@ def proxy(
     url=None,
     response_callback=None,
     sec_chk_hosts=True,
-    sec_chk_rules=True,
     timeout=None,
     allowed_hosts=[],
     headers=None,
@@ -109,23 +108,12 @@ def proxy(
             ):
                 proxy_urls_registry.register_host(url.hostname)
 
-        if url.hostname not in proxy_urls_registry.get_proxy_allowed_hosts():
-            # Check Remote Services base_urls
-            for _s in Service.objects.all():
-                _remote_host = urlsplit(_s.base_url).hostname
-                proxy_urls_registry.register_host(_remote_host)
-
         if not validate_host(extract_ip_or_domain(raw_url), proxy_urls_registry.get_proxy_allowed_hosts()):
             return HttpResponse(
                 "The path provided to the proxy service" " is not in the PROXY_ALLOWED_HOSTS setting.",
                 status=403,
                 content_type="text/plain",
             )
-
-    # Security checks based on rules; allow only specific requests
-    if sec_chk_rules:
-        # TODO: Not yet implemented
-        pass
 
     # Collecting headers and cookies
     if not headers:

--- a/geonode/proxy/views.py
+++ b/geonode/proxy/views.py
@@ -110,7 +110,7 @@ def proxy(
 
         if not validate_host(extract_ip_or_domain(raw_url), proxy_urls_registry.get_proxy_allowed_hosts()):
             return HttpResponse(
-                "The path provided to the proxy service" " is not in the PROXY_ALLOWED_HOSTS setting.",
+                "The path provided to the proxy service is not allowed.",
                 status=403,
                 content_type="text/plain",
             )

--- a/geonode/proxy/views.py
+++ b/geonode/proxy/views.py
@@ -103,10 +103,14 @@ def proxy(
 
     if sec_chk_hosts:
         if url.hostname not in proxy_urls_registry.get_proxy_allowed_hosts():
-            if any(needle.lower() in url.query.lower() for needle in PROXY_ALLOWED_PARAMS_NEEDLES) or any(
+            if not any(needle.lower() in url.query.lower() for needle in PROXY_ALLOWED_PARAMS_NEEDLES) and not any(
                 needle.lower() in url.path.lower() for needle in PROXY_ALLOWED_PATH_NEEDLES
             ):
-                proxy_urls_registry.register_host(url.hostname)
+                return HttpResponse(
+                    "The path provided to the proxy service is not allowed.",
+                    status=403,
+                    content_type="text/plain",
+                )
 
         if not validate_host(extract_ip_or_domain(raw_url), proxy_urls_registry.get_proxy_allowed_hosts()):
             return HttpResponse(

--- a/geonode/proxy/views.py
+++ b/geonode/proxy/views.py
@@ -103,17 +103,10 @@ def proxy(
 
     proxy_allowed_hosts = list(proxy_urls_registry.get_proxy_allowed_hosts())
     if sec_chk_hosts:
-        if url.hostname not in proxy_allowed_hosts:
-            if any(needle.lower() in url.query.lower() for needle in PROXY_ALLOWED_PARAMS_NEEDLES) or any(
-                needle.lower() in url.path.lower() for needle in PROXY_ALLOWED_PATH_NEEDLES
-            ):
-                proxy_allowed_hosts.append(url.hostname)
-            else:
-                return HttpResponse(
-                    "The path provided to the proxy service is not allowed.",
-                    status=403,
-                    content_type="text/plain",
-                )
+        if any(needle.lower() in url.query.lower() for needle in PROXY_ALLOWED_PARAMS_NEEDLES) or any(
+            needle.lower() in url.path.lower() for needle in PROXY_ALLOWED_PATH_NEEDLES
+        ):
+            proxy_allowed_hosts.append(url.hostname)
 
         if not validate_host(extract_ip_or_domain(raw_url), proxy_allowed_hosts):
             return HttpResponse(

--- a/geonode/proxy/views.py
+++ b/geonode/proxy/views.py
@@ -103,19 +103,19 @@ def proxy(
         locator += f"#{url.fragment}"
 
     if sec_chk_hosts:
-        if url.hostname not in proxy_urls_registry.get_proxy_alloed_hosts():
+        if url.hostname not in proxy_urls_registry.get_proxy_allowed_hosts():
             if any(needle.lower() in url.query.lower() for needle in PROXY_ALLOWED_PARAMS_NEEDLES) or any(
                 needle.lower() in url.path.lower() for needle in PROXY_ALLOWED_PATH_NEEDLES
             ):
                 proxy_urls_registry.register_host(url.hostname)
 
-        if url.hostname not in proxy_urls_registry.get_proxy_alloed_hosts():
+        if url.hostname not in proxy_urls_registry.get_proxy_allowed_hosts():
             # Check Remote Services base_urls
             for _s in Service.objects.all():
                 _remote_host = urlsplit(_s.base_url).hostname
                 proxy_urls_registry.register_host(_remote_host)
 
-        if not validate_host(extract_ip_or_domain(raw_url), proxy_urls_registry.get_proxy_alloed_hosts()):
+        if not validate_host(extract_ip_or_domain(raw_url), proxy_urls_registry.get_proxy_allowed_hosts()):
             return HttpResponse(
                 "The path provided to the proxy service" " is not in the PROXY_ALLOWED_HOSTS setting.",
                 status=403,

--- a/geonode/proxy/views.py
+++ b/geonode/proxy/views.py
@@ -415,8 +415,8 @@ def service_post_save(instance, sender, **kwargs):
 
 
 def service_post_delete(instance, sender, **kwargs):
-    service_hostname = urlsplit(instance.base_url).hostname
-    proxy_urls_registry.unregister_host(service_hostname)
+    # We reinitialize the registry otherwise we might delete a host requested by another service with the same hostanme
+    proxy_urls_registry.initialize()
 
 
 signals.post_save.connect(service_post_save, sender=Service)

--- a/geonode/proxy/views.py
+++ b/geonode/proxy/views.py
@@ -103,7 +103,7 @@ def proxy(
 
     proxy_allowed_hosts = list(proxy_urls_registry.get_proxy_allowed_hosts())
     if sec_chk_hosts:
-        if url.hostname not in proxy_urls_registry.get_proxy_allowed_hosts():
+        if url.hostname not in proxy_allowed_hosts:
             if any(needle.lower() in url.query.lower() for needle in PROXY_ALLOWED_PARAMS_NEEDLES) or any(
                 needle.lower() in url.path.lower() for needle in PROXY_ALLOWED_PATH_NEEDLES
             ):

--- a/geonode/proxy/views.py
+++ b/geonode/proxy/views.py
@@ -56,6 +56,8 @@ from geonode.base import register_event
 from geonode.base.auth import get_auth_user, get_token_from_auth_header
 from geonode.geoserver.helpers import ogc_server_settings
 
+from .utils import proxy_urls_registry
+
 logger = logging.getLogger(__name__)
 
 BUFFER_CHUNK_SIZE = 64 * 1024
@@ -63,41 +65,6 @@ TIMEOUT = 30
 LINK_TYPES = [L for L in _LT if L.startswith("OGC:")]
 
 site_url = urlsplit(settings.SITEURL)
-
-
-class ProxyUrlsRegistry:
-    def __init__(self):
-        self.proxy_alloed_hosts = set()
-
-        self.proxy_alloed_hosts.add(site_url.hostname)
-
-        hostname = ogc_server_settings.hostname if ogc_server_settings else None
-        if hostname:
-            self.proxy_alloed_hosts.add(hostname)
-
-        for _s in Service.objects.all():
-            _remote_host = urlsplit(_s.base_url).hostname
-            self.proxy_alloed_hosts.add(_remote_host)
-
-    def set(self, hosts):
-        self.proxy_alloed_hosts = set(hosts)
-        return self
-
-    def clear(self):
-        self.proxy_alloed_hosts = set()
-        return self
-
-    def register_host(self, host):
-        self.proxy_alloed_hosts.add(host)
-
-    def unregister_host(self, host):
-        self.proxy_alloed_hosts.remove(host)
-
-    def get_proxy_alloed_hosts(self):
-        return self.proxy_alloed_hosts
-
-
-proxy_urls_registry = ProxyUrlsRegistry()
 
 
 @requires_csrf_token

--- a/geonode/proxy/views.py
+++ b/geonode/proxy/views.py
@@ -101,20 +101,23 @@ def proxy(
     if url.fragment != "":
         locator += f"#{url.fragment}"
 
+    proxy_allowed_hosts = list(proxy_urls_registry.get_proxy_allowed_hosts())
     if sec_chk_hosts:
         if url.hostname not in proxy_urls_registry.get_proxy_allowed_hosts():
-            if not any(needle.lower() in url.query.lower() for needle in PROXY_ALLOWED_PARAMS_NEEDLES) and not any(
+            if any(needle.lower() in url.query.lower() for needle in PROXY_ALLOWED_PARAMS_NEEDLES) or any(
                 needle.lower() in url.path.lower() for needle in PROXY_ALLOWED_PATH_NEEDLES
             ):
+                proxy_allowed_hosts.append(url.hostname)
+            else:
                 return HttpResponse(
                     "The path provided to the proxy service is not allowed.",
                     status=403,
                     content_type="text/plain",
                 )
 
-        if not validate_host(extract_ip_or_domain(raw_url), proxy_urls_registry.get_proxy_allowed_hosts()):
+        if not validate_host(extract_ip_or_domain(raw_url), proxy_allowed_hosts):
             return HttpResponse(
-                "The path provided to the proxy service is not allowed.",
+                "The url provided to the proxy service is not a valid hostname.",
                 status=403,
                 content_type="text/plain",
             )

--- a/geonode/proxy/views.py
+++ b/geonode/proxy/views.py
@@ -39,6 +39,7 @@ from django.views.decorators.csrf import requires_csrf_token
 from geonode.layers.models import Dataset
 from geonode.upload.models import Upload
 from geonode.base.models import ResourceBase
+from geonode.services.models import Service
 from geonode.storage.manager import storage_manager
 from geonode.utils import (
     resolve_object,
@@ -53,17 +54,23 @@ from geonode.base.enumerations import LINK_TYPES as _LT
 from geonode import geoserver  # noqa
 from geonode.base import register_event
 from geonode.base.auth import get_auth_user, get_token_from_auth_header
-
-BUFFER_CHUNK_SIZE = 64 * 1024
-
-TIMEOUT = 30
-
-LINK_TYPES = [L for L in _LT if L.startswith("OGC:")]
+from geonode.geoserver.helpers import ogc_server_settings
 
 logger = logging.getLogger(__name__)
 
+BUFFER_CHUNK_SIZE = 64 * 1024
+TIMEOUT = 30
+LINK_TYPES = [L for L in _LT if L.startswith("OGC:")]
 
-ows_regexp = re.compile(r"^(?i)(version)=(\d\.\d\.\d)(?i)&(?i)request=(?i)(GetCapabilities)&(?i)service=(?i)(\w\w\w)$")
+PROXY_ALLOWED_HOSTS = set(getattr(settings, "PROXY_ALLOWED_HOSTS", ()))
+
+site_url = urlsplit(settings.SITEURL)
+if site_url.hostname not in PROXY_ALLOWED_HOSTS:
+    PROXY_ALLOWED_HOSTS.add(site_url.hostname)
+
+hostname = ogc_server_settings.hostname if ogc_server_settings else None
+if hostname not in PROXY_ALLOWED_HOSTS:
+    PROXY_ALLOWED_HOSTS.add(hostname)
 
 
 @requires_csrf_token
@@ -79,16 +86,13 @@ def proxy(
     access_token=None,
     **kwargs,
 ):
-    # Request default timeout
-    from geonode.geoserver.helpers import ogc_server_settings
 
     if not timeout:
         timeout = getattr(ogc_server_settings, "TIMEOUT", TIMEOUT)
 
-    # Security rules and settings
-    PROXY_ALLOWED_HOSTS = getattr(settings, "PROXY_ALLOWED_HOSTS", ())
+    PROXY_ALLOWED_PARAMS_NEEDLES = getattr(settings, "PROXY_ALLOWED_PARAMS_NEEDLES", ())
+    PROXY_ALLOWED_PATH_NEEDLES = getattr(settings, "PROXY_ALLOWED_PATH_NEEDLES", ())
 
-    # Sanity url checks
     if "url" not in request.GET and not url:
         return HttpResponse(
             "The proxy service requires a URL-encoded URL as a parameter.", status=400, content_type="text/plain"
@@ -104,38 +108,18 @@ def proxy(
     if url.fragment != "":
         locator += f"#{url.fragment}"
 
-    # White-Black Listing Hosts
-    site_url = urlsplit(settings.SITEURL)
-    if sec_chk_hosts and not settings.DEBUG:
-        # Attach current SITEURL
-        if site_url.hostname not in PROXY_ALLOWED_HOSTS:
-            PROXY_ALLOWED_HOSTS += (site_url.hostname,)
-
-        # Attach current hostname
-        hostname = (ogc_server_settings.hostname,) if ogc_server_settings else ()
-        if hostname not in PROXY_ALLOWED_HOSTS:
-            PROXY_ALLOWED_HOSTS += hostname
-
-        # Check OWS regexp
-        if url.query and ows_regexp.match(url.query):
-            ows_tokens = ows_regexp.match(url.query).groups()
-            if (
-                len(ows_tokens) == 4
-                and "version" == ows_tokens[0]
-                and StrictVersion(ows_tokens[1]) >= StrictVersion("1.0.0")
-                and StrictVersion(ows_tokens[1]) <= StrictVersion("3.0.0")
-                and ows_tokens[2].lower() in ("getcapabilities")
-                and ows_tokens[3].upper() in ("OWS", "WCS", "WFS", "WMS", "WPS", "CSW")
+    if sec_chk_hosts:
+        if url.hostname not in PROXY_ALLOWED_HOSTS:
+            if any(needle.lower() in url.query.lower() for needle in PROXY_ALLOWED_PARAMS_NEEDLES) or any(
+                needle.lower() in url.path.lower() for needle in PROXY_ALLOWED_PATH_NEEDLES
             ):
-                if url.hostname not in PROXY_ALLOWED_HOSTS:
-                    PROXY_ALLOWED_HOSTS += (url.hostname,)
+                PROXY_ALLOWED_HOSTS.add(url.hostname)
 
+        if url.hostname not in PROXY_ALLOWED_HOSTS:
         # Check Remote Services base_urls
-        from geonode.services.models import Service
-
-        for _s in Service.objects.all():
-            _remote_host = urlsplit(_s.base_url).hostname
-            PROXY_ALLOWED_HOSTS += (_remote_host,)
+            for _s in Service.objects.all():
+                _remote_host = urlsplit(_s.base_url).hostname
+                PROXY_ALLOWED_HOSTS.add(_remote_host)
 
         if not validate_host(extract_ip_or_domain(raw_url), PROXY_ALLOWED_HOSTS):
             return HttpResponse(
@@ -186,7 +170,6 @@ def proxy(
 
     # Avoid translating local geoserver calls into external ones
     if check_ogc_backend(geoserver.BACKEND_PACKAGE):
-        from geonode.geoserver.helpers import ogc_server_settings
 
         _url = _url.replace(f"{settings.SITEURL}geoserver", ogc_server_settings.LOCATION.rstrip("/"))
         _data = _data.replace(f"{settings.SITEURL}geoserver", ogc_server_settings.LOCATION.rstrip("/"))

--- a/geonode/services/models.py
+++ b/geonode/services/models.py
@@ -18,7 +18,7 @@
 #########################################################################
 import logging
 
-from urllib.parse import urlparse, urlsplit, ParseResult
+from urllib.parse import urlparse, ParseResult
 
 from django.db import models
 from django.conf import settings

--- a/geonode/services/models.py
+++ b/geonode/services/models.py
@@ -22,10 +22,9 @@ from urllib.parse import urlparse, urlsplit, ParseResult
 
 from django.db import models
 from django.conf import settings
-from django.db.models import signals
+
 from django.utils.translation import gettext_lazy as _
 
-from geonode.proxy.views import proxy_urls_registry
 from geonode.base.models import ResourceBase
 from geonode.harvesting.models import Harvester
 from geonode.layers.enumerations import GXP_PTYPES
@@ -129,18 +128,3 @@ class ServiceProfileRole(models.Model):
     role = models.CharField(
         choices=ROLE_VALUES, max_length=255, help_text=_("function performed by the responsible party")
     )
-
-
-def service_post_save(instance, sender, **kwargs):
-    service_hostname = urlsplit(instance.base_url).hostname
-    proxy_urls_registry.register_host(service_hostname)
-
-
-def service_post_delete(instance, sender, **kwargs):
-    service_hostname = urlsplit(instance.base_url).hostname
-    proxy_urls_registry.unregister_host(service_hostname)
-
-
-if "geonode.proxy" in settings.INSTALLED_APPS:
-    signals.post_save.connect(service_post_save, sender=Service)
-    signals.post_save.connect(service_post_delete, sender=Service)

--- a/geonode/services/models.py
+++ b/geonode/services/models.py
@@ -18,12 +18,14 @@
 #########################################################################
 import logging
 
-from urllib.parse import urlparse, ParseResult
+from urllib.parse import urlparse, urlsplit, ParseResult
 
 from django.db import models
 from django.conf import settings
+from django.db.models import signals
 from django.utils.translation import gettext_lazy as _
 
+from geonode.proxy.views import proxy_urls_registry
 from geonode.base.models import ResourceBase
 from geonode.harvesting.models import Harvester
 from geonode.layers.enumerations import GXP_PTYPES
@@ -127,3 +129,18 @@ class ServiceProfileRole(models.Model):
     role = models.CharField(
         choices=ROLE_VALUES, max_length=255, help_text=_("function performed by the responsible party")
     )
+
+
+def service_post_save(instance, sender, **kwargs):
+    service_hostname = urlsplit(instance.base_url).hostname
+    proxy_urls_registry.register_host(service_hostname)
+
+
+def service_post_delete(instance, sender, **kwargs):
+    service_hostname = urlsplit(instance.base_url).hostname
+    proxy_urls_registry.unregister_host(service_hostname)
+
+
+if "geonode.proxy" in settings.INSTALLED_APPS:
+    signals.post_save.connect(service_post_save, sender=Service)
+    signals.post_save.connect(service_post_delete, sender=Service)

--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -1289,6 +1289,11 @@ except ValueError:
         else re.split(r" *[,|:;] *", os.getenv("PROXY_ALLOWED_HOSTS"))
     )
 
+# Tuple with valid strings to be matched inside the request querystring to let it pass through the proxy
+PROXY_ALLOWED_PARAMS_NEEDLES = ()
+# Tuple with valid strings to be matched inside the request path to let it pass through the proxy
+PROXY_ALLOWED_PATH_NEEDLES = ()
+
 # The proxy to use when making cross origin requests.
 PROXY_URL = os.environ.get("PROXY_URL", "/proxy/?url=")
 

--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -1290,9 +1290,9 @@ except ValueError:
     )
 
 # Tuple with valid strings to be matched inside the request querystring to let it pass through the proxy
-PROXY_ALLOWED_PARAMS_NEEDLES = ()
+PROXY_ALLOWED_PARAMS_NEEDLES = ast.literal_eval(os.getenv("PROXY_ALLOWED_PARAMS_NEEDLES", "()"))
 # Tuple with valid strings to be matched inside the request path to let it pass through the proxy
-PROXY_ALLOWED_PATH_NEEDLES = ()
+PROXY_ALLOWED_PATH_NEEDLES = ast.literal_eval(os.getenv("PROXY_ALLOWED_PATH_NEEDLES", "()"))
 
 # The proxy to use when making cross origin requests.
 PROXY_URL = os.environ.get("PROXY_URL", "/proxy/?url=")

--- a/geonode/utils.py
+++ b/geonode/utils.py
@@ -1919,12 +1919,13 @@ def remove_credentials_from_url(url):
     return cleaned_url
 
 
+ip_regex = re.compile("^(?:http://|https://)(\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3})")
+domain_regex = re.compile("^(?:http://|https://)([a-zA-Z0-9.-]+)")
+
+
 def extract_ip_or_domain(url):
     # Decode the URL to handle percent-encoded characters
     _url = remove_credentials_from_url(unquote(url))
-
-    ip_regex = re.compile("^(?:http://|https://)(\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3})")
-    domain_regex = re.compile("^(?:http://|https://)([a-zA-Z0-9.-]+)")
 
     match = ip_regex.findall(_url)
     if len(match):


### PR DESCRIPTION
## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: black geonode && flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
