### PR TITLE
[Fixes #12484] Extend proxy allowed hosts to allow Link hosts connected to remote resources

### DIFF
--- a/geonode/proxy/utils.py
+++ b/geonode/proxy/utils.py
@@ -1,24 +1,34 @@
 from urllib.parse import urlsplit
 
 from django.conf import settings
+from django.db.models import signals
 
 
 site_url = urlsplit(settings.SITEURL)
 
+PROXIED_LINK_TYPES = ["OGC:WMS", "OGC:WFS", "data"]
+
 
 class ProxyUrlsRegistry:
+    _first_init = True
+
     def initialize(self):
+        from geonode.base.models import Link
         from geonode.geoserver.helpers import ogc_server_settings
-        from geonode.services.models import Service
 
         self.proxy_allowed_hosts = set([site_url.hostname] + list(getattr(settings, "PROXY_ALLOWED_HOSTS", ())))
 
         if ogc_server_settings:
-            self.proxy_allowed_hosts.add(ogc_server_settings.hostname)
+            self.register_host(ogc_server_settings.hostname)
 
-        for _s in Service.objects.all():
-            _remote_host = urlsplit(_s.base_url).hostname
-            self.proxy_allowed_hosts.add(_remote_host)
+        for link in Link.objects.filter(resource__sourcetype="REMOTE", link_type__in=PROXIED_LINK_TYPES):
+            remote_host = urlsplit(link.url).hostname
+            self.register_host(remote_host)
+
+        if self._first_init:
+            signals.post_save.connect(link_post_save, sender=Link)
+            signals.post_delete.connect(link_post_delete, sender=Link)
+            self._first_init = False
 
     def set(self, hosts):
         self.proxy_allowed_hosts = set(hosts)
@@ -39,3 +49,19 @@ class ProxyUrlsRegistry:
 
 
 proxy_urls_registry = ProxyUrlsRegistry()
+
+
+def link_post_save(instance, sender, **kwargs):
+    if (
+        instance.resource
+        and instance.resource.sourcetype == "REMOTE"
+        and instance.url
+        and instance.link_type in PROXIED_LINK_TYPES
+    ):
+        remote_host = urlsplit(instance.url).hostname
+        proxy_urls_registry.register_host(remote_host)
+
+
+def link_post_delete(instance, sender, **kwargs):
+    # We reinitialize the registry otherwise we might delete a host requested by another service with the same hostanme
+    proxy_urls_registry.initialize()


### PR DESCRIPTION
## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [ ] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [ ] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: black geonode && flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
