### PR TITLE
[Fixes #14519] GroupProfile.access default is "public'", not a valid choice

### DIFF
--- a/.clabot
+++ b/.clabot
@@ -89,6 +89,7 @@
     "jwkaltz",
     "dsuren1",
     "Valyrian-Code",
-    "brynsofz"
+    "brynsofz",
+    "christianbraun"
   ]
 }

--- a/geonode/groups/migrations/0036_fix_groupprofile_access_default.py
+++ b/geonode/groups/migrations/0036_fix_groupprofile_access_default.py
@@ -1,0 +1,38 @@
+from django.db import migrations, models
+
+# The old default, with a stray apostrophe that matches none of the field's own
+# GROUP_CHOICES. Every GroupProfile created without an explicit access — which is
+# what geonode_ldap's group mirroring does — was stored with this value.
+BAD_DEFAULT = "public'"
+
+
+def repair_access(apps, schema_editor):
+    GroupProfile = apps.get_model("groups", "GroupProfile")
+    GroupProfile.objects.filter(access=BAD_DEFAULT).update(access="public")
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("groups", "0035_remove_modeltranslation"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="groupprofile",
+            name="access",
+            field=models.CharField(
+                choices=[
+                    ("public", "Public"),
+                    ("public-invite", "Public (invite-only)"),
+                    ("private", "Private"),
+                ],
+                default="public",
+                help_text="Public: Any registered user can view and join a public group.<br>Public (invite-only):Any registered user can view the group.  Only invited users can join.<br>Private: Registered users cannot see any details about the group, including membership.  Only invited users can join.",
+                max_length=15,
+                verbose_name="Access",
+            ),
+        ),
+        # Reversing would mean writing the invalid value back, so this only goes
+        # forward; the AlterField above is reversible on its own.
+        migrations.RunPython(repair_access, migrations.RunPython.noop),
+    ]

--- a/geonode/groups/models.py
+++ b/geonode/groups/models.py
@@ -91,7 +91,7 @@ class GroupProfile(models.Model):
     email = models.EmailField(_("Email"), null=True, blank=True, help_text=email_help_text)
     keywords = TaggableManager(_("Keywords"), help_text=_("A space or comma-separated list of keywords"), blank=True)
     access = models.CharField(
-        _("Access"), max_length=15, default="public'", choices=GROUP_CHOICES, help_text=access_help_text
+        _("Access"), max_length=15, default="public", choices=GROUP_CHOICES, help_text=access_help_text
     )
     categories = models.ManyToManyField(GroupCategory, verbose_name=_("Categories"), blank=True, related_name="groups")
     created = models.DateTimeField(auto_now_add=True, null=True, blank=True)

--- a/geonode/groups/tests.py
+++ b/geonode/groups/tests.py
@@ -93,6 +93,17 @@ class GroupsSmokeTest(GeoNodeBaseTestSupport):
         group = Group.objects.filter(name=groups_settings.REGISTERED_MEMBERS_GROUP_NAME).first()
         self.assertTrue(group)
 
+    def test_default_access_is_a_valid_choice(self):
+        """
+        Ensures a GroupProfile created without an explicit access gets one of the
+        field's own GROUP_CHOICES, so that code filtering on access="public"
+        (e.g. geonode.people.utils.get_available_users) can see it.
+        """
+        group = GroupProfile.objects.create(slug="default_access_group", title="default_access_group")
+        self.assertEqual(group.access, "public")
+        self.assertIn(group.access, dict(GroupProfile.GROUP_CHOICES))
+        self.assertIn(group, GroupProfile.objects.filter(access="public"))
+
     def test_users_group_list_view(self):
         """
         1. Ensures that a superuser can see the whole group list.


### PR DESCRIPTION
Fixes #14519.

`GroupProfile.access` was declared with `default="public'"` — a stray apostrophe, matching none of the field's own `GROUP_CHOICES`. Any group created without an explicit `access` was stored with that value and became invisible to code filtering on `access="public"`, notably `geonode.people.utils.get_available_users`. The typo has been there since 796add43c (2014) and is also in `24_initial.py`.

Three changes:

- `geonode/groups/models.py` — `default="public'"` → `default="public"`.
- `geonode/groups/migrations/0036_fix_groupprofile_access_default.py` — the `AlterField` for the new default, plus a `RunPython` that rewrites existing `"public'"` rows to `"public"`. Existing installs need the data fix; the model fix alone leaves every group already created still broken. The `RunPython` is `noop` in reverse, since undoing it would mean writing an invalid value back.
- `geonode/groups/tests.py` — `test_default_access_is_a_valid_choice`, asserting a `GroupProfile` created without an `access` is both a valid choice and returned by `filter(access="public")`.

How we hit it: on an AD-backed instance, `geonode_ldap`'s `updateldapgroups` creates `GroupProfile`s without passing `access`, so all 276 mirrored groups carried `"public'"` and a group picker filtering on `"public"` showed none of them.

Most of core is unaffected because it keys on `access == "private"` instead, which the typo leaves alone — that is why this has survived so long.

## Checklist

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md)
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] PR title must be in the form "[Fixes #`<issue_number>`] Title of the PR"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented

Happy to backport to 4.4.x / 5.0.x once this lands. I could not run the full suite locally, so CI is the first real execution of the migration.
