### PR TITLE
[Fixes #13459] Improve sync_geonode_datasets logging [Fixes #13462] set_attributes_from_geoserver does not use authenticated calls

### DIFF
--- a/geonode/base/management/command_utils.py
+++ b/geonode/base/management/command_utils.py
@@ -1,34 +1,24 @@
 import logging
-from django.conf import settings
 
 DEFAULT_COMMAND_LOGGER_NAME = "geonode.commands"
 
 
-def setup_logger(logger_name=DEFAULT_COMMAND_LOGGER_NAME, formatter_name="command", handler_name="command"):
-    if logger_name not in settings.LOGGING["loggers"]:
-        format = "%(levelname)-7s %(asctime)s %(message)s"
+def setup_logger(logger_name=DEFAULT_COMMAND_LOGGER_NAME, level=logging.INFO, **kwargs):
+    logger = logging.getLogger(logger_name)
 
-        settings.LOGGING["formatters"][formatter_name] = {
-            "format": format
-        }
-        settings.LOGGING["handlers"][handler_name] = {
-            "level": "DEBUG",
-            "class": "logging.StreamHandler",
-            "formatter": formatter_name
-        }
-        settings.LOGGING["loggers"][logger_name] = {
-            "handlers": [handler_name],
-            "level": "INFO",
-            "propagate": False
-        }
+    # remove previous handlers
+    for old_handler in logger.handlers:
+        logger.removeHandler(old_handler)
 
-        handler = logging.StreamHandler()
-        handler.setFormatter(logging.Formatter(fmt=format))
-        handler.setLevel(logging.DEBUG)
+    format = "%(levelname)-7s %(asctime)s %(message)s"
 
-        logger = logging.getLogger(logger_name)
-        logger.addHandler(handler)
-        logger.setLevel(logging.INFO)
-        logger.propagate = False
+    handler = logging.StreamHandler()
+    handler.setFormatter(logging.Formatter(fmt=format))
+    handler.setLevel(level)
 
-        return logger
+    logger.addHandler(handler)
+
+    logger.setLevel(level)
+    logger.propagate = False
+
+    return logger

--- a/geonode/geoserver/helpers.py
+++ b/geonode/geoserver/helpers.py
@@ -1001,6 +1001,7 @@ def set_attributes_from_geoserver(layer, overwrite=False):
     else:
         server_url = ogc_server_settings.LOCATION
     if layer.subtype in ["tileStore", "remote"] and layer.remote_service.ptype == "gxp_arcrestsource":
+        logger.info(f"Getting info for {layer.subtype} '{layer.alternate or layer.typename}'")
         dft_url = f"{server_url}{(layer.alternate or layer.typename)}?f=json"
         try:
             # The code below will fail if http_client cannot be imported
@@ -1010,20 +1011,22 @@ def set_attributes_from_geoserver(layer, overwrite=False):
                 [n["name"], _esri_types[n["type"]]] for n in body["fields"] if n.get("name") and n.get("type")
             ]
         except Exception:
-            tb = traceback.format_exc()
-            logger.debug(tb)
+            logger.warning(
+                f"Error while retrieving info for {layer.subtype} '{layer.alternate or layer.typename}'", exc_info=True
+            )
             attribute_map = []
     elif layer.subtype in {"vector", "tileStore", "remote", "wmsStore", "vector_time"}:
         typename = layer.alternate if layer.alternate else layer.typename
+        logger.info(f"Getting WFS info for {layer.subtype} '{typename}'")
         dft_url_path = re.sub(r"\/wms\/?$", "/", server_url)
         dft_query = urlencode(
             {"service": "wfs", "version": "1.0.0", "request": "DescribeFeatureType", "typename": typename}
         )
         dft_url = urljoin(dft_url_path, f"ows?{dft_query}")
+        logger.debug(f"WFS URL is  {dft_url}")
         try:
             # The code below will fail if http_client cannot be imported or WFS not supported
-            req, body = http_client.get(dft_url, user=_user)
-            doc = dlxml.fromstring(body.encode())
+            doc = _get_xml(dft_url)
             xsd = "{http://www.w3.org/2001/XMLSchema}"
             path = f".//{xsd}extension/{xsd}sequence/{xsd}element"
             attribute_map = [
@@ -1032,8 +1035,9 @@ def set_attributes_from_geoserver(layer, overwrite=False):
                 if n.attrib.get("name") and n.attrib.get("type")
             ]
         except Exception:
