### PR TITLE
[Fixes #13311]: Implement caching for User Permission retrieval for Resource Base Endpoints Reducing number of queries in Database.

### DIFF
--- a/.clabot
+++ b/.clabot
@@ -81,6 +81,7 @@
     "cmotadev",
     "kilichenko-pixida",
     "ZuitAMB",
-    "marlowp"
+    "marlowp",
+    "sijandh35"
   ]
 }

--- a/.env_dev
+++ b/.env_dev
@@ -172,6 +172,7 @@ MEMCACHED_BACKEND=django.core.cache.backends.memcached.PyLibMCCache
 MEMCACHED_LOCATION=127.0.0.1:11211
 MEMCACHED_LOCK_EXPIRE=3600
 MEMCACHED_LOCK_TIMEOUT=10
+PERMISSION_CACHE_EXPIRATION_TIME=604800
 #
 # Options for memcached binary, e.g. -vvv to log all requests and cache hits
 #

--- a/.env_local
+++ b/.env_local
@@ -175,6 +175,7 @@ MEMCACHED_BACKEND=django.core.cache.backends.memcached.PyLibMCCache
 MEMCACHED_LOCATION=127.0.0.1:11211
 MEMCACHED_LOCK_EXPIRE=3600
 MEMCACHED_LOCK_TIMEOUT=10
+PERMISSION_CACHE_EXPIRATION_TIME=604800
 #
 # Options for memcached binary, e.g. -vvv to log all requests and cache hits
 #

--- a/.env_test
+++ b/.env_test
@@ -184,6 +184,7 @@ MEMCACHED_BACKEND=django.core.cache.backends.memcached.PyLibMCCache
 MEMCACHED_LOCATION=memcached:11211
 MEMCACHED_LOCK_EXPIRE=3600
 MEMCACHED_LOCK_TIMEOUT=10
+PERMISSION_CACHE_EXPIRATION_TIME=604800
 #
 # Options for memcached binary, e.g. -vvv to log all requests and cache hits
 #

--- a/geonode/base/api/serializers.py
+++ b/geonode/base/api/serializers.py
@@ -780,13 +780,17 @@ class ResourceBaseSerializer(DynamicModelSerializer):
             if not user.can_change_resource_field(instance, field) and field in validated_data:
                 validated_data.pop(field)
         return super().update(instance, validated_data)
-    
+
     def get_perms(self, instance):
         """
         Returns the permissions for the resource instance using Django cache.
         """
         request = self.context.get("request")
-        permissions = permissions_registry.get_perms(instance=instance, user=request.user,is_cache=True) if request and request.user and instance else []
+        permissions = (
+            permissions_registry.get_perms(instance=instance, user=request.user, is_cache=True)
+            if request and request.user and instance
+            else []
+        )
         return permissions
 
     def save(self, **kwargs):

--- a/geonode/base/api/serializers.py
+++ b/geonode/base/api/serializers.py
@@ -787,7 +787,7 @@ class ResourceBaseSerializer(DynamicModelSerializer):
         """
         request = self.context.get("request")
         permissions = (
-            permissions_registry.get_perms(instance=instance, user=request.user, is_cache=True)
+            permissions_registry.get_perms(instance=instance, user=request.user, use_cache=True)
             if request and request.user and instance
             else []
         )

--- a/geonode/base/api/serializers.py
+++ b/geonode/base/api/serializers.py
@@ -654,7 +654,7 @@ class ResourceBaseSerializer(DynamicModelSerializer):
     download_url = DownloadLinkField(read_only=True)
     favorite = FavoriteField(read_only=True)
     download_urls = DownloadArrayLinkField(read_only=True)
-    perms = DynamicRelationField(PermsSerializer, source="id", read_only=True)
+    perms = serializers.SerializerMethodField(read_only=True)
     links = DynamicRelationField(LinksSerializer, source="id", read_only=True)
 
     # Deferred fields
@@ -780,6 +780,14 @@ class ResourceBaseSerializer(DynamicModelSerializer):
             if not user.can_change_resource_field(instance, field) and field in validated_data:
                 validated_data.pop(field)
         return super().update(instance, validated_data)
+    
+    def get_perms(self, instance):
+        """
+        Returns the permissions for the resource instance using Django cache.
+        """
+        request = self.context.get("request")
+        permissions = permissions_registry.get_perms(instance=instance, user=request.user,is_cache=True) if request and request.user and instance else []
+        return permissions
 
     def save(self, **kwargs):
         extent = self.validated_data.pop("extent", None)

--- a/geonode/base/api/tests.py
+++ b/geonode/base/api/tests.py
@@ -3662,7 +3662,6 @@ class TestPermissionsCaching(GeoNodeBaseTestSupport):
         test_resource = self.resources[0]
 
         admin_perms_1 = permissions_registry.get_perms(instance=test_resource, user=self.admin_user, use_cache=True)
-
         admin_perms_2 = permissions_registry.get_perms(instance=test_resource, user=self.admin_user, use_cache=True)
 
         self.assertEqual(admin_perms_1, admin_perms_2)
@@ -3674,8 +3673,7 @@ class TestPermissionsCaching(GeoNodeBaseTestSupport):
         self.assertIn("change_resourcebase_permissions", admin_perms_1)
         self.assertIn("delete_resourcebase", admin_perms_1)
 
-    def test_permission_annonomous_users(self):
-
+    def test_permission_anonymous_users(self):
         permissions_registry = PermissionsHandlerRegistry()
         test_resource = self.resources[0]
         anonymous_user = AnonymousUser()
@@ -3688,12 +3686,10 @@ class TestPermissionsCaching(GeoNodeBaseTestSupport):
         self.assertEqual(anon_perms_1, anon_perms_2)
 
     def test_owner_user_permissions_caching(self):
-
         permissions_registry = PermissionsHandlerRegistry()
         test_resource = self.resources[0]
 
         user_perms_1 = permissions_registry.get_perms(instance=test_resource, user=self.test_user, use_cache=True)
-
         user_perms_2 = permissions_registry.get_perms(instance=test_resource, user=self.test_user, use_cache=True)
 
         self.assertEqual(user_perms_1, user_perms_2)
@@ -3709,34 +3705,76 @@ class TestPermissionsCaching(GeoNodeBaseTestSupport):
         for perm in expected_owner_perms:
             self.assertIn(perm, user_perms_1)
 
-    def test_cache_keys_are_different(self):
-
+    def test_group_permissions_caching(self):
+        """Test that group permissions are cached correctly"""
         permissions_registry = PermissionsHandlerRegistry()
         test_resource = self.resources[0]
 
+        group_perms_1 = permissions_registry.get_perms(instance=test_resource, group=self.test_group, use_cache=True)
+        group_perms_2 = permissions_registry.get_perms(instance=test_resource, group=self.test_group, use_cache=True)
+
+        self.assertEqual(list(group_perms_1), list(group_perms_2))
+
+        expected_group_perms = [
+            "view_resourcebase",
+            "change_resourcebase",
+            "change_resourcebase_metadata",
+            "change_resourcebase_permissions",
+            "delete_resourcebase",
+        ]
+
+        for perm in expected_group_perms:
+            self.assertIn(perm, group_perms_1)
+
+    def test_user_and_group_permissions_combined(self):
+        """Test getting both user and group permissions in one call"""
+        permissions_registry = PermissionsHandlerRegistry()
+        test_resource = self.resources[0]
+
+        combined_perms = permissions_registry.get_perms(
+            instance=test_resource, user=self.test_user, group=self.test_group, use_cache=True
+        )
+
+        self.assertIn("users", combined_perms)
+        self.assertIn("groups", combined_perms)
+        self.assertIn(self.test_user, combined_perms["users"])
+        self.assertIn(self.test_group, combined_perms["groups"])
+
+    def test_cache_keys_are_different(self):
+        permissions_registry = PermissionsHandlerRegistry()
+        test_resource = self.resources[0]
         anonymous_user = AnonymousUser()
 
+        # Generate permissions to populate cache
         permissions_registry.get_perms(instance=test_resource, user=anonymous_user, use_cache=True)
         permissions_registry.get_perms(instance=test_resource, user=self.admin_user, use_cache=True)
         permissions_registry.get_perms(instance=test_resource, user=self.test_user, use_cache=True)
+        permissions_registry.get_perms(instance=test_resource, group=self.test_group, use_cache=True)
 
+        # Updated cache key formats
         anonymous_key = f"resource_perms:{test_resource.pk}:anonymous"
-        admin_key = f"resource_perms:{test_resource.pk}:{self.admin_user.pk}"
-        test_user_key = f"resource_perms:{test_resource.pk}:{self.test_user.pk}"
+        admin_key = f"resource_perms:{test_resource.pk}:user:{self.admin_user.pk}"
+        test_user_key = f"resource_perms:{test_resource.pk}:user:{self.test_user.pk}"
+        group_key = f"resource_perms:{test_resource.pk}:group:{self.test_group.pk}"
 
+        # Verify all cache keys exist
         self.assertIsNotNone(cache.get(anonymous_key))
         self.assertIsNotNone(cache.get(admin_key))
         self.assertIsNotNone(cache.get(test_user_key))
+        self.assertIsNotNone(cache.get(group_key))
 
+        # Verify cached values are different
         anon_cached = cache.get(anonymous_key)
         admin_cached = cache.get(admin_key)
         user_cached = cache.get(test_user_key)
+        group_cached = cache.get(group_key)
 
         self.assertNotEqual(anon_cached, admin_cached)
         self.assertNotEqual(anon_cached, user_cached)
+        self.assertNotEqual(admin_cached, user_cached)
+        self.assertNotEqual(user_cached, group_cached)
 
     def test_multiple_resources_independent_caching(self):
-
         permissions_registry = PermissionsHandlerRegistry()
 
         resource_1 = self.resources[0]
@@ -3747,8 +3785,9 @@ class TestPermissionsCaching(GeoNodeBaseTestSupport):
 
         self.assertEqual(perms_r1, perms_r2)
 
-        cache_key_r1 = f"resource_perms:{resource_1.pk}:{self.test_user.pk}"
-        cache_key_r2 = f"resource_perms:{resource_2.pk}:{self.test_user.pk}"
+        # Updated cache key format
+        cache_key_r1 = f"resource_perms:{resource_1.pk}:user:{self.test_user.pk}"
+        cache_key_r2 = f"resource_perms:{resource_2.pk}:user:{self.test_user.pk}"
 
         self.assertIsNotNone(cache.get(cache_key_r1))
         self.assertIsNotNone(cache.get(cache_key_r2))
@@ -3756,57 +3795,279 @@ class TestPermissionsCaching(GeoNodeBaseTestSupport):
     def test_cache_key_generation_consistency(self):
         """
         Test that the _get_cache_key method generates consistent and correct cache keys
