### PR TITLE
[Backport PR #14402 to 5.1.x] Moving the logic of PROFILE_LANGUAGE_CHOICES to a helper function

### DIFF
--- a/geonode/people/forms/__init__.py
+++ b/geonode/people/forms/__init__.py
@@ -23,7 +23,8 @@ from django import forms
 from django.contrib.auth import get_user_model
 from django.contrib.auth.forms import UserCreationForm, UserChangeForm
 from django.utils.translation import gettext_lazy as _
-from django.conf import settings
+
+from geonode.people.utils import get_profile_language_choices
 
 # Ported in from django-registration
 attrs_dict = {"class": "required"}
@@ -52,7 +53,7 @@ class ProfileForm(forms.ModelForm):
 
     language = forms.ChoiceField(
         label=_("Language"),
-        choices=settings.PROFILE_LANGUAGE_CHOICES,
+        choices=get_profile_language_choices,
     )
 
     class Meta:

--- a/geonode/people/tests.py
+++ b/geonode/people/tests.py
@@ -1361,10 +1361,6 @@ class PeopleAndProfileTests(GeoNodeBaseTestSupport):
             ("en-us", "English"),
             ("it-it", "Italiano"),
         ),
-        PROFILE_LANGUAGE_CHOICES=(
-            ("en", "English"),
-            ("it", "Italiano"),
-        ),
     )
     def test_authenticated_user_language_switch_stores_profile_code_from_runtime_code(self):
         user = get_user_model().objects.get(username="bobby")

--- a/geonode/people/utils.py
+++ b/geonode/people/utils.py
@@ -253,4 +253,4 @@ def get_profile_language_choices():
     Build the list of DB-based (2-char) language choices from the currently
     configured settings.LANGUAGES
     """
-    return tuple((code.split("-")[0].lower(), label) for code, label in settings.LANGUAGES)
+    return tuple({code.split("-")[0].lower(): label for code, label in settings.LANGUAGES}.items())

--- a/geonode/people/utils.py
+++ b/geonode/people/utils.py
@@ -246,3 +246,11 @@ def runtime_to_profile_lang(lang):
         return None
 
     return lang.lower().split("-")[0]
+
+
+def get_profile_language_choices():
+    """
+    Build the list of DB-based (2-char) language choices from the currently
+    configured settings.LANGUAGES
+    """
+    return tuple((code.split("-")[0].lower(), label) for code, label in settings.LANGUAGES)

--- a/geonode/people/views.py
+++ b/geonode/people/views.py
@@ -33,7 +33,7 @@ from django.views.i18n import set_language as django_set_language
 
 from geonode.tasks.tasks import send_email
 from geonode.people.forms import ProfileForm
-from geonode.people.utils import get_available_users, runtime_to_profile_lang
+from geonode.people.utils import get_available_users, get_profile_language_choices, runtime_to_profile_lang
 from geonode.base.auth import get_or_create_token
 from geonode.people.forms import ForgotUsernameForm
 from geonode.base.views import user_and_group_permission
@@ -178,7 +178,7 @@ def set_session_language(request):
     raw_lang = request.POST.get("language")
     profile_lang = runtime_to_profile_lang(raw_lang)
 
-    if profile_lang in {code for code, _label in settings.PROFILE_LANGUAGE_CHOICES}:
+    if profile_lang in {code for code, _label in get_profile_language_choices()}:
         request.session[SESSION_LANG_KEY] = profile_lang
 
         is_read_only = Configuration.load().read_only

--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -1436,9 +1436,6 @@ if GEONODE_CLIENT_LAYER_PREVIEW_LIBRARY == "mapstore":
     else:
         LANGUAGES = MAPSTORE_DEFAULT_LANGUAGES
 
-    # This setting includes supported Maptstore language choices in a DB-based format
-    PROFILE_LANGUAGE_CHOICES = tuple((code.split("-")[0].lower(), label) for code, label in LANGUAGES)
-
     # The default mapstore client compiles the translations json files in the /static/mapstore directory
     # gn-translations are the custom translations for the client and ms-translations are the translations from the core framework
     MAPSTORE_TRANSLATIONS_PATH = os.environ.get(


### PR DESCRIPTION
Backport PR: https://github.com/GeoNode/geonode/pull/14402

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [ ] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] PR title must be in the form "[Fixes #<issue_number>] Title of the PR"
- [ ] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