-            tb = traceback.format_exc()
-            logger.debug(tb)
+            logger.warning(
+                f"Error while retrieving WFS info for {layer.subtype} '{typename}'... will try WMS", exc_info=True
+            )
             attribute_map = []
             # Try WMS instead
             dft_url = (
@@ -1058,7 +1062,9 @@ def set_attributes_from_geoserver(layer, overwrite=False):
                 )
             )
             try:
-                req, body = http_client.get(dft_url, user=_user)
+                logger.info(f"Getting WMS info for {layer.subtype} '{layer.alternate or layer.typename}'")
+                logger.debug(f"WMS URL is {dft_url}")
+                body = _get_from_catalog(dft_url)
                 soup = BeautifulSoup(body, features="lxml")
                 for field in soup.findAll("th"):
                     if field.string is None:
@@ -1067,21 +1073,19 @@ def set_attributes_from_geoserver(layer, overwrite=False):
                         field_name = field.string
                     attribute_map.append([field_name, "xsd:string"])
             except Exception:
-                tb = traceback.format_exc()
-                logger.debug(tb)
+                logger.warning(f"Error while retrieving WMS info for {layer.subtype} '{typename}'", exc_info=True)
                 attribute_map = []
     elif layer.subtype in ["raster"]:
         typename = layer.alternate if layer.alternate else layer.typename
+        logger.info(f"Getting WCS info for {layer.subtype} '{typename}'")
         dc_url = f"{server_url}wcs?{urlencode({'service': 'wcs', 'version': '1.1.0', 'request': 'DescribeCoverage', 'identifiers': typename})}"
         try:
-            req, body = http_client.get(dc_url, user=_user)
-            doc = dlxml.fromstring(body.encode())
+            doc = _get_xml(dc_url)
             wcs = "{http://www.opengis.net/wcs/1.1.1}"
             path = f".//{wcs}Axis/{wcs}AvailableKeys/{wcs}Key"
             attribute_map = [[n.text, "raster"] for n in doc.findall(path)]
         except Exception:
-            tb = traceback.format_exc()
-            logger.debug(tb)
+            logger.warning(f"Error while retrieving WCS info for {layer.subtype} '{typename}'", exc_info=True)
             attribute_map = []
     # Get attribute statistics & package for call to really_set_attributes()
     attribute_stats = defaultdict(dict)
@@ -1097,6 +1101,7 @@ def set_attributes_from_geoserver(layer, overwrite=False):
             else:
                 result = None
             attribute_stats[layer.name][field] = result
+    logger.info(f"Found {len(attribute_map)} attributes for {layer.subtype}")
     set_attributes(layer, attribute_map, overwrite=overwrite, attribute_stats=attribute_stats)
 
 
@@ -2288,3 +2293,19 @@ def ows_endpoint_in_path(path):
         or re.match(r".*(?<!w[a-z]s)/(w.*s)/.*$", path, re.IGNORECASE)
         or re.match(r".*(?<!ows)/(ows)/.*$", path, re.IGNORECASE)
     )
+
+
+def _get_from_catalog(url):
+    resp = gs_catalog.http_request(url)
+    if resp.status_code == 200:
+        return resp.content
+    else:
+        logger.debug(f"Request at {url} returned code {resp.status_code} and content {resp.content}")
+        raise Exception(f"Request returned code {resp.status_code}")
+
+
+def _get_xml(url):
+    content = _get_from_catalog(url)
+    if isinstance(content, bytes):
+        content = content.decode("UTF-8")
+    return dlxml.fromstring(content.encode())

--- a/geonode/geoserver/management/commands/sync_geonode_datasets.py
+++ b/geonode/geoserver/management/commands/sync_geonode_datasets.py
@@ -18,13 +18,17 @@
 #########################################################################
 import sys
 import json
+import logging
 
 from django.core.management.base import BaseCommand
 
