### PR TITLE
Fixes https://github.com/GeoNode/geonode-project/issues/562 Backup.sh procedure is just able to run once

### DIFF
--- a/geonode/br/management/commands/backup.py
+++ b/geonode/br/management/commands/backup.py
@@ -244,6 +244,7 @@ class Command(BaseCommand):
         error_backup = "Could not successfully backup GeoServer catalog [{}rest/br/backup/]: {} - {}"
 
         _options = [
+            "BK_SKIP_GWC=true",
             "BK_CLEANUP_TEMP=true",
             "BK_SKIP_SETTINGS=false",
             "BK_SKIP_SECURITY=false",


### PR DESCRIPTION
Fixes https://github.com/GeoNode/geonode-project/issues/562 @caocuongngo

<Include a few sentences describing the overall goals for this Pull Request>

For all pull requests:

- [x ] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] PR title must be in the form "[Fixes #<issue_number>] Title of the PR"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: black geonode && flake8 geonode
- [x] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [x] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
