### PR TITLE
[Backport Fixes #12828] New remote datasets are not registered inside…

### DIFF
--- a/geonode/proxy/utils.py
+++ b/geonode/proxy/utils.py
@@ -2,7 +2,7 @@ from urllib.parse import urlsplit
 
 from django.conf import settings
 from django.db.models import signals
-
+from django.utils.timezone import now
 
 site_url = urlsplit(settings.SITEURL)
 
@@ -11,6 +11,8 @@ PROXIED_LINK_TYPES = ["OGC:WMS", "OGC:WFS", "data"]
 
 class ProxyUrlsRegistry:
     _first_init = True
+    _last_registry_load = None
+    _registry_reload_threshold = getattr(settings, "PROXY_RELOAD_REGISTRY_THRESHOLD_DAYS", 1)
 
     def initialize(self):
         from geonode.base.models import Link
@@ -30,12 +32,16 @@ class ProxyUrlsRegistry:
             signals.post_delete.connect(link_post_delete, sender=Link)
             self._first_init = False
 
+        self._last_registry_load = now()
+
     def set(self, hosts):
         self.proxy_allowed_hosts = set(hosts)
+        self._last_registry_load = now()
         return self
 
     def clear(self):
         self.proxy_allowed_hosts = set()
+        self._last_registry_load = now()
         return self
 
     def register_host(self, host):
@@ -45,6 +51,11 @@ class ProxyUrlsRegistry:
         self.proxy_allowed_hosts.remove(host)
 
     def get_proxy_allowed_hosts(self):
+        if (
+            self._last_registry_load is None
+            or (now() - self._last_registry_load).days >= self._registry_reload_threshold
+        ):
+            self.initialize()
         return self.proxy_allowed_hosts
 
 


### PR DESCRIPTION
… proxy allowed hosts when GeoNode runs asynchoronously

<Include a few sentences describing the overall goals for this Pull Request>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] PR title must be in the form "[Fixes #<issue_number>] Title of the PR"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: black geonode && flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
