### PR TITLE
[Backport 5.1.x] bump pyjwt from 2.8.0 to 2.13.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ dependencies = [
     "django-widget-tweaks==1.5.0",
     "django-sequences==3.0",
     "oauthlib==3.3.1",
-    "pyjwt==2.8.0",
+    "pyjwt==2.13.0",
     "redis==6.2.0",
 
     # geopython dependencies


### PR DESCRIPTION
Backport fo https://github.com/GeoNode/geonode/pull/14256