### PR TITLE
[Fixes #12433] Uncomment Build Lines in docker-compose.yml

### DIFF
--- a/create-envfile.py
+++ b/create-envfile.py
@@ -183,3 +183,27 @@ if __name__ == "__main__":
             logger.error("Please enter a valid response")
         if overwrite_env == "y":
             generate_env_file(args)
+
+    docker_compose_file_path = 'docker-compose.yml'
+    patterns_to_uncomment = [
+        '  #build:',
+        '  #    context: ./',
+        '  #    dockerfile: Dockerfile'
+    ]
+
+    patterns_to_uncomment = [pattern.replace('  #', ' *#') for pattern in patterns_to_uncomment]
+
+    with open(docker_compose_file_path, 'r') as file:
+        lines = file.readlines()
+
+    modified_lines = []
+    for line in lines:
+        modified_line = line
+        for pattern in patterns_to_uncomment:
+            if re.match(pattern.replace(' *#', ' *#?'), line):
+                modified_line = re.sub(' *#', '  ', line, count=1)
+                break
+        modified_lines.append(modified_line)
+
+    with open(docker_compose_file_path, 'w') as file:
+        file.writelines(modified_lines)


### PR DESCRIPTION
This Pull Request aims to enhance the user experience in setting up GeoNode versions 4.3.x by modifying the create-envfile.py script. The update will allow the script to automatically uncomment the build lines in the docker-compose.yml file, facilitating a smoother installation process, especially for users behind proxies or using minimal installations.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [ x Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: black geonode && flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
