### PR TITLE
[Fixes #12261] Current user is assigned as owner on geoapp update

### DIFF
--- a/geonode/geoapps/api/serializers.py
+++ b/geonode/geoapps/api/serializers.py
@@ -61,12 +61,6 @@ class GeoAppSerializer(ResourceBaseSerializer):
 
         self.extra_update_checks(validated_data)
 
-    def validate(self, data):
-        request = self.context.get("request")
-        if request:
-            data["owner"] = request.user
-        return data
-
     def _sanitize_validated_data(self, validated_data, instance=None):
         # Extract users' profiles
         _user_profiles = {}

--- a/geonode/geoapps/api/tests.py
+++ b/geonode/geoapps/api/tests.py
@@ -238,3 +238,48 @@ class GeoAppsApiTests(APITestCase):
         self.assertEqual(exp.exception.category, "geoapp_api")
         self.assertEqual(exp.exception.default_code, "geoapp_exception")
         self.assertEqual(str(exp.exception.detail), "A GeoApp with the same 'name' already exists!")
+
+    def test_geoapp_creation_owner_is_mantained(self):
+        """
+        https://github.com/GeoNode/geonode/issues/12261
+        The geoapp owner should be mantained even if another
+        user save the instance.
+        """
+
+        url = f"{reverse('geoapps-list')}?include[]=data"
+        data = {
+            "name": "Test Create",
+            "title": "Test Create",
+            "resource_type": "geostory",
+            "extent": {"coords": [1123692.0, 5338214.0, 1339852.0, 5482615.0], "srid": "EPSG:3857"},
+        }
+
+        self.assertTrue(self.client.login(username="norman", password="norman"))
+
+        response = self.client.post(url, data=data, format="json")
+
+        self.assertEqual(201, response.status_code)
+        # let's check that the owner is the request one
+        self.assertEqual("norman", response.json()["geoapp"]["owner"]["username"])
+
+        # let's change the user of the request
+        self.assertTrue(self.client.login(username="admin", password="admin"))
+
+        sut = GeoApp.objects.get(pk=response.json()["geoapp"]["pk"])
+        # Update: PATCH
+        # we ensure that norman is the resource owner
+        self.assertEqual("norman", sut.owner.username)
+
+        url = reverse("geoapps-detail", kwargs={"pk": sut.pk})
+        data = {"blob": {"test_data": {"test": ["test_4", "test_5", "test_6"]}}}
+        # sending the update of the geoapp
+        response = self.client.patch(url, data=json.dumps(data), content_type="application/json")
+
+        self.assertEqual(response.status_code, 200)
+
+        # ensure that the value of the owner is not changed
+        sut.refresh_from_db()
+        self.assertEqual("norman", sut.owner.username)
+
+        # cleanup
+        sut.delete()

--- a/geonode/geoapps/api/views.py
+++ b/geonode/geoapps/api/views.py
@@ -59,3 +59,11 @@ class GeoAppViewSet(ApiPresetsInitializer, DynamicModelViewSet, AdvertisedListMi
     queryset = GeoApp.objects.all().order_by("-created")
     serializer_class = GeoAppSerializer
     pagination_class = GeoNodeApiPagination
+
+    def perform_create(self, serializer):
+        """
+        The owner is not passed from the FE
+        so we force the request.user to be the owner
+        in creation
+        """
+        return serializer.save(owner=self.request.user)


### PR DESCRIPTION
ref #12261 
## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: black geonode && flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
