### PR TITLE
[Fixes #13102] Define a specific version of the Wheel package

### DIFF
--- a/scripts/docker/base/ubuntu/Dockerfile
+++ b/scripts/docker/base/ubuntu/Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get install -y devscripts build-essential debhelper pkg-kde-tools sharut
 # Install pip packages
 RUN pip3 install uwsgi \
     && pip install pip --upgrade \
+    && pip install wheel==0.38.1 \
     && pip install pygdal==$(gdal-config --version).*
 
 # Install "sherlock" to be used with "memcached"


### PR DESCRIPTION
This PR was created and fixes this issue: #13102 
The version `0.38.1` of `wheel` is defined explicitly on [Dockerfile](https://github.com/GeoNode/geonode/blob/master/scripts/docker/base/ubuntu/Dockerfile) of the base image because otherwise Docker installs by default the version of `0.37.1`

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [X] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [X] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [X] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [X] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [X] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [X] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [X] PR title must be in the form "[Fixes #<issue_number>] Title of the PR"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: black geonode && flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
