### PR TITLE
[Fixes #13424] Make LocalAssetHandler deal with in-memory files

### DIFF
--- a/geonode/assets/local.py
+++ b/geonode/assets/local.py
@@ -3,11 +3,13 @@ import logging
 import os
 import shutil
 
+
 from django.conf import settings
 from django.http import HttpResponse, StreamingHttpResponse
 from django.urls import reverse
 from django_downloadview import DownloadResponse
 from zipstream import ZipStream
+from pathlib import Path
 
 from geonode.assets.handlers import asset_handler_registry, AssetHandlerInterface, AssetDownloadHandlerInterface
 from geonode.assets.models import LocalAsset
@@ -60,20 +62,27 @@ class LocalAssetHandler(AssetHandlerInterface):
         if not files:
             raise ValueError("File(s) expected")
 
-        if clone_files:
-            files = self._copy_data(files)
-        elif isinstance(files[0], str):
-            pass
-        else:
-            # if files are in-memory, need to handle them properly
-            new_path = self._create_asset_dir()
-            relative_dir = os.path.relpath(new_path, os.path.dirname(settings.ASSETS_ROOT))
-            processed_files = []
-            for f in files:
-                save_path = os.path.join(relative_dir, f.name)
-                self.get_storage_manager(None).save(save_path, f)
-                processed_files.append(os.path.join(new_path, f.name))
-            files = processed_files
+        local_files = [f for f in files if isinstance(f, (str, Path))]
+        in_memory_files = [f for f in files if not isinstance(f, (str, Path))]
+        final_files = []
+        asset_dir = None
+
+        if local_files:
+            if clone_files:
+                copied_files = self._copy_data(local_files)
+                if copied_files:
+                    final_files.extend(copied_files)
+                    asset_dir = os.path.dirname(copied_files[0])
+            else:
+                final_files.extend(local_files)
+
+        if in_memory_files:
+            if asset_dir is None:
+                logger.info("Creating asset dir for in-memory files")
+                asset_dir = self._create_asset_dir()
+            storage = StorageManager(remote_files={f.name: f for f in in_memory_files})
+            cloned_files = storage.clone_remote_files(cloning_directory=asset_dir, create_tempdir=False)
+            final_files.extend([str(p) for p in cloned_files.values()])
 
         asset = LocalAsset(
             title=title,
@@ -81,7 +90,7 @@ class LocalAssetHandler(AssetHandlerInterface):
             type=type,
             owner=owner,
             created=datetime.datetime.now(),
-            location=files,
+            location=final_files,
         )
         asset.save()
         return asset


### PR DESCRIPTION
Fixes #13424 

Changes:

- Update create method in LocalAssetHandler to support InMemoryFile
- Added test case to test in memory file support.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [x] PR title must be in the form "[Fixes #<issue_number>] Title of the PR"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
