### PR TITLE
[Fixes #13100] Fixing permissions bug of the delete_thumbnail endpoint

### DIFF
--- a/geonode/base/api/tests.py
+++ b/geonode/base/api/tests.py
@@ -2048,6 +2048,23 @@ class BaseApiTests(APITestCase):
         self.assertEqual(response.data["message"], "Resource not found.")
         self.assertFalse(response.data["success"])
 
+        # Check that a user without the permissions (norman) cannot delete the thumbnail of a bobby's resource
+        bobby = get_user_model().objects.get(username="bobby")
+
+        resource.owner = bobby
+        resource.thumbnail_url = "http://example.com/thumb/bobby_thumb.png"
+        resource.thumbnail_path = "thumb/bobby_thumb.png"
+        resource.save()
+
+        url = reverse("base-resources-delete-thumbnail", kwargs={"resource_id": resource.id})
+
+        # Connect as norman user
+        self.client.logout()
+        self.assertTrue(self.client.login(username="norman", password="norman"))
+
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 403)
+
     def test_set_thumbnail_from_bbox_from_Anonymous_user_raise_permission_error(self):
         """
         Given a request with Anonymous user, should raise an authentication error.

--- a/geonode/base/api/views.py
+++ b/geonode/base/api/views.py
@@ -753,6 +753,13 @@ class ResourceBaseViewSet(ApiPresetsInitializer, DynamicModelViewSet, Advertised
         try:
             resource = ResourceBase.objects.get(id=int(resource_id))
 
+            # Check if the current user has the permissions to delete the thumbnail
+            if not request.user.has_perm("change_resourcebase", resource.get_self_resource()):
+                return Response(
+                    {"message": "You do not have permission to delete this thumbnail.", "success": False},
+                    status=status.HTTP_403_FORBIDDEN,
+                )
+            
             # Check if thumbnail exists
             if not resource.thumbnail_url:
                 return Response(

--- a/geonode/base/api/views.py
+++ b/geonode/base/api/views.py
@@ -759,7 +759,7 @@ class ResourceBaseViewSet(ApiPresetsInitializer, DynamicModelViewSet, Advertised
                     {"message": "You do not have permission to delete this thumbnail.", "success": False},
                     status=status.HTTP_403_FORBIDDEN,
                 )
-            
+
             # Check if thumbnail exists
             if not resource.thumbnail_url:
                 return Response(


### PR DESCRIPTION
This PR fixes this issue: #13100 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [X] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [X] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [X] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [X] The issue connected to the PR must have Labels and Milestone assigned
- [X] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [X] PR title must be in the form "[Fixes #<issue_number>] Title of the PR"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: black geonode && flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
