### PR TITLE
Fixes #13316: Adoptd Django ORM select related to reduce the number of DB queries.

### DIFF
--- a/.clabot
+++ b/.clabot
@@ -81,6 +81,7 @@
     "cmotadev",
     "kilichenko-pixida",
     "ZuitAMB",
-    "marlowp"
+    "marlowp",
+    "sijandh35"
   ]
 }

--- a/geonode/base/api/views.py
+++ b/geonode/base/api/views.py
@@ -314,7 +314,7 @@ class ResourceBaseViewSet(ApiPresetsInitializer, DynamicModelViewSet, Advertised
         ResourceBasePermissionsFilter,
         FavoriteFilter,
     ]
-    queryset = ResourceBase.objects.all().order_by("-created")
+    queryset = ResourceBase.objects.select_related("owner").order_by("-created")
     serializer_class = ResourceBaseSerializer
     pagination_class = GeoNodeApiPagination
 


### PR DESCRIPTION
### Overview
Fixes #13316 
This PR optmize the number of queries on Database of ResourceBase API by using select related statement of Django ORM.Tasks Done in this PR is listed below:

1. Change the queryset of ResourceBaseViewSet.
2. Write test case so it didnt break the current response.

2 number of queries will be reduced shown below:

![Screenshot from 2025-06-30 16-28-18](https://github.com/user-attachments/assets/3b882334-64e5-47b6-aba2-ffdf37d37017)
Fig: without select related
![Screenshot from 2025-06-30 16-28-54](https://github.com/user-attachments/assets/1fd3be54-205c-4fce-8f19-7944a459a4de)
Fig: with select related


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] PR title must be in the form "[Fixes #<issue_number>] Title of the PR"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: black geonode && flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates
- [ ] Commits adding **new texts** do use gettext and have updated .po / .mo files (without location infos)

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
