### PR TITLE
Bump deprecated GitHub Actions to current major versions

### DIFF
--- a/.clabot
+++ b/.clabot
@@ -87,6 +87,7 @@
     "F0rtiter",
     "nrjadkry",
     "jwkaltz",
-    "dsuren1"
+    "dsuren1",
+    "Valyrian-Code"
   ]
 }

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,11 +41,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -59,7 +59,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -72,6 +72,6 @@ jobs:
     #   ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -20,10 +20,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
 
     - name: Set up Python ${{matrix.python-version}}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v6
       with:
         python-version: ${{matrix.python-version}}
 


### PR DESCRIPTION
Bumps GitHub Actions in the `flake8` (Code formatting) and `codeql` (CodeQL) workflows from deprecated major versions to the current ones. No behaviour change.

- `actions/checkout@v3` → `@v6` (matches the versions already used in `tests.yml` / `run-test-suite.yml`)
- `actions/setup-python@v2` → `@v6`
- `github/codeql-action/{init,autobuild,analyze}@v2` → `@v3`

Rationale: `actions/checkout@v3` and `actions/setup-python@v2` run on the end-of-life Node 16 runner, and `github/codeql-action@v2` has been deprecated by GitHub. These emit deprecation warnings today and will eventually stop executing.

## Checklist

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md)
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary — CI-only change, no source or new files (small-change exemption)
- [x] Make sure the first PR targets the master branch

For core and extension modules:

- [ ] There is a ticket describing the issue — CI maintenance, not visible to end users (template exemption for "changes not visible to end-users")
- [ ] The issue connected to the PR must have Labels and Milestone assigned — N/A (no issue, per the exemption above)
- [x] PR for bug fixes and small new features are presented as a single commit
- [ ] PR title must be in the form "[Fixes #<issue_number>] Title of the PR" — N/A (no issue, per the exemption above)
- [ ] New unit tests have been added — N/A: this is a CI configuration change with no runtime code; correctness is exercised by this PR's own workflow runs
