### PR TITLE
[Fixes #12921] Fix Layers admin interface raise error

### DIFF
--- a/geonode/base/forms.py
+++ b/geonode/base/forms.py
@@ -247,9 +247,6 @@ class TKeywordForm(forms.ModelForm):
         queryset=ThesaurusKeyword.objects.prefetch_related(
             Prefetch("keyword", queryset=ThesaurusKeywordLabel.objects.filter(lang="en"))
         ),
-        widget=autocomplete.ModelSelect2Multiple(
-            url="thesaurus_autocomplete",
-        ),
         label=_("Keywords from Thesaurus"),
         required=False,
         help_text=_(

--- a/geonode/documents/admin.py
+++ b/geonode/documents/admin.py
@@ -36,7 +36,7 @@ class DocumentAdminForm(ResourceBaseAdminForm):
 
 
 class DocumentAdmin(TabbedTranslationAdmin):
-    exclude = ("ll_bbox_polygon", "bbox_polygon", "srid")
+    exclude = ("ll_bbox_polygon", "bbox_polygon", "srid", "tkeywords")
     list_display = (
         "id",
         "title",

--- a/geonode/geoapps/admin.py
+++ b/geonode/geoapps/admin.py
@@ -32,7 +32,7 @@ class GeoAppAdminForm(ResourceBaseAdminForm):
 
 
 class GeoAppAdmin(TabbedTranslationAdmin):
-    exclude = ("ll_bbox_polygon", "bbox_polygon", "srid")
+    exclude = ("ll_bbox_polygon", "bbox_polygon", "srid", "tkeywords")
     list_display_links = ("title",)
     list_display = (
         "id",

--- a/geonode/layers/admin.py
+++ b/geonode/layers/admin.py
@@ -29,8 +29,6 @@ from geonode.base.admin import metadata_batch_edit
 from geonode.base.fields import MultiThesauriField
 from geonode.base.models import ThesaurusKeyword, ThesaurusKeywordLabel
 
-from dal import autocomplete
-
 
 class AttributeInline(admin.TabularInline):
     model = Attribute
@@ -44,9 +42,6 @@ class DatasetAdminForm(ResourceBaseAdminForm):
     tkeywords = MultiThesauriField(
         queryset=ThesaurusKeyword.objects.prefetch_related(
             Prefetch("keyword", queryset=ThesaurusKeywordLabel.objects.filter(lang="en"))
-        ),
-        widget=autocomplete.ModelSelect2Multiple(
-            url="thesaurus_autocomplete",
         ),
         label=("Keywords from Thesaurus"),
         required=False,

--- a/geonode/layers/admin.py
+++ b/geonode/layers/admin.py
@@ -18,16 +18,12 @@
 #########################################################################
 
 from django.contrib import admin
-from django.db.models import Prefetch
 
 from modeltranslation.admin import TabbedTranslationAdmin
 
 from geonode.base.admin import ResourceBaseAdminForm
 from geonode.layers.models import Dataset, Attribute, Style
 from geonode.base.admin import metadata_batch_edit
-
-from geonode.base.fields import MultiThesauriField
-from geonode.base.models import ThesaurusKeyword, ThesaurusKeywordLabel
 
 
 class AttributeInline(admin.TabularInline):
@@ -39,18 +35,9 @@ class DatasetAdminForm(ResourceBaseAdminForm):
         model = Dataset
         fields = "__all__"
 
-    tkeywords = MultiThesauriField(
-        queryset=ThesaurusKeyword.objects.prefetch_related(
-            Prefetch("keyword", queryset=ThesaurusKeywordLabel.objects.filter(lang="en"))
-        ),
-        label=("Keywords from Thesaurus"),
-        required=False,
-        help_text=("List of keywords from Thesaurus",),
-    )
-
 
 class DatasetAdmin(TabbedTranslationAdmin):
-    exclude = ("ll_bbox_polygon", "bbox_polygon", "srid")
+    exclude = ("ll_bbox_polygon", "bbox_polygon", "srid", "tkeywords")
     list_display = (
         "id",
         "alternate",

--- a/geonode/maps/admin.py
+++ b/geonode/maps/admin.py
@@ -44,7 +44,7 @@ class MapAdmin(TabbedTranslationAdmin):
     inlines = [
         MapLayerInline,
     ]
-    exclude = ("ll_bbox_polygon", "bbox_polygon", "srid")
+    exclude = ("ll_bbox_polygon", "bbox_polygon", "srid", "tkeywords")
     list_display_links = ("title",)
     list_display = (
         "id",


### PR DESCRIPTION
ref #12921 

The new metadata editor require an id while calling the autocomplete endpoint, so we cannot switch to it.
It means that we can mantain the tkeywords in the admin interface, but without autocomplete (like we have for regions and other metadata):
![image](https://github.com/user-attachments/assets/c1095360-5dd4-4502-ac92-7b0bc0ae13e5)


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] PR title must be in the form "[Fixes #<issue_number>] Title of the PR"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: black geonode && flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
