### PR TITLE
[Fixes #13043] Metadata editor: allow customization of error messages

### DIFF
--- a/geonode/metadata/api/views.py
+++ b/geonode/metadata/api/views.py
@@ -111,7 +111,7 @@ class MetadataViewSet(ViewSet):
                 #     logger.debug(f"handling content {json.dumps(request.data, indent=3)}")
                 # except Exception as e:
                 #     logger.warning(f"Can't parse JSON {request.data}: {e}")
-                errors = metadata_manager.update_schema_instance(resource, request.data)
+                errors = metadata_manager.update_schema_instance(resource, request.data, lang)
 
                 msg_t = (
                     ("m_metadata_update_error", "Some errors were found while updating the resource")

--- a/geonode/metadata/handlers/base.py
+++ b/geonode/metadata/handlers/base.py
@@ -229,4 +229,8 @@ class BaseHandler(MetadataHandler):
             setattr(resource, field_name, field_value)
         except Exception as e:
             logger.warning(f"Error setting field {field_name}={field_value}: {e}")
-            self._set_error(errors, [field_name], "Error while storing field. Contact your administrator")
+            self._set_error(
+                errors,
+                [field_name],
+                self.localize_message(context, "metadata_error_store", {"fieldname": field_name, "exc": e}),
+            )

--- a/geonode/metadata/handlers/contact.py
+++ b/geonode/metadata/handlers/contact.py
@@ -142,7 +142,13 @@ class ContactHandler(MetadataHandler):
             if rolename == Roles.OWNER.name:
                 if not users:
                     logger.warning(f"User not specified for role '{rolename}'")
-                    self._set_error(errors, ["contacts", rolename], f"User not specified for role '{rolename}'")
+                    self._set_error(
+                        errors,
+                        ["contacts", rolename],
+                        self.localize_message(
+                            context, "metadata_contact_error_missing_role", {"fieldname": field_name, "role": rolename}
+                        ),
+                    )
                 else:
                     resource.owner = get_user_model().objects.get(pk=users["id"])
             else:

--- a/geonode/metadata/handlers/sparse.py
+++ b/geonode/metadata/handlers/sparse.py
@@ -159,14 +159,32 @@ class SparseHandler(MetadataHandler):
                 field_value = str(float(bare_value)) if bare_value is not None else None
             except ValueError as e:
                 logger.warning(f"Error parsing sparse field '{field_name}'::'{field_type}'='{bare_value}': {e}")
-                self._set_error(errors, [field_name], f"Error parsing number '{bare_value}'")
+                self._set_error(
+                    errors,
+                    [field_name],
+                    self.localize_message(
+                        context,
+                        "metadata_sparse_error_parse",
+                        {"fieldname": field_name, "type": "number", "value": bare_value},
+                    ),
+                )
+
                 return
         elif self._check_type(field_type, "integer"):
             try:
                 field_value = str(int(bare_value)) if bare_value is not None else None
             except ValueError as e:
                 logger.warning(f"Error parsing sparse field '{field_name}'::'{field_type}'='{bare_value}': {e}")
-                self._set_error(errors, [field_name], f"Error parsing integer '{bare_value}'")
+                self._set_error(
+                    errors,
+                    [field_name],
+                    self.localize_message(
+                        context,
+                        "metadata_sparse_error_parse",
+                        {"fieldname": field_name, "type": "integer", "value": bare_value},
+                    ),
+                )
+
                 return
         elif field_type == "array":
             field_value = json.dumps(bare_value) if bare_value is not None else "[]"
@@ -174,7 +192,13 @@ class SparseHandler(MetadataHandler):
             field_value = json.dumps(bare_value) if bare_value is not None else "{}"
         else:
             logger.warning(f"Unhandled type '{field_type}' for sparse field '{field_name}'")
-            self._set_error(errors, [field_name], f"Unhandled type {field_type}. Contact your administrator")
+            self._set_error(
+                errors,
+                [field_name],
+                self.localize_message(
+                    context, "metadata_sparse_error_type", {"fieldname": field_name, "type": field_type}
+                ),
+            )
             return
 
         try:
@@ -185,8 +209,16 @@ class SparseHandler(MetadataHandler):
             elif is_nullable:
                 SparseField.objects.filter(resource=resource, name=field_name).delete()
             else:
-                self._set_error(errors, [field_name], f"Empty value not stored for field '{field_name}'")
+                self._set_error(
+                    errors,
+                    [field_name],
+                    self.localize_message(context, "metadata_error_empty_field", {"fieldname": field_name}),
+                )
                 logger.debug(f"Not setting null value for {field_name}")
         except Exception as e:
             logger.warning(f"Error setting field {field_name}={field_value}: {e}")
-            self._set_error(errors, [field_name], f"Error setting value: {e}")
+            self._set_error(
+                errors,
+                [field_name],
+                self.localize_message(context, "metadata_error_store", {"fieldname": field_name, "exc": e}),
+            )

--- a/geonode/metadata/i18n.py
+++ b/geonode/metadata/i18n.py
@@ -1,8 +1,11 @@
 import logging
+from datetime import datetime
 
+from cachetools import FIFOCache
 from django.db import connection
 
-from geonode.base.models import ThesaurusKeywordLabel
+from geonode.base.models import ThesaurusKeywordLabel, Thesaurus
+
 
 logger = logging.getLogger(__name__)
 
@@ -54,10 +57,6 @@ def get_localized_tkeywords(lang, thesaurus_identifier: str):
     return sorted(ret.values(), key=lambda i: i["label"].lower())
 
 
-def get_localized_labels(lang, key="about"):
-    return {i[key]: i["label"] for i in get_localized_tkeywords(lang, I18N_THESAURUS_IDENTIFIER)}
-
-
 def get_localized_label(lang, about):
     return (
         ThesaurusKeywordLabel.objects.filter(
@@ -66,3 +65,100 @@ def get_localized_label(lang, about):
         .values_list("label", flat=True)
         .first()
     )
+
+
+class I18nCache:
+
+    DATA_KEY_SCHEMA = "schema"
+    DATA_KEY_LABELS = "labels"
+
+    def __init__(self):
+        # the cache has the lang as key, and various info in the dict value:
+        # - date: the date field of the thesaurus when it was last loaded, it's used for the expiration check
+        # - labels: the keyword labels from the i18n thesaurus
+        # - schema: the localized json schema
+        # FIFO bc we want to renew the data once in a while
+        self.cache = FIFOCache(16)
+
+    def get_entry(self, lang, data_key):
+        """
+        returns date:str, data
+        date is needed for checking the entry freshness when setting info
+        data may be None if not cached or expired
+        """
+        cached_entry = self.cache.get(lang, None)
+
+        thesaurus_date = (  # may be none if thesaurus does not exist
+            Thesaurus.objects.filter(identifier=I18N_THESAURUS_IDENTIFIER).values_list("date", flat=True).first()
+        )
+        if cached_entry:
+            if thesaurus_date == cached_entry["date"]:
+                # only return cached data if thesaurus has not been modified
+                return thesaurus_date, cached_entry.get(data_key, None)
+            else:
+                logger.info(f"Schema for {lang}:{data_key} needs to be recreated")
+
+        return thesaurus_date, None
+
+    def set(self, lang: str, data_key: str, data: dict, request_date: str):
+        cached_entry: dict = self.cache.setdefault(lang, {})
+
+        latest_date = (
+            Thesaurus.objects.filter(identifier=I18N_THESAURUS_IDENTIFIER).values_list("date", flat=True).first()
+        )
+
+        if request_date == latest_date:
+            # no changes after processing, set the info right away
+            logger.debug(f"Caching lang:{lang} key:{data_key} date:{request_date}")
+            cached_entry.update({"date": latest_date, data_key: data})
+        else:
+            logger.warning(
+                f"Cache will not be updated for lang:{lang} key:{data_key} reqdate:{request_date} latest:{latest_date}"
+            )
+
+    def get_labels(self, lang):
+        date, labels = self.get_entry(lang, self.DATA_KEY_LABELS)
+        if labels is None:
+            labels = {i["about"]: i["label"] for i in get_localized_tkeywords(lang, I18N_THESAURUS_IDENTIFIER)}
+            self.set(lang, self.DATA_KEY_LABELS, labels, date)
+
+        return labels
+
+    def clear_schema_cache(self):
+        logger.info("Clearing schema cache")
+        while True:
+            try:
+                self.cache.popitem()
+            except KeyError:
+                return
+
+
+def thesaurus_changed(sender, instance, **kwargs):
+    if instance.identifier == I18N_THESAURUS_IDENTIFIER:
+        if hasattr(instance, "_signal_handled"):  # avoid signal recursion
+            return
+        logger.debug(f"Thesaurus changed: {instance.identifier}")
+        _update_thesaurus_date()
+
+
+def thesaurusk_changed(sender, instance, **kwargs):
+    if instance.thesaurus.identifier == I18N_THESAURUS_IDENTIFIER:
+        logger.debug(f"ThesaurusKeyword changed: {instance.about} ALT:{instance.alt_label}")
+        _update_thesaurus_date()
+
+
+def thesauruskl_changed(sender, instance, **kwargs):
+    if instance.keyword.thesaurus.identifier == I18N_THESAURUS_IDENTIFIER:
+        logger.debug(
+            f"ThesaurusKeywordLabel changed: {instance.keyword.about} ALT:{instance.keyword.alt_label} L:{instance.lang}"
+        )
+        _update_thesaurus_date()
+
+
+def _update_thesaurus_date():
+    logger.debug("Updating label thesaurus date")
+    # update timestamp to invalidate other processes also
+    i18n_thesaurus = Thesaurus.objects.get(identifier=I18N_THESAURUS_IDENTIFIER)
+    i18n_thesaurus.date = datetime.now().replace(microsecond=0).isoformat()
+    i18n_thesaurus._signal_handled = True
+    i18n_thesaurus.save()

--- a/geonode/metadata/manager.py
+++ b/geonode/metadata/manager.py
@@ -19,15 +19,12 @@
 
 import logging
 import copy
-from cachetools import FIFOCache
-from datetime import datetime
 
 from django.utils.translation import gettext as _
 
-from geonode.base.models import Thesaurus
 from geonode.metadata.handlers.abstract import MetadataHandler
 from geonode.metadata.exceptions import UnsetFieldException
-from geonode.metadata.i18n import get_localized_labels, I18N_THESAURUS_IDENTIFIER
+from geonode.metadata.i18n import I18nCache
 from geonode.metadata.settings import MODEL_SCHEMA
 
 logger = logging.getLogger(__name__)
@@ -42,28 +39,16 @@ class MetadataManager:
     to be delivered to the caller.
     """
 
-    # FIFO bc we want to renew the data once in a while
-    _schema_cache = FIFOCache(32)
-
     def __init__(self):
         self.root_schema = MODEL_SCHEMA
         self.handlers = {}
-
-    @classmethod
-    def clear_schema_cache(cls):
-        logger.info("Clearing schema cache")
-        while True:
-            try:
-                MetadataManager._schema_cache.popitem()
-            except KeyError:
-                return
+        self._i18n_cache = I18nCache()
 
     def add_handler(self, handler_id, handler):
         self.handlers[handler_id] = handler()
 
     def _init_schema_context(self, lang):
-        # todo: cache localizations
-        return {"labels": get_localized_labels(lang)}
+        return {"labels": self._i18n_cache.get_labels(lang)}
 
     def build_schema(self, lang=None):
         logger.debug(f"build_schema {lang}")
@@ -88,29 +73,20 @@ class MetadataManager:
         return schema
 
     def get_schema(self, lang=None):
-        cache_key = str(lang)
-        cached_entry = MetadataManager._schema_cache.get(cache_key, None)
-
-        thesaurus_date = (
-            Thesaurus.objects.filter(identifier=I18N_THESAURUS_IDENTIFIER).values_list("date", flat=True).first()
-        )
-        if cached_entry:
-            if thesaurus_date == cached_entry["date"]:
-                # only return cached schema if thesaurus has not been modified
-                return cached_entry["schema"]
-            else:
-                logger.info(f"Schema for {cache_key} needs to be recreated")
-
-        logger.info(f"Building schema for {cache_key}")
-        schema = self.build_schema(lang)
-        logger.debug("Schema built")
-        MetadataManager._schema_cache[cache_key] = {"schema": schema, "date": thesaurus_date}
+        lang = str(lang)
+        thesaurus_date, schema = self._i18n_cache.get_entry(lang, I18nCache.DATA_KEY_SCHEMA)
+        if schema is None:
+            logger.info(f"Building schema for {lang}")
+            schema = self.build_schema(lang)
+            logger.debug("Schema built")
+            self._i18n_cache.set(lang, I18nCache.DATA_KEY_SCHEMA, schema, thesaurus_date)
         return schema
 
     def build_schema_instance(self, resource, lang=None):
         schema = self.get_schema(lang)
 
-        context = {}
+        context = self._init_schema_context(lang)
+
         for handler in self.handlers.values():
             handler.load_serialization_context(resource, schema, context)
 
@@ -130,7 +106,7 @@ class MetadataManager:
                 pass
 
         # TESTING ONLY
-        if resource.title and "error" in resource.title.lower():
+        if "error" in resource.title.lower():
             for fieldname in schema["properties"]:
                 MetadataHandler._set_error(
                     errors, [fieldname], f"TEST: test msg for field '{fieldname}' in GET request"
@@ -139,11 +115,11 @@ class MetadataManager:
 
         return instance
 
-    def update_schema_instance(self, resource, json_instance) -> dict:
+    def update_schema_instance(self, resource, json_instance, lang=None) -> dict:
         logger.debug(f"RECEIVED INSTANCE {json_instance}")
         resource = resource.get_real_instance()
         schema = self.get_schema()
-        context = {}
+        context = self._init_schema_context(lang)
         for handler in self.handlers.values():
             handler.load_deserialization_context(resource, schema, context)
 
@@ -154,30 +130,47 @@ class MetadataManager:
             try:
                 handler.update_resource(resource, fieldname, json_instance, context, errors)
             except Exception as e:
-                MetadataHandler._set_error(errors, [fieldname], f"Error while processing this field: {e}")
-
+                MetadataHandler._set_error(
+                    errors,
+                    [],
+                    MetadataHandler.localize_message(
+                        context,
+                        "metadata_error_update",
+                        {"fieldname": fieldname, "handler": handler.__class__.__name__, "exc": e},
+                    ),
+                )
         for handler in self.handlers.values():
             try:
                 handler.pre_save(resource, json_instance, context, errors)
             except Exception as e:
-                err = f"Error in pre_save: handler {handler.__class__.__name__}"
-                logger.error(err, exc_info=e)
-                MetadataHandler._set_error(errors, [], f"{err} : {e}")
-
+                logger.error(f"Error in pre_save: handler {handler.__class__.__name__}", exc_info=e)
+                MetadataHandler._set_error(
+                    errors,
+                    [],
+                    MetadataHandler.localize_message(
+                        context, "metadata_error_pre_save", {"handler": handler.__class__.__name__, "exc": e}
+                    ),
+                )
         try:
             resource.save()
         except Exception as e:
             logger.warning(f"Error while updating schema instance: {e}")
-            MetadataHandler._set_error(errors, [], f"Error while saving the resource: {e}")
+            MetadataHandler._set_error(
+                errors, [], MetadataHandler.localize_message(context, "metadata_error_save", {"exc": e})
+            )
 
         for handler in self.handlers.values():
             try:
                 handler.post_save(resource, json_instance, context, errors)
             except Exception as e:
-                err = f"Error in post_save: handler {handler.__class__.__name__}"
-                logger.error(err, exc_info=e)
-                MetadataHandler._set_error(errors, [], f"{err} : {e}")
-
+                logger.error(f"Error in post_save: handler {handler.__class__.__name__}", exc_info=e)
+                MetadataHandler._set_error(
+                    errors,
+                    [],
+                    MetadataHandler.localize_message(
+                        context, "metadata_error_post_save", {"handler": handler.__class__.__name__, "exc": e}
+                    ),
+                )
         # TESTING ONLY
         if "_error_" in resource.title.lower():
             _create_test_errors(schema, errors, [], "TEST: field <{schema_type}>'{path}' PUT request")
@@ -195,37 +188,6 @@ def _create_test_errors(schema, errors, path, msg_template, create_message=True)
             _create_test_errors(subschema, errors, path + [field], msg_template)
     elif schema["type"] == "array":
         _create_test_errors(schema["items"], errors, path, msg_template, create_message=False)
-
-
-def thesaurus_changed(sender, instance, **kwargs):
-    if instance.identifier == I18N_THESAURUS_IDENTIFIER:
-        if hasattr(instance, "_signal_handled"):  # avoid signal recursion
-            return
-        logger.debug(f"Thesaurus changed: {instance.identifier}")
-        _update_thesaurus_date()
-
-
-def thesaurusk_changed(sender, instance, **kwargs):
-    if instance.thesaurus.identifier == I18N_THESAURUS_IDENTIFIER:
-        logger.debug(f"ThesaurusKeyword changed: {instance.about} ALT:{instance.alt_label}")
-        _update_thesaurus_date()
-
-
-def thesauruskl_changed(sender, instance, **kwargs):
-    if instance.keyword.thesaurus.identifier == I18N_THESAURUS_IDENTIFIER:
-        logger.debug(
-            f"ThesaurusKeywordLabel changed: {instance.keyword.about} ALT:{instance.keyword.alt_label} L:{instance.lang}"
-        )
-        _update_thesaurus_date()
-
-
-def _update_thesaurus_date():
-    logger.debug("Updating label thesaurus date")
-    # update timestamp to invalidate other processes also
-    i18n_thesaurus = Thesaurus.objects.get(identifier=I18N_THESAURUS_IDENTIFIER)
-    i18n_thesaurus.date = datetime.now().replace(microsecond=0).isoformat()
-    i18n_thesaurus._signal_handled = True
-    i18n_thesaurus.save()
 
 
 metadata_manager = MetadataManager()

--- a/geonode/metadata/signals.py
+++ b/geonode/metadata/signals.py
@@ -3,7 +3,7 @@ import logging
 from django.db.models.signals import post_save
 
 from geonode.base.models import Thesaurus, ThesaurusKeyword, ThesaurusKeywordLabel
-from geonode.metadata.manager import thesaurus_changed, thesaurusk_changed, thesauruskl_changed
+from geonode.metadata.i18n import thesaurus_changed, thesaurusk_changed, thesauruskl_changed
 
 logger = logging.getLogger(__name__)
 

--- a/geonode/metadata/tests/test_handlers.py
+++ b/geonode/metadata/tests/test_handlers.py
@@ -1779,7 +1779,8 @@ class HandlersTests(GeoNodeBaseTestSupport):
                         "object_field": {"type": "object"},
                     }
                 }
-            }
+            },
+            "labels": {},
         }
 
         # Test string field
@@ -1827,11 +1828,11 @@ class HandlersTests(GeoNodeBaseTestSupport):
         self.sparse_handler.update_resource(
             self.resource, "number_field", json_instance_invalid_number, self.context, self.errors
         )
-        self.assertIn("Error parsing number", str(self.errors))
+        self.assertIn("metadata_sparse_error_parse", str(self.errors))
 
         # Test invalid integer number
         json_instance_invalid_int_number = {"integer_field": "not_an_integer"}
         self.sparse_handler.update_resource(
             self.resource, "integer_field", json_instance_invalid_int_number, self.context, self.errors
         )
-        self.assertIn("Error parsing integer", str(self.errors))
+        self.assertIn("metadata_sparse_error_parse", str(self.errors))


### PR DESCRIPTION
See https://github.com/GeoNode/geonode/issues/13043

We may probably want to add a fixtures containg messages.
Best option would be to import the i18n thesaururs as RDF file and not as json fixture. TBD.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [ ] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [ ] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] PR title must be in the form "[Fixes #<issue_number>] Title of the PR"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: black geonode && flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
