### PR TITLE
[Fixes #13172] Respect `FILE_UPLOAD_PERMISSIONS=None` in layer uploads to avoid chmod errors

### DIFF
--- a/geonode/storage/data_retriever.py
+++ b/geonode/storage/data_retriever.py
@@ -161,7 +161,8 @@ class DataRetriever(object):
         for name, data_item_retriever in self.data_items.items():
             file_path = data_item_retriever.transfer_remote_file(self.temporary_folder)
             self.file_paths[name] = Path(file_path)
-            os.chmod(file_path, settings.FILE_UPLOAD_PERMISSIONS)
+            if settings.FILE_UPLOAD_PERMISSIONS is not None:
+                os.chmod(file_path, settings.FILE_UPLOAD_PERMISSIONS)
         """
         Is more usefull to have always unzipped file than the zip file
         So in case is a zip_file, we unzip it and than delete it

--- a/geonode/storage/manager.py
+++ b/geonode/storage/manager.py
@@ -205,7 +205,7 @@ class StorageManager(StorageManagerInterface):
                     new_file = f"{new_path}/{old_file_name}_{random_suffix}{ext}"
                 _new_path = self.copy_single_file(open_file, new_file)
                 out.append(_new_path)
-            if _new_path:
+            if _new_path and settings.FILE_UPLOAD_PERMISSIONS is not None:
                 os.chmod(_new_path, settings.FILE_UPLOAD_PERMISSIONS)
         return out
 

--- a/geonode/upload/tests/end2end/test_end2end.py
+++ b/geonode/upload/tests/end2end/test_end2end.py
@@ -196,6 +196,21 @@ class ImporterGeoPackageImportTest(BaseImporterEndToEndTest):
         self._assertimport(payload, initial_name, overwrite=True, last_update=prev_dataset.last_updated)
         self._cleanup_layers(name="stazioni_metropolitana")
 
+    @override_settings(FILE_UPLOAD_PERMISSIONS=None)
+    def test_file_upload_permissions_none_uploads_successfully(self):
+        """
+        Test that setting FILE_UPLOAD_PERMISSIONS=None prevents chmod errors during file upload.
+        This is important for compatibility with volume types (e.g., Azure Files) that disallow chmod.
+        """
+        self._cleanup_layers(name="stazioni_metropolitana")
+
+        payload = {"base_file": open(self.valid_gkpg, "rb"), "action": "upload"}
+        initial_name = "stazioni_metropolitana"
+
+        self._assertimport(payload, initial_name)
+
+        self._cleanup_layers(name="stazioni_metropolitana")
+
 
 class ImporterNoCRSImportTest(BaseImporterEndToEndTest):
     @override_settings(ASYNC_SIGNALS=False)

--- a/geonode/upload/tests/end2end/test_end2end.py
+++ b/geonode/upload/tests/end2end/test_end2end.py
@@ -200,7 +200,7 @@ class ImporterGeoPackageImportTest(BaseImporterEndToEndTest):
     @override_settings(
         FILE_UPLOAD_PERMISSIONS=None,
         ASYNC_SIGNALS=False,
-        GEODATABASE_URL=f"{geourl.split('/geonode_data')[0]}/test_geonode_data"
+        GEODATABASE_URL=f"{geourl.split('/geonode_data')[0]}/test_geonode_data",
     )
     def test_file_upload_permissions_none_uploads_successfully(self):
         """

--- a/geonode/upload/tests/end2end/test_end2end.py
+++ b/geonode/upload/tests/end2end/test_end2end.py
@@ -196,7 +196,12 @@ class ImporterGeoPackageImportTest(BaseImporterEndToEndTest):
         self._assertimport(payload, initial_name, overwrite=True, last_update=prev_dataset.last_updated)
         self._cleanup_layers(name="stazioni_metropolitana")
 
-    @override_settings(FILE_UPLOAD_PERMISSIONS=None)
+    @mock.patch.dict(os.environ, {"GEONODE_GEODATABASE": "test_geonode_data"})
+    @override_settings(
+        FILE_UPLOAD_PERMISSIONS=None,
+        ASYNC_SIGNALS=False,
+        GEODATABASE_URL=f"{geourl.split('/geonode_data')[0]}/test_geonode_data"
+    )
     def test_file_upload_permissions_none_uploads_successfully(self):
         """
         Test that setting FILE_UPLOAD_PERMISSIONS=None prevents chmod errors during file upload.


### PR DESCRIPTION
Addresses #13172 by ensuring that the file upload process respects the `FILE_UPLOAD_PERMISSIONS` setting when it's set to `None`.

Previously, the upload process unconditionally applied `os.chmod()` to uploaded files and directories, leading to a TypeError when `FILE_UPLOAD_PERMISSIONS` was `None`. This behavior caused issues in environments like Azure Files, where file permissions are managed externally and cannot be modified by the application.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] PR title must be in the form "[Fixes #<issue_number>] Title of the PR"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: black geonode && flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
