### PR TITLE
[Fixes #13138] Only admins are able to transfer the ownership in a resource

### DIFF
--- a/geonode/geoserver/manager.py
+++ b/geonode/geoserver/manager.py
@@ -157,6 +157,7 @@ class GeoServerResourceManager(ResourceManagerInterface):
         uuid: str,
         /,
         instance: ResourceBase = None,
+        request_user: settings.AUTH_USER_MODEL = None,
         owner: settings.AUTH_USER_MODEL = None,
         permissions: dict = {},
         created: bool = False,

--- a/geonode/resource/api/tasks.py
+++ b/geonode/resource/api/tasks.py
@@ -115,6 +115,10 @@ def resouce_service_dispatcher(self, execution_id: str):
                                         else:
                                             _kwargs[_param_name] = _param_value
 
+                                # Inject the user directly into kwargs if the method accepts it
+                                if "request_user" in _signature.parameters:
+                                    _kwargs["request_user"] = _request.user
+                                
                                 _bindings = _signature.bind(*_args, **_kwargs)
                                 _bindings.apply_defaults()
 

--- a/geonode/resource/manager.py
+++ b/geonode/resource/manager.py
@@ -152,6 +152,7 @@ class ResourceManagerInterface(metaclass=ABCMeta):
         uuid: str,
         /,
         instance: ResourceBase = None,
+        request_user: settings.AUTH_USER_MODEL = None,
         owner: settings.AUTH_USER_MODEL = None,
         permissions: dict = {},
         created: bool = False,
@@ -538,6 +539,7 @@ class ResourceManager(ResourceManagerInterface):
         uuid: str,
         /,
         instance: ResourceBase = None,
+        request_user: settings.AUTH_USER_MODEL = None,
         owner: settings.AUTH_USER_MODEL = None,
         permissions: dict = {},
         created: bool = False,
@@ -555,6 +557,8 @@ class ResourceManager(ResourceManagerInterface):
 
                     # default permissions for owner
                     if owner and owner != _resource.owner:
+                        if not (request_user.is_superuser or request_user.is_staff):
+                            raise Exception("Only admins are allowed to change the resource owner.")
                         _resource.owner = owner
                         ResourceBase.objects.filter(uuid=_resource.uuid).update(owner=owner)
                     _owner = _resource.owner

--- a/geonode/resource/tests.py
+++ b/geonode/resource/tests.py
@@ -23,7 +23,6 @@ from uuid import uuid4
 from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
-from django.core.exceptions import Exception
 
 from geonode.groups.models import GroupProfile
 from geonode.base.populate_test_data import create_models
@@ -229,11 +228,15 @@ class TestResourceManager(GeoNodeBaseTestSupport):
     def test_set_permissions(self):
         norman = get_user_model().objects.get(username="norman")
         anonymous = get_user_model().objects.get(username="AnonymousUser")
-        admin_user = get_user_model().objects.create(username="adminuser", is_superuser=True, is_staff=True)
-        new_owner = get_user_model().objects.create(username="newowner")
         doc = create_single_doc("test_delete_doc")
         map = create_single_map("test_delete_dataset")
         dt = create_single_dataset("test_delete_dataset")
+
+        # change ownlership test config
+        second_dt = create_single_dataset("test_change_ownership", owner=norman)
+        admin_user = get_user_model().objects.create(username="adminuser", is_superuser=True, is_staff=True)
+        new_owner = get_user_model().objects.create(username="newowner")
+
         public_group, _public_created = GroupProfile.objects.get_or_create(
             slug="public_group", title="public_group", access="public"
         )
@@ -251,23 +254,23 @@ class TestResourceManager(GeoNodeBaseTestSupport):
                 "private_group": ["view_resourcebase", "change_resourcebase"],
             },
         }
-        
-        # Attempt owner change with non-admin (should raise PermissionDenied)
+
+        # Attempt owner change with non-admin
         with self.assertRaises(Exception) as cm:
             self.rm.set_permissions(
-                dt.uuid, instance=dt, permissions=perm_spec, owner=new_owner, request_user=norman
+                second_dt.uuid, instance=second_dt, permissions=perm_spec, owner=new_owner, request_user=norman
             )
             self.assertEqual(str(cm.exception), "Only admins are allowed to change the resource owner.")
 
         # Attempt owner change with admin (should succeed)
         self.assertTrue(
             self.rm.set_permissions(
-                dt.uuid, instance=dt, permissions=perm_spec, owner=new_owner, request_user=admin_user
+                second_dt.uuid, instance=second_dt, permissions=perm_spec, owner=new_owner, request_user=admin_user
             )
         )
         dt.refresh_from_db()
-        self.assertEqual(dt.owner, new_owner)
-        
+        self.assertEqual(second_dt.owner, new_owner)
+
         self.assertTrue(self.rm.set_permissions(dt.uuid, instance=dt, permissions=perm_spec))
         self.assertFalse(self.rm.set_permissions("invalid_uuid", instance=None, permissions=perm_spec))
         # Test permissions assigned


### PR DESCRIPTION
This PR was created according to this issue: #13138 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [X] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [X] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [X] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [X] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [X] The issue connected to the PR must have Labels and Milestone assigned
- [X] PR for bug fixes and small new features are presented as a single commit
- [X] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [X] PR title must be in the form "[Fixes #<issue_number>] Title of the PR"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [X] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: black geonode && flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