-        for different user types and scenarios.
+        for different user types, groups, and scenarios.
         """
         permissions_registry = PermissionsHandlerRegistry()
         test_resource = self.resources[0]
         anonymous_user = AnonymousUser()
 
         # Test authenticated user cache key
-        expected_admin_key = f"resource_perms:{test_resource.pk}:{self.admin_user.pk}"
-        actual_admin_key = permissions_registry._get_cache_key(test_resource.pk, self.admin_user)
+        expected_admin_key = f"resource_perms:{test_resource.pk}:user:{self.admin_user.pk}"
+        actual_admin_key = permissions_registry._get_cache_key(test_resource.pk, user=self.admin_user)
         self.assertEqual(actual_admin_key, expected_admin_key)
 
         # Test test user cache key
-        expected_test_user_key = f"resource_perms:{test_resource.pk}:{self.test_user.pk}"
-        actual_test_user_key = permissions_registry._get_cache_key(test_resource.pk, self.test_user)
+        expected_test_user_key = f"resource_perms:{test_resource.pk}:user:{self.test_user.pk}"
+        actual_test_user_key = permissions_registry._get_cache_key(test_resource.pk, user=self.test_user)
         self.assertEqual(actual_test_user_key, expected_test_user_key)
 
         # Test anonymous user cache key
         expected_anon_key = f"resource_perms:{test_resource.pk}:anonymous"
-        actual_anon_key = permissions_registry._get_cache_key(test_resource.pk, anonymous_user)
+        actual_anon_key = permissions_registry._get_cache_key(test_resource.pk, user=anonymous_user)
         self.assertEqual(actual_anon_key, expected_anon_key)
 
-        # Test __ALL__ cache key (when user is None)
+        # Test group cache key
+        expected_group_key = f"resource_perms:{test_resource.pk}:group:{self.test_group.pk}"
+        actual_group_key = permissions_registry._get_cache_key(test_resource.pk, group=self.test_group)
+        self.assertEqual(actual_group_key, expected_group_key)
+
+        # Test __ALL__ cache key (when both user and group are None)
         expected_all_key = f"resource_perms:{test_resource.pk}:__ALL__"
-        actual_all_key = permissions_registry._get_cache_key(test_resource.pk, None)
+        actual_all_key = permissions_registry._get_cache_key(test_resource.pk, user=None, group=None)
         self.assertEqual(actual_all_key, expected_all_key)
 
-        # Test that keys are unique for different users
-        cache_keys = [actual_admin_key, actual_test_user_key, actual_anon_key, actual_all_key]
+        # Test that keys are unique for different users and groups
+        cache_keys = [actual_admin_key, actual_test_user_key, actual_anon_key, actual_group_key, actual_all_key]
         self.assertEqual(len(cache_keys), len(set(cache_keys)), "All cache keys should be unique")
 
         # Test consistency across multiple calls
-        key_call_1 = permissions_registry._get_cache_key(test_resource.pk, self.admin_user)
-        key_call_2 = permissions_registry._get_cache_key(test_resource.pk, self.admin_user)
+        key_call_1 = permissions_registry._get_cache_key(test_resource.pk, user=self.admin_user)
+        key_call_2 = permissions_registry._get_cache_key(test_resource.pk, user=self.admin_user)
         self.assertEqual(key_call_1, key_call_2, "Cache key generation should be consistent")
 
         # Test that the cache keys match what's actually used in caching
-        # Generate permissions to populate cache
         permissions_registry.get_perms(instance=test_resource, user=self.admin_user, use_cache=True)
         permissions_registry.get_perms(instance=test_resource, user=anonymous_user, use_cache=True)
+        permissions_registry.get_perms(instance=test_resource, group=self.test_group, use_cache=True)
 
         # Verify the generated keys match what's in cache
         self.assertIsNotNone(cache.get(actual_admin_key), "Admin cache key should exist in cache")
         self.assertIsNotNone(cache.get(actual_anon_key), "Anonymous cache key should exist in cache")
+        self.assertIsNotNone(cache.get(actual_group_key), "Group cache key should exist in cache")
 
-    def tearDown(self):
-        cache.clear()
+    def test_cache_invalidation_on_permission_change(self):
+        """Test that cache is properly invalidated when permissions change"""
+        permissions_registry = PermissionsHandlerRegistry()
+        test_resource = self.resources[0]
 
-    @classmethod
-    def tearDownClass(cls):
-        super().tearDownClass()
-        if hasattr(cls, "test_user"):
-            cls.test_user.delete()
-        if hasattr(cls, "test_group"):
-            cls.test_group.delete()
+        # Get initial permissions and cache them
+        permissions_registry.get_perms(instance=test_resource, user=self.test_user, use_cache=True)
+        cache_key = f"resource_perms:{test_resource.pk}:user:{self.test_user.pk}"
+
+        # Verify cache exists
+        self.assertIsNotNone(cache.get(cache_key))
+
+        # Clear cache using the delete_resource_permissions_cache method
+        permissions_registry.delete_resource_permissions_cache(test_resource)
+
+        # Verify cache is cleared
+        self.assertIsNone(cache.get(cache_key))
+
+    def test_all_permissions_caching(self):
+        """Test caching when getting all permissions (no user or group specified)"""
+        permissions_registry = PermissionsHandlerRegistry()
+        test_resource = self.resources[0]
+
+        all_perms_1 = permissions_registry.get_perms(instance=test_resource, use_cache=True)
+        all_perms_2 = permissions_registry.get_perms(instance=test_resource, use_cache=True)
+
+        self.assertEqual(all_perms_1, all_perms_2)
+
+        # Verify structure contains both users and groups
+        self.assertIn("users", all_perms_1)
+        self.assertIn("groups", all_perms_1)
+
+    def test_user_deletion_cache_invalidation(self):
+        """Test that cache is properly cleared when a user is deleted"""
+        permissions_registry = PermissionsHandlerRegistry()
+
+        # Create a temporary user for deletion testing
+        temp_user = get_user_model().objects.create_user(
+            username=f"temp_user_{uuid4()}", email="temp@example.com", password="temppass123"
+        )
+
+        for resource in self.resources[:2]:  # Use first 2 resources
+            perm_spec = {"users": {temp_user.username: ["view_resourcebase", "change_resourcebase"]}, "groups": {}}
+            resource.set_permissions(perm_spec)
+
+        cached_perms = []
+        cache_keys = []
+
+        for resource in self.resources[:2]:
+            perms = permissions_registry.get_perms(instance=resource, user=temp_user, use_cache=True)
+            cached_perms.append(perms)
+            cache_key = f"resource_perms:{resource.pk}:user:{temp_user.pk}"
+            cache_keys.append(cache_key)
+
+            # Verify permissions are cached
+            self.assertIsNotNone(cache.get(cache_key))
+            self.assertIn("view_resourcebase", perms)
+
+        other_user_cache_keys = []
+        for resource in self.resources[:2]:
+            permissions_registry.get_perms(instance=resource, user=self.test_user, use_cache=True)
+            other_key = f"resource_perms:{resource.pk}:user:{self.test_user.pk}"
+            other_user_cache_keys.append(other_key)
+            self.assertIsNotNone(cache.get(other_key))
+
+        temp_user_profile = temp_user
+
+        permissions_registry.delete_resource_permissions_cache(temp_user_profile, user_clear_cache=True)
+
+        for cache_key in cache_keys:
+            self.assertIsNone(cache.get(cache_key), f"Cache key {cache_key} should be cleared after user deletion")
+
+        for other_key in other_user_cache_keys:
+            self.assertIsNotNone(cache.get(other_key), f"Cache key {other_key} should not be affected by user deletion")
+
+        temp_user.delete()
+
+    def test_group_deletion_cache_invalidation(self):
+        """Test that cache is properly cleared when a group is deleted"""
+        permissions_registry = PermissionsHandlerRegistry()
+        temp_group, created = Group.objects.get_or_create(name=f"temp_group_{uuid4()}")
+
+        temp_group_profile, created = GroupProfile.objects.get_or_create(
+            group_id=temp_group.id,
+        )
+
+        temp_group, _ = Group.objects.get_or_create(name="test-group-2")
+        temp_group_profile = GroupProfile.objects.create(
+            group=temp_group, title="Test Group 2 ", slug="test-group-2", access="public"
+        )
+
+        temp_group_profile.refresh_from_db()
+
+        self.assertEqual(
+            temp_group_profile.group.id,
+            temp_group.id,
+            f"GroupProfile.group ({temp_group_profile.group}) should equal temp_group ({temp_group})",
+        )
+
+        temp_group.user_set.add(self.test_user, self.admin_user)
+
+        for resource in self.resources[:2]:  # Use first 2 resources
+            perm_spec = {"users": {}, "groups": {temp_group.name: ["view_resourcebase", "change_resourcebase"]}}
+            resource.set_permissions(perm_spec)
+
+        group_cache_keys = []
+        for resource in self.resources[:2]:
+            perms = permissions_registry.get_perms(instance=resource, group=temp_group, use_cache=True)
+            cache_key = f"resource_perms:{resource.pk}:group:{temp_group.pk}"
+            group_cache_keys.append(cache_key)
+
+            self.assertIsNotNone(cache.get(cache_key))
+            self.assertIn("view_resourcebase", perms)
+
+        user_cache_keys = []
+        for resource in self.resources[:2]:
+            for user in [self.test_user, self.admin_user]:
+                permissions_registry.get_perms(instance=resource, user=user, use_cache=True)
+                cache_key = f"resource_perms:{resource.pk}:user:{user.pk}"
+                user_cache_keys.append(cache_key)
+                self.assertIsNotNone(cache.get(cache_key))
+
+        unrelated_user = get_user_model().objects.create_user(
+            username=f"unrelated_user_{uuid4()}", email="unrelated@example.com", password="unrelated123"
+        )
+
+        unrelated_cache_keys = []
+        for resource in self.resources[:2]:
+            permissions_registry.get_perms(instance=resource, user=unrelated_user, use_cache=True)
+            cache_key = f"resource_perms:{resource.pk}:user:{unrelated_user.pk}"
+            unrelated_cache_keys.append(cache_key)
+            self.assertIsNotNone(cache.get(cache_key))
+
+        permissions_registry.delete_resource_permissions_cache(temp_group, group_clear_cache=True)
+
+        for cache_key in group_cache_keys:
+            self.assertIsNone(
+                cache.get(cache_key), f"Group cache key {cache_key} should be cleared after group deletion"
+            )
+
+    def test_resource_deletion_cache_invalidation(self):
+        """Test that cache is properly cleared when a resource is deleted"""
+        permissions_registry = PermissionsHandlerRegistry()
+
+        # Create a temporary resource for deletion testing
+        temp_resource = ResourceBase.objects.create(
+            title=f"temp_resource_{uuid4()}",
+            uuid=str(uuid4()),
+            owner=self.test_user,
+            abstract="Temporary resource for deletion testing",
+            subtype="vector",
+            is_approved=True,
+            is_published=True,
+        )
+
+        # Set permissions on the temporary resource
+        perm_spec = {
+            "users": {
+                self.test_user.username: [
+                    "view_resourcebase",
+                    "change_resourcebase",
+                    "delete_resourcebase",
+                ],
+                self.admin_user.username: [
+                    "view_resourcebase",
+                    "change_resourcebase",
+                ],
+            },
+            "groups": {
+                self.test_group.name: ["view_resourcebase"],
+                self.anonymous.name: ["view_resourcebase"],
+            },
+        }
+        temp_resource.set_permissions(perm_spec)
+
+        cache_keys_to_check = []
+
+        user_perms = permissions_registry.get_perms(instance=temp_resource, user=self.test_user, use_cache=True)
+        test_user_key = f"resource_perms:{temp_resource.pk}:user:{self.test_user.pk}"
+        cache_keys_to_check.append(test_user_key)
+
+        admin_perms = permissions_registry.get_perms(instance=temp_resource, user=self.admin_user, use_cache=True)
+        admin_user_key = f"resource_perms:{temp_resource.pk}:user:{self.admin_user.pk}"
+        cache_keys_to_check.append(admin_user_key)
+
+        anonymous_user = AnonymousUser()
+        anon_perms = permissions_registry.get_perms(instance=temp_resource, user=anonymous_user, use_cache=True)
+        anon_key = f"resource_perms:{temp_resource.pk}:anonymous"
+        cache_keys_to_check.append(anon_key)
+
+        group_perms = permissions_registry.get_perms(instance=temp_resource, group=self.test_group, use_cache=True)
+        group_key = f"resource_perms:{temp_resource.pk}:group:{self.test_group.pk}"
+        cache_keys_to_check.append(group_key)
+
+        permissions_registry.get_perms(instance=temp_resource, use_cache=True)
+        all_key = f"resource_perms:{temp_resource.pk}:__ALL__"
+        cache_keys_to_check.append(all_key)
+
+        for cache_key in cache_keys_to_check:
+            self.assertIsNotNone(cache.get(cache_key), f"Cache key {cache_key} should exist before deletion")
+
+        self.assertIn("view_resourcebase", user_perms)
+        self.assertIn("change_resourcebase", user_perms)
+        self.assertIn("delete_resourcebase", user_perms)
+
+        self.assertIn("view_resourcebase", admin_perms)
+        self.assertIn("change_resourcebase", admin_perms)
+
+        self.assertIn("view_resourcebase", anon_perms)
+        self.assertIn("view_resourcebase", group_perms)
+
+        other_resource = self.resources[0]
+        other_resource_key = f"resource_perms:{other_resource.pk}:user:{self.test_user.pk}"
+        permissions_registry.get_perms(instance=other_resource, user=self.test_user, use_cache=True)
+        self.assertIsNotNone(cache.get(other_resource_key))
+
+        permissions_registry.delete_resource_permissions_cache(temp_resource)
+
+        for cache_key in cache_keys_to_check:
+            self.assertIsNone(cache.get(cache_key), f"Cache key {cache_key} should be cleared after resource deletion")
+
+        self.assertIsNotNone(
+            cache.get(other_resource_key), "Cache keys for other resources should not be affected by resource deletion"
+        )
+
+        temp_resource.delete()

--- a/geonode/base/api/tests.py
+++ b/geonode/base/api/tests.py
@@ -3605,10 +3605,7 @@ class TestPermissionsCaching(GeoNodeBaseTestSupport):
         cls.test_group, _ = Group.objects.get_or_create(name="test-group")
         cls.test_group.user_set.add(cls.admin_user)
         cls.test_group_profile = GroupProfile.objects.create(
-            group=cls.test_group,
-            title="Test Group",
-            slug="test-group",
-            access="public"
+            group=cls.test_group, title="Test Group", slug="test-group", access="public"
         )
         cls.anonymous, _ = Group.objects.get_or_create(name="anonymous")
 
@@ -3626,21 +3623,23 @@ class TestPermissionsCaching(GeoNodeBaseTestSupport):
             perm_spec = {
                 "users": {
                     cls.test_user.username: [
-                        "view_resourcebase", "change_resourcebase",
+                        "view_resourcebase",
+                        "change_resourcebase",
                         "change_resourcebase_metadata",
                         "change_resourcebase_permissions",
-                        "delete_resourcebase"
+                        "delete_resourcebase",
                     ]
                 },
                 "groups": {
                     cls.test_group.name: [
-                        "view_resourcebase", "change_resourcebase",
+                        "view_resourcebase",
+                        "change_resourcebase",
                         "change_resourcebase_metadata",
                         "change_resourcebase_permissions",
-                        "delete_resourcebase"
+                        "delete_resourcebase",
                     ],
-                    cls.anonymous.name: ["view_resourcebase"]
-                }
+                    cls.anonymous.name: ["view_resourcebase"],
+                },
             }
             resource.set_permissions(perm_spec)
             cls.resources.append(resource)
@@ -3652,17 +3651,9 @@ class TestPermissionsCaching(GeoNodeBaseTestSupport):
         permissions_registry = PermissionsHandlerRegistry()
         test_resource = self.resources[0]
 
-        admin_perms_1 = permissions_registry.get_perms(
-            instance=test_resource,
-            user=self.admin_user,
-            is_cache=True
-        )
+        admin_perms_1 = permissions_registry.get_perms(instance=test_resource, user=self.admin_user, is_cache=True)
 
-        admin_perms_2 = permissions_registry.get_perms(
-            instance=test_resource,
-            user=self.admin_user,
-            is_cache=True
-        )
+        admin_perms_2 = permissions_registry.get_perms(instance=test_resource, user=self.admin_user, is_cache=True)
 
         self.assertEqual(admin_perms_1, admin_perms_2)
 
@@ -3679,18 +3670,10 @@ class TestPermissionsCaching(GeoNodeBaseTestSupport):
         test_resource = self.resources[0]
         anonymous_user = AnonymousUser()
 
-        anon_perms_1 = permissions_registry.get_perms(
-            instance=test_resource,
-            user=anonymous_user,
-            is_cache=True
-        )
+        anon_perms_1 = permissions_registry.get_perms(instance=test_resource, user=anonymous_user, is_cache=True)
         self.assertIn("view_resourcebase", anon_perms_1)
 
-        anon_perms_2 = permissions_registry.get_perms(
-            instance=test_resource,
-            user=anonymous_user,
-            is_cache=True
-        )
+        anon_perms_2 = permissions_registry.get_perms(instance=test_resource, user=anonymous_user, is_cache=True)
         self.assertIn("view_resourcebase", anon_perms_2)
         self.assertEqual(anon_perms_1, anon_perms_2)
 
@@ -3699,25 +3682,18 @@ class TestPermissionsCaching(GeoNodeBaseTestSupport):
         permissions_registry = PermissionsHandlerRegistry()
         test_resource = self.resources[0]
 
-        user_perms_1 = permissions_registry.get_perms(
-            instance=test_resource,
-            user=self.test_user,
-            is_cache=True
-        )
+        user_perms_1 = permissions_registry.get_perms(instance=test_resource, user=self.test_user, is_cache=True)
 
-        user_perms_2 = permissions_registry.get_perms(
-            instance=test_resource,
-            user=self.test_user,
-            is_cache=True
-        )
+        user_perms_2 = permissions_registry.get_perms(instance=test_resource, user=self.test_user, is_cache=True)
 
         self.assertEqual(user_perms_1, user_perms_2)
 
         expected_owner_perms = [
-            "view_resourcebase", "change_resourcebase",
+            "view_resourcebase",
+            "change_resourcebase",
             "change_resourcebase_metadata",
             "change_resourcebase_permissions",
-            "delete_resourcebase"
+            "delete_resourcebase",
         ]
 
         for perm in expected_owner_perms:

--- a/geonode/base/api/tests.py
+++ b/geonode/base/api/tests.py
@@ -3803,27 +3803,27 @@ class TestPermissionsCaching(GeoNodeBaseTestSupport):
 
         # Test authenticated user cache key
         expected_admin_key = f"resource_perms:{test_resource.pk}:user:{self.admin_user.pk}"
-        actual_admin_key = permissions_registry._get_cache_key(test_resource.pk, user=self.admin_user)
+        actual_admin_key = permissions_registry._get_cache_key([test_resource.pk], users=[self.admin_user])
         self.assertEqual(actual_admin_key, expected_admin_key)
 
         # Test test user cache key
         expected_test_user_key = f"resource_perms:{test_resource.pk}:user:{self.test_user.pk}"
-        actual_test_user_key = permissions_registry._get_cache_key(test_resource.pk, user=self.test_user)
+        actual_test_user_key = permissions_registry._get_cache_key([test_resource.pk], users=[self.test_user])
         self.assertEqual(actual_test_user_key, expected_test_user_key)
 
         # Test anonymous user cache key
         expected_anon_key = f"resource_perms:{test_resource.pk}:anonymous"
-        actual_anon_key = permissions_registry._get_cache_key(test_resource.pk, user=anonymous_user)
+        actual_anon_key = permissions_registry._get_cache_key([test_resource.pk], users=[anonymous_user])
         self.assertEqual(actual_anon_key, expected_anon_key)
 
         # Test group cache key
         expected_group_key = f"resource_perms:{test_resource.pk}:group:{self.test_group.pk}"
-        actual_group_key = permissions_registry._get_cache_key(test_resource.pk, group=self.test_group)
+        actual_group_key = permissions_registry._get_cache_key([test_resource.pk], groups=[self.test_group])
         self.assertEqual(actual_group_key, expected_group_key)
 
         # Test __ALL__ cache key (when both user and group are None)
         expected_all_key = f"resource_perms:{test_resource.pk}:__ALL__"
-        actual_all_key = permissions_registry._get_cache_key(test_resource.pk, user=None, group=None)
+        actual_all_key = permissions_registry._get_cache_key([test_resource.pk], users=None, groups=None)
         self.assertEqual(actual_all_key, expected_all_key)
 
         # Test that keys are unique for different users and groups
@@ -3831,8 +3831,8 @@ class TestPermissionsCaching(GeoNodeBaseTestSupport):
         self.assertEqual(len(cache_keys), len(set(cache_keys)), "All cache keys should be unique")
 
         # Test consistency across multiple calls
-        key_call_1 = permissions_registry._get_cache_key(test_resource.pk, user=self.admin_user)
-        key_call_2 = permissions_registry._get_cache_key(test_resource.pk, user=self.admin_user)
+        key_call_1 = permissions_registry._get_cache_key([test_resource.pk], users=[self.admin_user])
+        key_call_2 = permissions_registry._get_cache_key([test_resource.pk], users=[self.admin_user])
         self.assertEqual(key_call_1, key_call_2, "Cache key generation should be consistent")
 
         # Test that the cache keys match what's actually used in caching

--- a/geonode/base/api/tests.py
+++ b/geonode/base/api/tests.py
@@ -96,7 +96,7 @@ from geonode.resource.api.tasks import resouce_service_dispatcher
 from guardian.shortcuts import assign_perm
 from geonode.security.registry import permissions_registry
 
-from django.contrib.auth.models import AnonymousUser, Group
+from django.contrib.auth.models import AnonymousUser
 from django.core.cache import cache
 from geonode.security.registry import PermissionsHandlerRegistry
 
@@ -3594,6 +3594,16 @@ class TestBaseResourceBase(GeoNodeBaseTestSupport):
         return request
 
 
+@override_settings(
+    CACHES={
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "test-cache",
+            "TIMEOUT": 600,
+            "OPTIONS": {"MAX_ENTRIES": 10000},
+        }
+    }
+)
 class TestPermissionsCaching(GeoNodeBaseTestSupport):
     @classmethod
     def setUpClass(cls) -> None:

--- a/geonode/base/api/tests.py
+++ b/geonode/base/api/tests.py
@@ -3912,7 +3912,7 @@ class TestPermissionsCaching(GeoNodeBaseTestSupport):
 
         temp_user_profile = temp_user
 
-        permissions_registry.delete_resource_permissions_cache(temp_user_profile, user_clear_cache=True)
+        permissions_registry.delete_resource_permissions_cache(temp_user_profile, group_clear_cache=False)
 
         for cache_key in cache_keys:
             self.assertIsNone(cache.get(cache_key), f"Cache key {cache_key} should be cleared after user deletion")
@@ -3978,7 +3978,7 @@ class TestPermissionsCaching(GeoNodeBaseTestSupport):
             unrelated_cache_keys.append(cache_key)
             self.assertIsNotNone(cache.get(cache_key))
 
-        permissions_registry.delete_resource_permissions_cache(temp_group, group_clear_cache=True)
+        permissions_registry.delete_resource_permissions_cache(temp_group, user_clear_cache=False)
 
         for cache_key in group_cache_keys:
             self.assertIsNone(

--- a/geonode/groups/models.py
+++ b/geonode/groups/models.py
@@ -300,11 +300,7 @@ class GroupMember(models.Model):
         from geonode.security.utils import AdvancedSecurityWorkflowManager
         from geonode.security.registry import permissions_registry
 
-        permissions_registry.delete_resource_permissions_cache(
-            instance=self.group.group,
-            user_clear_cache=True,
-            group_clear_cache=True,
-        )
+        permissions_registry.delete_resource_permissions_cache(instance=self.group.group)
         if not AdvancedSecurityWorkflowManager.is_auto_publishing_workflow():
             AdvancedSecurityWorkflowManager.set_group_member_permissions(self.user, self.group, role)
 
@@ -318,11 +314,7 @@ def group_pre_delete(instance, sender, **kwargs):
             "Deletion of the anonymous group is\
          not permitted as will break the geonode permissions system"
         )
-    permissions_registry.delete_resource_permissions_cache(
-        instance=instance,
-        user_clear_cache=True,
-        group_clear_cache=True,
-    )
+    permissions_registry.delete_resource_permissions_cache(instance=instance)
 
 
 signals.pre_delete.connect(group_pre_delete, sender=Group)

--- a/geonode/people/models.py
+++ b/geonode/people/models.py
@@ -46,9 +46,17 @@ from allauth.socialaccount.signals import social_account_added
 from geonode.security.utils import can_approve, can_feature, can_publish
 
 from .utils import format_address
-from .signals import do_login, do_logout, profile_post_save, update_user_email_addresses, notify_admins_new_signup
+from .signals import (
+    do_login,
+    do_logout,
+    profile_post_save,
+    update_user_email_addresses,
+    notify_admins_new_signup,
+    clear_user_resource_permissions_cache_on_delete,
+)
 from .languages import LANGUAGES
 from .timezones import TIMEZONES
+
 
 logger = logging.getLogger(__name__)
 
@@ -115,9 +123,8 @@ class Profile(AbstractUser):
     keywords = TaggableManager(
         _("keywords"),
         blank=True,
-        help_text=_(
-            "commonly used word(s) or formalised word(s) or phrase(s) used to describe the subject \
-            (space or comma-separated"
+        help_text=(
+            "commonly used word(s) or formalised word(s) or phrase(s) used to describe the subject             (space or comma-separated)"
         ),
     )
     language = models.CharField(_("language"), max_length=10, choices=LANGUAGES, default=settings.LANGUAGE_CODE)
@@ -296,3 +303,4 @@ user_logged_out.connect(do_logout)
 social_account_added.connect(update_user_email_addresses, dispatch_uid=str(uuid4()), weak=False)
 user_signed_up.connect(notify_admins_new_signup, dispatch_uid=str(uuid4()), weak=False)
 signals.post_save.connect(profile_post_save, sender=settings.AUTH_USER_MODEL)
+signals.pre_delete.connect(clear_user_resource_permissions_cache_on_delete, sender=settings.AUTH_USER_MODEL)

--- a/geonode/people/signals.py
+++ b/geonode/people/signals.py
@@ -135,5 +135,5 @@ def clear_user_resource_permissions_cache_on_delete(sender, instance, **kwargs):
     # Clear cache for user permissions related to the instance being deleted
     permissions_registry.delete_resource_permissions_cache(
         instance=instance,
-        user_clear_cache=True,
+        group_clear_cache=False,
     )

--- a/geonode/people/signals.py
+++ b/geonode/people/signals.py
@@ -38,6 +38,7 @@ from geonode.base.auth import get_or_create_token, delete_old_tokens, set_sessio
 from geonode.notifications_helper import send_notification
 
 from .adapters import get_data_extractor
+from geonode.security.registry import permissions_registry
 
 logger = logging.getLogger(__name__)
 
@@ -124,3 +125,15 @@ def profile_post_save(instance, sender, **kwargs):
     # do not create email, when user-account signup code is in use
     if getattr(instance, "_disable_account_creation", False):
         return
+
+
+def clear_user_resource_permissions_cache_on_delete(sender, instance, **kwargs):
+    """
+    Signal handler to clear user-resource-related cache upon deletion.
+    """
+
+    # Clear cache for user permissions related to the instance being deleted
+    permissions_registry.delete_resource_permissions_cache(
+        instance=instance,
+        user_clear_cache=True,
+    )

--- a/geonode/resource/manager.py
+++ b/geonode/resource/manager.py
@@ -502,10 +502,10 @@ class ResourceManager(ResourceManagerInterface):
             users = Profile.objects.filter(
                 Q(groups__in=permissions["groups"].keys()) | Q(id__in=[x.id for x in permissions["users"].keys()])
             )
-            for user in users:
-                cache.delete(f"resource_perms:{_resource.pk}:{user.pk}")
-            cache.delete(f"resource_perms:{_resource.pk}:__ALL__")
-            cache.delete(f"resource_perms:{_resource.pk}:anonymous")
+            cache_keys = [f"resource_perms:{_resource.pk}:{user.pk}" for user in users]
+            cache_keys.extend([f"resource_perms:{_resource.pk}:__ALL__", f"resource_perms:{_resource.pk}:anonymous"])
+
+            cache.delete_many(cache_keys)
             return True
         return False
 

--- a/geonode/resource/manager.py
+++ b/geonode/resource/manager.py
@@ -69,7 +69,6 @@ from geonode.people.models import Profile
 from django.db.models import Q
 
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -494,7 +493,7 @@ class ResourceManager(ResourceManagerInterface):
                 _method = getattr(self._concrete_resource_manager, method)
                 return _method(method, uuid, instance=_resource, **kwargs)
         return instance
-    
+
     def invalidate_cache(self, uuid: str, /, instance: ResourceBase = None) -> bool:
         """Invalidate the cache for the given resource."""
         _resource = instance or ResourceManager._get_instance(uuid)

--- a/geonode/resource/manager.py
+++ b/geonode/resource/manager.py
@@ -494,7 +494,7 @@ class ResourceManager(ResourceManagerInterface):
                 return _method(method, uuid, instance=_resource, **kwargs)
         return instance
 
-    def invalidate_cache(self, uuid: str, /, instance: ResourceBase = None) -> bool:
+    def invalidate_permissions_cache(self, uuid: str, /, instance: ResourceBase = None) -> bool:
         """Invalidate the cache for the given resource."""
         _resource = instance or ResourceManager._get_instance(uuid)
         if _resource:
@@ -514,7 +514,7 @@ class ResourceManager(ResourceManagerInterface):
         If is a layer removes the layer specific permissions then the
         resourcebase permissions.
         """
