### PR TITLE
[Fixes #13180] Resolve warnings of testing library

### DIFF
--- a/geonode/api/tests.py
+++ b/geonode/api/tests.py
@@ -332,12 +332,12 @@ class PermissionsApiTests(ResourceTestCaseMixin, GeoNodeBaseTestSupport):
         resp = self.api_client.get(filter_url)
         self.assertValidJSONResponse(resp)
         self.assertEqual(len(self.deserialize(resp)["objects"]), 6)
-        # Returns limitted info about other users
+        # Returns limited info about other users
         bobby = get_user_model().objects.get(username="bobby")
         profiles = self.deserialize(resp)["objects"]
         for profile in profiles:
             if profile["username"] == "bobby":
-                self.assertEquals(profile.get("email"), bobby.email)
+                self.assertEqual(profile.get("email"), bobby.email)
             else:
                 self.assertIsNone(profile.get("email"))
 
@@ -356,12 +356,12 @@ class PermissionsApiTests(ResourceTestCaseMixin, GeoNodeBaseTestSupport):
         resp = self.api_client.get(filter_url)
         self.assertValidJSONResponse(resp)
         self.assertEqual(len(self.deserialize(resp)["objects"]), 6)
-        # Returns limitted info about other users
+        # Returns limited info about other users
         bobby = get_user_model().objects.get(username="bobby")
         owners = self.deserialize(resp)["objects"]
         for owner in owners:
             if owner["username"] == "bobby":
-                self.assertEquals(owner.get("email"), bobby.email)
+                self.assertEqual(owner.get("email"), bobby.email)
             else:
                 self.assertIsNone(owner.get("email"))
                 self.assertIsNone(owner.get("first_name"))


### PR DESCRIPTION
# PR Summary
This PR migrates from `unittest.assertEquals` to `unittest.assertEqual` which is deprecated from Python2.7:
```python
DeprecationWarning: Please use assertEqual instead.
```

Fixes #13180

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [ ] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] PR title must be in the form "[Fixes #<issue_number>] Title of the PR"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: black geonode && flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
