### PR TITLE
[Fixes #12763] 3D tiles geometricError mandatory field should be on tileset level

### DIFF
--- a/geonode/upload/handlers/tiles3d/handler.py
+++ b/geonode/upload/handlers/tiles3d/handler.py
@@ -138,7 +138,7 @@ class Tiles3DFileHandler(BaseVectorFileHandler):
         if not volume:
             raise Invalid3DTilesException("The mandatory 'boundingVolume' for the key 'root' is missing")
 
-        error = payload.get("root", {}).get("geometricError", None)
+        error = payload.get("geometricError", None) or payload.get("root", {}).get("geometricError", None)
         if error is None:
             raise Invalid3DTilesException("The mandatory 'geometricError' for the key 'root' is missing")
 

--- a/geonode/upload/handlers/tiles3d/tests.py
+++ b/geonode/upload/handlers/tiles3d/tests.py
@@ -154,7 +154,6 @@ class TestTiles3DFileHandler(TestCase):
     def test_validate_should_raise_exception_for_invalid_root_geometricError(self):
         _json = {
             "asset": {"version": "1.1"},
-            "geometricError": 1.0,
             "root": {"boundingVolume": {"box": []}, "foo": 0.0},
         }
         _path = "/tmp/tileset.json"

--- a/geonode/upload/handlers/tiles3d/tests.py
+++ b/geonode/upload/handlers/tiles3d/tests.py
@@ -163,7 +163,10 @@ class TestTiles3DFileHandler(TestCase):
             self.handler.is_valid(files={"base_file": _path}, user=self.user)
 
         self.assertIsNotNone(_exc)
-        self.assertTrue("The mandatory 'geometricError' for the key 'root' is missing" in str(_exc.exception.detail))
+        self.assertTrue(
+            "The provided 3DTiles is not valid, some of the mandatory keys are missing. Mandatory keys are: 'asset', 'geometricError', 'root'"
+            in str(_exc.exception.detail)
+        )
         os.remove(_path)
 
     def test_get_ogr2ogr_driver_should_return_the_expected_driver(self):

--- a/geonode/upload/tests/end2end/test_end2end.py
+++ b/geonode/upload/tests/end2end/test_end2end.py
@@ -457,7 +457,7 @@ class ImporterWMSImportTest(BaseImporterEndToEndTest):
             "parse_remote_metadata": True,
             "action": "upload",
         }
-        initial_name = res.title
+        initial_name = res.title.lower().replace(" ", "_")
         assert_payload = {
             "subtype": "remote",
             "title": res.title,


### PR DESCRIPTION
ref #12763 
## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] PR title must be in the form "[Fixes #<issue_number>] Title of the PR"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: black geonode && flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