-        self.invalidate_cache(uuid, instance=instance)
+        self.invalidate_permissions_cache(uuid, instance=instance)
         _resource = instance or ResourceManager._get_instance(uuid)
         if _resource:
             _resource.set_processing_state(enumerations.STATE_RUNNING)
@@ -568,7 +568,7 @@ class ResourceManager(ResourceManagerInterface):
         approval_status_changed: bool = False,
         group_status_changed: bool = False,
     ) -> bool:
-        self.invalidate_cache(uuid, instance=instance)
+        self.invalidate_permissions_cache(uuid, instance=instance)
         _resource = instance or ResourceManager._get_instance(uuid)
         if _resource:
             _resource = _resource.get_real_instance()

--- a/geonode/resource/manager.py
+++ b/geonode/resource/manager.py
@@ -204,11 +204,7 @@ class ResourceManager(ResourceManagerInterface):
         uuid = uuid or _resource.uuid
         if _resource and ResourceBase.objects.filter(uuid=uuid).exists():
             try:
-                permissions_registry.delete_resource_permissions_cache(
-                    instance=_resource,
-                    user_clear_cache=True,
-                    group_clear_cache=True,
-                )
+                permissions_registry.delete_resource_permissions_cache(instance=_resource)
                 _resource.set_processing_state(enumerations.STATE_RUNNING)
                 _resource.set_dirty_state()
                 try:
