### PR TITLE
[Fixes #12384] Uploaded thumbnail for 3dtiles resource is not saved

### DIFF
--- a/geonode/thumbs/tests/test_unit.py
+++ b/geonode/thumbs/tests/test_unit.py
@@ -24,6 +24,7 @@ from unittest.mock import patch, PropertyMock, MagicMock
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.gis.geos import Polygon
+from geonode.base.models import ResourceBase
 from geonode.documents.models import Document
 from geonode.geoapps.models import GeoApp
 from geonode.resource.manager import resource_manager
@@ -127,6 +128,16 @@ class ThumbnailsUnitTest(GeoNodeBaseTestSupport):
         self.assertIsNotNone(
             re.match(f"dataset-{self.re_uuid}-thumb.png", dataset_name, re.I),
             "Dataset name should meet a provided pattern",
+        )
+
+    def test_generate_thumbnail_name_resourcebase(self):
+        base_resource = resource_manager.create(
+            None, ResourceBase, defaults={"owner": get_user_model().objects.get(username="admin")}
+        )
+        thumbnail_name = thumbnails._generate_thumbnail_name(base_resource)
+        self.assertIsNotNone(
+            re.match(f"resourcebase-{self.re_uuid}-thumb.png", thumbnail_name, re.I),
+            "Map name should meet a provided pattern",
         )
 
     def test_get_unique_upload_path(self):

--- a/geonode/thumbs/thumbnails.py
+++ b/geonode/thumbs/thumbnails.py
@@ -234,8 +234,11 @@ def _generate_thumbnail_name(instance: Union[Dataset, Map, Document, GeoApp, Res
 
     elif isinstance(instance, GeoApp):
         file_name = f"geoapp-{instance.uuid}-thumb.png"
-    else:
+
+    elif isinstance(instance, ResourceBase):
         file_name = f"resourcebase-{instance.uuid}-thumb.png"
+    else:
+        raise ThumbnailError("Thumbnail generation didn't recognize the provided instance.")
 
     return file_name
 

--- a/geonode/thumbs/thumbnails.py
+++ b/geonode/thumbs/thumbnails.py
@@ -26,6 +26,7 @@ from django.conf import settings
 from django.utils.module_loading import import_string
 
 from geonode.base.enumerations import SOURCE_TYPE_REMOTE
+from geonode.base.models import ResourceBase
 from geonode.documents.models import Document
 from geonode.geoapps.models import GeoApp
 from geonode.maps.models import Map, MapLayer
@@ -207,7 +208,7 @@ def create_thumbnail(
     return instance.thumbnail_url
 
 
-def _generate_thumbnail_name(instance: Union[Dataset, Map, Document, GeoApp]) -> Optional[str]:
+def _generate_thumbnail_name(instance: Union[Dataset, Map, Document, GeoApp, ResourceBase]) -> Optional[str]:
     """
     Method returning file name for the thumbnail.
     If provided instance is a Map, and doesn't have any defined datasets, None is returned.
@@ -234,7 +235,7 @@ def _generate_thumbnail_name(instance: Union[Dataset, Map, Document, GeoApp]) ->
     elif isinstance(instance, GeoApp):
         file_name = f"geoapp-{instance.uuid}-thumb.png"
     else:
-        raise ThumbnailError("Thumbnail generation didn't recognize the provided instance.")
+        file_name = f"resourcebase-{instance.uuid}-thumb.png"
 
     return file_name
 


### PR DESCRIPTION
ref #12384
## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: black geonode && flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
