### PR TITLE
[Fixes #14444] Use COMPOSE_ENV_FILE instead of ENVIRONMENT

### DIFF
--- a/.github/workflows/run-test-suite.yml
+++ b/.github/workflows/run-test-suite.yml
@@ -28,20 +28,20 @@ jobs:
         run: docker load -i docker_images/django.tar
 
       - name: Start the stack
-        run: ENVIRONMENT=test docker compose up -d --no-deps db geoserver django nginx
+        run: COMPOSE_ENV_FILES=.env_test docker compose up -d --no-deps db geoserver django nginx
 
       - name: Setup test databases
         run: |
-          ENVIRONMENT=test docker compose exec db psql -U postgres -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE pid <> pg_backend_pid();"
-          ENVIRONMENT=test docker compose exec db createdb -U postgres -T postgres test_postgres
-          ENVIRONMENT=test docker compose exec db createdb -U postgres -T postgres test_geonode
-          ENVIRONMENT=test docker compose exec db createdb -U postgres -T postgres test_geonode_data
-          ENVIRONMENT=test docker compose exec db psql -U postgres -d test_geonode -c "CREATE EXTENSION IF NOT EXISTS postgis;"
-          ENVIRONMENT=test docker compose exec db psql -U postgres -d test_geonode_data -c "CREATE EXTENSION IF NOT EXISTS postgis;"
+          COMPOSE_ENV_FILES=.env_test docker compose exec db psql -U postgres -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE pid <> pg_backend_pid();"
+          COMPOSE_ENV_FILES=.env_test docker compose exec db createdb -U postgres -T postgres test_postgres
+          COMPOSE_ENV_FILES=.env_test docker compose exec db createdb -U postgres -T postgres test_geonode
+          COMPOSE_ENV_FILES=.env_test docker compose exec db createdb -U postgres -T postgres test_geonode_data
+          COMPOSE_ENV_FILES=.env_test docker compose exec db psql -U postgres -d test_geonode -c "CREATE EXTENSION IF NOT EXISTS postgis;"
+          COMPOSE_ENV_FILES=.env_test docker compose exec db psql -U postgres -d test_geonode_data -c "CREATE EXTENSION IF NOT EXISTS postgis;"
 
       - name: Run ${{ inputs.suite_name }}
         run: |
-          ENVIRONMENT=test docker compose exec -T django bash -s <<'BASH'
+          COMPOSE_ENV_FILES=.env_test docker compose exec -T django bash -s <<'BASH'
           set -euo pipefail
           ${{ inputs.test_command }}
           BASH
@@ -52,8 +52,8 @@ jobs:
 
       - name: Codecov
         run: |
-          ENVIRONMENT=test docker compose exec django bash -c "bash <(curl -s https://codecov.io/bash) -t 2c0e7780-1640-45f0-93a3-e103b057d8c8"
+          COMPOSE_ENV_FILES=.env_test docker compose exec django bash -c "bash <(curl -s https://codecov.io/bash) -t 2c0e7780-1640-45f0-93a3-e103b057d8c8"
 
       - name: Stop the stack
         if: always()
-        run: ENVIRONMENT=test docker compose down -v
+        run: COMPOSE_ENV_FILES=.env_test docker compose down -v

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Build all services (Docker Compose v2)
-        run: ENVIRONMENT=test docker compose build db geoserver django nginx --progress plain
+        run: COMPOSE_ENV_FILES=.env_test docker compose build db geoserver django nginx --progress plain
 
       - name: Save built Docker images
         run: |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ x-common-django:
       dockerfile: Dockerfile
   restart: unless-stopped
   env_file:
-    - .env${ENVIRONMENT:+_}${ENVIRONMENT:-}
+    - ${COMPOSE_ENV_FILES:-.env}
   volumes:
     - '.:/usr/src/geonode'
     - statics:/mnt/volumes/statics
@@ -60,7 +60,7 @@ services:
     image: geonode/nginx:1.31.2-latest
     container_name: nginx4${COMPOSE_PROJECT_NAME}
     env_file:
-      - .env${ENVIRONMENT:+_}${ENVIRONMENT:-}
+      - ${COMPOSE_ENV_FILES:-.env}
     environment:
       - RESOLVER=127.0.0.11
     ports:
@@ -83,7 +83,7 @@ services:
     image: geonode/letsencrypt:2.6.0-latest
     container_name: letsencrypt4${COMPOSE_PROJECT_NAME}
     env_file:
-      - .env${ENVIRONMENT:+_}${ENVIRONMENT:-}
+      - ${COMPOSE_ENV_FILES:-.env}
     volumes:
       - nginx-certificates:/geonode-certificates
     restart: unless-stopped
@@ -102,7 +102,7 @@ services:
       timeout: 10s
       retries: 3
     env_file:
-      - .env${ENVIRONMENT:+_}${ENVIRONMENT:-}
+      - ${COMPOSE_ENV_FILES:-.env}
     ports:
       - "8080:8080"
     volumes:
@@ -128,7 +128,7 @@ services:
       - config_file=/etc/postgresql/postgresql.conf
     container_name: db4${COMPOSE_PROJECT_NAME}
     env_file:
-      - .env${ENVIRONMENT:+_}${ENVIRONMENT:-}
+      - ${COMPOSE_ENV_FILES:-.env}
     volumes:
       - dbdata:/var/lib/postgresql/data
       - dbbackups:/pg_backups


### PR DESCRIPTION
Fixes #14444

Replace the custom `ENVIRONMENT` variable with Compose's native `COMPOSE_ENV_FILES`, which Compose itself uses to resolve `COMPOSE_PROJECT_NAME` (and thus volume/container names) -- unlike `ENVIRONMENT`, which only affected `env_file:` and left project naming to always fall back to the default `.env`.

`COMPOSE_ENV_FILES` isn't automatically injected into container environments, so each service's `env_file:` now reads `${COMPOSE_ENV_FILES:-.env}` to keep naming and container config in sync from a single variable.

Also updates `.github/workflows/tests.yml` and `run-test-suite.yml` to use `COMPOSE_ENV_FILES=.env_test` instead of `ENVIRONMENT=test`.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [ ] PR title must be in the form "[Fixes #<issue_number>] Title of the PR"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
