### PR TITLE
[Fixes #14291] Add parameter for beat DB file location

### DIFF
--- a/celery-cmd
+++ b/celery-cmd
@@ -16,6 +16,7 @@ CELERY__WORKER_CONCURRENCY=${CELERY__WORKER_CONCURRENCY:-"4"}
 
 # Celery beat settings
 CELERY__BEAT_SCHEDULE=${CELERY__BEAT_SCHEDULE:-"celery.beat:PersistentScheduler"}
+CELERY__BEAT_DB=${CELERY__BEAT_DB:-"/tmp/celerybeat-schedule"}
 CELERY__BEAT_LOG=${CELERY__BEAT_LOG:-"/var/log/celery_beat.log"}
 
 # Harvester settings
@@ -43,6 +44,7 @@ fi
 
 echo "Starting Celery Beat..."
 $CELERY_BIN -A $CELERY_APP beat --scheduler=$CELERY__BEAT_SCHEDULE \
+    --schedule=$CELERY__BEAT_DB \
     --loglevel=$CELERY__LOG_LEVEL -f $CELERY__BEAT_LOG --pidfile=/tmp/celerybeat.pid &
 
 echo "Starting Default Celery Worker..."

--- a/celery-cmd
+++ b/celery-cmd
@@ -16,7 +16,7 @@ CELERY__WORKER_CONCURRENCY=${CELERY__WORKER_CONCURRENCY:-"4"}
 
 # Celery beat settings
 CELERY__BEAT_SCHEDULE=${CELERY__BEAT_SCHEDULE:-"celery.beat:PersistentScheduler"}
-CELERY__BEAT_DB=${CELERY__BEAT_DB:-"/tmp/celerybeat-schedule"}
+CELERY__BEAT_DB=${CELERY__BEAT_DB:-"/mnt/volumes/statics/celerybeat-schedule"}
 CELERY__BEAT_LOG=${CELERY__BEAT_LOG:-"/var/log/celery_beat.log"}
 
 # Harvester settings


### PR DESCRIPTION
The celery-cmd script currently writes the celery-beat-db file in the same directory, which is problematic when running as non-root. This pull request adds an option to be able to specify the file location to be used.

## Checklist

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation) -> small change, so I suppose a CLA is not necessary
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [x] PR title must be in the form "[Fixes #<issue_number>] Title of the PR"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
