### PR TITLE
[Fixes #12998] Metadata editor: improve return info when updating data

### DIFF
--- a/geonode/metadata/i18n.py
+++ b/geonode/metadata/i18n.py
@@ -2,6 +2,8 @@ import logging
 
 from django.db import connection
 
+from geonode.base.models import ThesaurusKeywordLabel
+
 logger = logging.getLogger(__name__)
 
 I18N_THESAURUS_IDENTIFIER = "labels-i18n"
@@ -54,3 +56,13 @@ def get_localized_tkeywords(lang, thesaurus_identifier: str):
 
 def get_localized_labels(lang, key="about"):
     return {i[key]: i["label"] for i in get_localized_tkeywords(lang, I18N_THESAURUS_IDENTIFIER)}
+
+
+def get_localized_label(lang, about):
+    return (
+        ThesaurusKeywordLabel.objects.filter(
+            keyword__thesaurus__identifier=I18N_THESAURUS_IDENTIFIER, keyword__about=about, lang=lang
+        )
+        .values_list("label", flat=True)
+        .first()
+    )

--- a/geonode/metadata/tests/tests.py
+++ b/geonode/metadata/tests/tests.py
@@ -245,11 +245,30 @@ class MetadataApiTests(APITestCase):
         mock_update_schema_instance.return_value = errors
 
         response = self.client.put(url, data=fake_payload, format="json")
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
         self.assertJSONEqual(
             response.content,
             {"message": "Some errors were found while updating the resource", "extraErrors": errors},
         )
+        mock_update_schema_instance.assert_called_with(self.resource, fake_payload)
+
+    @patch("geonode.metadata.manager.metadata_manager.update_schema_instance")
+    @patch("geonode.base.api.permissions.UserHasPerms.has_permission", return_value=True)
+    def test_put_patch_schema_instance_with_bad_payload(self, mock_has_permission, mock_update_schema_instance):
+        """
+        Test the PUT method with an invalid json payload
+        """
+
+        url = reverse("metadata-schema_instance", kwargs={"pk": self.resource.pk})
+        fake_payload = "I_AM_BAD"
+
+        # Set fake errors
+        errors = {"fake_error_1": "Field 'title' is required", "fake_error_2": "Invalid value for 'type'"}
+        mock_update_schema_instance.return_value = errors
+
+        response = self.client.put(url, data=fake_payload, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
         mock_update_schema_instance.assert_called_with(self.resource, fake_payload)
 
     @patch("geonode.base.api.permissions.UserHasPerms.has_permission", return_value=True)


### PR DESCRIPTION
- different HTTP return code according to the error
- possibility to localize the return message


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [ ] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [ ] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] PR title must be in the form "[Fixes #<issue_number>] Title of the PR"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: black geonode && flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
