### PR TITLE
Fix packaging of sub-packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -179,8 +179,12 @@ Repository = "https://github.com/GeoNode/geonode"
 Documentation = "https://docs.geonode.org/"
 
 [tool.setuptools]
-packages = ["geonode"]
 include-package-data = true
+
+[tool.setuptools.packages.find]
+where = ["."]
+exclude = ["tests*"]
+include = ["geonode*"]
 
 [tool.setuptools.dynamic]
 version = {attr = "geonode.__version__"}


### PR DESCRIPTION
Without this, the sub-packages (geonode.api, etc.) are not packaged and are not available inside the Python path.