### PR TITLE
Do not create genode folder inside base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM geonode/geonode-base:latest-ubuntu-24.04
 LABEL GeoNode development team
 
+RUN mkdir -p /usr/src/geonode
 # copy local geonode src inside container
 COPY . /usr/src/geonode/
 WORKDIR /usr/src/geonode

--- a/docker/base/ubuntu/Dockerfile
+++ b/docker/base/ubuntu/Dockerfile
@@ -1,7 +1,5 @@
 FROM ubuntu:24.04
 
-RUN mkdir -p /usr/src/geonode
-
 ## Enable postgresql-client-15
 RUN apt-get update -y && apt-get install curl wget unzip gnupg2 -y
 RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -


### PR DESCRIPTION
Otherwise, it will be created inside geonode projects too, where it's not used and will be an empty folder.