### PR TITLE
Use self-published PyCSW 3 Beta temporarily

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -46,7 +46,7 @@ pyjwt==2.8.0
 redis==6.2.0
 
 # geopython dependencies
-git+https://github.com/geopython/pycsw.git@3.0.0-beta1#egg=pycsw
+geonode-pycsw==3.0.0b1
 pyproj<3.8.0
 OWSLib==0.34.1
 SQLAlchemy==2.0.43 # required by PyCSW

--- a/setup.cfg
+++ b/setup.cfg
@@ -74,7 +74,7 @@ install_requires =
     # geopython dependencies
     pyproj<3.8.0
     OWSLib==0.34.1
-    pycsw @ git+https://github.com/geopython/pycsw.git@3.0.0-beta1#egg=pycsw
+    geonode-pycsw==3.0.0b1
     SQLAlchemy==2.0.30 # required by PyCSW
     Shapely==2.1.2
     mercantile==1.2.1


### PR DESCRIPTION
This is required because we cannot publish to PyPi with a reference to a github tag