### PR TITLE
[FIXIES #13030] Endpoint to delete a resource's thumbnail

### DIFF
--- a/geonode/base/api/tests.py
+++ b/geonode/base/api/tests.py
@@ -2000,16 +2000,16 @@ class BaseApiTests(APITestCase):
 
     @patch("geonode.base.api.views.remove_thumb")
     def test_delete_thumbnail(self, mock_remove_thumb):
-        
+
         resource = Dataset.objects.first()
-        
+
         # Set a thumbnail url and path
         resource.thumbnail_url = "http://example.com/thumb/test.png"
         resource.thumbnail_path = "thumb/test.png"
         resource.save()
 
         url = reverse("base-resources-delete-thumbnail", kwargs={"resource_id": resource.id})
-        
+
         # Anonymous user
         response = self.client.post(url)
         self.assertEqual(response.status_code, 403)
@@ -2047,7 +2047,7 @@ class BaseApiTests(APITestCase):
         self.assertEqual(response.status_code, 404)
         self.assertEqual(response.data["message"], "Resource not found.")
         self.assertFalse(response.data["success"])
-    
+
     def test_set_thumbnail_from_bbox_from_Anonymous_user_raise_permission_error(self):
         """
         Given a request with Anonymous user, should raise an authentication error.

--- a/geonode/base/api/tests.py
+++ b/geonode/base/api/tests.py
@@ -1998,6 +1998,56 @@ class BaseApiTests(APITestCase):
                 )
                 self.assertEqual(response.status_code, 200)
 
+    @patch("geonode.base.api.views.remove_thumb")
+    def test_delete_thumbnail(self, mock_remove_thumb):
+        
+        resource = Dataset.objects.first()
+        
+        # Set a thumbnail url and path
+        resource.thumbnail_url = "http://example.com/thumb/test.png"
+        resource.thumbnail_path = "thumb/test.png"
+        resource.save()
+
+        url = reverse("base-resources-delete-thumbnail", kwargs={"resource_id": resource.id})
+        
+        # Anonymous user
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 403)
+
+        # Authenticated user (admin)
+        self.assertTrue(self.client.login(username="admin", password="admin"))
+
+        # Valid thumbnail removal
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["message"], "Thumbnail deleted successfully.")
+        resource.refresh_from_db()
+        self.assertIsNone(resource.thumbnail_url)
+        self.assertIsNone(resource.thumbnail_path)
+        mock_remove_thumb.assert_called_once_with("test.png")
+
+        # Thumbnail already deleted
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["message"], "The thumbnail URL field is already empty.")
+        self.assertFalse(response.data["success"])
+
+        # Invalid image format
+        resource.thumbnail_url = "http://example.com/media/thumb/test.txt"
+        resource.thumbnail_path = "thumb/test.txt"
+        resource.save()
+
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("not a valid image", response.data)
+
+        # Resource does not exist
+        invalid_url = reverse("base-resources-delete-thumbnail", kwargs={"resource_id": 9999})
+        response = self.client.post(invalid_url)
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.data["message"], "Resource not found.")
+        self.assertFalse(response.data["success"])
+    
     def test_set_thumbnail_from_bbox_from_Anonymous_user_raise_permission_error(self):
         """
         Given a request with Anonymous user, should raise an authentication error.

--- a/geonode/base/api/views.py
+++ b/geonode/base/api/views.py
@@ -57,7 +57,7 @@ from geonode.favorite.models import Favorite
 from geonode.base.models import Configuration, ExtraMetadata, LinkedResource
 from geonode.thumbs.exceptions import ThumbnailError
 from geonode.thumbs.thumbnails import create_thumbnail
-from geonode.thumbs.utils import _decode_base64, BASE64_PATTERN
+from geonode.thumbs.utils import _decode_base64, BASE64_PATTERN, remove_thumb
 from geonode.groups.conf import settings as groups_settings
 from geonode.base.models import HierarchicalKeyword, Region, ResourceBase, TopicCategory, ThesaurusKeyword
 from geonode.base.api.filters import (
@@ -721,6 +721,60 @@ class ResourceBaseViewSet(ApiPresetsInitializer, DynamicModelViewSet, Advertised
             logger.error(e)
             return Response(data={"message": e.args[0], "success": False}, status=500, exception=True)
 
+    @extend_schema(
+        methods=["post"],
+        responses={200},
+        description="API endpoint allowing to delete a thumbnail for an existing dataset.",
+    )
+    @action(
+        detail=False,
+        url_path="(?P<resource_id>\d+)/delete_thumbnail",  # noqa
+        url_name="delete-thumbnail",
+        methods=["post"],
+        permission_classes=[IsAuthenticated, UserHasPerms(perms_dict={"default": {"POST": ["base.add_resourcebase"]}})],
+    )
+
+    def delete_thumbnail(self, request, resource_id, *args, **kwargs):
+        
+        try:
+            resource = ResourceBase.objects.get(id=int(resource_id))
+
+            if not isinstance(resource.get_real_instance(), (Dataset, Map)):
+                return Response(
+                {"message": "Endpoint only available for Datasets and Maps.", "success": False},
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
+            # Check if thumbnail exists
+            if not resource.thumbnail_url:
+                return Response(
+                    {"message": "The thumbnail URL field is already empty.", "success": False},
+                    status=status.HTTP_200_OK
+                )
+
+            # request_body = request.data if request.data else json.loads(request.body)
+            thumb_parsed_url = urlparse(resource.thumbnail_url)
+            thumb_filename = thumb_parsed_url.path.split("/")[-1]
+            # remove_thumb will call the thumb_path function and then the storage_manager which will delete it
+            remove_thumb(thumb_filename)
+
+            # Clear the field in the database
+            resource.thumbnail_url = ""
+            resource.save(update_fields=["thumbnail_url"])
+
+            return Response(
+                    {"message": "Thumbnail deleted successfully.", "success": True}, status=status.HTTP_200_OK
+            )
+
+        except ResourceBase.DoesNotExist:
+            return Response({"message": "Resource not found.", "success": False}, status=status.HTTP_404_NOT_FOUND)
+        except ValueError:
+            return Response({"message": "Invalid resource ID.", "success": False}, status=status.HTTP_400_BAD_REQUEST)
+        except Exception as e:
+            logger.error(e)
+            return Response({"message": "Unexpected error occurred.", "success": False}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+    
     @extend_schema(
         methods=["post"], responses={200}, description="Instructs the Async dispatcher to execute a 'INGEST' operation."
     )


### PR DESCRIPTION
This PR is created according to this issue #13030 . The endpoint will delete the thumbnail image from disk and the corresponding database fields: thumbnail_field and thumbnail_path

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] PR title must be in the form "[Fixes #<issue_number>] Title of the PR"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: black geonode && flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
