### PR TITLE
[Fixes #12616] Document upload permissions fix

### DIFF
--- a/.clabot
+++ b/.clabot
@@ -77,6 +77,7 @@
     "ahmdthr",
     "fvicent",
     "RegisSinjari",
-    "Gpetrak"
+    "Gpetrak",
+    "kilichenko-pixida"
   ]
 }

--- a/geonode/documents/api/views.py
+++ b/geonode/documents/api/views.py
@@ -137,7 +137,7 @@ class DocumentViewSet(ApiPresetsInitializer, DynamicModelViewSet, AdvertisedList
 
             resource.set_missing_info()
             resourcebase_post_save(resource.get_real_instance())
-            resource_manager.set_permissions(None, instance=resource, permissions=None, created=True)
+            resource.set_default_permissions(owner=self.request.user, created=True)
             resource.handle_moderated_uploads()
             resource_manager.set_thumbnail(resource.uuid, instance=resource, overwrite=False)
             return resource

--- a/geonode/documents/views.py
+++ b/geonode/documents/views.py
@@ -200,9 +200,7 @@ class DocumentUploadView(CreateView):
             )
 
         self.object.handle_moderated_uploads()
-        resource_manager.set_permissions(
-            None, instance=self.object, permissions=form.cleaned_data["permissions"], created=True
-        )
+        self.object.set_default_permissions(owner=self.request.user, created=True)
 
         abstract = None
         date = None


### PR DESCRIPTION
Aims to resolve https://github.com/GeoNode/geonode/issues/12616

It seems like the problem was that permissions were assigned to None both when handling UI and API document upload. On UI it didn't cause a problem because in UI upload there is also a call setting permissions to defaults again. Here I am removing the unnecceary assigment of permissions to None in UI code and setting permissiosn to defaults in API code.


- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.
- [X] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [X] PR title must be in the form "[Fixes #<issue_number>] Title of the PR"
