### PR TITLE
[Fixes #13162] Fixes hardcoded geonode init lock in entrypoint.sh

### DIFF
--- a/.clabot
+++ b/.clabot
@@ -79,6 +79,7 @@
     "RegisSinjari",
     "Gpetrak",
     "cmotadev",
-    "kilichenko-pixida"
+    "kilichenko-pixida",
+    "ZuitAMB"
   ]
 }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -48,7 +48,9 @@ else
     invoke migrations
     invoke prepare
 
-    if [ ${FORCE_REINIT} = "true" ]  || [ ${FORCE_REINIT} = "True" ] || [ ! -e "/mnt/volumes/statics/geonode_init.lock" ]; then
+    STATIC_ROOT="${STATIC_ROOT:-/mnt/volumes/statics/static/}"
+    LOCKFILE_DIR="$(dirname "$STATIC_ROOT")"
+    if [ ${FORCE_REINIT} = "true" ]  || [ ${FORCE_REINIT} = "True" ] || [ ! -e "${LOCKFILE_DIR}/geonode_init.lock" ]; then
         invoke fixtures
         invoke initialized
         invoke updateadmin


### PR DESCRIPTION
Issue: https://github.com/GeoNode/geonode/issues/13162 

When the static root is set to a non default location, entrypoint.sh would crash as the hardcoded file location is not present.

Background:
Celery and Geonode sometimes throw SuspiciousFileExceptions by Django Path checks:
`ERROR/ForkPoolWorker-172] Detected path traversal attempt in '/mnt/volumes/statics/uploaded/thumbs/dataset-c3e2c0df-78bb-47c9-b449-b0e23c25726a-thumb-671e619d-97a9-47a9-b50d-81b5baf45ca5.jpg'
   File "/usr/src/geonode/geonode/base/models.py", line 1570, in save_thumbnail
 Traceback (most recent call last):
     storage_manager.save(storage_manager.path(upload_path), img)
   File "/usr/src/geonode/geonode/storage/manager.py", line 161, in save
   File "/usr/src/geonode/geonode/base/models.py", line 1570, in save_thumbnail
     storage_manager.save(storage_manager.path(upload_path), img)
   File "/usr/src/geonode/geonode/storage/manager.py", line 161, in save
     return self._concrete_storage_manager.save(name, content, max_length=max_length)
     return self._concrete_storage_manager.save(name, content, max_length=max_length)
   File "/usr/src/geonode/geonode/storage/manager.py", line 300, in save
   File "/usr/src/geonode/geonode/storage/manager.py", line 300, in save
     return self._fsm.save(name, content, max_length=max_length)
     return self._fsm.save(name, content, max_length=max_length)
   File "/usr/local/lib/python3.10/dist-packages/django/core/files/storage/base.py", line 41, in save
     validate_file_name(name, allow_relative_path=True)
   File "/usr/local/lib/python3.10/dist-packages/django/core/files/utils.py", line 17, in validate_file_name
   File "/usr/local/lib/python3.10/dist-packages/django/core/files/storage/base.py", line 41, in save
     validate_file_name(name, allow_relative_path=True)
   File "/usr/local/lib/python3.10/dist-packages/django/core/files/utils.py", line 17, in validate_file_name
     raise SuspiciousFileOperation(
 django.core.exceptions.SuspiciousFileOperation: Detected path traversal attempt in '/mnt/volumes/statics/uploaded/thumbs/dataset-c3e2c0df-78bb-47c9-b449-b0e23c25726a-thumb-671e619d-97a9-47a9-b50d-81b5baf45ca5.jpg'
     raise SuspiciousFileOperation(
 django.core.exceptions.SuspiciousFileOperation: Detected path traversal attempt in '/mnt/volumes/statics/uploaded/thumbs/dataset-c3e2c0df-78bb-47c9-b449-b0e23c25726a-thumb-671e619d-97a9-47a9-b50d-81b5baf45ca5.jpg'`

We traced back the root cause to the following django file util which might have been changed:
https://github.com/django/django/blob/dd133054cb98f77577c06d7ef1f2391a865784bc/django/core/files/utils.py#L16
It causes absolute paths to be problematic.

As a quick workaround/solution, we moved the static root to a local folder, but the entrypoint.sh crashed, as an old path was hardcoded.
The init file and code logic assumes the location currently used in task.py, see https://github.com/GeoNode/geonode/blob/90a90cb7597a7031b16949f8335e1d304ea13ba1/tasks.py#L389C1-L395C1

A solution for the original absolute path might be allowing relative paths in the file validation but is out of scope of this pull request.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [X] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [X] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [X] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [X] PR for bug fixes and small new features are presented as a single commit
- [X] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [X] PR title must be in the form "[Fixes #<issue_number>] Title of the PR"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: black geonode && flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