@@ -504,11 +500,7 @@ class ResourceManager(ResourceManagerInterface):
 
         _resource = instance or ResourceManager._get_instance(uuid)
         if _resource:
-            permissions_registry.delete_resource_permissions_cache(
-                instance=_resource,
-                user_clear_cache=True,
-                group_clear_cache=True,
-            )
+            permissions_registry.delete_resource_permissions_cache(instance=_resource)
             _resource.set_processing_state(enumerations.STATE_RUNNING)
             try:
                 with transaction.atomic():
@@ -561,11 +553,7 @@ class ResourceManager(ResourceManagerInterface):
     ) -> bool:
         _resource = instance or ResourceManager._get_instance(uuid)
         if _resource:
-            permissions_registry.delete_resource_permissions_cache(
-                instance=_resource,
-                user_clear_cache=True,
-                group_clear_cache=True,
-            )
+            permissions_registry.delete_resource_permissions_cache(instance=_resource)
             _resource = _resource.get_real_instance()
             _resource.set_processing_state(enumerations.STATE_RUNNING)
             logger.debug(f"Finalizing (permissions and notifications) on resource {instance}")

--- a/geonode/security/registry.py
+++ b/geonode/security/registry.py
@@ -250,8 +250,6 @@ class PermissionsHandlerRegistry:
 
         if user:
             if include_user_add_resource and user.has_perm("base.add_resourcebase"):
