### PR TITLE
[Backport 5.0.x] bump cryptography from 46.0.3 to 46.0.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -148,5 +148,5 @@ selenium-requests==2.0.4
 webdriver_manager==4.0.1
 
 # Security and audit
-cryptography==46.0.3
+cryptography==46.0.5
 jwcrypto>=1.5.6

--- a/setup.cfg
+++ b/setup.cfg
@@ -174,7 +174,7 @@ install_requires =
     webdriver_manager==4.0.1
 
     # Security and audit
-    cryptography==46.0.3
+    cryptography==46.0.5
     jwcrypto>=1.5.6
 
 


### PR DESCRIPTION
Backport of https://github.com/GeoNode/geonode/pull/13949