+from geonode.base.management.command_utils import setup_logger
 from geonode.layers.models import Dataset
 from geonode.security.views import _perms_info_json
 from geonode.base.utils import remove_duplicate_links
 from geonode.geoserver.helpers import create_gs_thumbnail, sync_instance_with_geoserver, set_attributes_from_geoserver
+
+logger = logging.getLogger(__name__)
 
 
 def sync_geonode_datasets(
@@ -46,47 +50,52 @@ def sync_geonode_datasets(
     layers_count = layers.count()
     count = 0
     dataset_errors = []
+
+    if not layers:
+        logger.warning(f"No layers selected by filter '{filter}'")
+        return
+
     for layer in layers:
         try:
             count += 1
-            print(f"Syncing layer {count}/{layers_count}: {layer.name}")
+            logger.info(f"=== Syncing layer {count}/{layers_count}: {layer.name}")
             if updatepermissions:
-                print("Syncing permissions...")
+                logger.info("Syncing permissions...")
                 # sync permissions in GeoFence
                 perm_spec = json.loads(_perms_info_json(layer))
                 # re-sync GeoFence security rules
                 layer.set_permissions(perm_spec)
             if updateattributes:
                 # recalculate the layer statistics
+                logger.info("Setting attributes...")
                 set_attributes_from_geoserver(layer, overwrite=True)
             if updatethumbnails:
-                print("Regenerating thumbnails...")
+                logger.info("Regenerating thumbnails...")
                 create_gs_thumbnail(layer, overwrite=True, check_bbox=False)
             if updatebbox:
-                print("Regenerating BBOX...")
+                logger.info("Regenerating BBOX...")
                 sync_instance_with_geoserver(layer.id, updatemetadata=False, updatebbox=True)
             if updatemetadata:
-                print("Updating metadata...")
+                logger.info("Updating metadata...")
                 sync_instance_with_geoserver(layer.id, updatemetadata=True, updatebbox=False)
             if removeduplicates:
                 # remove duplicates
-                print("Removing duplicate links...")
+                logger.info("Removing duplicate links...")
                 remove_duplicate_links(layer)
         except (Exception, RuntimeError):
             dataset_errors.append(layer.alternate)
             exception_type, error, traceback = sys.exc_info()
-            print(exception_type, error, traceback)
+            logger.info(exception_type, error, traceback)
             if ignore_errors:
                 pass
             else:
-                import traceback
-
-                traceback.print_exc()
-                print("Stopping process because --ignore-errors was not set and an error was found.")
+                logger.error(
+                    "Stopping process because --ignore-errors was not set and an error was found.", stack_info=True
+                )
                 return
-    print(f"There are {len(dataset_errors)} layers which could not be updated because of errors")
+    logger.info(f"There are {len(dataset_errors)} layers which could not be updated because of errors")
     for dataset_error in dataset_errors:
-        print(dataset_error)
+        logger.info(dataset_error)
 
 
 class Command(BaseCommand):
@@ -148,10 +157,23 @@ class Command(BaseCommand):
             action="store_true",
             dest="updatemetadata",
             default=False,
-            help="Update the Geoserver ayer metadata.",
+            help="Update the Geoserver layer metadata.",
+        )
+        parser.add_argument(
+            "--debug",
+            action="store_true",
+            dest="log_debug",
+            default=False,
+            help="Enable debug logging.",
         )
 
     def handle(self, **options):
+        log_level = logging.DEBUG if options.get("log_debug") else logging.INFO
+        setup_logger(__name__, level=log_level)
+        import geonode.geoserver.helpers as helpers
+
+        setup_logger(helpers.__name__, level=log_level)
+
         ignore_errors = options.get("ignore_errors")
         removeduplicates = options.get("removeduplicates")
         updatepermissions = options.get("updatepermissions")


### PR DESCRIPTION
Quick fix for 4.4.x for:

- [Fixes #13459] Improve sync_geonode_datasets logging 
- [Fixes #13462] set_attributes_from_geoserver does not use authenticated calls

On master we will:
- separate the fix for each issue in its own PR
- investigate and expand #13462 since the not-authenticated call are performed also in other functions

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [ ] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [ ] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] PR title must be in the form "[Fixes #<issue_number>] Title of the PR"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
