### PR TITLE
[Fixes #12981] Fix encoding for Shapefile uploads

### DIFF
--- a/geonode/upload/handlers/shapefile/handler.py
+++ b/geonode/upload/handlers/shapefile/handler.py
@@ -165,7 +165,7 @@ class ShapeFileHandler(BaseVectorFileHandler):
         if layer is not None and "Point" not in ogr.GeometryTypeToName(layer.GetGeomType()):
             additional_options.append("-nlt PROMOTE_TO_MULTI")
         if encoding:
-            additional_options.append(f"-lco ENCODING={encoding}")
+            additional_options.append(f"--config SHAPE_ENCODING {encoding}")
 
         return (
             f"{base_command } -lco precision=no -lco GEOMETRY_NAME={BaseVectorFileHandler().default_geometry_column_name} "

--- a/geonode/upload/handlers/shapefile/tests.py
+++ b/geonode/upload/handlers/shapefile/tests.py
@@ -137,7 +137,7 @@ class TestShapeFileFileHandler(TestCase):
             actual = self.handler.create_ogr2ogr_command(shp_with_cst, "a", False, "a")
 
             _file.assert_called_once_with(cst_file, "r")
-            self.assertIn("ENCODING=UTF-8", actual)
+            self.assertIn("--config SHAPE_ENCODING UTF-8", actual)
 
     @patch("geonode.upload.handlers.common.vector.Popen")
     def test_import_with_ogr2ogr_without_errors_should_call_the_right_command(self, _open):


### PR DESCRIPTION
Use `SHAPE_ENCODING` parameter to inform the ogr2ogr command of the encoding for the Shapefile so it can transform accordingly.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] PR title must be in the form "[Fixes #<issue_number>] Title of the PR"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: black geonode && flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
