### PR TITLE
[Fixies #13057] Removing Twisted library from the dependencies and the related code

### DIFF
--- a/geonode/tests/suite/base.py
+++ b/geonode/tests/suite/base.py
@@ -37,4 +37,3 @@ def destroy_test_db(database_name):
 
 def load_db_fixtures(fixtures):
     call_command("loaddata", *fixtures)
-

--- a/geonode/tests/suite/base.py
+++ b/geonode/tests/suite/base.py
@@ -1,5 +1,3 @@
-from twisted.python import log
-
 from django.conf import settings
 from django.core import management
 from django.core.management import call_command
@@ -40,29 +38,3 @@ def destroy_test_db(database_name):
 def load_db_fixtures(fixtures):
     call_command("loaddata", *fixtures)
 
-
-def setup_test_db(worker_index, fixtures, fn, *args):
-    management.get_commands()
-    management._commands["syncdb"] = "django.core"
-
-    old_name = settings.DATABASES["default"]["NAME"]
-    if worker_index is not None:
-        test_database_name = f"test_{worker_index}_{old_name}"
-    else:
-        test_database_name = f"test_{old_name}"
-
-    create_test_db(test_database_name)
-    if fixtures:
-        load_db_fixtures(fixtures)
-
-    result = None
-    try:
-        result = fn(*args)
-    except Exception as e:
-        log.err(str(e))
-        raise
-    finally:
-        destroy_test_db(test_database_name)
-
-    connection.settings_dict["NAME"] = old_name
-    return result

--- a/requirements.txt
+++ b/requirements.txt
@@ -161,7 +161,6 @@ pytest-splinter==3.3.2
 pytest-django==4.8.0
 pip==24.1.2
 setuptools>=70.2.0,<70.3.0
-Twisted==24.3.0
 pixelmatch==0.3.0
 factory-boy==3.3.0
 flaky==3.8.1

--- a/requirements_tests.txt
+++ b/requirements_tests.txt
@@ -1,3 +1,2 @@
-Twisted
 pixelmatch==0.3.0
 setuptools>=65.5.1 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/setup.cfg
+++ b/setup.cfg
@@ -183,7 +183,6 @@ install_requires =
     pytest-django==4.8.0
     pip==24.1.2
     setuptools>=70.2.0,<70.3.0
-    Twisted==24.3.0
     pixelmatch==0.3.0
     factory-boy==3.3.0
     flaky==3.8.1


### PR DESCRIPTION
This PR was created according to this issue: #13057 The Twisted library is used by `TwistedParallelTestSuiteRunner` class but this runner is not used by the testing suite. Thus, it can be completely removed.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] PR title must be in the form "[Fixes #<issue_number>] Title of the PR"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: black geonode && flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
