### PR TITLE
[Fixes #12436] Linked resources are not present in maps api payload

### DIFF
--- a/geonode/base/api/serializers.py
+++ b/geonode/base/api/serializers.py
@@ -505,7 +505,11 @@ class LinkedResourceEmbeddedSerializer(DynamicModelSerializer):
         request = self.context.get("request", None)
         _resource = ResourceBase.objects.get(pk=instance)
 
-        return base_linked_resources_payload(_resource, request.user) if request and request.user and _resource else {}
+        return (
+            base_linked_resources_payload(_resource.get_real_instance(), request.user)
+            if request and request.user and _resource
+            else {}
+        )
 
 
 api_bbox_settable_resource_models = [Document, GeoApp]

--- a/geonode/storage/data_retriever.py
+++ b/geonode/storage/data_retriever.py
@@ -112,10 +112,9 @@ class DataItemRetriever(object):
                     for chunk in self._django_form_file.chunks():
                         tmp_file.write(chunk)
             else:
-                with (
-                    open(self.file_path, "wb") as tmp_file,
-                    smart_open.open(uri=self._original_file_uri, mode="rb") as original_file,
-                ):
+                with open(self.file_path, "wb") as tmp_file, smart_open.open(
+                    uri=self._original_file_uri, mode="rb"
+                ) as original_file:
                     for chunk in file_chunks_iterable(original_file):
                         tmp_file.write(chunk)
 

--- a/geonode/storage/data_retriever.py
+++ b/geonode/storage/data_retriever.py
@@ -112,9 +112,10 @@ class DataItemRetriever(object):
                     for chunk in self._django_form_file.chunks():
                         tmp_file.write(chunk)
             else:
-                with open(self.file_path, "wb") as tmp_file, smart_open.open(
-                    uri=self._original_file_uri, mode="rb"
-                ) as original_file:
+                with (
+                    open(self.file_path, "wb") as tmp_file,
+                    smart_open.open(uri=self._original_file_uri, mode="rb") as original_file,
+                ):
                     for chunk in file_chunks_iterable(original_file):
                         tmp_file.write(chunk)
 


### PR DESCRIPTION
ref #12436 

The `get_real_instance()` method should be called to use the proper model instance method instead of the base one to get the linked resources

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: black geonode && flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
