### PR TITLE
[Fixes #12674] store spatial file is always false during cloning

### DIFF
--- a/.env_dev
+++ b/.env_dev
@@ -166,9 +166,6 @@ DEBUG=True
 
 SECRET_KEY='myv-y4#7j-d*p-__@j#*3z@!y24fz8%^z2v6atuy4bo9vqr1_a'
 
-# STATIC_ROOT=/mnt/volumes/statics/static/
-# MEDIA_ROOT=/mnt/volumes/statics/uploaded/
-# GEOIP_PATH=/mnt/volumes/statics/geoip.db
 
 CACHE_BUSTING_STATIC_ENABLED=False
 

--- a/geonode/upload/handlers/common/raster.py
+++ b/geonode/upload/handlers/common/raster.py
@@ -125,7 +125,7 @@ class BaseRasterFileHandler(BaseHandler):
         """
         if action == exa.COPY.value:
             title = json.loads(_data.get("defaults"))
-            return {"title": title.pop("title")}, _data
+            return {"title": title.pop("title"), "store_spatial_file": True}, _data
 
         return {
             "skip_existing_layers": _data.pop("skip_existing_layers", "False"),

--- a/geonode/upload/handlers/common/remote.py
+++ b/geonode/upload/handlers/common/remote.py
@@ -102,7 +102,7 @@ class BaseRemoteResourceHandler(BaseHandler):
         """
         if action == exa.COPY.value:
             title = json.loads(_data.get("defaults"))
-            return {"title": title.pop("title")}, _data
+            return {"title": title.pop("title"), "store_spatial_file": True}, _data
 
         return {
             "source": _data.pop("source", "upload"),

--- a/geonode/upload/handlers/common/vector.py
+++ b/geonode/upload/handlers/common/vector.py
@@ -135,7 +135,7 @@ class BaseVectorFileHandler(BaseHandler):
         """
         if action == exa.COPY.value:
             title = json.loads(_data.get("defaults"))
-            return {"title": title.pop("title")}, _data
+            return {"title": title.pop("title"), "store_spatial_file": True}, _data
 
         return {
             "skip_existing_layers": _data.pop("skip_existing_layers", "False"),
@@ -258,7 +258,7 @@ class BaseVectorFileHandler(BaseHandler):
         that the execution is completed
         """
         _exec = BaseHandler.perform_last_step(execution_id=execution_id)
-        if _exec and not _exec.input_params.get("store_spatial_file", False):
+        if _exec and not _exec.input_params.get("store_spatial_file", True):
             resources = ResourceHandlerInfo.objects.filter(execution_request=_exec)
             # getting all assets list
             assets = filter(None, [get_default_asset(x.resource) for x in resources])

--- a/geonode/upload/handlers/shapefile/handler.py
+++ b/geonode/upload/handlers/shapefile/handler.py
@@ -103,7 +103,7 @@ class ShapeFileHandler(BaseVectorFileHandler):
         """
         if action == exa.COPY.value:
             title = json.loads(_data.get("defaults"))
-            return {"title": title.pop("title")}, _data
+            return {"title": title.pop("title"), "store_spatial_file": True}, _data
 
         additional_params = {
             "skip_existing_layers": _data.pop("skip_existing_layers", "False"),

--- a/geonode/upload/handlers/tiles3d/handler.py
+++ b/geonode/upload/handlers/tiles3d/handler.py
@@ -146,7 +146,7 @@ class Tiles3DFileHandler(BaseVectorFileHandler):
         """
         if action == exa.COPY.value:
             title = json.loads(_data.get("defaults"))
-            return {"title": title.pop("title")}, _data
+            return {"title": title.pop("title"), "store_spatial_file": True}, _data
 
         return {
             "skip_existing_layers": _data.pop("skip_existing_layers", "False"),

--- a/geonode/upload/handlers/tiles3d/tests.py
+++ b/geonode/upload/handlers/tiles3d/tests.py
@@ -99,7 +99,7 @@ class TestTiles3DFileHandler(TestCase):
             action="copy",
         )
 
-        self.assertEqual(actual, {"title": "title_of_the_cloned_resource"})
+        self.assertEqual(actual, {'store_spatial_file': True, 'title': 'title_of_the_cloned_resource'})
 
     def test_is_valid_should_raise_exception_if_the_3dtiles_is_invalid(self):
         data = {"base_file": "/using/double/dot/in/the/name/is/an/error/file.invalid.json"}

--- a/geonode/upload/handlers/tiles3d/tests.py
+++ b/geonode/upload/handlers/tiles3d/tests.py
@@ -99,7 +99,7 @@ class TestTiles3DFileHandler(TestCase):
             action="copy",
         )
 
-        self.assertEqual(actual, {'store_spatial_file': True, 'title': 'title_of_the_cloned_resource'})
+        self.assertEqual(actual, {"store_spatial_file": True, "title": "title_of_the_cloned_resource"})
 
     def test_is_valid_should_raise_exception_if_the_3dtiles_is_invalid(self):
         data = {"base_file": "/using/double/dot/in/the/name/is/an/error/file.invalid.json"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -87,7 +87,7 @@ geonode-pinax-notifications==6.0.0.2
 
 # GeoNode org maintained apps.
 # django-geonode-mapstore-client==4.0.5
-git+https://github.com/GeoNode/geonode-mapstore-client.git@master#egg=django_geonode_mapstore_client
+git+https://github.com/GeoNode/geonode-mapstore-client.git@ISSUE_12657#egg=django_geonode_mapstore_client
 django-avatar==8.0.0
 geonode-oauth-toolkit==2.2.2.2
 geonode-user-messages==2.0.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -87,7 +87,7 @@ geonode-pinax-notifications==6.0.0.2
 
 # GeoNode org maintained apps.
 # django-geonode-mapstore-client==4.0.5
-git+https://github.com/GeoNode/geonode-mapstore-client.git@ISSUE_12657#egg=django_geonode_mapstore_client
+git+https://github.com/GeoNode/geonode-mapstore-client.git@master#egg=django_geonode_mapstore_client
 django-avatar==8.0.0
 geonode-oauth-toolkit==2.2.2.2
 geonode-user-messages==2.0.2.2


### PR DESCRIPTION
ref https://github.com/GeoNode/geonode/issues/12674
for 44x -> https://github.com/GeoNode/geonode-importer/pull/277
## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] PR title must be in the form "[Fixes #<issue_number>] Title of the PR"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: black geonode && flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
