### PR TITLE
[Fixes #14473] Fix payload handling in the users transfer_resources endpoint

### DIFF
--- a/geonode/people/api/views.py
+++ b/geonode/people/api/views.py
@@ -171,12 +171,16 @@ class UserViewSet(DynamicModelViewSet):
         )
         target = None
 
-        if not target_user and previous_owner:
+        if not target_user:
             return Response("Payload not passed", status=400)
 
-        if user.is_superuser or (
-            not user.is_superuser
-            and ResourceBase.objects.filter(owner=user, pk__in=transfer_resource_subset).count()
+        # `currentOwner` is optional and defaults to the user the resources are read from.
+        source_owner = get_object_or_404(get_user_model(), id=previous_owner) if previous_owner else user
+
+        if (
+            user.is_superuser
+            or not transfer_resource_subset
+            or ResourceBase.objects.filter(owner=user, pk__in=transfer_resource_subset).count()
             == len(transfer_resource_subset)
         ):
 
@@ -185,8 +189,7 @@ class UserViewSet(DynamicModelViewSet):
             if target == user:
                 return Response("Cannot reassign to self", status=400)
 
-            # we need to filter by the previous owner id
-            filter_payload = dict(owner=previous_owner or user)
+            filter_payload = dict(owner=source_owner)
 
             if transfer_resource_subset:
                 # transfer_resources
@@ -198,8 +201,7 @@ class UserViewSet(DynamicModelViewSet):
                 we can use the resource manager because inside it will automatically update
                 the owner
                 """
-                prev_owner = get_object_or_404(get_user_model(), id=previous_owner)
-                resource_manager_registry.get_for_instance(instance).transfer_ownership(instance, target, prev_owner)
+                resource_manager_registry.get_for_instance(instance).transfer_ownership(instance, target, source_owner)
 
             return Response("Resources transfered successfully", status=200)
 

--- a/geonode/people/tests.py
+++ b/geonode/people/tests.py
@@ -1262,12 +1262,36 @@ class PeopleAndProfileTests(GeoNodeBaseTestSupport):
         self.assertTrue(bobby_resources.exists())
         # call api
         response = self.client.post(path=f"{reverse('users-list')}/{bobby.pk}/transfer_resources", data={})
-        # response should be 404
-        self.assertEqual(response.status_code, 404)
+        # a missing newOwner is a bad request, not a missing object
+        self.assertEqual(response.status_code, 400)
         # check that bobby still owns the resources
         self.assertTrue(bobby_resources.exists())
         later_bobby_resources = ResourceBase.objects.filter(owner=bobby).all()
         self.assertTrue(set(prior_bobby_resources) == set(later_bobby_resources))
+
+    def test_transfer_resources_without_current_owner(self):
+        """
+        currentOwner is optional: it defaults to the user the resources are read from.
+        Sent as JSON, so `resources` is absent rather than an empty list.
+        """
+        bobby = get_user_model().objects.get(username="bobby")
+        norman = get_user_model().objects.get(username="norman")
+
+        # login as admin user
+        self.assertTrue(self.client.login(username="admin", password="admin"))
+
+        bobby_resources = ResourceBase.objects.filter(owner=bobby)
+        prior_bobby_resources = set(bobby_resources.all())
+        self.assertTrue(bobby_resources.exists())
+
+        response = self.client.post(
+            path=f"{reverse('users-list')}/{bobby.pk}/transfer_resources",
+            data={"newOwner": norman.id},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(bobby_resources.exists())
+        self.assertTrue(prior_bobby_resources.issubset(set(ResourceBase.objects.filter(owner=norman).all())))
 
     def test_transfer_resource_subset(self):
         """


### PR DESCRIPTION
Fixes #14473.

`POST /api/v2/users/{pk}/transfer_resources` could not be called with the minimal payload, and one of its guards was unreachable.

- `if not target_user and previous_owner` only rejected a missing `newOwner` when `currentOwner` was present. Without either, the request fell through to `get_object_or_404(User, id=None)` and answered 404 instead of 400.
- `currentOwner` is optional as far as the filter is concerned (`filter_payload = dict(owner=previous_owner or user)`), but the loop resolved it unconditionally with `get_object_or_404`, so `{"newOwner": <id>}` on its own always returned 404. It is now resolved once, up front, defaulting to the user the resources are read from - which also takes the query out of the loop.
- With a JSON body and no `resources` key the subset is `None`, so `len(transfer_resource_subset)` raised `TypeError` whenever the source user is not a superuser. Skipping the subset check when there is no subset keeps the whole-account transfer working.

Everything that already worked keeps its status code. The one behaviour change is the empty-body case, which now answers the 400 the guard was clearly written for: `test_transfer_resources_nopayload` asserted the 404 from the first bug and now asserts 400.

`test_transfer_resources_without_current_owner` is new and covers the other two - it sends a JSON body, so `resources` is genuinely absent rather than the empty list a form-encoded `QueryDict.getlist` returns. That difference is why the existing tests pass today.

I have not been able to run the full Django suite locally; `black` and `flake8` are clean on both files.