-                if user not in payload["users"]:
-                    payload["users"][user] = []
                 payload["users"][user].append("add_resourcebase")
 
             result = payload["users"][user]

--- a/geonode/security/registry.py
+++ b/geonode/security/registry.py
@@ -107,7 +107,7 @@ class PermissionsHandlerRegistry:
             permissions = permissions_registry.get_perms(instance=instance)
             users = Profile.objects.filter(
                 Q(groups__in=permissions["groups"].keys()) | Q(id__in=[x.id for x in permissions["users"].keys()])
-            )
+            ).distinct()
 
             cache_keys = _generate_cache_keys(
                 resource_pks=[instance.pk],

--- a/geonode/security/registry.py
+++ b/geonode/security/registry.py
@@ -19,7 +19,7 @@
 from django.conf import settings
 from django.utils.module_loading import import_string
 from geonode.security.handlers import BasePermissionsHandler
-from django.core.cache import cache 
+from django.core.cache import cache
 
 
 class PermissionsHandlerRegistry:
@@ -64,7 +64,14 @@ class PermissionsHandlerRegistry:
         return payload
 
     def get_perms(
-        self, instance, user=None, include_virtual=True, include_user_add_resource=False, is_cache=False, *args, **kwargs
+        self,
+        instance,
+        user=None,
+        include_virtual=True,
+        include_user_add_resource=False,
+        is_cache=False,
+        *args,
+        **kwargs,
     ):
         """
         Return the payload with the permissions from the handlers.
@@ -94,8 +101,8 @@ class PermissionsHandlerRegistry:
             if include_user_add_resource and user.has_perm("base.add_resourcebase"):
                 payload["users"][user].extend(["add_resourcebase"])
             if is_cache and cache_key:
-                #set cache for 7 days
-                cache.set(cache_key, payload["users"][user], 604800) 
+                # set cache for 7 days
+                cache.set(cache_key, payload["users"][user], 604800)
             return payload["users"][user]
         if is_cache and cache_key:
             cache.set(cache_key, payload, 604800)  # set cache for 7 days

--- a/geonode/security/tests.py
+++ b/geonode/security/tests.py
@@ -26,6 +26,7 @@ import os
 import requests
 import importlib
 import mock
+from uuid import uuid4
 
 from requests.auth import HTTPBasicAuth
 from tastypie.test import ResourceTestCaseMixin
@@ -87,6 +88,8 @@ from .utils import (
 )
 
 from .permissions import PermSpec, PermSpecCompact
+from django.core.cache import cache
+from geonode.base.models import ResourceBase
 
 logger = logging.getLogger(__name__)
 
@@ -2871,3 +2874,535 @@ class TestPermissionsHandlers(GeoNodeBaseTestSupport):
 
         # Still empty, since user had no base perms
         self.assertListEqual(updated_perms_empty["users"][self.group_manager], [])
+
+
+@override_settings(
+    CACHES={
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "test-cache",
+            "TIMEOUT": 600,
+            "OPTIONS": {"MAX_ENTRIES": 10000},
+        }
+    }
+)
+class TestPermissionsCaching(GeoNodeBaseTestSupport):
+    @classmethod
+    def setUpClass(cls) -> None:
+        super().setUpClass()
+        cls.admin_user = get_user_model().objects.get(username="admin")
+        cls.test_user = get_user_model().objects.create_user(
+            username=f"test_user{uuid4()}", email="test_user@example.com", password="testpass123"
+        )
+        cls.test_user_owner = get_user_model().objects.create_user(
+            username=f"test_user_owner{uuid4()}", email="test_user_owner@example.com", password="testpass123"
+        )
+        cls.test_group, _ = Group.objects.get_or_create(name="test-group")
+        cls.test_group.user_set.add(cls.admin_user)
+        cls.test_group_profile = GroupProfile.objects.create(
+            group=cls.test_group, title="Test Group", slug="test-group", access="public"
+        )
+        cls.anonymous, _ = Group.objects.get_or_create(name="anonymous")
+
+        cls.resources = []
+        for i in range(4):
+            resource = ResourceBase.objects.create(
+                title=f"test_dataset_{i:02d}",
+                uuid=str(uuid4()),
+                owner=cls.test_user_owner,
+                abstract=f"Test dataset {i:02d} by test_user",
+                subtype="vector",
+                is_approved=True,
+                is_published=True,
+            )
+            perm_spec = {
+                "users": {
+                    cls.test_user.username: [
+                        "view_resourcebase",
+                        "change_resourcebase",
+                        "change_resourcebase_metadata",
+                        "change_resourcebase_permissions",
+                        "delete_resourcebase",
+                    ]
+                },
+                "groups": {
+                    cls.test_group.name: [
+                        "view_resourcebase",
+                        "change_resourcebase",
+                        "change_resourcebase_metadata",
+                        "change_resourcebase_permissions",
+                        "delete_resourcebase",
+                    ],
+                    cls.anonymous.name: ["view_resourcebase"],
+                },
+            }
+            resource.set_permissions(perm_spec)
+            cls.resources.append(resource)
+
+    def setUp(self):
+        cache.clear()
+
+    def test_admin_user_permissions_caching(self):
+        test_resource = self.resources[0]
+
+        admin_perms_1 = permissions_registry.get_perms(instance=test_resource, user=self.admin_user, use_cache=True)
+        admin_perms_2 = permissions_registry.get_perms(instance=test_resource, user=self.admin_user, use_cache=True)
+
+        self.assertEqual(admin_perms_1, admin_perms_2)
+
+        self.assertIn("view_resourcebase", admin_perms_1)
+        self.assertIn("download_resourcebase", admin_perms_1)
+        self.assertIn("change_resourcebase", admin_perms_1)
+        self.assertIn("change_resourcebase_metadata", admin_perms_1)
+        self.assertIn("change_resourcebase_permissions", admin_perms_1)
+        self.assertIn("delete_resourcebase", admin_perms_1)
+
+    def test_permission_anonymous_users(self):
+        test_resource = self.resources[0]
+        anonymous_user = AnonymousUser()
+
+        anon_perms_1 = permissions_registry.get_perms(instance=test_resource, user=anonymous_user, use_cache=True)
+        self.assertIn("view_resourcebase", anon_perms_1)
+
+        anon_perms_2 = permissions_registry.get_perms(instance=test_resource, user=anonymous_user, use_cache=True)
+        self.assertIn("view_resourcebase", anon_perms_2)
+        self.assertEqual(anon_perms_1, anon_perms_2)
+
+    def test_owner_user_permissions_caching(self):
+        test_resource = self.resources[0]
+
+        user_perms_1 = permissions_registry.get_perms(instance=test_resource, user=self.test_user, use_cache=True)
+        user_perms_2 = permissions_registry.get_perms(instance=test_resource, user=self.test_user, use_cache=True)
+
+        self.assertEqual(user_perms_1, user_perms_2)
+
+        expected_owner_perms = [
+            "view_resourcebase",
+            "change_resourcebase",
+            "change_resourcebase_metadata",
+            "change_resourcebase_permissions",
+            "delete_resourcebase",
+        ]
+
+        for perm in expected_owner_perms:
+            self.assertIn(perm, user_perms_1)
+
+    def test_group_permissions_caching(self):
+        """Test that group permissions are cached correctly"""
+        test_resource = self.resources[0]
+
+        group_perms_1 = permissions_registry.get_perms(instance=test_resource, group=self.test_group, use_cache=True)
+        group_perms_2 = permissions_registry.get_perms(instance=test_resource, group=self.test_group, use_cache=True)
+
+        self.assertEqual(list(group_perms_1), list(group_perms_2))
+
+        expected_group_perms = [
+            "view_resourcebase",
+            "change_resourcebase",
+            "change_resourcebase_metadata",
+            "change_resourcebase_permissions",
+            "delete_resourcebase",
+        ]
+
+        for perm in expected_group_perms:
+            self.assertIn(perm, group_perms_1)
+
+    def test_user_and_group_permissions_combined(self):
+        """Test getting both user and group permissions in one call"""
+        test_resource = self.resources[0]
+
+        combined_perms = permissions_registry.get_perms(
+            instance=test_resource, user=self.test_user, group=self.test_group, use_cache=True
+        )
+
+        self.assertIn("users", combined_perms)
+        self.assertIn("groups", combined_perms)
+        self.assertIn(self.test_user, combined_perms["users"])
+        self.assertIn(self.test_group, combined_perms["groups"])
+
+    def test_cache_keys_are_different(self):
+        test_resource = self.resources[0]
+        anonymous_user = AnonymousUser()
+
+        # Generate permissions to populate cache
+        permissions_registry.get_perms(instance=test_resource, user=anonymous_user, use_cache=True)
+        permissions_registry.get_perms(instance=test_resource, user=self.admin_user, use_cache=True)
+        permissions_registry.get_perms(instance=test_resource, user=self.test_user, use_cache=True)
+        permissions_registry.get_perms(instance=test_resource, group=self.test_group, use_cache=True)
+
+        # Updated cache key formats
+        anonymous_key = f"resource_perms:{test_resource.pk}:anonymous"
+        admin_key = f"resource_perms:{test_resource.pk}:user:{self.admin_user.pk}"
+        test_user_key = f"resource_perms:{test_resource.pk}:user:{self.test_user.pk}"
+        group_key = f"resource_perms:{test_resource.pk}:group:{self.test_group.pk}"
+
+        # Verify all cache keys exist
+        self.assertIsNotNone(cache.get(anonymous_key))
+        self.assertIsNotNone(cache.get(admin_key))
+        self.assertIsNotNone(cache.get(test_user_key))
+        self.assertIsNotNone(cache.get(group_key))
+
+        # Verify cached values are different
+        anon_cached = cache.get(anonymous_key)
+        admin_cached = cache.get(admin_key)
+        user_cached = cache.get(test_user_key)
+        group_cached = cache.get(group_key)
+
+        self.assertNotEqual(anon_cached, admin_cached)
+        self.assertNotEqual(anon_cached, user_cached)
+        self.assertNotEqual(admin_cached, user_cached)
+        self.assertNotEqual(user_cached, group_cached)
+
+    def test_multiple_resources_independent_caching(self):
+
+        resource_1 = self.resources[0]
+        resource_2 = self.resources[1]
+
+        perms_r1 = permissions_registry.get_perms(instance=resource_1, user=self.test_user, use_cache=True)
+        perms_r2 = permissions_registry.get_perms(instance=resource_2, user=self.test_user, use_cache=True)
+
+        self.assertEqual(perms_r1, perms_r2)
+
+        # Updated cache key format
+        cache_key_r1 = f"resource_perms:{resource_1.pk}:user:{self.test_user.pk}"
+        cache_key_r2 = f"resource_perms:{resource_2.pk}:user:{self.test_user.pk}"
+
+        self.assertIsNotNone(cache.get(cache_key_r1))
+        self.assertIsNotNone(cache.get(cache_key_r2))
+
+    def test_cache_key_generation_consistency(self):
+        """
+        Test that the _get_cache_key method generates consistent and correct cache keys
+        for different user types, groups, and scenarios.
+        """
+        test_resource = self.resources[0]
+        anonymous_user = AnonymousUser()
+
+        # Test authenticated user cache key
+        expected_admin_key = f"resource_perms:{test_resource.pk}:user:{self.admin_user.pk}"
+        actual_admin_key = permissions_registry._get_cache_key([test_resource.pk], users=[self.admin_user])
+        self.assertEqual(actual_admin_key, expected_admin_key)
+
+        # Test test user cache key
+        expected_test_user_key = f"resource_perms:{test_resource.pk}:user:{self.test_user.pk}"
+        actual_test_user_key = permissions_registry._get_cache_key([test_resource.pk], users=[self.test_user])
+        self.assertEqual(actual_test_user_key, expected_test_user_key)
+
+        # Test anonymous user cache key
+        expected_anon_key = f"resource_perms:{test_resource.pk}:anonymous"
+        actual_anon_key = permissions_registry._get_cache_key([test_resource.pk], users=[anonymous_user])
+        self.assertEqual(actual_anon_key, expected_anon_key)
+
+        # Test group cache key
+        expected_group_key = f"resource_perms:{test_resource.pk}:group:{self.test_group.pk}"
+        actual_group_key = permissions_registry._get_cache_key([test_resource.pk], groups=[self.test_group])
+        self.assertEqual(actual_group_key, expected_group_key)
+
+        # Test __ALL__ cache key (when both user and group are None)
+        expected_all_key = f"resource_perms:{test_resource.pk}:__ALL__"
+        actual_all_key = permissions_registry._get_cache_key([test_resource.pk], users=None, groups=None)
+        self.assertEqual(actual_all_key, expected_all_key)
+
+        # Test that keys are unique for different users and groups
+        cache_keys = [actual_admin_key, actual_test_user_key, actual_anon_key, actual_group_key, actual_all_key]
+        self.assertEqual(len(cache_keys), len(set(cache_keys)), "All cache keys should be unique")
+
+        # Test consistency across multiple calls
+        key_call_1 = permissions_registry._get_cache_key([test_resource.pk], users=[self.admin_user])
+        key_call_2 = permissions_registry._get_cache_key([test_resource.pk], users=[self.admin_user])
+        self.assertEqual(key_call_1, key_call_2, "Cache key generation should be consistent")
+
+        # Test that the cache keys match what's actually used in caching
+        permissions_registry.get_perms(instance=test_resource, user=self.admin_user, use_cache=True)
+        permissions_registry.get_perms(instance=test_resource, user=anonymous_user, use_cache=True)
+        permissions_registry.get_perms(instance=test_resource, group=self.test_group, use_cache=True)
+
+        # Verify the generated keys match what's in cache
+        self.assertIsNotNone(cache.get(actual_admin_key), "Admin cache key should exist in cache")
+        self.assertIsNotNone(cache.get(actual_anon_key), "Anonymous cache key should exist in cache")
+        self.assertIsNotNone(cache.get(actual_group_key), "Group cache key should exist in cache")
+
+    def test_cache_invalidation_on_permission_change(self):
+        """Test that cache is properly invalidated when permissions are actually changed"""
+        test_resource = self.resources[0]
+        cache_key = f"resource_perms:{test_resource.pk}:user:{self.test_user.pk}"
+
+        initial_perms = permissions_registry.get_perms(instance=test_resource, user=self.test_user, use_cache=True)
+
+        self.assertIsNotNone(cache.get(cache_key))
+        self.assertIn("view_resourcebase", initial_perms)
+        self.assertIn("change_resourcebase", initial_perms)
+        self.assertIn("delete_resourcebase", initial_perms)
+
+        new_perm_spec = {
+            "users": {
+                f"{self.test_user.username}": [
+                    "view_resourcebase",
+                ]
+            },
+            "groups": {
+                f"{self.test_group.name}": [
+                    "view_resourcebase",
+                    "change_resourcebase",
+                    "change_resourcebase_metadata",
+                    "change_resourcebase_permissions",
+                    "delete_resourcebase",
+                ],
+                f"{self.anonymous.name}": ["view_resourcebase"],
+            },
+        }
+
+        test_resource.set_permissions(new_perm_spec)
+
+        self.assertIsNone(cache.get(cache_key), "Cache should be cleared after permission change")
+
+        updated_perms = permissions_registry.get_perms(instance=test_resource, user=self.test_user, use_cache=True)
+
+        self.assertIsNotNone(cache.get(cache_key), "Cache should be populated after fresh permission fetch")
+
+        self.assertIn("view_resourcebase", updated_perms)
+        self.assertNotIn("change_resourcebase", updated_perms)
+        self.assertNotIn("delete_resourcebase", updated_perms)
+
+        cached_perms = permissions_registry.get_perms(instance=test_resource, user=self.test_user, use_cache=True)
+        self.assertEqual(updated_perms, cached_perms)
+
+        restored_perm_spec = {
+            "users": {
+                self.test_user.username: [
+                    "view_resourcebase",
+                    "change_resourcebase",  # Add back change permission
+                    "delete_resourcebase",  # Add back delete permission
+                ]
+            },
+            "groups": {
+                self.test_group.name: [
+                    "view_resourcebase",
+                    "change_resourcebase",
+                    "change_resourcebase_metadata",
+                    "change_resourcebase_permissions",
+                    "delete_resourcebase",
+                ],
+                self.anonymous.name: ["view_resourcebase"],
+            },
+        }
+
+        test_resource.set_permissions(restored_perm_spec)
+
+        self.assertIsNone(cache.get(cache_key), "Cache should be cleared after second permission change")
+
+        final_perms = permissions_registry.get_perms(instance=test_resource, user=self.test_user, use_cache=True)
+        self.assertIsNotNone(cache.get(cache_key), "Cache should be populated after final permission fetch")
+
+        self.assertIn("view_resourcebase", final_perms)
+        self.assertIn("change_resourcebase", final_perms)
+        self.assertIn("delete_resourcebase", final_perms)
+
+        self.assertNotEqual(
+            updated_perms, final_perms, "Final permissions should be different from updated permissions"
+        )
+
+    def test_all_permissions_caching(self):
+        """Test caching when getting all permissions (no user or group specified)"""
+        test_resource = self.resources[0]
+
+        all_perms_1 = permissions_registry.get_perms(instance=test_resource, use_cache=True)
+        all_perms_2 = permissions_registry.get_perms(instance=test_resource, use_cache=True)
+
+        self.assertEqual(all_perms_1, all_perms_2)
+
+        # Verify structure contains both users and groups
+        self.assertIn("users", all_perms_1)
+        self.assertIn("groups", all_perms_1)
+
+    def test_user_deletion_cache_invalidation(self):
+        """Test that cache is properly cleared when a user is deleted"""
+
+        # Create a temporary user for deletion testing
+        temp_user = get_user_model().objects.create_user(
+            username=f"temp_user_{uuid4()}", email="temp@example.com", password="temppass123"
+        )
+
+        for resource in self.resources[:2]:  # Use first 2 resources
+            perm_spec = {"users": {temp_user.username: ["view_resourcebase", "change_resourcebase"]}, "groups": {}}
+            resource.set_permissions(perm_spec)
+
+        cached_perms = []
+        cache_keys = []
+
+        for resource in self.resources[:2]:
+            perms = permissions_registry.get_perms(instance=resource, user=temp_user, use_cache=True)
+            cached_perms.append(perms)
+            cache_key = f"resource_perms:{resource.pk}:user:{temp_user.pk}"
+            cache_keys.append(cache_key)
+
+            # Verify permissions are cached
+            self.assertIsNotNone(cache.get(cache_key))
+            self.assertIn("view_resourcebase", perms)
+
+        other_user_cache_keys = []
+        for resource in self.resources[:2]:
+            permissions_registry.get_perms(instance=resource, user=self.test_user, use_cache=True)
+            other_key = f"resource_perms:{resource.pk}:user:{self.test_user.pk}"
+            other_user_cache_keys.append(other_key)
+            self.assertIsNotNone(cache.get(other_key))
+
+        temp_user_profile = temp_user
+
+        permissions_registry.delete_resource_permissions_cache(temp_user_profile, group_clear_cache=False)
+
+        for cache_key in cache_keys:
+            self.assertIsNone(cache.get(cache_key), f"Cache key {cache_key} should be cleared after user deletion")
+
+        for other_key in other_user_cache_keys:
+            self.assertIsNotNone(cache.get(other_key), f"Cache key {other_key} should not be affected by user deletion")
+
+        temp_user.delete()
+
+    def test_group_deletion_cache_invalidation(self):
+        """Test that cache is properly cleared when a group is deleted"""
+        temp_group, created = Group.objects.get_or_create(name=f"temp_group_{uuid4()}")
+
+        temp_group_profile, created = GroupProfile.objects.get_or_create(
+            group_id=temp_group.id,
+        )
+
+        temp_group, _ = Group.objects.get_or_create(name="test-group-2")
+        temp_group_profile = GroupProfile.objects.create(
+            group=temp_group, title="Test Group 2 ", slug="test-group-2", access="public"
+        )
+
+        temp_group_profile.refresh_from_db()
+
+        self.assertEqual(
+            temp_group_profile.group.id,
+            temp_group.id,
+            f"GroupProfile.group ({temp_group_profile.group}) should equal temp_group ({temp_group})",
+        )
+
+        temp_group.user_set.add(self.test_user, self.admin_user)
+
+        for resource in self.resources[:2]:  # Use first 2 resources
+            perm_spec = {"users": {}, "groups": {temp_group.name: ["view_resourcebase", "change_resourcebase"]}}
+            resource.set_permissions(perm_spec)
+
+        group_cache_keys = []
+        for resource in self.resources[:2]:
+            perms = permissions_registry.get_perms(instance=resource, group=temp_group, use_cache=True)
+            cache_key = f"resource_perms:{resource.pk}:group:{temp_group.pk}"
+            group_cache_keys.append(cache_key)
+
+            self.assertIsNotNone(cache.get(cache_key))
+            self.assertIn("view_resourcebase", perms)
+
+        user_cache_keys = []
+        for resource in self.resources[:2]:
+            for user in [self.test_user, self.admin_user]:
+                permissions_registry.get_perms(instance=resource, user=user, use_cache=True)
+                cache_key = f"resource_perms:{resource.pk}:user:{user.pk}"
+                user_cache_keys.append(cache_key)
+                self.assertIsNotNone(cache.get(cache_key))
+
+        unrelated_user = get_user_model().objects.create_user(
+            username=f"unrelated_user_{uuid4()}", email="unrelated@example.com", password="unrelated123"
+        )
+
+        unrelated_cache_keys = []
+        for resource in self.resources[:2]:
+            permissions_registry.get_perms(instance=resource, user=unrelated_user, use_cache=True)
+            cache_key = f"resource_perms:{resource.pk}:user:{unrelated_user.pk}"
+            unrelated_cache_keys.append(cache_key)
+            self.assertIsNotNone(cache.get(cache_key))
+
+        permissions_registry.delete_resource_permissions_cache(temp_group, user_clear_cache=False)
+
+        for cache_key in group_cache_keys:
+            self.assertIsNone(
+                cache.get(cache_key), f"Group cache key {cache_key} should be cleared after group deletion"
+            )
+
+    def test_resource_deletion_cache_invalidation(self):
+        """Test that cache is properly cleared when a resource is deleted"""
+
+        # Create a temporary resource for deletion testing
+        temp_resource = ResourceBase.objects.create(
+            title=f"temp_resource_{uuid4()}",
+            uuid=str(uuid4()),
+            owner=self.test_user,
+            abstract="Temporary resource for deletion testing",
+            subtype="vector",
+            is_approved=True,
+            is_published=True,
+        )
+
+        # Set permissions on the temporary resource
+        perm_spec = {
+            "users": {
+                self.test_user.username: [
+                    "view_resourcebase",
+                    "change_resourcebase",
+                    "delete_resourcebase",
+                ],
+                self.admin_user.username: [
+                    "view_resourcebase",
+                    "change_resourcebase",
+                ],
+            },
+            "groups": {
+                self.test_group.name: ["view_resourcebase"],
+                self.anonymous.name: ["view_resourcebase"],
+            },
+        }
+        temp_resource.set_permissions(perm_spec)
+
+        cache_keys_to_check = []
+
+        user_perms = permissions_registry.get_perms(instance=temp_resource, user=self.test_user, use_cache=True)
+        test_user_key = f"resource_perms:{temp_resource.pk}:user:{self.test_user.pk}"
+        cache_keys_to_check.append(test_user_key)
+
+        admin_perms = permissions_registry.get_perms(instance=temp_resource, user=self.admin_user, use_cache=True)
+        admin_user_key = f"resource_perms:{temp_resource.pk}:user:{self.admin_user.pk}"
+        cache_keys_to_check.append(admin_user_key)
+
+        anonymous_user = AnonymousUser()
+        anon_perms = permissions_registry.get_perms(instance=temp_resource, user=anonymous_user, use_cache=True)
+        anon_key = f"resource_perms:{temp_resource.pk}:anonymous"
+        cache_keys_to_check.append(anon_key)
+
+        group_perms = permissions_registry.get_perms(instance=temp_resource, group=self.test_group, use_cache=True)
+        group_key = f"resource_perms:{temp_resource.pk}:group:{self.test_group.pk}"
+        cache_keys_to_check.append(group_key)
+
+        permissions_registry.get_perms(instance=temp_resource, use_cache=True)
+        all_key = f"resource_perms:{temp_resource.pk}:__ALL__"
+        cache_keys_to_check.append(all_key)
+
+        for cache_key in cache_keys_to_check:
+            self.assertIsNotNone(cache.get(cache_key), f"Cache key {cache_key} should exist before deletion")
+
+        self.assertIn("view_resourcebase", user_perms)
+        self.assertIn("change_resourcebase", user_perms)
+        self.assertIn("delete_resourcebase", user_perms)
+
+        self.assertIn("view_resourcebase", admin_perms)
+        self.assertIn("change_resourcebase", admin_perms)
+
+        self.assertIn("view_resourcebase", anon_perms)
+        self.assertIn("view_resourcebase", group_perms)
+
+        other_resource = self.resources[0]
+        other_resource_key = f"resource_perms:{other_resource.pk}:user:{self.test_user.pk}"
+        permissions_registry.get_perms(instance=other_resource, user=self.test_user, use_cache=True)
+        self.assertIsNotNone(cache.get(other_resource_key))
+
+        permissions_registry.delete_resource_permissions_cache(temp_resource)
+
+        for cache_key in cache_keys_to_check:
+            self.assertIsNone(cache.get(cache_key), f"Cache key {cache_key} should be cleared after resource deletion")
+
+        self.assertIsNotNone(
+            cache.get(other_resource_key), "Cache keys for other resources should not be affected by resource deletion"
+        )
+
+        temp_resource.delete()

--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -336,9 +336,11 @@ MEMCACHED_LOCK_EXPIRE = int(os.getenv("MEMCACHED_LOCK_EXPIRE", 3600))
 MEMCACHED_LOCK_TIMEOUT = int(os.getenv("MEMCACHED_LOCK_TIMEOUT", 10))
 
 CACHES = {
-    # DUMMY CACHE FOR DEVELOPMENT
+    # Local Memory CACHE FOR DEVELOPMENT
     "default": {
-        "BACKEND": "django.core.cache.backends.dummy.DummyCache",
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "TIMEOUT": 600,
+        "OPTIONS": {"MAX_ENTRIES": 10000},
     },
     "memcached": {"BACKEND": MEMCACHED_BACKEND, "LOCATION": MEMCACHED_LOCATION},
     # MEMCACHED EXAMPLE

--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -372,6 +372,8 @@ CACHES = {
     },
 }
 
+PERMISSION_CACHE_EXPIRATION_TIME = int(os.getenv("PERMISSION_CACHE_EXPIRATION_TIME", 60 * 60 * 24 * 7))  # 7 days
+
 if MEMCACHED_ENABLED:
     CACHES["default"] = {
         "BACKEND": MEMCACHED_BACKEND,


### PR DESCRIPTION
Fixes #13311
This PR optimizes the performance of the Resource API as described in the issue [GeoNode/geonode#13311](https://github.com/GeoNode/geonode/issues/13311). As mentioned in the issue, a test case has been written to validate the improvements. 

![Screenshot from 2025-06-30 11-21-03](https://github.com/user-attachments/assets/b3c62f4e-fe44-4bc4-8b81-4dc1f8966c1d)

Fig: This figures shows initial curl request results without implementing cache on resource endpoint.

![Screenshot from 2025-06-30 11-23-31](https://github.com/user-attachments/assets/be54e473-2421-4333-aea8-f02dcb93ded0)

Fig: This figures shows curl request results  implementing cache on resource endpoint.

A local Python test script was also executed to evaluate cache performance and scalability. The results are shown below:

![Screenshot from 2025-06-30 12-51-54](https://github.com/user-attachments/assets/a9d00011-212f-4729-b580-dc3146ff0b3d)

Fig: Performance test results demonstrating cache scalability.



## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] PR title must be in the form "[Fixes #<issue_number>] Title of the PR"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: black geonode && flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
